### PR TITLE
Wire workflows to per-job GitHub Environments

### DIFF
--- a/.github/workflows/daily-state-run.yml
+++ b/.github/workflows/daily-state-run.yml
@@ -25,6 +25,7 @@ jobs:
   run-daily-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: news-items-ingest
 
     steps:
       - name: Checkout code repo

--- a/.github/workflows/news-items-backup.yml
+++ b/.github/workflows/news-items-backup.yml
@@ -25,6 +25,7 @@ jobs:
   run-backup:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: news-items-backup
 
     steps:
       - name: Checkout code repo

--- a/.github/workflows/news-items-release.yml
+++ b/.github/workflows/news-items-release.yml
@@ -27,6 +27,7 @@ jobs:
   run-release:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: news-items-release
 
     steps:
       - name: Checkout code repo

--- a/.github/workflows/weekly-state-run.yml
+++ b/.github/workflows/weekly-state-run.yml
@@ -27,6 +27,7 @@ jobs:
   run-weekly-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: news-items-ingest
 
     steps:
       - name: Checkout code repo

--- a/README.md
+++ b/README.md
@@ -383,6 +383,15 @@ The Phase B integrations are intentionally split into:
 
 The release and backup workflows both support `workflow_dispatch` for manual runs and weekly schedules for automated runs.
 
+Recommended GitHub Environment mapping:
+
+- `news-items-ingest` for `daily-state-run.yml` and `weekly-state-run.yml`
+- `news-items-release` for `news-items-release.yml`
+- `news-items-backup` for `news-items-backup.yml`
+
+The code reads generic env vars at runtime, so the same variable names can safely have different
+values per GitHub Environment.
+
 ## Supabase setup
 
 Phase B adds SQL migrations under:


### PR DESCRIPTION
## Summary
- bind the news ingest, release, and backup workflows to explicit GitHub Environments
- keep the current generic env var names so each environment can inject its own dataset/job-specific secret values
- document the recommended environment mapping in the README

## Details
This is a workflow-only follow-up to the Phase B work. It does not change runtime code or secret names. It makes the current setup compatible with environment-scoped secrets from the start:

- `news-items-ingest`
- `news-items-release`
- `news-items-backup`

## Testing
- inspected the workflow diffs to confirm this is limited to job-level `environment:` bindings plus README guidance