### PR TITLE
PR 3.4: add typology-aware validation reports

### DIFF
--- a/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
+++ b/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
@@ -24,13 +24,14 @@ This note breaks Milestone 3 from [CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clo
   - taxonomy category / subcategory
   - index relevance
 - Keep legacy rows usable, while making taxonomy-aware metrics conditional on taxonomy-labeled examples.
-- Status: current next PR.
+- Status: merged.
 
 ## PR 3.4 — typology-aware evaluation reports
 
 - Add richer validation outputs for humans, built on top of PR 3.3 metrics.
 - Include category/subcategory breakdowns and explicit handling of legacy versus taxonomy-labeled examples.
 - Keep this as a reporting/output PR rather than another schema or import PR.
+- Status: current next PR.
 
 ## Sequencing
 

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -373,6 +373,7 @@ def validation_evaluate(
     )
     typer.echo(render_rankings_table(result.rankings))
     typer.echo(f"Saved JSON report to {result.output_path}")
+    typer.echo(f"Saved Markdown report to {result.markdown_path}")
 
 
 @app.command()

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -183,7 +183,9 @@ def _label_breakdown_metrics(
             correct=matches[label],
             accuracy=(matches[label] / evaluated_examples) if evaluated_examples else 0.0,
         )
-        for label, evaluated_examples in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        for label, evaluated_examples in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        )
     ]
 
 

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -31,6 +31,7 @@ from denbust.validation.models import (
     ClassifierVariantMatrix,
     ClassifierVariantSpec,
     LabelBreakdownMetrics,
+    LabelCountMetrics,
     ValidationDatasetSummary,
     ValidationReportPayload,
     VariantMetrics,
@@ -189,6 +190,16 @@ def _label_breakdown_metrics(
     ]
 
 
+def _label_count_metrics(counts: Counter[str]) -> list[LabelCountMetrics]:
+    return [
+        LabelCountMetrics(
+            label=label,
+            evaluated_examples=evaluated_examples,
+        )
+        for label, evaluated_examples in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
 def _display_label(value: str) -> str:
     return value if value else "(none)"
 
@@ -211,10 +222,18 @@ def _build_dataset_summary(labels: Sequence[ValidationLabel]) -> ValidationDatas
             relevant_examples += 1
             legacy_category_counts[label.category] += 1
             legacy_subcategory_counts[label.sub_category] += 1
-        if label.taxonomy_category_id and label.taxonomy_subcategory_id:
+        has_taxonomy_category = bool(label.taxonomy_category_id)
+        has_taxonomy_subcategory = bool(label.taxonomy_subcategory_id)
+        if has_taxonomy_category and has_taxonomy_subcategory:
             taxonomy_labeled_examples += 1
             taxonomy_category_counts[label.taxonomy_category_id] += 1
             taxonomy_subcategory_counts[label.taxonomy_subcategory_id] += 1
+        elif has_taxonomy_category != has_taxonomy_subcategory:
+            msg = (
+                "Validation label has partial taxonomy ids; both taxonomy_category_id "
+                "and taxonomy_subcategory_id must be provided together."
+            )
+            raise ValueError(msg)
         else:
             legacy_only_examples += 1
 
@@ -223,10 +242,10 @@ def _build_dataset_summary(labels: Sequence[ValidationLabel]) -> ValidationDatas
         relevant_examples=relevant_examples,
         legacy_only_examples=legacy_only_examples,
         taxonomy_labeled_examples=taxonomy_labeled_examples,
-        legacy_category_counts_relevant_only=_label_breakdown_metrics(legacy_category_counts),
-        legacy_subcategory_counts_relevant_only=_label_breakdown_metrics(legacy_subcategory_counts),
-        taxonomy_category_counts=_label_breakdown_metrics(taxonomy_category_counts),
-        taxonomy_subcategory_counts=_label_breakdown_metrics(taxonomy_subcategory_counts),
+        legacy_category_counts_relevant_only=_label_count_metrics(legacy_category_counts),
+        legacy_subcategory_counts_relevant_only=_label_count_metrics(legacy_subcategory_counts),
+        taxonomy_category_counts=_label_count_metrics(taxonomy_category_counts),
+        taxonomy_subcategory_counts=_label_count_metrics(taxonomy_subcategory_counts),
     )
 
 
@@ -468,6 +487,44 @@ def _render_breakdown_table(
     return lines
 
 
+def _render_count_table(
+    title: str,
+    counts: Sequence[LabelCountMetrics],
+) -> list[str]:
+    lines = [f"### {title}"]
+    if not counts:
+        lines.append("")
+        lines.append("_No applicable examples._")
+        lines.append("")
+        return lines
+    headers = ("label", "n")
+    rows = [
+        [
+            _display_label(item.label),
+            str(item.evaluated_examples),
+        ]
+        for item in counts
+    ]
+    widths = [
+        max(len(header), *(len(row[column]) for row in rows))
+        for column, header in enumerate(headers)
+    ]
+    lines.extend(
+        [
+            "",
+            "```text",
+            "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)),
+            *[
+                "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row))
+                for row in rows
+            ],
+            "```",
+            "",
+        ]
+    )
+    return lines
+
+
 def render_evaluation_markdown(
     *,
     evaluated_at: datetime,
@@ -503,25 +560,25 @@ def render_evaluation_markdown(
         "",
     ]
     lines.extend(
-        _render_breakdown_table(
+        _render_count_table(
             "Legacy Categories on Relevant Rows",
             dataset_summary.legacy_category_counts_relevant_only,
         )
     )
     lines.extend(
-        _render_breakdown_table(
+        _render_count_table(
             "Legacy Subcategories on Relevant Rows",
             dataset_summary.legacy_subcategory_counts_relevant_only,
         )
     )
     lines.extend(
-        _render_breakdown_table(
+        _render_count_table(
             "Taxonomy Categories",
             dataset_summary.taxonomy_category_counts,
         )
     )
     lines.extend(
-        _render_breakdown_table(
+        _render_count_table(
             "Taxonomy Subcategories",
             dataset_summary.taxonomy_subcategory_counts,
         )

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -210,6 +210,23 @@ def _markdown_path_for_json(path: Path) -> Path:
     return path.with_suffix(".md")
 
 
+def _resolve_report_paths(
+    *,
+    config: Config,
+    collected_at: datetime,
+    output_path: Path | None,
+) -> tuple[Path, Path]:
+    report_path = output_path or default_evaluation_output_path(config, collected_at)
+    if output_path is not None and report_path.suffix.casefold() != ".json":
+        msg = f"Evaluation output path must end with .json: {report_path}"
+        raise ValueError(msg)
+    markdown_path = _markdown_path_for_json(report_path)
+    if markdown_path == report_path:
+        msg = "Markdown report path must differ from the JSON report path"
+        raise ValueError(msg)
+    return report_path, markdown_path
+
+
 def _build_dataset_summary(labels: Sequence[ValidationLabel]) -> ValidationDatasetSummary:
     relevant_examples = 0
     legacy_only_examples = 0
@@ -636,7 +653,8 @@ async def evaluate_classifier_variants(
     output_path: Path | None = None,
 ) -> ValidationEvaluateResult:
     """Evaluate tracked classifier variants against the permanent validation set."""
-    api_key = Config().anthropic_api_key
+    config = Config()
+    api_key = config.anthropic_api_key
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY environment variable not set")
 
@@ -685,8 +703,11 @@ async def evaluate_classifier_variants(
         rankings.append(_score_predictions(labels, predictions, variant=variant, model=model))
 
     sorted_rankings = _sort_rankings(rankings)
-    report_path = output_path or default_evaluation_output_path(Config(), collected_at)
-    markdown_path = _markdown_path_for_json(report_path)
+    report_path, markdown_path = _resolve_report_paths(
+        config=config,
+        collected_at=collected_at,
+        output_path=output_path,
+    )
     report_path.parent.mkdir(parents=True, exist_ok=True)
     payload = ValidationReportPayload(
         evaluated_at=collected_at,

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -196,7 +196,9 @@ def _label_count_metrics(counts: Counter[str]) -> list[LabelCountMetrics]:
             label=label,
             evaluated_examples=evaluated_examples,
         )
-        for label, evaluated_examples in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        for label, evaluated_examples in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        )
     ]
 
 

--- a/src/denbust/validation/evaluate.py
+++ b/src/denbust/validation/evaluate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -29,6 +30,9 @@ from denbust.validation.models import (
     BinaryStageMetrics,
     ClassifierVariantMatrix,
     ClassifierVariantSpec,
+    LabelBreakdownMetrics,
+    ValidationDatasetSummary,
+    ValidationReportPayload,
     VariantMetrics,
 )
 
@@ -74,6 +78,8 @@ class ValidationEvaluateResult:
     """Result of evaluating classifier variants."""
 
     output_path: Path
+    markdown_path: Path
+    dataset_summary: ValidationDatasetSummary
     rankings: list[VariantMetrics]
 
 
@@ -165,6 +171,63 @@ def _accuracy_stage_metrics(*, correct: int, evaluated_examples: int) -> Accurac
     )
 
 
+def _label_breakdown_metrics(
+    counts: Counter[str],
+    correct_counts: Counter[str] | None = None,
+) -> list[LabelBreakdownMetrics]:
+    matches = correct_counts or Counter()
+    return [
+        LabelBreakdownMetrics(
+            label=label,
+            evaluated_examples=evaluated_examples,
+            correct=matches[label],
+            accuracy=(matches[label] / evaluated_examples) if evaluated_examples else 0.0,
+        )
+        for label, evaluated_examples in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _display_label(value: str) -> str:
+    return value if value else "(none)"
+
+
+def _markdown_path_for_json(path: Path) -> Path:
+    return path.with_suffix(".md")
+
+
+def _build_dataset_summary(labels: Sequence[ValidationLabel]) -> ValidationDatasetSummary:
+    relevant_examples = 0
+    legacy_only_examples = 0
+    taxonomy_labeled_examples = 0
+    legacy_category_counts: Counter[str] = Counter()
+    legacy_subcategory_counts: Counter[str] = Counter()
+    taxonomy_category_counts: Counter[str] = Counter()
+    taxonomy_subcategory_counts: Counter[str] = Counter()
+
+    for label in labels:
+        if label.relevant:
+            relevant_examples += 1
+            legacy_category_counts[label.category] += 1
+            legacy_subcategory_counts[label.sub_category] += 1
+        if label.taxonomy_category_id and label.taxonomy_subcategory_id:
+            taxonomy_labeled_examples += 1
+            taxonomy_category_counts[label.taxonomy_category_id] += 1
+            taxonomy_subcategory_counts[label.taxonomy_subcategory_id] += 1
+        else:
+            legacy_only_examples += 1
+
+    return ValidationDatasetSummary(
+        total_examples=len(labels),
+        relevant_examples=relevant_examples,
+        legacy_only_examples=legacy_only_examples,
+        taxonomy_labeled_examples=taxonomy_labeled_examples,
+        legacy_category_counts_relevant_only=_label_breakdown_metrics(legacy_category_counts),
+        legacy_subcategory_counts_relevant_only=_label_breakdown_metrics(legacy_subcategory_counts),
+        taxonomy_category_counts=_label_breakdown_metrics(taxonomy_category_counts),
+        taxonomy_subcategory_counts=_label_breakdown_metrics(taxonomy_subcategory_counts),
+    )
+
+
 def _score_predictions(
     labels: Sequence[ValidationLabel | tuple[bool, bool, str, str]],
     predictions: Sequence[ValidationLabel | tuple[bool, bool, str, str]],
@@ -183,6 +246,14 @@ def _score_predictions(
     taxonomy_category_matches = 0
     taxonomy_subcategory_matches = 0
     index_tp = index_fp = index_fn = index_tn = 0
+    legacy_category_counts: Counter[str] = Counter()
+    legacy_category_correct: Counter[str] = Counter()
+    legacy_subcategory_counts: Counter[str] = Counter()
+    legacy_subcategory_correct: Counter[str] = Counter()
+    taxonomy_category_counts: Counter[str] = Counter()
+    taxonomy_category_correct: Counter[str] = Counter()
+    taxonomy_subcategory_counts: Counter[str] = Counter()
+    taxonomy_subcategory_correct: Counter[str] = Counter()
 
     for raw_true_label, raw_predicted_label in zip(labels, predictions, strict=True):
         true_label = _coerce_label(raw_true_label)
@@ -202,6 +273,8 @@ def _score_predictions(
 
         if true_label.relevant:
             relevant_rows += 1
+            legacy_category_counts[true_label.category] += 1
+            legacy_subcategory_counts[true_label.sub_category] += 1
             if true_label.enforcement_related and predicted_enforcement_related:
                 enforcement_tp += 1
             elif not true_label.enforcement_related and predicted_enforcement_related:
@@ -213,11 +286,15 @@ def _score_predictions(
             if predicted_label.relevant:
                 if predicted_label.category == true_label.category:
                     category_matches += 1
+                    legacy_category_correct[true_label.category] += 1
                 if predicted_label.sub_category == true_label.sub_category:
                     subcategory_matches += 1
+                    legacy_subcategory_correct[true_label.sub_category] += 1
 
         if true_label.taxonomy_category_id and true_label.taxonomy_subcategory_id:
             taxonomy_labeled_rows += 1
+            taxonomy_category_counts[true_label.taxonomy_category_id] += 1
+            taxonomy_subcategory_counts[true_label.taxonomy_subcategory_id] += 1
             if predicted_label.index_relevant and true_label.index_relevant:
                 index_tp += 1
             elif predicted_label.index_relevant and not true_label.index_relevant:
@@ -229,8 +306,10 @@ def _score_predictions(
 
             if predicted_label.taxonomy_category_id == true_label.taxonomy_category_id:
                 taxonomy_category_matches += 1
+                taxonomy_category_correct[true_label.taxonomy_category_id] += 1
             if predicted_label.taxonomy_subcategory_id == true_label.taxonomy_subcategory_id:
                 taxonomy_subcategory_matches += 1
+                taxonomy_subcategory_correct[true_label.taxonomy_subcategory_id] += 1
 
         exact_match = (
             predicted_label.relevant == true_label.relevant
@@ -291,6 +370,22 @@ def _score_predictions(
         taxonomy_category_stage_taxonomy_labeled=taxonomy_category_stage,
         taxonomy_subcategory_stage_taxonomy_labeled=taxonomy_subcategory_stage,
         index_relevance_stage_taxonomy_labeled=index_stage,
+        legacy_category_breakdown_relevant_only=_label_breakdown_metrics(
+            legacy_category_counts,
+            legacy_category_correct,
+        ),
+        legacy_subcategory_breakdown_relevant_only=_label_breakdown_metrics(
+            legacy_subcategory_counts,
+            legacy_subcategory_correct,
+        ),
+        taxonomy_category_breakdown_taxonomy_labeled=_label_breakdown_metrics(
+            taxonomy_category_counts,
+            taxonomy_category_correct,
+        ),
+        taxonomy_subcategory_breakdown_taxonomy_labeled=_label_breakdown_metrics(
+            taxonomy_subcategory_counts,
+            taxonomy_subcategory_correct,
+        ),
         relevance_precision=relevance_stage.precision,
         relevance_recall=relevance_stage.recall,
         relevance_f1=relevance_stage.f1,
@@ -331,6 +426,148 @@ def _sort_rankings(metrics: list[VariantMetrics]) -> list[VariantMetrics]:
     )
 
 
+def _render_breakdown_table(
+    title: str,
+    breakdowns: Sequence[LabelBreakdownMetrics],
+) -> list[str]:
+    lines = [f"### {title}"]
+    if not breakdowns:
+        lines.append("")
+        lines.append("_No applicable examples._")
+        lines.append("")
+        return lines
+    headers = ("label", "n", "correct", "acc")
+    rows = [
+        [
+            _display_label(item.label),
+            str(item.evaluated_examples),
+            str(item.correct),
+            f"{item.accuracy:.3f}",
+        ]
+        for item in breakdowns
+    ]
+    widths = [
+        max(len(header), *(len(row[column]) for row in rows))
+        for column, header in enumerate(headers)
+    ]
+    lines.extend(
+        [
+            "",
+            "```text",
+            "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)),
+            *[
+                "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row))
+                for row in rows
+            ],
+            "```",
+            "",
+        ]
+    )
+    return lines
+
+
+def render_evaluation_markdown(
+    *,
+    evaluated_at: datetime,
+    validation_set_path: Path,
+    variants_path: Path,
+    dataset_summary: ValidationDatasetSummary,
+    metrics: Sequence[VariantMetrics],
+) -> str:
+    """Render a human-readable markdown validation report."""
+    lines = [
+        "# Classifier Variant Evaluation",
+        "",
+        f"- Evaluated at: `{evaluated_at.isoformat()}`",
+        f"- Validation set: `{validation_set_path}`",
+        f"- Variant matrix: `{variants_path}`",
+        "",
+        "## Dataset Coverage",
+        "",
+        f"- Total examples: `{dataset_summary.total_examples}`",
+        f"- Relevant examples: `{dataset_summary.relevant_examples}`",
+        f"- Taxonomy-labeled examples: `{dataset_summary.taxonomy_labeled_examples}`",
+        f"- Legacy-only examples: `{dataset_summary.legacy_only_examples}`",
+        "",
+        "Taxonomy-aware stages use only taxonomy-labeled examples. Legacy-only rows remain included in relevance and legacy category/subcategory evaluation.",
+        "",
+        "## Variant Ranking",
+        "",
+        "```text",
+        render_rankings_table(list(metrics)),
+        "```",
+        "",
+        "## Validation Set Typology Coverage",
+        "",
+    ]
+    lines.extend(
+        _render_breakdown_table(
+            "Legacy Categories on Relevant Rows",
+            dataset_summary.legacy_category_counts_relevant_only,
+        )
+    )
+    lines.extend(
+        _render_breakdown_table(
+            "Legacy Subcategories on Relevant Rows",
+            dataset_summary.legacy_subcategory_counts_relevant_only,
+        )
+    )
+    lines.extend(
+        _render_breakdown_table(
+            "Taxonomy Categories",
+            dataset_summary.taxonomy_category_counts,
+        )
+    )
+    lines.extend(
+        _render_breakdown_table(
+            "Taxonomy Subcategories",
+            dataset_summary.taxonomy_subcategory_counts,
+        )
+    )
+
+    lines.append("## Variant Details")
+    lines.append("")
+    for metric in metrics:
+        lines.extend(
+            [
+                f"### {metric.name}",
+                "",
+                f"- Model: `{metric.model}`",
+                f"- Relevance: `{metric.relevance_stage.f1:.3f}` F1 on `{metric.relevance_stage.evaluated_examples}` examples",
+                f"- Enforcement (relevant only): `{metric.enforcement_stage_relevant_only.f1:.3f}` F1 on `{metric.enforcement_stage_relevant_only.evaluated_examples}` examples",
+                f"- Taxonomy subcategory accuracy: `{metric.taxonomy_subcategory_stage_taxonomy_labeled.accuracy:.3f}` on `{metric.taxonomy_subcategory_stage_taxonomy_labeled.evaluated_examples}` examples",
+                f"- Index relevance: `{metric.index_relevance_stage_taxonomy_labeled.f1:.3f}` F1 on `{metric.index_relevance_stage_taxonomy_labeled.evaluated_examples}` examples",
+                f"- Overall exact match: `{metric.overall_exact_match:.3f}`",
+                "",
+            ]
+        )
+        lines.extend(
+            _render_breakdown_table(
+                f"{metric.name} Legacy Category Accuracy",
+                metric.legacy_category_breakdown_relevant_only,
+            )
+        )
+        lines.extend(
+            _render_breakdown_table(
+                f"{metric.name} Legacy Subcategory Accuracy",
+                metric.legacy_subcategory_breakdown_relevant_only,
+            )
+        )
+        lines.extend(
+            _render_breakdown_table(
+                f"{metric.name} Taxonomy Category Accuracy",
+                metric.taxonomy_category_breakdown_taxonomy_labeled,
+            )
+        )
+        lines.extend(
+            _render_breakdown_table(
+                f"{metric.name} Taxonomy Subcategory Accuracy",
+                metric.taxonomy_subcategory_breakdown_taxonomy_labeled,
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
 async def evaluate_classifier_variants(
     *,
     validation_set_path: Path = DEFAULT_VALIDATION_SET_PATH,
@@ -345,6 +582,7 @@ async def evaluate_classifier_variants(
     articles, labels = _load_validation_examples(validation_set_path)
     matrix = _load_variant_matrix(variants_path)
     collected_at = datetime.now(UTC)
+    dataset_summary = _build_dataset_summary(labels)
 
     rankings: list[VariantMetrics] = []
     default_model = matrix.defaults.model or Config().classifier.model
@@ -387,20 +625,31 @@ async def evaluate_classifier_variants(
 
     sorted_rankings = _sort_rankings(rankings)
     report_path = output_path or default_evaluation_output_path(Config(), collected_at)
+    markdown_path = _markdown_path_for_json(report_path)
     report_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = ValidationReportPayload(
+        evaluated_at=collected_at,
+        validation_set_path=str(validation_set_path),
+        variants_path=str(variants_path),
+        dataset_summary=dataset_summary,
+        rankings=sorted_rankings,
+    )
     with report_path.open("w", encoding="utf-8") as handle:
-        json.dump(
-            {
-                "evaluated_at": collected_at.isoformat(),
-                "validation_set_path": str(validation_set_path),
-                "variants_path": str(variants_path),
-                "rankings": [metric.model_dump(mode="json") for metric in sorted_rankings],
-            },
-            handle,
-            ensure_ascii=False,
-            indent=2,
-        )
-    return ValidationEvaluateResult(output_path=report_path, rankings=sorted_rankings)
+        json.dump(payload.model_dump(mode="json"), handle, ensure_ascii=False, indent=2)
+    markdown = render_evaluation_markdown(
+        evaluated_at=collected_at,
+        validation_set_path=validation_set_path,
+        variants_path=variants_path,
+        dataset_summary=dataset_summary,
+        metrics=sorted_rankings,
+    )
+    markdown_path.write_text(markdown, encoding="utf-8")
+    return ValidationEvaluateResult(
+        output_path=report_path,
+        markdown_path=markdown_path,
+        dataset_summary=dataset_summary,
+        rankings=sorted_rankings,
+    )
 
 
 def render_rankings_table(metrics: list[VariantMetrics]) -> str:

--- a/src/denbust/validation/models.py
+++ b/src/denbust/validation/models.py
@@ -122,6 +122,30 @@ class AccuracyStageMetrics(BaseModel):
     accuracy: float = 0.0
 
 
+class LabelBreakdownMetrics(BaseModel):
+    """Accuracy breakdown for one expected label."""
+
+    label: str
+    evaluated_examples: int = 0
+    correct: int = 0
+    accuracy: float = 0.0
+
+
+class ValidationDatasetSummary(BaseModel):
+    """Composition summary of the validation set used for evaluation."""
+
+    total_examples: int = 0
+    relevant_examples: int = 0
+    legacy_only_examples: int = 0
+    taxonomy_labeled_examples: int = 0
+    legacy_category_counts_relevant_only: list[LabelBreakdownMetrics] = Field(default_factory=list)
+    legacy_subcategory_counts_relevant_only: list[LabelBreakdownMetrics] = Field(
+        default_factory=list
+    )
+    taxonomy_category_counts: list[LabelBreakdownMetrics] = Field(default_factory=list)
+    taxonomy_subcategory_counts: list[LabelBreakdownMetrics] = Field(default_factory=list)
+
+
 class VariantMetrics(BaseModel):
     """Computed metrics for a single classifier variant."""
 
@@ -142,6 +166,18 @@ class VariantMetrics(BaseModel):
     )
     index_relevance_stage_taxonomy_labeled: BinaryStageMetrics = Field(
         default_factory=BinaryStageMetrics
+    )
+    legacy_category_breakdown_relevant_only: list[LabelBreakdownMetrics] = Field(
+        default_factory=list
+    )
+    legacy_subcategory_breakdown_relevant_only: list[LabelBreakdownMetrics] = Field(
+        default_factory=list
+    )
+    taxonomy_category_breakdown_taxonomy_labeled: list[LabelBreakdownMetrics] = Field(
+        default_factory=list
+    )
+    taxonomy_subcategory_breakdown_taxonomy_labeled: list[LabelBreakdownMetrics] = Field(
+        default_factory=list
     )
     relevance_precision: float
     relevance_recall: float
@@ -166,3 +202,13 @@ class VariantMetrics(BaseModel):
     tn: int
     total_examples: int
     taxonomy_labeled_examples: int = 0
+
+
+class ValidationReportPayload(BaseModel):
+    """Serialized payload written to validation evaluation JSON reports."""
+
+    evaluated_at: datetime
+    validation_set_path: str
+    variants_path: str
+    dataset_summary: ValidationDatasetSummary
+    rankings: list[VariantMetrics] = Field(default_factory=list)

--- a/src/denbust/validation/models.py
+++ b/src/denbust/validation/models.py
@@ -131,6 +131,13 @@ class LabelBreakdownMetrics(BaseModel):
     accuracy: float = 0.0
 
 
+class LabelCountMetrics(BaseModel):
+    """Frequency-only count for one label in the validation set."""
+
+    label: str
+    evaluated_examples: int = 0
+
+
 class ValidationDatasetSummary(BaseModel):
     """Composition summary of the validation set used for evaluation."""
 
@@ -138,12 +145,10 @@ class ValidationDatasetSummary(BaseModel):
     relevant_examples: int = 0
     legacy_only_examples: int = 0
     taxonomy_labeled_examples: int = 0
-    legacy_category_counts_relevant_only: list[LabelBreakdownMetrics] = Field(default_factory=list)
-    legacy_subcategory_counts_relevant_only: list[LabelBreakdownMetrics] = Field(
-        default_factory=list
-    )
-    taxonomy_category_counts: list[LabelBreakdownMetrics] = Field(default_factory=list)
-    taxonomy_subcategory_counts: list[LabelBreakdownMetrics] = Field(default_factory=list)
+    legacy_category_counts_relevant_only: list[LabelCountMetrics] = Field(default_factory=list)
+    legacy_subcategory_counts_relevant_only: list[LabelCountMetrics] = Field(default_factory=list)
+    taxonomy_category_counts: list[LabelCountMetrics] = Field(default_factory=list)
+    taxonomy_subcategory_counts: list[LabelCountMetrics] = Field(default_factory=list)
 
 
 class VariantMetrics(BaseModel):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -588,6 +588,7 @@ class TestCli:
 
             class Result:
                 output_path = Path("report.json")
+                markdown_path = Path("report.md")
                 rankings: list[object] = []
 
             return Result()
@@ -609,3 +610,5 @@ class TestCli:
         )
         assert captured["variants_path"] == Path("agents/validation/classifier_variants.yaml")
         assert captured["output_path"] is None
+        assert "Saved JSON report to report.json" in result.stdout
+        assert "Saved Markdown report to report.md" in result.stdout

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1672,7 +1672,12 @@ class TestValidationEvaluate:
         )
         variants_path = tmp_path / "variants.yaml"
         variants_path.write_text(
-            yaml.safe_dump({"defaults": {"model": "claude-sonnet-4-20250514"}, "variants": [{"name": "baseline"}]}),
+            yaml.safe_dump(
+                {
+                    "defaults": {"model": "claude-sonnet-4-20250514"},
+                    "variants": [{"name": "baseline"}],
+                }
+            ),
             encoding="utf-8",
         )
 

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1432,13 +1432,22 @@ class TestValidationEvaluate:
 
         assert [metric.name for metric in result.rankings] == ["prompt-tuned", "baseline"]
         assert result.output_path.exists()
+        assert result.markdown_path.exists()
         report = json.loads(result.output_path.read_text(encoding="utf-8"))
+        assert report["dataset_summary"]["total_examples"] == 2
+        assert report["dataset_summary"]["legacy_only_examples"] == 2
         first = report["rankings"][0]
         assert first["relevance_stage"]["evaluated_examples"] == 2
         assert first["enforcement_stage_relevant_only"]["evaluated_examples"] == 1
         assert first["category_stage_relevant_only"]["evaluated_examples"] == 1
         assert first["taxonomy_subcategory_stage_taxonomy_labeled"]["evaluated_examples"] == 0
         assert first["index_relevance_stage_taxonomy_labeled"]["evaluated_examples"] == 0
+        assert first["legacy_category_breakdown_relevant_only"][0]["label"] == "brothel"
+        markdown = result.markdown_path.read_text(encoding="utf-8")
+        assert "## Dataset Coverage" in markdown
+        assert "Legacy-only examples" in markdown
+        assert "## Validation Set Typology Coverage" in markdown
+        assert "### prompt-tuned" in markdown
 
     def test_score_predictions_uses_only_relevant_rows_for_category_metrics(self) -> None:
         """Category and sub-category metrics should ignore non-relevant gold rows."""
@@ -1588,6 +1597,7 @@ class TestValidationEvaluate:
 
             class Result:
                 output_path = tmp_path / "report.json"
+                markdown_path = tmp_path / "report.md"
                 rankings: list[object] = []
 
             return Result()

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -49,6 +49,7 @@ from denbust.validation.evaluate import (
     _build_dataset_summary,
     _load_validation_examples,
     _load_variant_matrix,
+    _resolve_report_paths,
     _score_predictions,
     evaluate_classifier_variants,
     render_rankings_table,
@@ -1627,6 +1628,24 @@ class TestValidationEvaluate:
         assert summary.taxonomy_labeled_examples == 1
         assert summary.taxonomy_category_counts[0].label == "brothels"
         assert summary.taxonomy_subcategory_counts[0].label == "administrative_closure"
+
+    def test_resolve_report_paths_rejects_markdown_json_collision(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        report_path = tmp_path / "report.json"
+        monkeypatch.setattr(
+            "denbust.validation.evaluate._markdown_path_for_json",
+            lambda path: path,
+        )
+
+        with pytest.raises(ValueError, match="must differ"):
+            _resolve_report_paths(
+                config=Config(),
+                collected_at=datetime(2026, 4, 10, tzinfo=UTC),
+                output_path=report_path,
+            )
 
     @pytest.mark.asyncio
     async def test_evaluate_classifier_variants_rejects_non_json_output_path(

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -45,6 +45,8 @@ from denbust.validation.dataset import (
     run_validation_finalize,
 )
 from denbust.validation.evaluate import (
+    ValidationLabel,
+    _build_dataset_summary,
     _load_validation_examples,
     _load_variant_matrix,
     _score_predictions,
@@ -1436,6 +1438,10 @@ class TestValidationEvaluate:
         report = json.loads(result.output_path.read_text(encoding="utf-8"))
         assert report["dataset_summary"]["total_examples"] == 2
         assert report["dataset_summary"]["legacy_only_examples"] == 2
+        assert report["dataset_summary"]["legacy_category_counts_relevant_only"][0] == {
+            "label": "brothel",
+            "evaluated_examples": 1,
+        }
         first = report["rankings"][0]
         assert first["relevance_stage"]["evaluated_examples"] == 2
         assert first["enforcement_stage_relevant_only"]["evaluated_examples"] == 1
@@ -1447,6 +1453,8 @@ class TestValidationEvaluate:
         assert "## Dataset Coverage" in markdown
         assert "Legacy-only examples" in markdown
         assert "## Validation Set Typology Coverage" in markdown
+        assert "label    n" in markdown
+        assert "correct" in markdown
         assert "### prompt-tuned" in markdown
 
     def test_score_predictions_uses_only_relevant_rows_for_category_metrics(self) -> None:
@@ -1578,6 +1586,25 @@ class TestValidationEvaluate:
         assert metrics.enforcement_recall_relevant_only == 0.0
         assert metrics.enforcement_f1_relevant_only == 0.0
         assert metrics.enforcement_accuracy_relevant_only == 0.0
+
+    def test_build_dataset_summary_rejects_partial_taxonomy_ids(self) -> None:
+        with pytest.raises(ValueError, match="partial taxonomy ids"):
+            _build_dataset_summary(
+                [
+                    (
+                        ValidationLabel(
+                            relevant=True,
+                            enforcement_related=True,
+                            category="brothel",
+                            sub_category="closure",
+                            index_relevant=False,
+                            taxonomy_version="1",
+                            taxonomy_category_id="brothels",
+                            taxonomy_subcategory_id="",
+                        )
+                    )
+                ]
+            )
 
     def test_run_validation_evaluate_delegates(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1606,6 +1606,105 @@ class TestValidationEvaluate:
                 ]
             )
 
+    def test_build_dataset_summary_counts_taxonomy_labeled_rows(self) -> None:
+        summary = _build_dataset_summary(
+            [
+                ValidationLabel(
+                    relevant=True,
+                    enforcement_related=True,
+                    category="brothel",
+                    sub_category="closure",
+                    index_relevant=True,
+                    taxonomy_version="1",
+                    taxonomy_category_id="brothels",
+                    taxonomy_subcategory_id="administrative_closure",
+                )
+            ]
+        )
+
+        assert summary.total_examples == 1
+        assert summary.legacy_only_examples == 0
+        assert summary.taxonomy_labeled_examples == 1
+        assert summary.taxonomy_category_counts[0].label == "brothels"
+        assert summary.taxonomy_subcategory_counts[0].label == "administrative_closure"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_classifier_variants_rejects_non_json_output_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        validation_set_path = tmp_path / "validation.csv"
+        write_csv_rows(
+            validation_set_path,
+            VALIDATION_SET_COLUMNS,
+            [
+                {
+                    "source_name": "ynet",
+                    "article_date": "2026-03-01T00:00:00+00:00",
+                    "url": "https://example.com/a",
+                    "canonical_url": "https://example.com/a",
+                    "title": "title a",
+                    "snippet": "snippet a",
+                    "relevant": "False",
+                    "enforcement_related": "False",
+                    "index_relevant": "False",
+                    "taxonomy_version": "",
+                    "taxonomy_category_id": "",
+                    "taxonomy_subcategory_id": "",
+                    "category": "not_relevant",
+                    "sub_category": "",
+                    "review_status": "reviewed",
+                    "annotation_source": "",
+                    "expected_month_bucket": "",
+                    "expected_city": "",
+                    "expected_status": "",
+                    "manual_city": "",
+                    "manual_address": "",
+                    "manual_event_label": "",
+                    "manual_status": "",
+                    "annotation_notes": "",
+                    "collected_at": "2026-03-01T00:00:00+00:00",
+                    "finalized_at": "2026-03-02T00:00:00+00:00",
+                    "draft_source": "draft.csv",
+                }
+            ],
+        )
+        variants_path = tmp_path / "variants.yaml"
+        variants_path.write_text(
+            yaml.safe_dump({"defaults": {"model": "claude-sonnet-4-20250514"}, "variants": [{"name": "baseline"}]}),
+            encoding="utf-8",
+        )
+
+        class VariantClassifier:
+            async def classify_batch(self, articles: list[RawArticle]) -> list[ClassifiedArticle]:
+                return [
+                    ClassifiedArticle(
+                        article=article,
+                        classification=ClassificationResult(
+                            relevant=False,
+                            enforcement_related=False,
+                            category=Category.NOT_RELEVANT,
+                            sub_category=None,
+                            confidence="high",
+                        ),
+                    )
+                    for article in articles
+                ]
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "denbust.validation.evaluate.create_classifier",
+            lambda **_kwargs: VariantClassifier(),
+        )
+
+        with pytest.raises(ValueError, match="must end with \\.json"):
+            await evaluate_classifier_variants(
+                validation_set_path=validation_set_path,
+                variants_path=variants_path,
+                output_path=tmp_path / "report.md",
+            )
+
     def test_run_validation_evaluate_delegates(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_validation_taxonomy_metrics.py
+++ b/tests/unit/test_validation_taxonomy_metrics.py
@@ -58,6 +58,10 @@ def test_taxonomy_metrics_only_use_taxonomy_labeled_rows() -> None:
     assert metrics.taxonomy_category_stage_taxonomy_labeled.evaluated_examples == 1
     assert metrics.taxonomy_subcategory_stage_taxonomy_labeled.evaluated_examples == 1
     assert metrics.index_relevance_stage_taxonomy_labeled.evaluated_examples == 1
+    assert metrics.taxonomy_category_breakdown_taxonomy_labeled[0].label == "brothels"
+    assert metrics.taxonomy_subcategory_breakdown_taxonomy_labeled[0].label == (
+        "administrative_closure"
+    )
     assert metrics.taxonomy_category_accuracy_taxonomy_labeled == 1.0
     assert metrics.taxonomy_subcategory_accuracy_taxonomy_labeled == 1.0
     assert metrics.index_relevance_f1_taxonomy_labeled == 1.0


### PR DESCRIPTION
## Summary
- add a human-readable markdown validation report alongside the existing JSON artifact
- include dataset coverage and typology-aware breakdowns for legacy and taxonomy-labeled examples
- keep evaluation invocation and ranking behavior stable while making the outputs more useful for review

## What changed
- added report-oriented models in `src/denbust/validation/models.py`:
  - `LabelBreakdownMetrics`
  - `ValidationDatasetSummary`
  - `ValidationReportPayload`
- extended `src/denbust/validation/evaluate.py` to:
  - build a dataset summary covering total, relevant, legacy-only, and taxonomy-labeled examples
  - compute per-label breakdowns for legacy category/subcategory stages and taxonomy category/subcategory stages
  - write those richer structures into the JSON report payload
  - render a markdown report with:
    - dataset coverage
    - compact ranking table
    - validation-set typology coverage
    - per-variant breakdown sections
- extended `ValidationEvaluateResult` with `markdown_path` and `dataset_summary`
- updated `validation-evaluate` CLI output in `src/denbust/cli.py` to announce both JSON and Markdown artifacts
- updated `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` to mark PR 3.3 merged and PR 3.4 current

## Why
PR 3.3 exposed stage-wise metrics, but the outputs were still optimized for machines and a compact CLI table. PR 3.4 turns those metrics into reviewable artifacts for humans, especially around the split between legacy rows and taxonomy-labeled rows and the category/subcategory coverage inside the validation set.

## Verification
- `pytest -q tests/unit/test_validation.py tests/unit/test_validation_taxonomy_metrics.py tests/unit/test_cli.py`
- `ruff check src/denbust/validation/models.py src/denbust/validation/evaluate.py src/denbust/cli.py tests/unit/test_validation.py tests/unit/test_validation_taxonomy_metrics.py tests/unit/test_cli.py docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md`
- `mypy src/`