### PR TITLE
PR 3.2: add generic reviewed examples import adapter

### DIFF
--- a/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
+++ b/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
@@ -7,12 +7,14 @@ This note breaks Milestone 3 from [CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clo
 - Expand the permanent validation CSV and typed models to carry taxonomy-aware labels plus optional expected output fields.
 - Keep finalize/evaluate backward-compatible with older validation rows that do not yet have the new columns.
 - Migrate the tracked `validation/news_items/classifier_validation.csv` asset to the new header shape.
+- Status: merged.
 
 ## PR 3.2 — import reviewed manual example tables
 
-- Add the reviewed-examples import path into the validation subsystem.
-- Normalize occasional manually generated example tables into the existing reviewed/finalize flow.
-- Preserve provenance such as `annotation_source` while validating taxonomy fields against the packaged TFHT taxonomy.
+- Add a generic reviewed-examples import adapter into the validation subsystem.
+- Keep the existing TFHT manual-tracking workbook adapter, but add support for occasional manually generated CSV/XLSX reviewed-example tables.
+- Normalize those tables into the existing reviewed/finalize flow, including taxonomy validation, canonical-URL dedupe, and provenance such as `annotation_source`.
+- Status: current next PR.
 
 ## PR 3.3 — stage-wise validation metrics
 

--- a/src/denbust/validation/__init__.py
+++ b/src/denbust/validation/__init__.py
@@ -19,6 +19,7 @@ from denbust.validation.evaluate import (
 )
 from denbust.validation.import_reviewed import (
     TFHT_MANUAL_TRACKING_V1,
+    VALIDATION_REVIEWED_EXAMPLES_V1,
     ReviewedTableImportResult,
     import_reviewed_table,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "RELAXED_VALIDATION_KEYWORDS",
     "ReviewedTableImportResult",
     "TFHT_MANUAL_TRACKING_V1",
+    "VALIDATION_REVIEWED_EXAMPLES_V1",
     "ValidationCollectResult",
     "ValidationEvaluateResult",
     "ValidationFinalizeResult",

--- a/src/denbust/validation/dataset.py
+++ b/src/denbust/validation/dataset.py
@@ -102,7 +102,7 @@ def _parse_existing_validation_row(raw_row: dict[str, str]) -> ValidationSetRow:
     )
 
 
-def _validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> ValidationSetRow:
+def validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> ValidationSetRow:
     taxonomy = default_taxonomy()
     relevant = parse_bool(raw_row["relevant"])
     enforcement_related = parse_bool(raw_row.get("enforcement_related", "False") or "False")
@@ -213,7 +213,7 @@ def finalize_validation_set(
     added_rows: list[ValidationSetRow] = []
     skipped_duplicates = 0
     for raw_row in reviewed_rows:
-        validated = _validate_reviewed_row(raw_row, draft_source=str(input_path))
+        validated = validate_reviewed_row(raw_row, draft_source=str(input_path))
         key = (validated.source_name, validated.canonical_url)
         if key in existing_keys:
             skipped_duplicates += 1

--- a/src/denbust/validation/import_reviewed.py
+++ b/src/denbust/validation/import_reviewed.py
@@ -12,9 +12,11 @@ from denbust.news_items.normalize import canonicalize_news_url
 from denbust.taxonomy import default_taxonomy
 from denbust.validation.collect import serialize_draft_rows
 from denbust.validation.common import DRAFT_COLUMNS, write_csv_rows
+from denbust.validation.dataset import _validate_reviewed_row
 from denbust.validation.models import ValidationDraftRow
 
 TFHT_MANUAL_TRACKING_V1 = "tfht_manual_tracking_v1"
+VALIDATION_REVIEWED_EXAMPLES_V1 = "validation_reviewed_examples_v1"
 _MONTH_NAMES = {
     "ינואר": 1,
     "פברואר": 2,
@@ -114,8 +116,150 @@ def _infer_taxonomy_leaf(
     return None
 
 
+def _normalize_headers(row: dict[str, object]) -> dict[str, str]:
+    return {
+        re.sub(r"[^a-z0-9]+", "_", str(key).strip().casefold()).strip("_"): str(value or "").strip()
+        for key, value in row.items()
+        if key is not None
+    }
+
+
+def _string_value(normalized: dict[str, str], *keys: str) -> str:
+    for key in keys:
+        value = normalized.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _read_tabular_rows(input_path: Path) -> list[dict[str, object]]:
+    suffix = input_path.suffix.casefold()
+    if suffix == ".csv":
+        import csv
+
+        with input_path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            return [dict(row) for row in reader]
+
+    if suffix in {".xlsx", ".xlsm"}:
+        from openpyxl import load_workbook  # type: ignore[import-untyped]
+
+        workbook = load_workbook(input_path, data_only=True)
+        sheet = workbook.active
+        rows = list(sheet.iter_rows(values_only=True))
+        if not rows:
+            return []
+        headers = [str(value or "").strip() for value in rows[0]]
+        parsed_rows: list[dict[str, object]] = []
+        for row in rows[1:]:
+            parsed_rows.append(dict(zip(headers, row, strict=False)))
+        return parsed_rows
+
+    raise ValueError(f"Unsupported reviewed examples file type: {input_path.suffix}")
+
+
+def _normalize_reviewed_examples_row(
+    row: dict[str, object],
+    *,
+    collected_at: datetime,
+) -> dict[str, str]:
+    normalized = _normalize_headers(row)
+    url = _string_value(normalized, "url", "source_url", "article_url")
+    if not url:
+        raise ValueError("url is required")
+    article_date = _string_value(
+        normalized,
+        "article_date",
+        "event_date",
+        "publication_datetime",
+        "date",
+    )
+    if not article_date:
+        raise ValueError("article_date is required")
+    title = _string_value(normalized, "title", "headline")
+    if not title:
+        raise ValueError("title is required")
+
+    canonical_url = canonicalize_news_url(_string_value(normalized, "canonical_url") or url)
+    source_name = _string_value(normalized, "source_name") or _source_name_for_url(url)
+    snippet = _string_value(normalized, "snippet", "summary", "description")
+
+    draft_row = {
+        "source_name": source_name,
+        "article_date": article_date,
+        "url": url,
+        "canonical_url": canonical_url,
+        "title": title,
+        "snippet": snippet,
+        "suggested_relevant": _string_value(normalized, "suggested_relevant", "relevant"),
+        "suggested_enforcement_related": _string_value(
+            normalized,
+            "suggested_enforcement_related",
+            "enforcement_related",
+        ),
+        "suggested_index_relevant": _string_value(
+            normalized,
+            "suggested_index_relevant",
+            "index_relevant",
+        ),
+        "suggested_taxonomy_version": _string_value(
+            normalized, "suggested_taxonomy_version", "taxonomy_version"
+        ),
+        "suggested_taxonomy_category_id": _string_value(
+            normalized,
+            "suggested_taxonomy_category_id",
+            "taxonomy_category_id",
+            "category_id",
+            "tfht_category_id",
+        ),
+        "suggested_taxonomy_subcategory_id": _string_value(
+            normalized,
+            "suggested_taxonomy_subcategory_id",
+            "taxonomy_subcategory_id",
+            "subcategory_id",
+            "tfht_subcategory_id",
+        ),
+        "suggested_category": _string_value(normalized, "suggested_category", "category"),
+        "suggested_sub_category": _string_value(
+            normalized, "suggested_sub_category", "sub_category", "subcategory"
+        ),
+        "suggested_confidence": _string_value(normalized, "suggested_confidence") or "manual",
+        "relevant": _string_value(normalized, "relevant"),
+        "enforcement_related": _string_value(normalized, "enforcement_related"),
+        "index_relevant": _string_value(normalized, "index_relevant"),
+        "taxonomy_version": _string_value(normalized, "taxonomy_version"),
+        "taxonomy_category_id": _string_value(
+            normalized,
+            "taxonomy_category_id",
+            "category_id",
+            "tfht_category_id",
+        ),
+        "taxonomy_subcategory_id": _string_value(
+            normalized,
+            "taxonomy_subcategory_id",
+            "subcategory_id",
+            "tfht_subcategory_id",
+        ),
+        "category": _string_value(normalized, "category"),
+        "sub_category": _string_value(normalized, "sub_category", "subcategory"),
+        "review_status": _string_value(normalized, "review_status") or "reviewed",
+        "annotation_source": _string_value(normalized, "annotation_source") or "manual_table",
+        "expected_month_bucket": _string_value(normalized, "expected_month_bucket"),
+        "expected_city": _string_value(normalized, "expected_city"),
+        "expected_status": _string_value(normalized, "expected_status"),
+        "manual_city": _string_value(normalized, "manual_city"),
+        "manual_address": _string_value(normalized, "manual_address"),
+        "manual_event_label": _string_value(normalized, "manual_event_label"),
+        "manual_status": _string_value(normalized, "manual_status"),
+        "annotation_notes": _string_value(normalized, "annotation_notes", "notes"),
+        "collected_at": _string_value(normalized, "collected_at") or collected_at.isoformat(),
+    }
+    _validate_reviewed_row(draft_row, draft_source="reviewed_examples_import")
+    return draft_row
+
+
 def _manual_tracking_rows(input_path: Path) -> tuple[list[ValidationDraftRow], list[str]]:
-    from openpyxl import load_workbook  # type: ignore[import-untyped]
+    from openpyxl import load_workbook
 
     taxonomy = default_taxonomy()
     workbook = load_workbook(input_path, data_only=True)
@@ -241,6 +385,28 @@ def _manual_tracking_rows(input_path: Path) -> tuple[list[ValidationDraftRow], l
     return list(deduped.values()), warnings
 
 
+def _reviewed_examples_rows(input_path: Path) -> tuple[list[ValidationDraftRow], list[str]]:
+    raw_rows = _read_tabular_rows(input_path)
+    collected_at = datetime.now(UTC)
+    rows: list[ValidationDraftRow] = []
+    warnings: list[str] = []
+
+    for row_number, raw_row in enumerate(raw_rows, start=2):
+        try:
+            normalized = _normalize_reviewed_examples_row(raw_row, collected_at=collected_at)
+            rows.append(ValidationDraftRow.model_validate(normalized))
+        except Exception as exc:
+            warnings.append(f"row {row_number}: skipped because {exc}")
+
+    deduped: dict[tuple[str, str], ValidationDraftRow] = {}
+    for draft_row in rows:
+        deduped[(draft_row.source_name, draft_row.canonical_url)] = draft_row
+    skipped_duplicates = len(rows) - len(deduped)
+    if skipped_duplicates:
+        warnings.append(f"Skipped {skipped_duplicates} duplicate row(s) by source/canonical_url")
+    return list(deduped.values()), warnings
+
+
 def import_reviewed_table(
     *,
     input_path: Path,
@@ -248,12 +414,16 @@ def import_reviewed_table(
     output_path: Path | None = None,
 ) -> ReviewedTableImportResult:
     """Import a reviewed external table into the validation draft CSV shape."""
-    if format_name != TFHT_MANUAL_TRACKING_V1:
-        raise ValueError(f"Unsupported reviewed-table format: {format_name}")
     if not input_path.exists():
         raise FileNotFoundError(f"Reviewed table not found: {input_path}")
 
-    rows, warnings = _manual_tracking_rows(input_path)
+    if format_name == TFHT_MANUAL_TRACKING_V1:
+        rows, warnings = _manual_tracking_rows(input_path)
+    elif format_name == VALIDATION_REVIEWED_EXAMPLES_V1:
+        rows, warnings = _reviewed_examples_rows(input_path)
+    else:
+        raise ValueError(f"Unsupported reviewed-table format: {format_name}")
+
     final_output_path = output_path or _default_output_path(input_path, format_name)
     write_csv_rows(final_output_path, DRAFT_COLUMNS, serialize_draft_rows(rows))
     skipped_rows = sum(1 for warning in warnings if "skipped because" in warning)

--- a/src/denbust/validation/import_reviewed.py
+++ b/src/denbust/validation/import_reviewed.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
+from pydantic import ValidationError
+
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.taxonomy import default_taxonomy
 from denbust.validation.collect import serialize_draft_rows
@@ -404,8 +406,11 @@ def _reviewed_examples_rows(input_path: Path) -> tuple[list[ValidationDraftRow],
         try:
             normalized = _normalize_reviewed_examples_row(raw_row, collected_at=collected_at)
             rows.append(ValidationDraftRow.model_validate(normalized))
-        except Exception as exc:
+        except (ValueError, ValidationError) as exc:
             warnings.append(f"row {row_number}: skipped because {exc}")
+        except Exception as exc:
+            msg = f"row {row_number}: unexpected import failure"
+            raise RuntimeError(msg) from exc
 
     deduped: dict[tuple[str, str], ValidationDraftRow] = {}
     for draft_row in rows:

--- a/src/denbust/validation/import_reviewed.py
+++ b/src/denbust/validation/import_reviewed.py
@@ -6,13 +6,14 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlsplit
 
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.taxonomy import default_taxonomy
 from denbust.validation.collect import serialize_draft_rows
 from denbust.validation.common import DRAFT_COLUMNS, write_csv_rows
-from denbust.validation.dataset import _validate_reviewed_row
+from denbust.validation.dataset import validate_reviewed_row
 from denbust.validation.models import ValidationDraftRow
 
 TFHT_MANUAL_TRACKING_V1 = "tfht_manual_tracking_v1"
@@ -118,7 +119,9 @@ def _infer_taxonomy_leaf(
 
 def _normalize_headers(row: dict[str, object]) -> dict[str, str]:
     return {
-        re.sub(r"[^a-z0-9]+", "_", str(key).strip().casefold()).strip("_"): str(value or "").strip()
+        re.sub(r"[^a-z0-9]+", "_", str(key).strip().casefold()).strip("_"): (
+            "" if value is None else str(value).strip()
+        )
         for key, value in row.items()
         if key is not None
     }
@@ -132,6 +135,18 @@ def _string_value(normalized: dict[str, str], *keys: str) -> str:
     return ""
 
 
+def _load_workbook(input_path: Path) -> Any:
+    from openpyxl import load_workbook  # type: ignore[import-untyped]
+
+    return load_workbook(input_path, data_only=True)
+
+
+def _load_workbook_values(input_path: Path) -> list[tuple[object, ...]]:
+    workbook = _load_workbook(input_path)
+    sheet = workbook.active
+    return list(sheet.iter_rows(values_only=True))
+
+
 def _read_tabular_rows(input_path: Path) -> list[dict[str, object]]:
     suffix = input_path.suffix.casefold()
     if suffix == ".csv":
@@ -142,11 +157,7 @@ def _read_tabular_rows(input_path: Path) -> list[dict[str, object]]:
             return [dict(row) for row in reader]
 
     if suffix in {".xlsx", ".xlsm"}:
-        from openpyxl import load_workbook  # type: ignore[import-untyped]
-
-        workbook = load_workbook(input_path, data_only=True)
-        sheet = workbook.active
-        rows = list(sheet.iter_rows(values_only=True))
+        rows = _load_workbook_values(input_path)
         if not rows:
             return []
         headers = [str(value or "").strip() for value in rows[0]]
@@ -254,15 +265,13 @@ def _normalize_reviewed_examples_row(
         "annotation_notes": _string_value(normalized, "annotation_notes", "notes"),
         "collected_at": _string_value(normalized, "collected_at") or collected_at.isoformat(),
     }
-    _validate_reviewed_row(draft_row, draft_source="reviewed_examples_import")
+    validate_reviewed_row(draft_row, draft_source="reviewed_examples_import")
     return draft_row
 
 
 def _manual_tracking_rows(input_path: Path) -> tuple[list[ValidationDraftRow], list[str]]:
-    from openpyxl import load_workbook
-
     taxonomy = default_taxonomy()
-    workbook = load_workbook(input_path, data_only=True)
+    workbook = _load_workbook(input_path)
     if "מדד האכיפה" not in workbook.sheetnames:
         raise ValueError("Workbook is missing the 'מדד האכיפה' sheet")
     sheet = workbook["מדד האכיפה"]

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -308,13 +308,21 @@ def test_import_reviewed_table_normalizes_generic_reviewed_examples_xlsx(tmp_pat
     sheet["B2"] = "כותרת"
     sheet["C2"] = "תקציר"
     sheet["D2"] = "2026-04-03T00:00:00+00:00"
-    sheet["E2"] = "True"
-    sheet["F2"] = "True"
-    sheet["G2"] = "True"
+    sheet["E2"] = True
+    sheet["F2"] = True
+    sheet["G2"] = True
     sheet["H2"] = "brothels"
     sheet["I2"] = "administrative_closure"
     sheet["J2"] = "brothel"
     sheet["K2"] = "closure"
+    sheet["A3"] = "https://example.com/xlsx-false"
+    sheet["B3"] = "כותרת שלילית"
+    sheet["C3"] = "תקציר שלילי"
+    sheet["D3"] = "2026-04-04T00:00:00+00:00"
+    sheet["E3"] = False
+    sheet["F3"] = False
+    sheet["G3"] = False
+    sheet["J3"] = "not_relevant"
     workbook_path = tmp_path / "reviewed_examples.xlsx"
     workbook.save(workbook_path)
 
@@ -324,9 +332,14 @@ def test_import_reviewed_table_normalizes_generic_reviewed_examples_xlsx(tmp_pat
     )
 
     rows = read_csv_rows(result.output_path)
-    assert result.imported_rows == 1
+    assert result.imported_rows == 2
     assert rows[0]["canonical_url"] == "https://example.com/xlsx"
     assert rows[0]["source_name"] == "example"
+    assert rows[1]["canonical_url"] == "https://example.com/xlsx-false"
+    assert rows[1]["relevant"] == "False"
+    assert rows[1]["enforcement_related"] == "False"
+    assert rows[1]["index_relevant"] == "False"
+    assert rows[1]["category"] == "not_relevant"
 
 
 def test_import_reviewed_table_generic_adapter_rejects_invalid_reviewed_labels(

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -363,3 +363,59 @@ def test_import_reviewed_table_generic_adapter_rejects_invalid_reviewed_labels(
         for warning in result.warnings
     )
     assert any("title is required" in warning for warning in result.warnings)
+
+
+def test_import_reviewed_table_generic_adapter_handles_empty_xlsx(tmp_path: Path) -> None:
+    workbook = Workbook()
+    workbook_path = tmp_path / "empty_reviewed_examples.xlsx"
+    workbook.save(workbook_path)
+
+    result = import_reviewed_table(
+        input_path=workbook_path,
+        format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+    )
+
+    rows = read_csv_rows(result.output_path)
+    assert result.imported_rows == 0
+    assert result.skipped_rows == 0
+    assert result.warnings == []
+    assert rows == []
+
+
+def test_import_reviewed_table_generic_adapter_rejects_unsupported_file_type(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "reviewed_examples.txt"
+    input_path.write_text("placeholder", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported reviewed examples file type"):
+        import_reviewed_table(
+            input_path=input_path,
+            format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+        )
+
+
+def test_import_reviewed_table_generic_adapter_requires_url_and_article_date(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "reviewed_examples_missing_fields.csv"
+    input_path.write_text(
+        "\n".join(
+            [
+                "URL,Title,Article Date,Relevant,Enforcement Related,Category,Review Status",
+                ",כתבה ללא URL,2026-04-01T00:00:00+00:00,False,False,not_relevant,reviewed",
+                "https://example.com/missing-date,כתבה ללא תאריך,,False,False,not_relevant,reviewed",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = import_reviewed_table(
+        input_path=input_path,
+        format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+    )
+
+    assert result.imported_rows == 0
+    assert result.skipped_rows == 2
+    assert any("url is required" in warning for warning in result.warnings)
+    assert any("article_date is required" in warning for warning in result.warnings)

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -10,6 +10,7 @@ from openpyxl import Workbook
 from denbust.validation.common import read_csv_rows
 from denbust.validation.import_reviewed import (
     TFHT_MANUAL_TRACKING_V1,
+    VALIDATION_REVIEWED_EXAMPLES_V1,
     _default_output_path,
     _infer_city,
     _infer_taxonomy_leaf,
@@ -235,3 +236,127 @@ def test_import_reviewed_table_skips_rows_for_missing_url_bad_taxonomy_and_bad_d
     assert any("no source URL was found" in warning for warning in result.warnings)
     assert any("taxonomy inference failed" in warning for warning in result.warnings)
     assert any("date parsing failed" in warning for warning in result.warnings)
+
+
+def test_import_reviewed_table_normalizes_generic_reviewed_examples_csv(tmp_path: Path) -> None:
+    input_path = tmp_path / "reviewed_examples.csv"
+    input_path.write_text(
+        "\n".join(
+            [
+                (
+                    "URL,Title,Snippet,Article Date,Source Name,Relevant,Enforcement Related,"
+                    "Index Relevant,Taxonomy Version,Taxonomy Category ID,Taxonomy Subcategory ID,"
+                    "Category,Sub Category,Review Status,Annotation Source,Expected Month Bucket,"
+                    "Expected City,Expected Status"
+                ),
+                (
+                    "https://example.com/keep?utm_source=one,כתבה א,סיכום א,2026-04-01T00:00:00+00:00,"
+                    "ynet,True,True,True,1,brothels,administrative_closure,brothel,closure,"
+                    "reviewed,manual table,2026-04,חיפה,closed"
+                ),
+                (
+                    "https://example.com/keep?utm_source=two,כתבה א,סיכום א,2026-04-01T00:00:00+00:00,"
+                    "ynet,True,True,True,1,brothels,administrative_closure,brothel,closure,"
+                    "reviewed,manual table,2026-04,חיפה,closed"
+                ),
+                (
+                    "https://example.com/outside,כתבה ב,סיכום ב,2026-04-02T00:00:00+00:00,"
+                    ",False,False,False,,,,not_relevant,,reviewed,Google alerts comparison,,,"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = import_reviewed_table(
+        input_path=input_path,
+        format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+    )
+
+    rows = read_csv_rows(result.output_path)
+    assert result.imported_rows == 2
+    assert result.skipped_rows == 0
+    assert any("duplicate" in warning for warning in result.warnings)
+
+    first_row = rows[0]
+    second_row = rows[1]
+    assert first_row["canonical_url"] == "https://example.com/keep"
+    assert first_row["annotation_source"] == "manual table"
+    assert first_row["expected_month_bucket"] == "2026-04"
+    assert first_row["expected_city"] == "חיפה"
+    assert first_row["expected_status"] == "closed"
+    assert second_row["source_name"] == "example"
+    assert second_row["category"] == "not_relevant"
+    assert second_row["annotation_source"] == "Google alerts comparison"
+
+
+def test_import_reviewed_table_normalizes_generic_reviewed_examples_xlsx(tmp_path: Path) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet["A1"] = "URL"
+    sheet["B1"] = "Title"
+    sheet["C1"] = "Snippet"
+    sheet["D1"] = "Article Date"
+    sheet["E1"] = "Relevant"
+    sheet["F1"] = "Enforcement Related"
+    sheet["G1"] = "Index Relevant"
+    sheet["H1"] = "Taxonomy Category ID"
+    sheet["I1"] = "Taxonomy Subcategory ID"
+    sheet["J1"] = "Category"
+    sheet["K1"] = "Sub Category"
+    sheet["A2"] = "https://example.com/xlsx"
+    sheet["B2"] = "כותרת"
+    sheet["C2"] = "תקציר"
+    sheet["D2"] = "2026-04-03T00:00:00+00:00"
+    sheet["E2"] = "True"
+    sheet["F2"] = "True"
+    sheet["G2"] = "True"
+    sheet["H2"] = "brothels"
+    sheet["I2"] = "administrative_closure"
+    sheet["J2"] = "brothel"
+    sheet["K2"] = "closure"
+    workbook_path = tmp_path / "reviewed_examples.xlsx"
+    workbook.save(workbook_path)
+
+    result = import_reviewed_table(
+        input_path=workbook_path,
+        format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+    )
+
+    rows = read_csv_rows(result.output_path)
+    assert result.imported_rows == 1
+    assert rows[0]["canonical_url"] == "https://example.com/xlsx"
+    assert rows[0]["source_name"] == "example"
+
+
+def test_import_reviewed_table_generic_adapter_rejects_invalid_reviewed_labels(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "reviewed_examples.csv"
+    input_path.write_text(
+        "\n".join(
+            [
+                (
+                    "URL,Title,Article Date,Relevant,Enforcement Related,Index Relevant,"
+                    "Taxonomy Version,Taxonomy Category ID,Taxonomy Subcategory ID,Category,"
+                    "Sub Category,Review Status"
+                ),
+                (
+                    "https://example.com/bad,כתבה,2026-04-01T00:00:00+00:00,True,True,False,"
+                    "1,brothels,administrative_closure,brothel,closure,reviewed"
+                ),
+                "https://example.com/missing-title,,2026-04-01T00:00:00+00:00,True,False,False,,,,brothel,,reviewed",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = import_reviewed_table(
+        input_path=input_path,
+        format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+    )
+
+    assert result.imported_rows == 0
+    assert result.skipped_rows == 2
+    assert any("index_relevant does not match the packaged taxonomy" in warning for warning in result.warnings)
+    assert any("title is required" in warning for warning in result.warnings)

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -432,3 +432,32 @@ def test_import_reviewed_table_generic_adapter_requires_url_and_article_date(
     assert result.skipped_rows == 2
     assert any("url is required" in warning for warning in result.warnings)
     assert any("article_date is required" in warning for warning in result.warnings)
+
+
+def test_import_reviewed_table_generic_adapter_reraises_unexpected_row_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "reviewed_examples.csv"
+    input_path.write_text(
+        "\n".join(
+            [
+                "URL,Title,Article Date,Relevant,Enforcement Related,Category,Review Status",
+                "https://example.com/boom,כתבה,2026-04-01T00:00:00+00:00,False,False,not_relevant,reviewed",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def boom(_raw_row: dict[str, object], *, _collected_at: object) -> dict[str, str]:
+        raise TypeError("boom")
+
+    monkeypatch.setattr("denbust.validation.import_reviewed._normalize_reviewed_examples_row", boom)
+
+    with pytest.raises(RuntimeError, match="row 2: unexpected import failure") as error:
+        import_reviewed_table(
+            input_path=input_path,
+            format_name=VALIDATION_REVIEWED_EXAMPLES_V1,
+        )
+
+    assert isinstance(error.value.__cause__, TypeError)

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -358,5 +358,8 @@ def test_import_reviewed_table_generic_adapter_rejects_invalid_reviewed_labels(
 
     assert result.imported_rows == 0
     assert result.skipped_rows == 2
-    assert any("index_relevant does not match the packaged taxonomy" in warning for warning in result.warnings)
+    assert any(
+        "index_relevant does not match the packaged taxonomy" in warning
+        for warning in result.warnings
+    )
     assert any("title is required" in warning for warning in result.warnings)


### PR DESCRIPTION
## Summary

This is PR 3.2 from the Milestone 3 validation-upgrade split. It adds the missing generic reviewed-examples import path while keeping the existing TFHT manual-tracking workbook adapter intact.

The goal is to support occasional manually generated reviewed example tables in CSV or XLSX form and normalize them into the existing `validation-import-reviewed-table` -> `validation-finalize` flow.

## What changed

### Reviewed examples import
- Added a new reviewed-table adapter format: `validation_reviewed_examples_v1`
- Kept the existing `tfht_manual_tracking_v1` adapter unchanged for the TFHT enforcement workbook
- Added a generic tabular reader that supports:
  - `.csv`
  - `.xlsx`
  - `.xlsm`
- Normalized generic reviewed-example rows into the existing `ValidationDraftRow` / `DRAFT_COLUMNS` shape

### Validation behavior for imported reviewed examples
- Generic reviewed-example rows are validated against the same reviewed-label rules already used by finalization:
  - required URL / date / title
  - taxonomy pair validation against the packaged taxonomy
  - category / sub-category consistency
  - `index_relevant` consistency for taxonomy-labeled rows
- Imported rows preserve provenance through `annotation_source`
- Imported rows preserve optional expectations metadata such as:
  - `expected_month_bucket`
  - `expected_city`
  - `expected_status`
- Imported rows are deduplicated by `(source_name, canonical_url)` before draft output

### Docs
- Updated `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` to:
  - mark PR 3.1 as merged
  - clarify that PR 3.2 is the generic reviewed-examples import slice

## What this PR does not do
- no permanent validation schema changes beyond what landed in PR 3.1
- no stage-wise metrics yet
- no typology-aware reporting yet

Those stay in PR 3.3 and PR 3.4.

## Verification

Ran locally:
- `pytest -q tests/unit/test_validation_import_reviewed.py tests/unit/test_cli.py`
- `ruff check src/denbust/validation/import_reviewed.py src/denbust/validation/__init__.py tests/unit/test_validation_import_reviewed.py`
- `mypy src/`

## Review notes
- `validation-import-reviewed-table` now supports both the original workbook-specific adapter and a generic reviewed examples adapter.
- The new adapter intentionally emits reviewed draft rows rather than merging directly into the permanent set, so the existing finalize path remains the single merge boundary.
