### PR TITLE
PR 3.3: add stage-wise validation metrics

### DIFF
--- a/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
+++ b/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
@@ -14,7 +14,7 @@ This note breaks Milestone 3 from [CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clo
 - Add a generic reviewed-examples import adapter into the validation subsystem.
 - Keep the existing TFHT manual-tracking workbook adapter, but add support for occasional manually generated CSV/XLSX reviewed-example tables.
 - Normalize those tables into the existing reviewed/finalize flow, including taxonomy validation, canonical-URL dedupe, and provenance such as `annotation_source`.
-- Status: current next PR.
+- Status: merged.
 
 ## PR 3.3 — stage-wise validation metrics
 
@@ -24,6 +24,7 @@ This note breaks Milestone 3 from [CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clo
   - taxonomy category / subcategory
   - index relevance
 - Keep legacy rows usable, while making taxonomy-aware metrics conditional on taxonomy-labeled examples.
+- Status: current next PR.
 
 ## PR 3.4 — typology-aware evaluation reports
 

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -25,6 +25,8 @@ from denbust.validation.common import (
     read_csv_rows,
 )
 from denbust.validation.models import (
+    AccuracyStageMetrics,
+    BinaryStageMetrics,
     ClassifierVariantMatrix,
     ClassifierVariantSpec,
     VariantMetrics,
@@ -136,6 +138,33 @@ def _load_validation_examples(path: Path) -> tuple[list[RawArticle], list[Valida
     return articles, labels
 
 
+def _binary_stage_metrics(*, tp: int, fp: int, fn: int, tn: int) -> BinaryStageMetrics:
+    evaluated_examples = tp + fp + fn + tn
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    accuracy = (tp + tn) / evaluated_examples if evaluated_examples else 0.0
+    return BinaryStageMetrics(
+        evaluated_examples=evaluated_examples,
+        tp=tp,
+        fp=fp,
+        fn=fn,
+        tn=tn,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        accuracy=accuracy,
+    )
+
+
+def _accuracy_stage_metrics(*, correct: int, evaluated_examples: int) -> AccuracyStageMetrics:
+    return AccuracyStageMetrics(
+        evaluated_examples=evaluated_examples,
+        correct=correct,
+        accuracy=(correct / evaluated_examples) if evaluated_examples else 0.0,
+    )
+
+
 def _score_predictions(
     labels: Sequence[ValidationLabel | tuple[bool, bool, str, str]],
     predictions: Sequence[ValidationLabel | tuple[bool, bool, str, str]],
@@ -219,70 +248,65 @@ def _score_predictions(
             exact_matches += 1
 
     total = len(labels)
-    precision = tp / (tp + fp) if (tp + fp) else 0.0
-    recall = tp / (tp + fn) if (tp + fn) else 0.0
-    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
-    relevance_accuracy = (tp + tn) / total if total else 0.0
-    enforcement_precision = (
-        enforcement_tp / (enforcement_tp + enforcement_fp)
-        if (enforcement_tp + enforcement_fp)
-        else 0.0
+    relevance_stage = _binary_stage_metrics(tp=tp, fp=fp, fn=fn, tn=tn)
+    enforcement_stage = _binary_stage_metrics(
+        tp=enforcement_tp,
+        fp=enforcement_fp,
+        fn=enforcement_fn,
+        tn=enforcement_tn,
     )
-    enforcement_recall = (
-        enforcement_tp / (enforcement_tp + enforcement_fn)
-        if (enforcement_tp + enforcement_fn)
-        else 0.0
+    category_stage = _accuracy_stage_metrics(
+        correct=category_matches,
+        evaluated_examples=relevant_rows,
     )
-    enforcement_f1 = (
-        2
-        * enforcement_precision
-        * enforcement_recall
-        / (enforcement_precision + enforcement_recall)
-        if (enforcement_precision + enforcement_recall)
-        else 0.0
+    subcategory_stage = _accuracy_stage_metrics(
+        correct=subcategory_matches,
+        evaluated_examples=relevant_rows,
     )
-    enforcement_accuracy = (
-        (enforcement_tp + enforcement_tn) / relevant_rows if relevant_rows else 0.0
-    )
-    category_accuracy = category_matches / relevant_rows if relevant_rows else 0.0
-    subcategory_accuracy = subcategory_matches / relevant_rows if relevant_rows else 0.0
     overall_exact_match = exact_matches / total if total else 0.0
 
-    index_precision = index_tp / (index_tp + index_fp) if (index_tp + index_fp) else 0.0
-    index_recall = index_tp / (index_tp + index_fn) if (index_tp + index_fn) else 0.0
-    index_f1 = (
-        2 * index_precision * index_recall / (index_precision + index_recall)
-        if (index_precision + index_recall)
-        else 0.0
+    index_stage = _binary_stage_metrics(
+        tp=index_tp,
+        fp=index_fp,
+        fn=index_fn,
+        tn=index_tn,
     )
-    index_accuracy = (index_tp + index_tn) / taxonomy_labeled_rows if taxonomy_labeled_rows else 0.0
-    taxonomy_category_accuracy = (
-        taxonomy_category_matches / taxonomy_labeled_rows if taxonomy_labeled_rows else 0.0
+    taxonomy_category_stage = _accuracy_stage_metrics(
+        correct=taxonomy_category_matches,
+        evaluated_examples=taxonomy_labeled_rows,
     )
-    taxonomy_subcategory_accuracy = (
-        taxonomy_subcategory_matches / taxonomy_labeled_rows if taxonomy_labeled_rows else 0.0
+    taxonomy_subcategory_stage = _accuracy_stage_metrics(
+        correct=taxonomy_subcategory_matches,
+        evaluated_examples=taxonomy_labeled_rows,
     )
 
     return VariantMetrics(
         name=variant.name,
         description=variant.description,
         model=model,
-        relevance_precision=precision,
-        relevance_recall=recall,
-        relevance_f1=f1,
-        relevance_accuracy=relevance_accuracy,
-        enforcement_precision_relevant_only=enforcement_precision,
-        enforcement_recall_relevant_only=enforcement_recall,
-        enforcement_f1_relevant_only=enforcement_f1,
-        enforcement_accuracy_relevant_only=enforcement_accuracy,
-        category_accuracy_relevant_only=category_accuracy,
-        subcategory_accuracy_relevant_only=subcategory_accuracy,
-        index_relevance_precision_taxonomy_labeled=index_precision,
-        index_relevance_recall_taxonomy_labeled=index_recall,
-        index_relevance_f1_taxonomy_labeled=index_f1,
-        index_relevance_accuracy_taxonomy_labeled=index_accuracy,
-        taxonomy_category_accuracy_taxonomy_labeled=taxonomy_category_accuracy,
-        taxonomy_subcategory_accuracy_taxonomy_labeled=taxonomy_subcategory_accuracy,
+        relevance_stage=relevance_stage,
+        enforcement_stage_relevant_only=enforcement_stage,
+        category_stage_relevant_only=category_stage,
+        subcategory_stage_relevant_only=subcategory_stage,
+        taxonomy_category_stage_taxonomy_labeled=taxonomy_category_stage,
+        taxonomy_subcategory_stage_taxonomy_labeled=taxonomy_subcategory_stage,
+        index_relevance_stage_taxonomy_labeled=index_stage,
+        relevance_precision=relevance_stage.precision,
+        relevance_recall=relevance_stage.recall,
+        relevance_f1=relevance_stage.f1,
+        relevance_accuracy=relevance_stage.accuracy,
+        enforcement_precision_relevant_only=enforcement_stage.precision,
+        enforcement_recall_relevant_only=enforcement_stage.recall,
+        enforcement_f1_relevant_only=enforcement_stage.f1,
+        enforcement_accuracy_relevant_only=enforcement_stage.accuracy,
+        category_accuracy_relevant_only=category_stage.accuracy,
+        subcategory_accuracy_relevant_only=subcategory_stage.accuracy,
+        index_relevance_precision_taxonomy_labeled=index_stage.precision,
+        index_relevance_recall_taxonomy_labeled=index_stage.recall,
+        index_relevance_f1_taxonomy_labeled=index_stage.f1,
+        index_relevance_accuracy_taxonomy_labeled=index_stage.accuracy,
+        taxonomy_category_accuracy_taxonomy_labeled=taxonomy_category_stage.accuracy,
+        taxonomy_subcategory_accuracy_taxonomy_labeled=taxonomy_subcategory_stage.accuracy,
         overall_exact_match=overall_exact_match,
         tp=tp,
         fp=fp,

--- a/src/denbust/validation/models.py
+++ b/src/denbust/validation/models.py
@@ -100,12 +100,53 @@ class ClassifierVariantMatrix(BaseModel):
     variants: list[ClassifierVariantSpec] = Field(default_factory=list)
 
 
+class BinaryStageMetrics(BaseModel):
+    """Precision/recall metrics for a binary evaluation stage."""
+
+    evaluated_examples: int = 0
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    tn: int = 0
+    precision: float = 0.0
+    recall: float = 0.0
+    f1: float = 0.0
+    accuracy: float = 0.0
+
+
+class AccuracyStageMetrics(BaseModel):
+    """Match-rate metrics for a categorical evaluation stage."""
+
+    evaluated_examples: int = 0
+    correct: int = 0
+    accuracy: float = 0.0
+
+
 class VariantMetrics(BaseModel):
     """Computed metrics for a single classifier variant."""
 
     name: str
     description: str | None = None
     model: str
+    relevance_stage: BinaryStageMetrics = Field(default_factory=BinaryStageMetrics)
+    enforcement_stage_relevant_only: BinaryStageMetrics = Field(
+        default_factory=BinaryStageMetrics
+    )
+    category_stage_relevant_only: AccuracyStageMetrics = Field(
+        default_factory=AccuracyStageMetrics
+    )
+    subcategory_stage_relevant_only: AccuracyStageMetrics = Field(
+        default_factory=AccuracyStageMetrics
+    )
+    taxonomy_category_stage_taxonomy_labeled: AccuracyStageMetrics = Field(
+        default_factory=AccuracyStageMetrics
+    )
+    taxonomy_subcategory_stage_taxonomy_labeled: AccuracyStageMetrics = Field(
+        default_factory=AccuracyStageMetrics
+    )
+    index_relevance_stage_taxonomy_labeled: BinaryStageMetrics = Field(
+        default_factory=BinaryStageMetrics
+    )
     relevance_precision: float
     relevance_recall: float
     relevance_f1: float

--- a/src/denbust/validation/models.py
+++ b/src/denbust/validation/models.py
@@ -129,12 +129,8 @@ class VariantMetrics(BaseModel):
     description: str | None = None
     model: str
     relevance_stage: BinaryStageMetrics = Field(default_factory=BinaryStageMetrics)
-    enforcement_stage_relevant_only: BinaryStageMetrics = Field(
-        default_factory=BinaryStageMetrics
-    )
-    category_stage_relevant_only: AccuracyStageMetrics = Field(
-        default_factory=AccuracyStageMetrics
-    )
+    enforcement_stage_relevant_only: BinaryStageMetrics = Field(default_factory=BinaryStageMetrics)
+    category_stage_relevant_only: AccuracyStageMetrics = Field(default_factory=AccuracyStageMetrics)
     subcategory_stage_relevant_only: AccuracyStageMetrics = Field(
         default_factory=AccuracyStageMetrics
     )

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -1431,6 +1432,13 @@ class TestValidationEvaluate:
 
         assert [metric.name for metric in result.rankings] == ["prompt-tuned", "baseline"]
         assert result.output_path.exists()
+        report = json.loads(result.output_path.read_text(encoding="utf-8"))
+        first = report["rankings"][0]
+        assert first["relevance_stage"]["evaluated_examples"] == 2
+        assert first["enforcement_stage_relevant_only"]["evaluated_examples"] == 1
+        assert first["category_stage_relevant_only"]["evaluated_examples"] == 1
+        assert first["taxonomy_subcategory_stage_taxonomy_labeled"]["evaluated_examples"] == 0
+        assert first["index_relevance_stage_taxonomy_labeled"]["evaluated_examples"] == 0
 
     def test_score_predictions_uses_only_relevant_rows_for_category_metrics(self) -> None:
         """Category and sub-category metrics should ignore non-relevant gold rows."""
@@ -1448,7 +1456,11 @@ class TestValidationEvaluate:
         )
 
         assert metrics.enforcement_accuracy_relevant_only == 1.0
+        assert metrics.category_stage_relevant_only.evaluated_examples == 1
+        assert metrics.category_stage_relevant_only.correct == 1
         assert metrics.category_accuracy_relevant_only == 1.0
+        assert metrics.subcategory_stage_relevant_only.evaluated_examples == 1
+        assert metrics.subcategory_stage_relevant_only.correct == 1
         assert metrics.subcategory_accuracy_relevant_only == 1.0
 
     def test_score_predictions_requires_predicted_relevance_for_category_credit(self) -> None:
@@ -1466,7 +1478,11 @@ class TestValidationEvaluate:
 
         assert metrics.relevance_f1 == 0.0
         assert metrics.enforcement_f1_relevant_only == 0.0
+        assert metrics.category_stage_relevant_only.evaluated_examples == 1
+        assert metrics.category_stage_relevant_only.correct == 0
         assert metrics.category_accuracy_relevant_only == 0.0
+        assert metrics.subcategory_stage_relevant_only.evaluated_examples == 1
+        assert metrics.subcategory_stage_relevant_only.correct == 0
         assert metrics.subcategory_accuracy_relevant_only == 0.0
 
     def test_score_predictions_counts_false_positives(self) -> None:
@@ -1508,6 +1524,11 @@ class TestValidationEvaluate:
         assert metrics.enforcement_precision_relevant_only == 0.0
         assert metrics.enforcement_recall_relevant_only == 0.0
         assert metrics.enforcement_f1_relevant_only == 0.0
+        assert metrics.enforcement_stage_relevant_only.evaluated_examples == 2
+        assert metrics.enforcement_stage_relevant_only.tp == 0
+        assert metrics.enforcement_stage_relevant_only.fp == 0
+        assert metrics.enforcement_stage_relevant_only.fn == 1
+        assert metrics.enforcement_stage_relevant_only.tn == 1
         assert metrics.enforcement_accuracy_relevant_only == 0.5
 
     def test_score_predictions_ignores_enforcement_when_prediction_is_irrelevant(self) -> None:
@@ -1524,6 +1545,8 @@ class TestValidationEvaluate:
         )
 
         assert metrics.fn == 1
+        assert metrics.relevance_stage.evaluated_examples == 1
+        assert metrics.relevance_stage.fn == 1
         assert metrics.enforcement_precision_relevant_only == 0.0
         assert metrics.enforcement_recall_relevant_only == 0.0
         assert metrics.enforcement_f1_relevant_only == 0.0

--- a/tests/unit/test_validation_taxonomy_metrics.py
+++ b/tests/unit/test_validation_taxonomy_metrics.py
@@ -55,6 +55,9 @@ def test_taxonomy_metrics_only_use_taxonomy_labeled_rows() -> None:
     )
 
     assert metrics.taxonomy_labeled_examples == 1
+    assert metrics.taxonomy_category_stage_taxonomy_labeled.evaluated_examples == 1
+    assert metrics.taxonomy_subcategory_stage_taxonomy_labeled.evaluated_examples == 1
+    assert metrics.index_relevance_stage_taxonomy_labeled.evaluated_examples == 1
     assert metrics.taxonomy_category_accuracy_taxonomy_labeled == 1.0
     assert metrics.taxonomy_subcategory_accuracy_taxonomy_labeled == 1.0
     assert metrics.index_relevance_f1_taxonomy_labeled == 1.0
@@ -156,6 +159,10 @@ def test_taxonomy_index_metrics_cover_fp_fn_and_tn_branches() -> None:
     )
 
     assert metrics.taxonomy_labeled_examples == 3
+    assert metrics.index_relevance_stage_taxonomy_labeled.tp == 0
+    assert metrics.index_relevance_stage_taxonomy_labeled.fp == 1
+    assert metrics.index_relevance_stage_taxonomy_labeled.fn == 1
+    assert metrics.index_relevance_stage_taxonomy_labeled.tn == 1
     assert metrics.index_relevance_precision_taxonomy_labeled == 0.0
     assert metrics.index_relevance_recall_taxonomy_labeled == 0.0
     assert metrics.index_relevance_accuracy_taxonomy_labeled == 1 / 3


### PR DESCRIPTION
## Summary
- add explicit stage-metrics objects to classifier variant evaluation
- keep the existing top-level metric fields and ranking behavior backward-compatible
- update the milestone breakdown note to mark PR 3.2 merged and PR 3.3 current

## What changed
- added `BinaryStageMetrics` and `AccuracyStageMetrics` in `src/denbust/validation/models.py`
- extended `VariantMetrics` with structured stage outputs for:
  - relevance
  - enforcement-related on relevant rows
  - legacy category/subcategory on relevant rows
  - taxonomy category/subcategory on taxonomy-labeled rows
  - index relevance on taxonomy-labeled rows
- refactored `_score_predictions(...)` in `src/denbust/validation/evaluate.py` to compute those stage objects and derive the existing top-level metrics from them
- preserved current sort order and compact rankings table so this PR stays in the metrics layer, not reporting
- updated `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` status lines for PR 3.2 and PR 3.3

## Why
Milestone 3 needs evaluation to expose each classifier stage explicitly before PR 3.4 adds richer typology-aware reports. This PR makes the staged denominators and counts available in the JSON output while keeping legacy rows and existing consumers usable.

## Verification
- `pytest -q tests/unit/test_validation.py tests/unit/test_validation_taxonomy_metrics.py`
- `ruff check src/denbust/validation/models.py src/denbust/validation/evaluate.py tests/unit/test_validation.py tests/unit/test_validation_taxonomy_metrics.py docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md`
- `mypy src/`