### PR TITLE
Use coverage XML artifacts for PR agent context

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -99,15 +99,6 @@ jobs:
           path: .coverage.unit
           include-hidden-files: true
 
-      - name: Upload raw coverage data for PR agent context
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: pr-agent-context-coverage-unit-tests
-          path: .coverage.unit
-          include-hidden-files: true
-          if-no-files-found: ignore
-
   integration-tests:
     needs: [smoke-tests]
     runs-on: ubuntu-latest
@@ -140,15 +131,6 @@ jobs:
           name: coverage-integration-data
           path: .coverage.integration
           include-hidden-files: true
-
-      - name: Upload raw coverage data for PR agent context
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: pr-agent-context-coverage-integration-tests
-          path: .coverage.integration
-          include-hidden-files: true
-          if-no-files-found: ignore
 
   coverage:
     needs: [lint, unit-tests, integration-tests]
@@ -217,6 +199,8 @@ jobs:
       include_review_comments: true
       include_failing_checks: true
       include_patch_coverage: true
-      coverage_artifact_prefix: pr-agent-context-coverage
+      patch_coverage_source_mode: coverage_xml_artifact
+      coverage_report_artifact_name: coverage-xml
+      coverage_report_filename: coverage.xml
       prompt_template_file: .github/pr-agent-context-template.md
       debug_artifacts: true

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -48,7 +48,9 @@ jobs:
       include_review_comments: true
       include_failing_checks: true
       include_patch_coverage: true
-      coverage_artifact_prefix: pr-agent-context-coverage
+      patch_coverage_source_mode: coverage_xml_artifact
+      coverage_report_artifact_name: coverage-xml
+      coverage_report_filename: coverage.xml
       enable_cross_run_coverage_lookup: true
       coverage_source_workflows: ci-test
       prompt_template_file: .github/pr-agent-context-template.md


### PR DESCRIPTION
## Summary
- switch `pr-agent-context` in `ci-test.yml` to consume the combined `coverage-xml` artifact directly
- update the refresh workflow to use the same XML artifact mode with cross-run lookup from `ci-test`
- remove obsolete PR-agent-specific raw coverage artifact uploads from unit and integration jobs

## Why
The repo already has a `coverage` job that combines unit and integration coverage data, generates a final `coverage.xml`, and uploads it as the `coverage-xml` artifact. That makes it a direct fit for `coverage_xml_artifact` mode, so `pr-agent-context` no longer needs the intermediate raw `.coverage*` artifacts for patch coverage.