### PR TITLE
Fix Mako browser user agent

### DIFF
--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -22,8 +22,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# User agent for HTTP requests
-USER_AGENT = "denbust/0.1.0 (news monitoring bot; +https://github.com/denbust)"
+# Browser user agent for Playwright requests.
+#
+# Mako's Radware/Perfdrive layer increasingly blocks custom or bot-identifying UAs,
+# including Playwright's default HeadlessChrome UA. Use a stable desktop Chrome UA
+# so the browser session behaves like a normal interactive visit.
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/134.0.0.0 Safari/537.36"
+)
 
 # Base URLs
 MAKO_BASE_URL = "https://www.mako.co.il"

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -497,6 +497,8 @@ class TestMakoScraper:
 
             async def new_context(self, **kwargs: Any) -> FakeContext:
                 events.append("new_context")
+                assert kwargs["user_agent"].startswith("Mozilla/5.0")
+                assert "Chrome/134.0.0.0" in kwargs["user_agent"]
                 assert kwargs["locale"] == "he-IL"
                 assert kwargs["viewport"]["width"] == 1440
                 return self.context


### PR DESCRIPTION
## Summary
- switch the Playwright Mako browser session away from the explicit bot-style `denbust/...` user agent
- use a stable desktop Chrome user agent for the browser context
- lock the behavior in with a browser-session regression test

## Why
Mako's Radware/Perfdrive layer is now treating the custom scraper browser identity as suspicious for some searches. That causes intermittent redirects to `validate.perfdrive.com`, Radware block pages, and repeated search timeouts even on local runs.

Using a normal desktop browser UA restores the existing search flow without changing the parser or the broader pipeline behavior.

## Validation
- targeted Mako integration tests passed
- `ruff check src/denbust/sources/mako.py tests/integration/test_scrapers.py`
- `mypy src/denbust/sources/mako.py`
- direct local scraper run returned Mako results again for the previously failing keywords