### PR TITLE
Improve source diagnostics and source-specific discovery coverage

### DIFF
--- a/agents/news-github.yaml
+++ b/agents/news-github.yaml
@@ -8,7 +8,7 @@ max_articles: 30
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 
   # Scraped sources - archive/search scraping with keyword/date filtering

--- a/agents/news.yaml
+++ b/agents/news.yaml
@@ -9,7 +9,7 @@ sources:
   # RSS sources - filter by keywords after fetching
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 
   # Scraped sources - archive/search scraping with keyword/date filtering

--- a/agents/news/github.yaml
+++ b/agents/news/github.yaml
@@ -8,7 +8,7 @@ max_articles: 30
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 
   - name: walla

--- a/agents/news/local.yaml
+++ b/agents/news/local.yaml
@@ -8,7 +8,7 @@ max_articles: 30
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 
   - name: walla

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -742,9 +742,7 @@ async def _probe_mako(
             containers = soup.select("article, .article, .item, li")
             parsed_articles = [
                 article
-                for article in (
-                    scraper._parse_article_item(item, cutoff) for item in containers
-                )
+                for article in (scraper._parse_article_item(item, cutoff) for item in containers)
                 if article is not None
             ]
             keyword_matches = [
@@ -763,7 +761,9 @@ async def _probe_mako(
                 summary = "Section page contains candidates but parsing returned zero articles"
             elif len(keyword_matches) == 0:
                 status = DiagnosticStatus.WARN
-                summary = "Section page returned parsed articles but none match the sampled keywords"
+                summary = (
+                    "Section page returned parsed articles but none match the sampled keywords"
+                )
             else:
                 status = DiagnosticStatus.OK
                 summary = "Section page returned parsed keyword-matching articles"
@@ -892,7 +892,11 @@ async def _probe_ice(
             if results_article is None:
                 status = DiagnosticStatus.FAIL
                 summary = "Search page did not expose the expected ICE results container"
-            elif parsed_article_count == 0 and stale_candidate_count == len(candidates) and candidates:
+            elif (
+                parsed_article_count == 0
+                and stale_candidate_count == len(candidates)
+                and candidates
+            ):
                 status = DiagnosticStatus.WARN
                 summary = "Search page returned only stale candidates outside the cutoff window"
             elif parsed_article_count == 0:

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -18,8 +18,11 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 
 import denbust.sources.ice as ice_source
+import denbust.sources.haaretz as haaretz_source
+import denbust.sources.mako as mako_source
 import denbust.sources.maariv as maariv_source
 import denbust.sources.rss as rss_source
+import denbust.sources.walla as walla_source
 from denbust.config import DEFAULT_KEYWORDS, Config, SourceConfig, load_config
 from denbust.pipeline import create_sources
 from denbust.sources.base import Source
@@ -46,6 +49,7 @@ class FailureBucket(StrEnum):
 
     FEED_FETCH_FAILED = "feed_fetch_failed"
     FEED_EMPTY_OR_STALE = "feed_empty_or_stale"
+    STALE_RESULTS = "stale_results"
     KEYWORD_FILTER_ZEROED_RESULTS = "keyword_filter_zeroed_results"
     HTTP_FETCH_FAILED = "http_fetch_failed"
     UNEXPECTED_REDIRECT = "unexpected_redirect"
@@ -345,8 +349,14 @@ async def _probe_source(
         return await _probe_ynet(source_cfg=source_cfg, days=days, sample_keywords=sample_keywords)
     if source_name == "maariv":
         return await _probe_maariv(days=days, sample_keywords=sample_keywords)
+    if source_name == "mako":
+        return await _probe_mako(days=days, sample_keywords=sample_keywords)
+    if source_name == "haaretz":
+        return await _probe_haaretz(days=days, sample_keywords=sample_keywords)
     if source_name == "ice":
         return await _probe_ice(days=days, sample_keywords=sample_keywords)
+    if source_name == "walla":
+        return await _probe_walla(days=days, sample_keywords=sample_keywords)
     if source is None:
         return SourceDiagnosticResult(
             source_name=source_name,
@@ -605,6 +615,217 @@ async def _probe_maariv(
     )
 
 
+async def _probe_mako(
+    *,
+    days: int,
+    sample_keywords: list[str],
+) -> SourceDiagnosticResult:
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    scraper = mako_source.MakoScraper(rate_limit_delay_seconds=0.0)
+
+    try:
+        session = await scraper._open_browser_session()
+    except RuntimeError as exc:
+        message = str(exc)
+        status = (
+            DiagnosticStatus.SKIP
+            if "playwright" in message.lower() or "chromium" in message.lower()
+            else DiagnosticStatus.FAIL
+        )
+        return _live_result(
+            source_name="mako",
+            status=status,
+            bucket=None if status is DiagnosticStatus.SKIP else FailureBucket.LIVE_PROBE_EXCEPTION,
+            checks=[
+                ProbeCheck(
+                    name="browser_session",
+                    status=status,
+                    summary=message,
+                )
+            ],
+        )
+    except Exception as exc:
+        return _live_result(
+            source_name="mako",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.LIVE_PROBE_EXCEPTION,
+            checks=[
+                ProbeCheck(
+                    name="browser_session",
+                    status=DiagnosticStatus.FAIL,
+                    summary=f"Browser session failed unexpectedly: {exc}",
+                )
+            ],
+        )
+
+    checks: list[ProbeCheck] = []
+    saw_search_success = False
+    saw_search_keyword_match = False
+    saw_search_parseable_results = False
+    saw_section_success = False
+    saw_section_keyword_match = False
+    saw_section_parseable_results = False
+    unexpected_redirect = False
+
+    try:
+        for keyword in sample_keywords:
+            search_url = scraper._build_search_url(keyword)
+            try:
+                html = await scraper._fetch_search_html(session, keyword)
+            except Exception as exc:
+                checks.append(
+                    ProbeCheck(
+                        name=f"search:{keyword}",
+                        status=DiagnosticStatus.FAIL,
+                        summary=f"Search fetch failed: {exc}",
+                        details={"requested_url": search_url},
+                    )
+                )
+                continue
+
+            saw_search_success = True
+            if _is_unexpected_redirect(session.page.url, search_url):
+                unexpected_redirect = True
+
+            parsed_articles = scraper._parse_search_results(html, cutoff) if html else []
+            saw_search_parseable_results = saw_search_parseable_results or bool(parsed_articles)
+            keyword_hit = any(
+                scraper._matches_keywords(article, sample_keywords) for article in parsed_articles
+            )
+            saw_search_keyword_match = saw_search_keyword_match or keyword_hit
+
+            if html is None:
+                status = DiagnosticStatus.WARN
+                summary = "Search reached a terminal page but returned no rendered results"
+            elif len(parsed_articles) == 0:
+                status = DiagnosticStatus.WARN
+                summary = "Search page rendered but parsing returned zero articles"
+            elif keyword_hit:
+                status = DiagnosticStatus.OK
+                summary = "Search page returned parsed keyword-matching articles"
+            else:
+                status = DiagnosticStatus.OK
+                summary = "Search page returned parsed articles"
+
+            checks.append(
+                ProbeCheck(
+                    name=f"search:{keyword}",
+                    status=status,
+                    summary=summary,
+                    details={
+                        "requested_url": search_url,
+                        "final_url": session.page.url,
+                        "payload_length": len(html) if html is not None else 0,
+                        "article_count": len(parsed_articles),
+                        "article_urls": [str(article.url) for article in parsed_articles[:5]],
+                    },
+                )
+            )
+
+        try:
+            section_html = await scraper._fetch_section_html(session, mako_source.MAKO_MEN_NEWS_URL)
+        except Exception as exc:
+            checks.append(
+                ProbeCheck(
+                    name="section:men-men_news",
+                    status=DiagnosticStatus.FAIL,
+                    summary=f"Section fetch failed: {exc}",
+                    details={"requested_url": mako_source.MAKO_MEN_NEWS_URL},
+                )
+            )
+        else:
+            saw_section_success = True
+            if _is_unexpected_redirect(session.page.url, mako_source.MAKO_MEN_NEWS_URL):
+                unexpected_redirect = True
+
+            soup = BeautifulSoup(section_html, "lxml")
+            containers = soup.select("article, .article, .item, li")
+            parsed_articles = [
+                article
+                for article in (
+                    scraper._parse_article_item(item, cutoff) for item in containers
+                )
+                if article is not None
+            ]
+            keyword_matches = [
+                article
+                for article in parsed_articles
+                if scraper._matches_keywords(article, sample_keywords)
+            ]
+            saw_section_parseable_results = bool(parsed_articles)
+            saw_section_keyword_match = bool(keyword_matches)
+
+            if len(containers) == 0:
+                status = DiagnosticStatus.FAIL
+                summary = "Section page rendered but no candidate containers were found"
+            elif len(parsed_articles) == 0:
+                status = DiagnosticStatus.WARN
+                summary = "Section page contains candidates but parsing returned zero articles"
+            elif len(keyword_matches) == 0:
+                status = DiagnosticStatus.WARN
+                summary = "Section page returned parsed articles but none match the sampled keywords"
+            else:
+                status = DiagnosticStatus.OK
+                summary = "Section page returned parsed keyword-matching articles"
+
+            checks.append(
+                ProbeCheck(
+                    name="section:men-men_news",
+                    status=status,
+                    summary=summary,
+                    details={
+                        "requested_url": mako_source.MAKO_MEN_NEWS_URL,
+                        "final_url": session.page.url,
+                        "payload_length": len(section_html),
+                        "container_count": len(containers),
+                        "parsed_article_count": len(parsed_articles),
+                        "keyword_match_count": len(keyword_matches),
+                        "article_urls": [str(article.url) for article in keyword_matches[:5]],
+                    },
+                )
+            )
+    finally:
+        try:
+            await scraper._close_browser_session(session)
+        except Exception:
+            pass
+
+    if unexpected_redirect:
+        return _live_result(
+            source_name="mako",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.UNEXPECTED_REDIRECT,
+            checks=checks,
+        )
+    if not saw_search_success and not saw_section_success:
+        return _live_result(
+            source_name="mako",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.HTTP_FETCH_FAILED,
+            checks=checks,
+        )
+    if not saw_search_parseable_results and not saw_section_parseable_results:
+        return _live_result(
+            source_name="mako",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.PARSE_ZEROED_RESULTS,
+            checks=checks,
+        )
+    if not saw_search_keyword_match and not saw_section_keyword_match:
+        return _live_result(
+            source_name="mako",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            checks=checks,
+        )
+
+    return _live_result(
+        source_name="mako",
+        status=DiagnosticStatus.OK,
+        checks=checks,
+    )
+
+
 async def _probe_ice(
     *,
     days: int,
@@ -616,6 +837,7 @@ async def _probe_ice(
     saw_successful_page = False
     saw_results_container = False
     parsed_article_total = 0
+    stale_candidate_total = 0
     unexpected_redirect = False
 
     async with httpx.AsyncClient(
@@ -654,16 +876,25 @@ async def _probe_ice(
 
             unparseable_date_count = 0
             parsed_article_count = 0
+            stale_candidate_count = 0
             for candidate in candidates:
-                if scraper._parse_date(candidate.get_text(" ", strip=True)) is None:
+                candidate_text = candidate.get_text(" ", strip=True)
+                parsed_date = scraper._parse_date(candidate_text)
+                if parsed_date is None:
                     unparseable_date_count += 1
+                elif parsed_date < cutoff:
+                    stale_candidate_count += 1
                 if scraper._parse_article_item(candidate, cutoff) is not None:
                     parsed_article_count += 1
 
             parsed_article_total += parsed_article_count
+            stale_candidate_total += stale_candidate_count
             if results_article is None:
                 status = DiagnosticStatus.FAIL
                 summary = "Search page did not expose the expected ICE results container"
+            elif parsed_article_count == 0 and stale_candidate_count == len(candidates) and candidates:
+                status = DiagnosticStatus.WARN
+                summary = "Search page returned only stale candidates outside the cutoff window"
             elif parsed_article_count == 0:
                 status = DiagnosticStatus.WARN
                 summary = "Search page contains candidates but parsing returned zero articles"
@@ -684,6 +915,7 @@ async def _probe_ice(
                         "payload_length": len(fetch_result.text),
                         "candidate_count": len(candidates),
                         "parsed_article_count": parsed_article_count,
+                        "stale_candidate_count": stale_candidate_count,
                         "unparseable_date_count": unparseable_date_count,
                         "has_results_container": results_article is not None,
                     },
@@ -718,6 +950,13 @@ async def _probe_ice(
             bucket=FailureBucket.SELECTOR_DRIFT_SUSPECTED,
             checks=checks,
         )
+    if parsed_article_total == 0 and stale_candidate_total > 0:
+        return _live_result(
+            source_name="ice",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.STALE_RESULTS,
+            checks=checks,
+        )
     if parsed_article_total == 0:
         return _live_result(
             source_name="ice",
@@ -728,6 +967,285 @@ async def _probe_ice(
 
     return _live_result(
         source_name="ice",
+        status=DiagnosticStatus.OK,
+        checks=checks,
+    )
+
+
+async def _probe_walla(
+    *,
+    days: int,
+    sample_keywords: list[str],
+) -> SourceDiagnosticResult:
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=days)
+    scraper = walla_source.WallaScraper(rate_limit_delay_seconds=0.0)
+    checks: list[ProbeCheck] = []
+    saw_successful_page = False
+    unexpected_redirect = False
+    entry_total = 0
+    recent_entry_total = 0
+    keyword_match_total = 0
+
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        headers={"User-Agent": walla_source.USER_AGENT},
+        follow_redirects=True,
+    ) as client:
+        months = scraper._iter_months(cutoff, now)
+        for category_id in walla_source.WALLA_ARCHIVE_CATEGORY_IDS:
+            for year, month in months:
+                archive_url = scraper._build_archive_url(category_id, year, month, page_number=1)
+                try:
+                    fetch_result = await _fetch_text(
+                        archive_url,
+                        user_agent=walla_source.USER_AGENT,
+                        client=client,
+                    )
+                except Exception as exc:
+                    checks.append(
+                        ProbeCheck(
+                            name=f"archive:{category_id}:{year}-{month:02d}",
+                            status=DiagnosticStatus.FAIL,
+                            summary=f"Archive fetch failed: {exc}",
+                            details={"url": archive_url},
+                        )
+                    )
+                    continue
+
+                saw_successful_page = True
+                if _is_unexpected_redirect(fetch_result.final_url, archive_url):
+                    unexpected_redirect = True
+
+                entries = scraper._parse_archive_entries(fetch_result.text)
+                recent_entries = [entry for entry in entries if entry.date >= cutoff]
+                keyword_matches = [
+                    entry
+                    for entry in recent_entries
+                    if scraper._matches_keywords(entry, sample_keywords)
+                ]
+
+                entry_total += len(entries)
+                recent_entry_total += len(recent_entries)
+                keyword_match_total += len(keyword_matches)
+
+                if len(entries) == 0:
+                    status = DiagnosticStatus.FAIL
+                    summary = "Archive page fetched but parsed zero entries"
+                elif len(recent_entries) == 0:
+                    status = DiagnosticStatus.WARN
+                    summary = "Archive page parsed entries but none are inside the cutoff window"
+                elif len(keyword_matches) == 0:
+                    status = DiagnosticStatus.WARN
+                    summary = "Archive page has recent entries but none match the sampled keywords"
+                else:
+                    status = DiagnosticStatus.OK
+                    summary = "Archive page returned recent keyword-matching entries"
+
+                checks.append(
+                    ProbeCheck(
+                        name=f"archive:{category_id}:{year}-{month:02d}",
+                        status=status,
+                        summary=summary,
+                        details={
+                            "requested_url": archive_url,
+                            "final_url": fetch_result.final_url,
+                            "status_code": fetch_result.status_code,
+                            "content_type": fetch_result.content_type,
+                            "payload_length": len(fetch_result.text),
+                            "entry_count": len(entries),
+                            "recent_entry_count": len(recent_entries),
+                            "keyword_match_count": len(keyword_matches),
+                        },
+                    )
+                )
+
+    if not saw_successful_page:
+        return _live_result(
+            source_name="walla",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.HTTP_FETCH_FAILED,
+            checks=checks
+            or [
+                ProbeCheck(
+                    name="live_probe",
+                    status=DiagnosticStatus.FAIL,
+                    summary="All Walla archive fetches failed",
+                )
+            ],
+        )
+    if unexpected_redirect:
+        return _live_result(
+            source_name="walla",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.UNEXPECTED_REDIRECT,
+            checks=checks,
+        )
+    if entry_total == 0:
+        return _live_result(
+            source_name="walla",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.SELECTOR_DRIFT_SUSPECTED,
+            checks=checks,
+        )
+    if recent_entry_total == 0:
+        return _live_result(
+            source_name="walla",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.STALE_RESULTS,
+            checks=checks,
+        )
+    if keyword_match_total == 0:
+        return _live_result(
+            source_name="walla",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            checks=checks,
+        )
+
+    return _live_result(
+        source_name="walla",
+        status=DiagnosticStatus.OK,
+        checks=checks,
+    )
+
+
+async def _probe_haaretz(
+    *,
+    days: int,
+    sample_keywords: list[str],
+) -> SourceDiagnosticResult:
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    scraper = haaretz_source.HaaretzScraper(rate_limit_delay_seconds=0.0)
+    checks: list[ProbeCheck] = []
+    saw_successful_page = False
+    unexpected_redirect = False
+    entry_total = 0
+    recent_entry_total = 0
+    keyword_match_total = 0
+
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        headers={"User-Agent": haaretz_source.USER_AGENT},
+        follow_redirects=True,
+    ) as client:
+        for keyword in sample_keywords:
+            page_url = scraper._build_search_url(keyword, page_number=1)
+            try:
+                fetch_result = await _fetch_text(
+                    page_url,
+                    user_agent=haaretz_source.USER_AGENT,
+                    client=client,
+                )
+            except Exception as exc:
+                checks.append(
+                    ProbeCheck(
+                        name=f"search:{keyword}",
+                        status=DiagnosticStatus.FAIL,
+                        summary=f"Search fetch failed: {exc}",
+                        details={"url": page_url},
+                    )
+                )
+                continue
+
+            saw_successful_page = True
+            if _is_unexpected_redirect(fetch_result.final_url, page_url):
+                unexpected_redirect = True
+
+            title_tag = BeautifulSoup(fetch_result.text, "lxml").find("title")
+            page_title = title_tag.get_text(" ", strip=True) if title_tag is not None else ""
+            has_results_heading = "מציג תוצאות בנושא" in fetch_result.text
+            entries = scraper._parse_search_results(fetch_result.text)
+            recent_entries = [entry for entry in entries if entry.date >= cutoff]
+            keyword_matches = [
+                entry for entry in recent_entries if scraper._matches_keywords(entry, [keyword])
+            ]
+
+            entry_total += len(entries)
+            recent_entry_total += len(recent_entries)
+            keyword_match_total += len(keyword_matches)
+
+            if not has_results_heading and len(entries) == 0:
+                status = DiagnosticStatus.FAIL
+                summary = "Search page fetched but parsed zero entries"
+            elif len(entries) == 0:
+                status = DiagnosticStatus.FAIL
+                summary = "Search results container was present but parsed zero entries"
+            elif len(recent_entries) == 0:
+                status = DiagnosticStatus.WARN
+                summary = "Search page returned only out-of-window results"
+            elif len(keyword_matches) == 0:
+                status = DiagnosticStatus.WARN
+                summary = "Search page returned recent entries but none matched after filtering"
+            else:
+                status = DiagnosticStatus.OK
+                summary = "Search page returned recent keyword-matching entries"
+
+            checks.append(
+                ProbeCheck(
+                    name=f"search:{keyword}",
+                    status=status,
+                    summary=summary,
+                    details={
+                        "requested_url": page_url,
+                        "final_url": fetch_result.final_url,
+                        "status_code": fetch_result.status_code,
+                        "content_type": fetch_result.content_type,
+                        "payload_length": len(fetch_result.text),
+                        "page_title": page_title,
+                        "has_results_heading": has_results_heading,
+                        "entry_count": len(entries),
+                        "recent_entry_count": len(recent_entries),
+                        "keyword_match_count": len(keyword_matches),
+                    },
+                )
+            )
+
+    if not saw_successful_page:
+        return _live_result(
+            source_name="haaretz",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.HTTP_FETCH_FAILED,
+            checks=checks
+            or [
+                ProbeCheck(
+                    name="live_probe",
+                    status=DiagnosticStatus.FAIL,
+                    summary="All Haaretz search fetches failed",
+                )
+            ],
+        )
+    if unexpected_redirect:
+        return _live_result(
+            source_name="haaretz",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.UNEXPECTED_REDIRECT,
+            checks=checks,
+        )
+    if entry_total == 0:
+        return _live_result(
+            source_name="haaretz",
+            status=DiagnosticStatus.FAIL,
+            bucket=FailureBucket.SELECTOR_DRIFT_SUSPECTED,
+            checks=checks,
+        )
+    if recent_entry_total == 0:
+        return _live_result(
+            source_name="haaretz",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.STALE_RESULTS,
+            checks=checks,
+        )
+    if keyword_match_total == 0:
+        return _live_result(
+            source_name="haaretz",
+            status=DiagnosticStatus.WARN,
+            bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            checks=checks,
+        )
+
+    return _live_result(
+        source_name="haaretz",
         status=DiagnosticStatus.OK,
         checks=checks,
     )

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -697,7 +697,7 @@ async def _probe_mako(
 
             if html is None:
                 status = DiagnosticStatus.WARN
-                summary = "Search reached a terminal page but returned no rendered results"
+                summary = "Search reached Mako's not-found terminal state"
             elif len(parsed_articles) == 0:
                 status = DiagnosticStatus.WARN
                 summary = "Search page rendered but parsing returned zero articles"
@@ -716,6 +716,7 @@ async def _probe_mako(
                     details={
                         "requested_url": search_url,
                         "final_url": session.page.url,
+                        "terminal_state": "not_found" if html is None else "results",
                         "payload_length": len(html) if html is not None else 0,
                         "article_count": len(parsed_articles),
                         "article_urls": [str(article.url) for article in parsed_articles[:5]],

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import calendar
 import json
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
@@ -17,10 +18,10 @@ import httpx
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 
-import denbust.sources.ice as ice_source
 import denbust.sources.haaretz as haaretz_source
-import denbust.sources.mako as mako_source
+import denbust.sources.ice as ice_source
 import denbust.sources.maariv as maariv_source
+import denbust.sources.mako as mako_source
 import denbust.sources.rss as rss_source
 import denbust.sources.walla as walla_source
 from denbust.config import DEFAULT_KEYWORDS, Config, SourceConfig, load_config
@@ -785,10 +786,8 @@ async def _probe_mako(
                 )
             )
     finally:
-        try:
+        with suppress(Exception):
             await scraper._close_browser_session(session)
-        except Exception:
-            pass
 
     if unexpected_redirect:
         return _live_result(

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -279,9 +279,10 @@ def _build_source_summaries(
         error_map.setdefault(source_name, []).append(error)
 
     source_debug = {
-        source.name: source.get_debug_state()
+        source.name: debug_state
         for source in sources
-        if source.get_debug_state() is not None
+        for debug_state in [source.get_debug_state()]
+        if debug_state is not None
     }
 
     return [
@@ -447,11 +448,11 @@ def _build_ingest_debug_payload(
     rejected_articles = [
         article for article in classified_articles if not article.classification.relevant
     ]
-    source_runtime_debug = {
-        source.name: source.get_debug_state()
-        for source in sources
-        if source.get_debug_state() is not None
-    }
+    source_runtime_debug: dict[str, object] = {}
+    for source in sources:
+        debug_state = source.get_debug_state()
+        if debug_state is not None:
+            source_runtime_debug[source.name] = debug_state
     source_summaries = _build_source_summaries(
         sources=sources,
         source_names=source_names,

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -261,6 +261,7 @@ def _source_name_from_error(error: str) -> str | None:
 
 def _build_source_summaries(
     *,
+    sources: list[Source],
     source_names: list[str],
     raw_articles: list[RawArticle],
     errors: list[str],
@@ -277,6 +278,12 @@ def _build_source_summaries(
             continue
         error_map.setdefault(source_name, []).append(error)
 
+    source_debug = {
+        source.name: source.get_debug_state()
+        for source in sources
+        if source.get_debug_state() is not None
+    }
+
     return [
         {
             "source_name": source_name,
@@ -285,6 +292,7 @@ def _build_source_summaries(
             "error_messages": error_map.get(source_name, []),
             "returned_zero_results": article_counts.get(source_name, 0) == 0
             and source_name not in error_map,
+            "runtime_debug": source_debug.get(source_name),
         }
         for source_name in source_names
     ]
@@ -425,6 +433,7 @@ def _workflow_metadata() -> dict[str, object]:
 def _build_ingest_debug_payload(
     *,
     result: RunSnapshot,
+    sources: list[Source],
     source_names: list[str],
     raw_articles: list[RawArticle],
     unseen_articles: list[RawArticle],
@@ -438,7 +447,13 @@ def _build_ingest_debug_payload(
     rejected_articles = [
         article for article in classified_articles if not article.classification.relevant
     ]
+    source_runtime_debug = {
+        source.name: source.get_debug_state()
+        for source in sources
+        if source.get_debug_state() is not None
+    }
     source_summaries = _build_source_summaries(
+        sources=sources,
         source_names=source_names,
         raw_articles=raw_articles,
         errors=result.errors,
@@ -471,6 +486,7 @@ def _build_ingest_debug_payload(
             "seen_count_before": result.seen_count_before,
             "seen_count_after": result.seen_count_after,
         },
+        "source_runtime_debug": source_runtime_debug,
         "source_summaries": source_summaries,
         "classifier_summary": classifier_summary,
         "problems": problems,
@@ -552,6 +568,7 @@ async def run_news_ingest_job(
         result.set_debug_payload(
             _build_ingest_debug_payload(
                 result=result,
+                sources=sources,
                 source_names=source_names,
                 raw_articles=all_articles,
                 unseen_articles=unseen_articles,
@@ -570,6 +587,7 @@ async def run_news_ingest_job(
         result.set_debug_payload(
             _build_ingest_debug_payload(
                 result=result,
+                sources=sources,
                 source_names=source_names,
                 raw_articles=all_articles,
                 unseen_articles=unseen_articles,
@@ -599,6 +617,7 @@ async def run_news_ingest_job(
         result.set_debug_payload(
             _build_ingest_debug_payload(
                 result=result.finish("no relevant articles found"),
+                sources=sources,
                 source_names=source_names,
                 raw_articles=all_articles,
                 unseen_articles=unseen_articles,
@@ -636,6 +655,7 @@ async def run_news_ingest_job(
     result.set_debug_payload(
         _build_ingest_debug_payload(
             result=result,
+            sources=sources,
             source_names=source_names,
             raw_articles=all_articles,
             unseen_articles=unseen_articles,

--- a/src/denbust/sources/base.py
+++ b/src/denbust/sources/base.py
@@ -1,8 +1,7 @@
 """Base protocol for news sources."""
 
-from typing import Any
-
 from abc import ABC, abstractmethod
+from typing import Any
 
 from denbust.data_models import RawArticle
 

--- a/src/denbust/sources/base.py
+++ b/src/denbust/sources/base.py
@@ -1,5 +1,7 @@
 """Base protocol for news sources."""
 
+from typing import Any
+
 from abc import ABC, abstractmethod
 
 from denbust.data_models import RawArticle
@@ -26,3 +28,7 @@ class Source(ABC):
             List of raw articles matching the criteria.
         """
         ...
+
+    def get_debug_state(self) -> dict[str, Any] | None:
+        """Return optional structured runtime telemetry for debug logs."""
+        return None

--- a/src/denbust/sources/haaretz.py
+++ b/src/denbust/sources/haaretz.py
@@ -43,6 +43,14 @@ BLOCKED_RESOURCE_URL_FRAGMENTS = (
     "outbrain.com",
     "taboola.com",
 )
+HAARETZ_CONTEXTUAL_LIVUI_PHRASES = (
+    "נערות ליווי",
+    "שירותי ליווי",
+    "מכון ליווי",
+    "דירת ליווי",
+    "סוכנות ליווי",
+    "ליווי בזנות",
+)
 HAARETZ_MONTHS = {
     "ינואר": 1,
     "פברואר": 2,
@@ -368,14 +376,27 @@ class HaaretzScraper(Source):
     def _matches_keywords(self, entry: _HaaretzSearchEntry, keywords: list[str]) -> bool:
         """Check whether a Haaretz search result matches any monitored keyword."""
         haystack = f"{entry.title} {entry.snippet}".casefold()
-        return any(keyword.casefold() in haystack for keyword in keywords)
+        for keyword in keywords:
+            normalized_keyword = keyword.casefold()
+            if normalized_keyword == "ליווי":
+                if any(phrase.casefold() in haystack for phrase in HAARETZ_CONTEXTUAL_LIVUI_PHRASES):
+                    return True
+                continue
+            if normalized_keyword in haystack:
+                return True
+        return False
 
     def _is_article_url(self, url: str) -> bool:
         """Check whether a normalized URL points to an internal Haaretz article."""
         parsed = urlsplit(url)
         if parsed.netloc not in {"www.haaretz.co.il", "haaretz.co.il"}:
             return False
-        if "/labels/" in parsed.path or "/promotion" in parsed.path or "/account/" in parsed.path:
+        if (
+            "/labels/" in parsed.path
+            or "/promotion" in parsed.path
+            or "/account/" in parsed.path
+            or "/talkback/" in parsed.path
+        ):
             return False
         return "/ty-article" in parsed.path
 

--- a/src/denbust/sources/haaretz.py
+++ b/src/denbust/sources/haaretz.py
@@ -379,7 +379,9 @@ class HaaretzScraper(Source):
         for keyword in keywords:
             normalized_keyword = keyword.casefold()
             if normalized_keyword == "ליווי":
-                if any(phrase.casefold() in haystack for phrase in HAARETZ_CONTEXTUAL_LIVUI_PHRASES):
+                if any(
+                    phrase.casefold() in haystack for phrase in HAARETZ_CONTEXTUAL_LIVUI_PHRASES
+                ):
                     return True
                 continue
             if normalized_keyword in haystack:

--- a/src/denbust/sources/maariv.py
+++ b/src/denbust/sources/maariv.py
@@ -22,6 +22,8 @@ USER_AGENT = "denbust/0.1.0 (news monitoring bot; +https://github.com/denbust)"
 MAARIV_BASE_URL = "https://www.maariv.co.il"
 # Law/crime section
 MAARIV_LAW_URL = "https://www.maariv.co.il/news/law"
+# Breaking-news index
+MAARIV_BREAKING_NEWS_URL = "https://www.maariv.co.il/breaking-news"
 # Search URL
 MAARIV_SEARCH_URL = "https://www.maariv.co.il/search"
 MAARIV_SUPPLEMENTAL_KEYWORDS = [
@@ -34,6 +36,7 @@ MAARIV_SUPPLEMENTAL_KEYWORDS = [
     "סחר מיני",
     "מכון עיסוי",
 ]
+TIME_PATTERN = re.compile(r"(\d{1,2}):(\d{2})")
 
 
 def effective_maariv_keywords(keywords: list[str]) -> list[str]:
@@ -95,10 +98,13 @@ class MaarivScraper(Source):
         ) as client:
             self._client = client
 
-            # Scrape the law section (search endpoint is broken, returns 404)
-            await asyncio.sleep(1.5)  # Rate limiting
-            section_articles = await self._scrape_section(MAARIV_LAW_URL, cutoff, keywords)
-            articles.extend(section_articles)
+            # Scrape the law section and breaking-news index.
+            # Maariv's search endpoint currently returns 404 for relevant queries,
+            # so section discovery is the only reliable path.
+            for section_url in (MAARIV_LAW_URL, MAARIV_BREAKING_NEWS_URL):
+                await asyncio.sleep(1.5)  # Rate limiting
+                section_articles = await self._scrape_section(section_url, cutoff, keywords)
+                articles.extend(section_articles)
 
             self._client = None
 
@@ -158,7 +164,7 @@ class MaarivScraper(Source):
         try:
             response = await self._client.get(url)
             response.raise_for_status()
-            return self._parse_section_page(response.text, cutoff, keywords)
+            return self._parse_section_page(response.text, cutoff, keywords, source_url=url)
         except httpx.HTTPError as e:
             logger.error(f"Error scraping Maariv section {url}: {e}")
             return []
@@ -185,7 +191,11 @@ class MaarivScraper(Source):
         return articles
 
     def _parse_section_page(
-        self, html: str, cutoff: datetime, keywords: list[str]
+        self,
+        html: str,
+        cutoff: datetime,
+        keywords: list[str],
+        source_url: str | None = None,
     ) -> list[RawArticle]:
         """Parse Maariv section page HTML.
 
@@ -200,13 +210,18 @@ class MaarivScraper(Source):
         soup = BeautifulSoup(html, "lxml")
         articles: list[RawArticle] = []
 
-        # Look for article containers - Maariv uses article.category-article
-        for item in soup.select("article.category-article, article, .article"):
+        for item in soup.select(self._section_item_selector(source_url)):
             article = self._parse_article_item(item, cutoff)
             if article and self._matches_keywords(article, keywords):
                 articles.append(article)
 
         return articles
+
+    def _section_item_selector(self, source_url: str | None = None) -> str:
+        """Return a targeted article-card selector for the section page."""
+        if source_url and "/breaking-news" in source_url:
+            return "article.breaking-news-item"
+        return "article.category-article, article.main-article, article.article"
 
     def _parse_article_item(self, item: Tag, cutoff: datetime) -> RawArticle | None:
         """Parse a single article item from HTML.
@@ -241,8 +256,18 @@ class MaarivScraper(Source):
             return None
 
         # Get title
-        title_elem = item.select_one("h1, h2, h3, .title, .headline")
-        title = title_elem.get_text(strip=True) if title_elem else link.get_text(strip=True)
+        title_elem = item.select_one(
+            "h1, h2, h3, .title, .headline, .category-article-title"
+        )
+        title = ""
+        if title_elem:
+            title = title_elem.get_text(" ", strip=True)
+        if not title:
+            title_attr = str(link.get("title", "")).strip()
+            if title_attr:
+                title = title_attr
+        if not title:
+            title = link.get_text(" ", strip=True)
 
         if not title:
             return None
@@ -282,12 +307,20 @@ class MaarivScraper(Source):
             dt_attr = date_elem.get("datetime")
             if dt_attr:
                 try:
-                    return datetime.fromisoformat(str(dt_attr).replace("Z", "+00:00"))
+                    parsed = datetime.fromisoformat(str(dt_attr).replace("Z", "+00:00"))
+                    date_text = date_elem.get_text(" ", strip=True)
+                    time_match = TIME_PATTERN.search(date_text)
+                    if time_match and parsed.hour == 0 and parsed.minute == 0:
+                        return parsed.replace(
+                            hour=int(time_match.group(1)),
+                            minute=int(time_match.group(2)),
+                        )
+                    return parsed
                 except ValueError:
                     pass
 
             # Try text content
-            date_text = date_elem.get_text(strip=True)
+            date_text = date_elem.get_text(" ", strip=True)
             date = self._parse_hebrew_date(date_text)
             if date:
                 return date

--- a/src/denbust/sources/maariv.py
+++ b/src/denbust/sources/maariv.py
@@ -256,9 +256,7 @@ class MaarivScraper(Source):
             return None
 
         # Get title
-        title_elem = item.select_one(
-            "h1, h2, h3, .title, .headline, .category-article-title"
-        )
+        title_elem = item.select_one("h1, h2, h3, .title, .headline, .category-article-title")
         title = ""
         if title_elem:
             title = title_elem.get_text(" ", strip=True)

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -292,7 +292,7 @@ class MakoScraper(Source):
             raise
 
         state = (
-            "empty"
+            "not_found"
             if html is None
             else self._classify_search_page(self._get_page_url(page, search_url), title, html)[0]
         )

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -116,11 +116,16 @@ class MakoScraper(Source):
         """Initialize Mako scraper."""
         self._name = "mako"
         self._rate_limit_delay_seconds = rate_limit_delay_seconds
+        self._debug_state: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
         """Return the source name."""
         return self._name
+
+    def get_debug_state(self) -> dict[str, Any] | None:
+        """Return structured runtime telemetry for debug logs."""
+        return self._debug_state or None
 
     async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
         """Fetch articles from Mako, filtering by date and keywords.
@@ -136,12 +141,22 @@ class MakoScraper(Source):
 
         articles: list[RawArticle] = []
         cutoff = datetime.now(UTC) - timedelta(days=days)
+        self._reset_debug_state(days=days, keywords=keywords)
 
         try:
             session = await self._open_browser_session()
+            self._debug_state["browser_session"] = {
+                "status": "ok",
+                "headless": True,
+                "user_agent": USER_AGENT,
+            }
         except Exception as e:
+            self._debug_state["browser_session"] = {
+                "status": "error",
+                "error": str(e),
+            }
             logger.exception("Mako browser session could not be opened: %s", e)
-            return []
+            raise RuntimeError(f"Mako browser session could not be opened: {e}") from e
 
         try:
             for keyword in keywords:
@@ -180,7 +195,27 @@ class MakoScraper(Source):
                 unique.append(article)
 
         logger.info("Found %s unique articles from Mako", len(unique))
+        self._debug_state["result"] = {
+            "raw_article_count": len(articles),
+            "unique_article_count": len(unique),
+        }
         return unique
+
+    def _reset_debug_state(self, *, days: int, keywords: list[str]) -> None:
+        """Reset per-fetch runtime telemetry."""
+        self._debug_state = {
+            "days": days,
+            "keywords": list(keywords),
+            "browser_session": {"status": "pending"},
+            "searches": [],
+            "sections": [],
+        }
+
+    def _append_debug_entry(self, key: str, entry: dict[str, Any]) -> None:
+        """Append a telemetry entry under a list-valued key."""
+        bucket = self._debug_state.setdefault(key, [])
+        if isinstance(bucket, list):
+            bucket.append(entry)
 
     async def _rate_limit(self) -> None:
         """Sleep between Mako requests unless disabled for tests."""
@@ -239,18 +274,75 @@ class MakoScraper(Source):
         self, session: _BrowserSession, keyword: str, cutoff: datetime
     ) -> list[RawArticle]:
         """Search Mako for a specific keyword."""
-        html = await self._fetch_search_html(session, keyword)
-        if not html:
-            return []
+        search_url = self._build_search_url(keyword)
+        try:
+            html = await self._fetch_search_html(session, keyword)
+            title = await session.page.title()
+        except Exception as exc:
+            self._append_debug_entry(
+                "searches",
+                {
+                    "keyword": keyword,
+                    "requested_url": search_url,
+                    "status": "error",
+                    "error": str(exc),
+                },
+            )
+            raise
 
-        return self._parse_search_results(html, cutoff)
+        state = "empty" if html is None else self._classify_search_page(session.page.url, title, html)[0]
+        parsed_articles = self._parse_search_results(html, cutoff) if html else []
+        self._append_debug_entry(
+            "searches",
+            {
+                "keyword": keyword,
+                "requested_url": search_url,
+                "final_url": session.page.url,
+                "page_title": title,
+                "terminal_state": state,
+                "html_present": html is not None,
+                "payload_length": len(html) if html is not None else 0,
+                "parsed_article_count": len(parsed_articles),
+                "article_urls": [str(article.url) for article in parsed_articles[:5]],
+            },
+        )
+        return parsed_articles
 
     async def _scrape_section(
         self, session: _BrowserSession, url: str, cutoff: datetime, keywords: list[str]
     ) -> list[RawArticle]:
         """Scrape a Mako section page."""
-        html = await self._fetch_section_html(session, url)
-        return self._parse_section_page(html, cutoff, keywords)
+        try:
+            html = await self._fetch_section_html(session, url)
+            title = await session.page.title()
+        except Exception as exc:
+            self._append_debug_entry(
+                "sections",
+                {
+                    "requested_url": url,
+                    "status": "error",
+                    "error": str(exc),
+                },
+            )
+            raise
+
+        soup = BeautifulSoup(html, "lxml")
+        container_count = len(soup.select("article, .article, .item, li"))
+        parsed_articles = self._parse_section_page(html, cutoff, keywords)
+        self._append_debug_entry(
+            "sections",
+            {
+                "requested_url": url,
+                "final_url": session.page.url,
+                "page_title": title,
+                "status": "ok",
+                "payload_length": len(html),
+                "container_count": container_count,
+                "parsed_article_count": len(parsed_articles),
+                "article_urls": [str(article.url) for article in parsed_articles[:5]],
+            },
+        )
+        return parsed_articles
 
     async def _fetch_search_html(self, session: _BrowserSession, keyword: str) -> str | None:
         """Fetch rendered search page HTML via Playwright."""

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -290,7 +290,11 @@ class MakoScraper(Source):
             )
             raise
 
-        state = "empty" if html is None else self._classify_search_page(session.page.url, title, html)[0]
+        state = (
+            "empty"
+            if html is None
+            else self._classify_search_page(session.page.url, title, html)[0]
+        )
         parsed_articles = self._parse_search_results(html, cutoff) if html else []
         self._append_debug_entry(
             "searches",

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -275,9 +275,10 @@ class MakoScraper(Source):
     ) -> list[RawArticle]:
         """Search Mako for a specific keyword."""
         search_url = self._build_search_url(keyword)
+        page = getattr(session, "page", None)
         try:
             html = await self._fetch_search_html(session, keyword)
-            title = await session.page.title()
+            title = await self._get_page_title(page)
         except Exception as exc:
             self._append_debug_entry(
                 "searches",
@@ -293,7 +294,7 @@ class MakoScraper(Source):
         state = (
             "empty"
             if html is None
-            else self._classify_search_page(session.page.url, title, html)[0]
+            else self._classify_search_page(self._get_page_url(page, search_url), title, html)[0]
         )
         parsed_articles = self._parse_search_results(html, cutoff) if html else []
         self._append_debug_entry(
@@ -301,7 +302,7 @@ class MakoScraper(Source):
             {
                 "keyword": keyword,
                 "requested_url": search_url,
-                "final_url": session.page.url,
+                "final_url": self._get_page_url(page, search_url),
                 "page_title": title,
                 "terminal_state": state,
                 "html_present": html is not None,
@@ -316,9 +317,10 @@ class MakoScraper(Source):
         self, session: _BrowserSession, url: str, cutoff: datetime, keywords: list[str]
     ) -> list[RawArticle]:
         """Scrape a Mako section page."""
+        page = getattr(session, "page", None)
         try:
             html = await self._fetch_section_html(session, url)
-            title = await session.page.title()
+            title = await self._get_page_title(page)
         except Exception as exc:
             self._append_debug_entry(
                 "sections",
@@ -337,7 +339,7 @@ class MakoScraper(Source):
             "sections",
             {
                 "requested_url": url,
-                "final_url": session.page.url,
+                "final_url": self._get_page_url(page, url),
                 "page_title": title,
                 "status": "ok",
                 "payload_length": len(html),
@@ -347,6 +349,21 @@ class MakoScraper(Source):
             },
         )
         return parsed_articles
+
+    @staticmethod
+    def _get_page_url(page: object | None, fallback: str) -> str:
+        """Return the current browser URL when available."""
+        url = getattr(page, "url", None)
+        return url if isinstance(url, str) and url else fallback
+
+    @staticmethod
+    async def _get_page_title(page: object | None) -> str:
+        """Return the current browser title when available."""
+        title_method = getattr(page, "title", None)
+        if callable(title_method):
+            title = await title_method()
+            return title if isinstance(title, str) else ""
+        return ""
 
     async def _fetch_search_html(self, session: _BrowserSession, keyword: str) -> str | None:
         """Fetch rendered search page HTML via Playwright."""

--- a/src/denbust/sources/rss.py
+++ b/src/denbust/sources/rss.py
@@ -259,7 +259,7 @@ def create_ynet_source() -> RSSSource:
     """Create Ynet RSS source."""
     return RSSSource(
         source_name="ynet",
-        feed_url="https://www.ynet.co.il/Integration/StoryRss2.xml",
+        feed_url="https://www.ynet.co.il/Integration/StoryRss190.xml",
     )
 
 

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup, Tag
 from httpx import Response
 
 from denbust.data_models import RawArticle
-from denbust.sources.haaretz import HaaretzScraper, create_haaretz_source
+from denbust.sources.haaretz import _HaaretzSearchEntry, HaaretzScraper, create_haaretz_source
 from denbust.sources.ice import IceScraper, create_ice_source
 from denbust.sources.maariv import MaarivScraper, create_maariv_source
 from denbust.sources.mako import SEARCH_POLL_INTERVAL_MS, MakoScraper, create_mako_source
@@ -172,6 +172,53 @@ class TestMakoScraper:
         assert len(urls) == len(set(urls))
 
     @pytest.mark.asyncio
+    async def test_fetch_records_runtime_debug_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fetch should retain per-search and per-section telemetry for debug logs."""
+        html_content = load_fixture("html/mako_search.html")
+        scraper = self._create_scraper()
+
+        class FakePage:
+            def __init__(self) -> None:
+                self.url = "https://www.mako.co.il/Search?searchstring_input=%D7%A1%D7%A8%D7%A1%D7%95%D7%A8"
+
+            async def title(self) -> str:
+                return "mako חדשות"
+
+        session = SimpleNamespace(page=FakePage())
+
+        async def open_browser_session() -> object:
+            return session
+
+        async def close_browser_session(_session: object) -> None:
+            return None
+
+        async def fetch_search_html(_session: object, keyword: str) -> str:
+            session.page.url = f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+            return html_content
+
+        async def fetch_section_html(_session: object, url: str) -> str:
+            session.page.url = url
+            return html_content
+
+        monkeypatch.setattr(scraper, "_open_browser_session", open_browser_session)
+        monkeypatch.setattr(scraper, "_close_browser_session", close_browser_session)
+        monkeypatch.setattr(scraper, "_fetch_search_html", fetch_search_html)
+        monkeypatch.setattr(scraper, "_fetch_section_html", fetch_section_html)
+
+        await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=["סרסור"])
+
+        debug_state = scraper.get_debug_state()
+
+        assert debug_state is not None
+        assert debug_state["browser_session"]["status"] == "ok"
+        assert debug_state["result"]["unique_article_count"] == 2
+        assert len(debug_state["searches"]) == 1
+        assert debug_state["searches"][0]["keyword"] == "סרסור"
+        assert debug_state["searches"][0]["parsed_article_count"] >= 1
+        assert len(debug_state["sections"]) == 1
+        assert debug_state["sections"][0]["requested_url"] == "https://www.mako.co.il/men-men_news"
+
+    @pytest.mark.asyncio
     async def test_fetch_uses_only_canonical_search_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -207,7 +254,7 @@ class TestMakoScraper:
 
     @pytest.mark.asyncio
     async def test_handles_browser_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test browser failures are handled gracefully."""
+        """Browser session failures should surface as source errors."""
         scraper = self._create_scraper()
 
         async def open_browser_session() -> object:
@@ -215,9 +262,8 @@ class TestMakoScraper:
 
         monkeypatch.setattr(scraper, "_open_browser_session", open_browser_session)
 
-        articles = await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=["סרסור"])
-
-        assert articles == []
+        with pytest.raises(RuntimeError, match="Mako browser session could not be opened"):
+            await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=["סרסור"])
 
     @pytest.mark.asyncio
     async def test_fetch_logs_cleanup_failure_and_keeps_articles(
@@ -1651,6 +1697,28 @@ class TestHaaretzScraper:
         assert not scraper._is_article_url(
             "https://www.haaretz.co.il/labels/2026-03-15/ty-article/abc"
         )
+        assert not scraper._is_article_url(
+            "https://www.haaretz.co.il/talkback/2026-03-15/ty-article/abc"
+        )
+
+    def test_matches_keywords_requires_context_for_bare_livui(self) -> None:
+        """Bare 'ליווי' should only match explicit sex-work phrases."""
+        scraper = self._create_scraper()
+        false_positive = _HaaretzSearchEntry(
+            url="https://www.haaretz.co.il/news/politics/2026-04-06/ty-article/.premium/abc",
+            title="מתנחלים הקימו מאחז חדש בצפון הגדה - בליווי חיילים",
+            snippet="כתבה פוליטית כללית.",
+            date=datetime(2026, 4, 6, tzinfo=UTC),
+        )
+        true_positive = _HaaretzSearchEntry(
+            url="https://www.haaretz.co.il/news/law/2026-04-06/ty-article/.premium/def",
+            title="המשטרה חשפה שירותי ליווי בדירה בתל אביב",
+            snippet="חשד להפעלת זנות במקום.",
+            date=datetime(2026, 4, 6, tzinfo=UTC),
+        )
+
+        assert not scraper._matches_keywords(false_positive, ["ליווי"])
+        assert scraper._matches_keywords(true_positive, ["ליווי"])
 
     @pytest.mark.asyncio
     async def test_rate_limit_sleeps_when_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2900,6 +2968,41 @@ class TestMaarivScraper:
 
         assert len(articles) == 1
 
+    def test_parse_breaking_news_page_keeps_matching_articles(self) -> None:
+        """Breaking-news parsing should retain relevant cards from the index page."""
+        scraper = MaarivScraper()
+        html = """
+        <article class="breaking-news-item">
+          <a class="breaking-news-link" href="/breaking-news/article-1305266"></a>
+          <h2 class="breaking-news-title">בלב שכונת אחוזה: שוטרים חשפו בית בושת שפעל בדירה בחיפה</h2>
+          <p>במקום הוצא צו סגירה.</p>
+          <time datetime="2026-04-05T10:52:00+03:00">10:52</time>
+        </article>
+        """
+
+        articles = scraper._parse_section_page(
+            html,
+            cutoff=datetime(2026, 4, 1, tzinfo=UTC),
+            keywords=["בית בושת"],
+            source_url="https://www.maariv.co.il/breaking-news",
+        )
+
+        assert len(articles) == 1
+        assert str(articles[0].url) == "https://www.maariv.co.il/breaking-news/article-1305266"
+        assert articles[0].title == "בלב שכונת אחוזה: שוטרים חשפו בית בושת שפעל בדירה בחיפה"
+
+    def test_section_item_selector_prefers_breaking_news_cards(self) -> None:
+        """Breaking-news pages should use a narrow card selector instead of generic wrappers."""
+        scraper = MaarivScraper()
+
+        assert (
+            scraper._section_item_selector("https://www.maariv.co.il/breaking-news")
+            == "article.breaking-news-item"
+        )
+        assert "category-article" in scraper._section_item_selector(
+            "https://www.maariv.co.il/news/law"
+        )
+
     def test_parse_section_page_keeps_source_specific_relaxed_matches(self) -> None:
         """Maariv supplemental phrases should recover relevant enforcement stories."""
         scraper = MaarivScraper()
@@ -3021,6 +3124,33 @@ class TestMaarivScraper:
         )
         assert no_date is not None
 
+    def test_parse_article_item_uses_link_title_and_clean_time_markup(self) -> None:
+        """Live-like Maariv cards should keep title clean and preserve visible publish time."""
+        scraper = MaarivScraper()
+        article = scraper._parse_article_item(
+            BeautifulSoup(
+                """
+                <article class="category-article main-article">
+                  <a class="category-article-link" href="/news/law/article-1307154"
+                     title="כתב אישום הוגש נגד תושב ג'לג'וליה על אונס נער בן 14">
+                    <p class="category-article-title">כתב אישום הוגש נגד תושב ג'לג'וליה על אונס נער בן 14</p>
+                    <section class="category-article-dates-and-promo">
+                      <time class="category-article-time" datetime="2026-04-10T00:00:00+03:00">10:35</time>
+                    </section>
+                  </a>
+                </article>
+                """,
+                "lxml",
+            ).select_one("article"),
+            datetime(2026, 4, 1, tzinfo=UTC),
+        )
+
+        assert article is not None
+        assert article.title == "כתב אישום הוגש נגד תושב ג'לג'וליה על אונס נער בן 14"
+        assert article.date.date().isoformat() == "2026-04-10"
+        assert article.date.hour == 10
+        assert article.date.minute == 35
+
     def test_parse_date_prefers_datetime_attribute(self) -> None:
         """ISO datetime attributes should be parsed directly."""
         scraper = MaarivScraper()
@@ -3032,6 +3162,18 @@ class TestMaarivScraper:
         parsed = scraper._parse_date(soup.select_one("article"))
 
         assert parsed == datetime(2026, 3, 1, 10, 0, tzinfo=UTC)
+
+    def test_parse_date_combines_datetime_attribute_with_visible_time(self) -> None:
+        """Visible time should refine date-only datetime attributes on section cards."""
+        scraper = MaarivScraper()
+        soup = BeautifulSoup(
+            '<article><time class="category-article-time" datetime="2026-04-10T00:00:00+03:00">10:35</time></article>',
+            "lxml",
+        )
+
+        parsed = scraper._parse_date(soup.select_one("article"))
+
+        assert parsed == datetime(2026, 4, 10, 10, 35, tzinfo=parsed.tzinfo)
 
     def test_parse_date_handles_invalid_datetime_and_text_fallback(self) -> None:
         """Date parsing should fall back from invalid datetime attrs to visible text."""
@@ -3121,11 +3263,55 @@ class TestMaarivScraper:
             == []
         )
 
+    @pytest.mark.asyncio
+    async def test_fetch_scrapes_law_and_breaking_news_sections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Maariv fetch should query both law and breaking-news discovery pages."""
+        scraper = MaarivScraper()
+        seen_urls: list[str] = []
+
+        async def fake_scrape_section(
+            url: str, cutoff: datetime, keywords: list[str]
+        ) -> list[RawArticle]:
+            del cutoff
+            assert keywords == ["בית בושת"]
+            seen_urls.append(url)
+            if url.endswith("/breaking-news"):
+                return [
+                    RawArticle(
+                        url="https://www.maariv.co.il/breaking-news/article-1305266",
+                        title="בלב שכונת אחוזה: שוטרים חשפו בית בושת שפעל בדירה בחיפה",
+                        snippet="במקום הוצא צו סגירה.",
+                        date=datetime(2026, 4, 5, 10, 52, tzinfo=UTC),
+                        source_name="maariv",
+                    )
+                ]
+            return []
+
+        async def fake_sleep(seconds: float) -> None:
+            assert seconds == 1.5
+
+        monkeypatch.setattr(scraper, "_scrape_section", fake_scrape_section)
+        monkeypatch.setattr("denbust.sources.maariv.asyncio.sleep", fake_sleep)
+
+        articles = await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=["בית בושת"])
+
+        assert seen_urls == [
+            "https://www.maariv.co.il/news/law",
+            "https://www.maariv.co.il/breaking-news",
+        ]
+        assert len(articles) == 1
+        assert str(articles[0].url) == "https://www.maariv.co.il/breaking-news/article-1305266"
+
     @respx.mock
     @pytest.mark.asyncio
     async def test_handles_empty_results(self) -> None:
         """Test handling empty search results."""
         respx.get("https://www.maariv.co.il/news/law").mock(
+            return_value=Response(200, text="<html><body></body></html>")
+        )
+        respx.get("https://www.maariv.co.il/breaking-news").mock(
             return_value=Response(200, text="<html><body></body></html>")
         )
         respx.get("https://www.maariv.co.il/search").mock(
@@ -3142,6 +3328,7 @@ class TestMaarivScraper:
     async def test_handles_http_error(self) -> None:
         """Test handling HTTP errors gracefully."""
         respx.get("https://www.maariv.co.il/news/law").mock(return_value=Response(500))
+        respx.get("https://www.maariv.co.il/breaking-news").mock(return_value=Response(500))
         respx.get("https://www.maariv.co.il/search").mock(return_value=Response(404))
 
         scraper = MaarivScraper()

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -3153,7 +3153,29 @@ class TestMaarivScraper:
         assert article.title == "כתב אישום הוגש נגד תושב ג'לג'וליה על אונס נער בן 14"
         assert article.date.date().isoformat() == "2026-04-10"
         assert article.date.hour == 10
-        assert article.date.minute == 35
+
+    def test_parse_article_item_uses_link_title_when_heading_missing(self) -> None:
+        """Link title should be used when no dedicated heading element exists."""
+        scraper = MaarivScraper()
+        article = scraper._parse_article_item(
+            BeautifulSoup(
+                """
+                <article class="category-article">
+                  <a class="category-article-link"
+                     href="/breaking-news/article-1305266"
+                     title="בלב שכונת אחוזה: שוטרים חשפו בית בושת שפעל בדירה בחיפה">
+                    <time datetime="2026-04-05T10:52:00+03:00">10:52</time>
+                  </a>
+                </article>
+                """,
+                "lxml",
+            ).select_one("article"),
+            datetime(2026, 4, 1, tzinfo=UTC),
+        )
+
+        assert article is not None
+        assert article.title == "בלב שכונת אחוזה: שוטרים חשפו בית בושת שפעל בדירה בחיפה"
+        assert article.date.minute == 52
 
     def test_parse_date_prefers_datetime_attribute(self) -> None:
         """ISO datetime attributes should be parsed directly."""

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -14,7 +14,11 @@ from bs4 import BeautifulSoup, Tag
 from httpx import Response
 
 from denbust.data_models import RawArticle
-from denbust.sources.haaretz import _HaaretzSearchEntry, HaaretzScraper, create_haaretz_source
+from denbust.sources.haaretz import (
+    HaaretzScraper,
+    _HaaretzSearchEntry,
+    create_haaretz_source,
+)
 from denbust.sources.ice import IceScraper, create_ice_source
 from denbust.sources.maariv import MaarivScraper, create_maariv_source
 from denbust.sources.mako import SEARCH_POLL_INTERVAL_MS, MakoScraper, create_mako_source

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -223,6 +223,41 @@ class TestMakoScraper:
         assert debug_state["sections"][0]["requested_url"] == "https://www.mako.co.il/men-men_news"
 
     @pytest.mark.asyncio
+    async def test_fetch_records_not_found_terminal_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A Mako not-found search should be recorded explicitly in runtime telemetry."""
+        scraper = self._create_scraper()
+        session = SimpleNamespace(page=SimpleNamespace(url="https://www.mako.co.il/not-found"))
+
+        async def open_browser_session() -> object:
+            return session
+
+        async def close_browser_session(_session: object) -> None:
+            return None
+
+        async def fetch_search_html(_session: object, keyword: str) -> None:
+            session.page.url = f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+            return None
+
+        async def fetch_section_html(_session: object, url: str) -> str:
+            session.page.url = url
+            return "<html></html>"
+
+        monkeypatch.setattr(scraper, "_open_browser_session", open_browser_session)
+        monkeypatch.setattr(scraper, "_close_browser_session", close_browser_session)
+        monkeypatch.setattr(scraper, "_fetch_search_html", fetch_search_html)
+        monkeypatch.setattr(scraper, "_fetch_section_html", fetch_section_html)
+
+        await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=["זנות"])
+
+        debug_state = scraper.get_debug_state()
+
+        assert debug_state is not None
+        assert debug_state["searches"][0]["terminal_state"] == "not_found"
+        assert debug_state["searches"][0]["html_present"] is False
+
+    @pytest.mark.asyncio
     async def test_fetch_uses_only_canonical_search_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -91,15 +91,25 @@ def build_unified_item(url: str = "https://example.com/article") -> UnifiedItem:
 class FakeSource:
     """Simple async source stub."""
 
-    def __init__(self, name: str, fetch_result: list[RawArticle] | Exception) -> None:
+    def __init__(
+        self,
+        name: str,
+        fetch_result: list[RawArticle] | Exception,
+        *,
+        debug_state: dict[str, object] | None = None,
+    ) -> None:
         self.name = name
         self._fetch_result = fetch_result
+        self._debug_state = debug_state
 
     async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
         del days, keywords
         if isinstance(self._fetch_result, Exception):
             raise self._fetch_result
         return self._fetch_result
+
+    def get_debug_state(self) -> dict[str, object] | None:
+        return self._debug_state
 
 
 class TestSetupLogging:
@@ -231,6 +241,15 @@ class TestFetchAndClassifyHelpers:
     def test_machine_debug_helpers_flag_source_errors_and_zero_results(self) -> None:
         """Machine-oriented summaries should expose source errors and zero-result sources."""
         source_summaries = _build_source_summaries(
+            sources=[
+                FakeSource(
+                    "mako",
+                    [],
+                    debug_state={"searches": [{"keyword": "בית בושת", "status": "ok"}]},
+                ),
+                FakeSource("haaretz", []),
+                FakeSource("ice", []),
+            ],
             source_names=["mako", "haaretz", "ice"],
             raw_articles=[build_raw_article("https://example.com/one")],
             errors=["mako: timeout", "plain warning without source prefix"],
@@ -259,6 +278,9 @@ class TestFetchAndClassifyHelpers:
 
         assert source_summaries[0]["source_name"] == "mako"
         assert source_summaries[0]["had_error"] is True
+        assert source_summaries[0]["runtime_debug"] == {
+            "searches": [{"keyword": "בית בושת", "status": "ok"}]
+        }
         assert source_summaries[1]["source_name"] == "haaretz"
         assert source_summaries[1]["returned_zero_results"] is True
         assert source_summaries[2]["source_name"] == "ice"
@@ -493,7 +515,11 @@ class TestRunPipelineAsync:
         classifier.classify_batch = AsyncMock(
             return_value=[build_classified_article("https://example.com/rejected", relevant=False)]
         )
-        source = type("SourceStub", (), {"name": "test"})()
+        source = type(
+            "SourceStub",
+            (),
+            {"name": "test", "get_debug_state": lambda self: {"phase": "fetch", "status": "ok"}},
+        )()
         monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [source])
         monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
         monkeypatch.setattr("denbust.pipeline.create_deduplicator", fake_create_deduplicator)
@@ -510,11 +536,18 @@ class TestRunPipelineAsync:
         assert result.debug_payload is not None
         assert result.debug_payload["schema_version"] == "news_items.ingest.debug.v1"
         assert result.debug_payload["counts"]["unseen_article_count"] == 1
+        assert result.debug_payload["source_runtime_debug"] == {
+            "test": {"phase": "fetch", "status": "ok"}
+        }
         assert result.debug_payload["classifier_summary"]["rejected_article_count"] == 1
         assert result.debug_payload["problems"]["all_unseen_rejected"] is True
         assert "all_unseen_rejected" in result.debug_payload["suspicions"]
         assert result.debug_payload["source_summaries"][0]["source_name"] == "test"
         assert result.debug_payload["source_summaries"][0]["raw_article_count"] == 1
+        assert result.debug_payload["source_summaries"][0]["runtime_debug"] == {
+            "phase": "fetch",
+            "status": "ok",
+        }
         rejected = result.debug_payload["rejected_articles"]
         assert len(rejected) == 1
         assert rejected[0]["canonical_url"] == "https://example.com/rejected"
@@ -525,6 +558,7 @@ class TestRunPipelineAsync:
     ) -> None:
         """Incomplete classifier output should not emit the all-unseen-rejected signal."""
         source_summaries = _build_source_summaries(
+            sources=[FakeSource("mako", [])],
             source_names=["mako"],
             raw_articles=[],
             errors=[],

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -553,8 +553,52 @@ class TestRunPipelineAsync:
         }
         rejected = result.debug_payload["rejected_articles"]
         assert len(rejected) == 1
-        assert rejected[0]["canonical_url"] == "https://example.com/rejected"
-        assert rejected[0]["relevant"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_pipeline_async_calls_get_debug_state_once_per_payload_site(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per payload site, debug state should be captured once and reused."""
+
+        def fake_create_deduplicator(*, threshold: float) -> MagicMock:
+            del threshold
+            return MagicMock()
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        unseen_article = build_raw_article("https://example.com/rejected")
+        seen_store = MagicMock(count=4)
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[build_classified_article("https://example.com/rejected", relevant=False)]
+        )
+
+        class SourceStub:
+            name = "test"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def get_debug_state(self) -> dict[str, int]:
+                self.calls += 1
+                return {"call": self.calls}
+
+        source = SourceStub()
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [source])
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", fake_create_deduplicator)
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline.fetch_all_sources",
+            AsyncMock(return_value=([unseen_article], [])),
+        )
+        monkeypatch.setattr("denbust.pipeline.filter_seen", lambda articles, _seen_store: articles)
+
+        result = await run_pipeline_async(Config(max_articles=5), days=3)
+
+        assert result.debug_payload is not None
+        assert source.calls == 2
+        assert result.debug_payload["source_runtime_debug"] == {"test": {"call": 1}}
+        assert result.debug_payload["source_summaries"][0]["runtime_debug"] == {"call": 2}
 
     def test_machine_debug_helpers_do_not_flag_all_unseen_rejected_on_classification_anomaly(
         self,

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -515,11 +515,14 @@ class TestRunPipelineAsync:
         classifier.classify_batch = AsyncMock(
             return_value=[build_classified_article("https://example.com/rejected", relevant=False)]
         )
-        source = type(
-            "SourceStub",
-            (),
-            {"name": "test", "get_debug_state": lambda self: {"phase": "fetch", "status": "ok"}},
-        )()
+
+        class SourceStub:
+            name = "test"
+
+            def get_debug_state(self) -> dict[str, str]:
+                return {"phase": "fetch", "status": "ok"}
+
+        source = SourceStub()
         monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [source])
         monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
         monkeypatch.setattr("denbust.pipeline.create_deduplicator", fake_create_deduplicator)

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -553,6 +553,8 @@ class TestRunPipelineAsync:
         }
         rejected = result.debug_payload["rejected_articles"]
         assert len(rejected) == 1
+        assert rejected[0]["canonical_url"] == "https://example.com/rejected"
+        assert rejected[0]["relevant"] is False
 
     @pytest.mark.asyncio
     async def test_run_pipeline_async_calls_get_debug_state_once_per_payload_site(

--- a/tests/unit/test_source_base.py
+++ b/tests/unit/test_source_base.py
@@ -20,3 +20,7 @@ class TestSourceBase:
         result = await Source.fetch(object(), 1, [])
 
         assert result is None
+
+    def test_get_debug_state_defaults_to_none(self) -> None:
+        """The default debug-state hook should be a no-op."""
+        assert Source.get_debug_state(object()) is None

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -1761,6 +1761,58 @@ async def test_probe_mako_reports_section_keyword_match(
 
 
 @pytest.mark.asyncio
+async def test_probe_mako_reports_not_found_search_terminal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakePage:
+        def __init__(self) -> None:
+            self.url = "https://www.mako.co.il/Search"
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=FakePage())
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> None:
+            session.page.url = self._build_search_url(keyword)
+            return None
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return []
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> object:
+            del item, cutoff
+            return article
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del keywords
+            return candidate is article
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    search_check = next(check for check in result.checks if check.name == "search:בית בושת")
+    assert search_check.summary == "Search reached Mako's not-found terminal state"
+    assert search_check.details["terminal_state"] == "not_found"
+
+
+@pytest.mark.asyncio
 async def test_probe_mako_skips_when_browser_runtime_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -1255,7 +1255,9 @@ async def test_probe_haaretz_distinguishes_parse_zero_with_results_heading(
 
     assert result.live_status == DiagnosticStatus.FAIL
     assert result.failure_bucket == FailureBucket.SELECTOR_DRIFT_SUSPECTED
-    assert result.checks[0].summary == "Search results container was present but parsed zero entries"
+    assert (
+        result.checks[0].summary == "Search results container was present but parsed zero entries"
+    )
 
 
 @pytest.mark.asyncio
@@ -1888,7 +1890,10 @@ async def test_probe_mako_reports_unexpected_redirect_after_keyword_hit(
 
     assert result.live_status == DiagnosticStatus.WARN
     assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
-    assert any(check.summary == "Search page returned parsed keyword-matching articles" for check in result.checks)
+    assert any(
+        check.summary == "Search page returned parsed keyword-matching articles"
+        for check in result.checks
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -31,7 +31,7 @@ def _config_with_state_root(state_root: Path) -> Config:
                 {
                     "name": "ynet",
                     "type": "rss",
-                    "url": "https://www.ynet.co.il/Integration/StoryRss2.xml",
+                    "url": "https://www.ynet.co.il/Integration/StoryRss190.xml",
                 },
                 {"name": "maariv", "type": "scraper"},
                 {"name": "ice", "type": "scraper"},
@@ -306,15 +306,15 @@ def test_merge_status_and_derive_bucket_and_live_result() -> None:
 def test_is_unexpected_redirect() -> None:
     assert source_health._is_unexpected_redirect(
         "https://other.example.com/feed",
-        "https://www.ynet.co.il/Integration/StoryRss2.xml",
+        "https://www.ynet.co.il/Integration/StoryRss190.xml",
     )
     assert source_health._is_unexpected_redirect(
         "https://www.ynet.co.il/other",
-        "https://www.ynet.co.il/Integration/StoryRss2.xml",
+        "https://www.ynet.co.il/Integration/StoryRss190.xml",
     )
     assert not source_health._is_unexpected_redirect(
-        "https://www.ynet.co.il/Integration/StoryRss2.xml",
-        "https://www.ynet.co.il/Integration/StoryRss2.xml",
+        "https://www.ynet.co.il/Integration/StoryRss190.xml",
+        "https://www.ynet.co.il/Integration/StoryRss190.xml",
     )
 
 
@@ -461,7 +461,7 @@ async def test_probe_ynet_distinguishes_unexpected_redirect(
     monkeypatch.setattr(source_health.feedparser, "parse", fake_parse)
 
     result = await source_health._probe_ynet(
-        source_cfg=SimpleNamespace(url="https://www.ynet.co.il/Integration/StoryRss2.xml"),
+        source_cfg=SimpleNamespace(url="https://www.ynet.co.il/Integration/StoryRss190.xml"),
         days=21,
         sample_keywords=["זנות"],
     )
@@ -735,6 +735,47 @@ async def test_probe_ice_distinguishes_parse_zeroed_results(
 
 
 @pytest.mark.asyncio
+async def test_probe_ice_distinguishes_stale_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    html = """
+    <html>
+      <body>
+        <h1>תוצאות חיפוש</h1>
+        <article>
+          <ul>
+            <li>
+              <a href="/article/123">בית בושת אותר</a>
+              <span>01/01/2025 12:00</span>
+            </li>
+          </ul>
+        </article>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_ice(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.STALE_RESULTS
+    assert result.checks[0].details["stale_candidate_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_probe_ice_reports_successful_page(monkeypatch: pytest.MonkeyPatch) -> None:
     html = """
     <html>
@@ -853,6 +894,267 @@ async def test_probe_ice_handles_unexpected_redirect(monkeypatch: pytest.MonkeyP
     assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
 
 
+@pytest.mark.asyncio
+async def test_probe_walla_distinguishes_selector_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="<html><body><div>nothing here</div></body></html>",
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.SELECTOR_DRIFT_SUSPECTED
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_distinguishes_keyword_zeroing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    html = """
+    <html>
+      <body>
+        <li>
+          <a href="https://news.walla.co.il/item/3823239">
+            <article>
+              <h3>חדשות כלליות</h3>
+              <p>ללא התאמה</p>
+              <span class="pub-date">12:00 01/01/2099</span>
+            </article>
+          </a>
+        </li>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_distinguishes_stale_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    html = """
+    <html>
+      <body>
+        <li>
+          <a href="https://news.walla.co.il/item/3823239">
+            <article>
+              <h3>בית בושת אותר</h3>
+              <p>פרטים נוספים</p>
+              <span class="pub-date">12:00 01/01/2025</span>
+            </article>
+          </a>
+        </li>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.STALE_RESULTS
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html>
+      <body>
+        <li>
+          <a href="https://news.walla.co.il/item/3823239">
+            <article>
+              <h3>בית בושת אותר</h3>
+              <p>פרטים נוספים</p>
+              <span class="pub-date">12:00 01/01/2099</span>
+            </article>
+          </a>
+        </li>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.OK
+    assert result.failure_bucket is None
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_handles_all_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del url, user_agent, client
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_handles_unexpected_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html>
+      <body>
+        <li>
+          <a href="https://news.walla.co.il/item/3823239">
+            <article>
+              <h3>בית בושת אותר</h3>
+              <p>פרטים נוספים</p>
+              <span class="pub-date">12:00 01/01/2099</span>
+            </article>
+          </a>
+        </li>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url="https://example.com/redirect",
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_distinguishes_keyword_zeroing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html><head><title>search</title></head><body>
+              <h2>מציג תוצאות בנושא</h2>
+              <article>
+                <h3><a href="/news/politics/2026-04-06/ty-article/abc">מתנחלים הקימו מאחז חדש בצפון הגדה - בליווי חיילים</a></h3>
+                <div>כתבה פוליטית כללית.</div>
+                <time>6 באפריל 2026</time>
+              </article>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS
+    assert result.checks[0].details["entry_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html><head><title>search</title></head><body>
+              <h2>מציג תוצאות בנושא</h2>
+              <article>
+                <h3><a href="/news/law/2026-04-06/ty-article/abc">המשטרה חשפה שירותי ליווי בדירה בתל אביב</a></h3>
+                <div>חשד להפעלת זנות במקום.</div>
+                <time>6 באפריל 2026</time>
+              </article>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.OK
+    assert result.failure_bucket is None
+
+
 class _FakeSource(Source):
     def __init__(self, name: str, count: int) -> None:
         self._name = name
@@ -891,7 +1193,7 @@ days: 21
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
   - name: maariv
     type: scraper
@@ -1007,7 +1309,7 @@ days: 21
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 store:
   state_root: {state_root}
@@ -1075,7 +1377,7 @@ keywords: []
 sources:
   - name: ynet
     type: rss
-    url: https://www.ynet.co.il/Integration/StoryRss2.xml
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
     enabled: true
 store:
   state_root: {state_root}
@@ -1126,11 +1428,19 @@ async def test_probe_source_dispatches_named_sources(monkeypatch: pytest.MonkeyP
     async def fake_maariv(**_kwargs: object) -> SourceDiagnosticResult:
         return SourceDiagnosticResult(source_name="maariv", status=DiagnosticStatus.OK)
 
+    async def fake_mako(**_kwargs: object) -> SourceDiagnosticResult:
+        return SourceDiagnosticResult(source_name="mako", status=DiagnosticStatus.OK)
+
+    async def fake_haaretz(**_kwargs: object) -> SourceDiagnosticResult:
+        return SourceDiagnosticResult(source_name="haaretz", status=DiagnosticStatus.OK)
+
     async def fake_ice(**_kwargs: object) -> SourceDiagnosticResult:
         return SourceDiagnosticResult(source_name="ice", status=DiagnosticStatus.OK)
 
     monkeypatch.setattr(source_health, "_probe_ynet", fake_ynet)
     monkeypatch.setattr(source_health, "_probe_maariv", fake_maariv)
+    monkeypatch.setattr(source_health, "_probe_mako", fake_mako)
+    monkeypatch.setattr(source_health, "_probe_haaretz", fake_haaretz)
     monkeypatch.setattr(source_health, "_probe_ice", fake_ice)
 
     assert (
@@ -1151,6 +1461,24 @@ async def test_probe_source_dispatches_named_sources(monkeypatch: pytest.MonkeyP
             sample_keywords=["זנות"],
         )
     ).source_name == "maariv"
+    assert (
+        await source_health._probe_source(
+            source_name="mako",
+            source=_FakeSource("mako", 1),
+            source_cfg=SimpleNamespace(name="mako"),
+            days=21,
+            sample_keywords=["זנות"],
+        )
+    ).source_name == "mako"
+    assert (
+        await source_health._probe_source(
+            source_name="haaretz",
+            source=_FakeSource("haaretz", 1),
+            source_cfg=SimpleNamespace(name="haaretz"),
+            days=21,
+            sample_keywords=["זנות"],
+        )
+    ).source_name == "haaretz"
     assert (
         await source_health._probe_source(
             source_name="ice",
@@ -1184,6 +1512,102 @@ async def test_probe_source_uses_fallback_for_unknown_source(
     )
 
     assert result.probe_mode == "fallback_fetch"
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_parse_zeroed_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=SimpleNamespace(url="https://www.mako.co.il/Search"))
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> str:
+            session.page.url = self._build_search_url(keyword)
+            return "<html><body><div>לא נמצאו תוצאות</div></body></html>"
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><div>empty</div></body></html>"
+
+        def _parse_search_results(self, html: str, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return []
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> None:
+            del item, cutoff
+            return None
+
+        def _matches_keywords(self, article: object, keywords: list[str]) -> bool:
+            del article, keywords
+            return False
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.PARSE_ZEROED_RESULTS
+    assert {check.name for check in result.checks} == {
+        "search:בית בושת",
+        "section:men-men_news",
+    }
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_section_keyword_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=SimpleNamespace(url="https://www.mako.co.il/Search"))
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> None:
+            session.page.url = self._build_search_url(keyword)
+            return None
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return []
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> object:
+            del item, cutoff
+            return article
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del keywords
+            return candidate is article
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.OK
+    assert result.failure_bucket is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -1155,6 +1155,141 @@ async def test_probe_haaretz_reports_success(monkeypatch: pytest.MonkeyPatch) ->
     assert result.failure_bucket is None
 
 
+@pytest.mark.asyncio
+async def test_probe_haaretz_handles_all_fetch_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del url, user_agent, client
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
+    assert result.checks[0].summary == "Search fetch failed: boom"
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_handles_unexpected_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url="https://example.com/redirect",
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html><head><title>search</title></head><body>
+              <h2>מציג תוצאות בנושא</h2>
+              <article>
+                <h3><a href="/news/law/2026-04-06/ty-article/abc">המשטרה חשפה שירותי ליווי בדירה בתל אביב</a></h3>
+                <div>חשד להפעלת זנות במקום.</div>
+                <time>6 באפריל 2026</time>
+              </article>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_distinguishes_parse_zero_without_results_heading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="<html><head><title>search</title></head><body><div>no results</div></body></html>",
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.SELECTOR_DRIFT_SUSPECTED
+    assert result.checks[0].summary == "Search page fetched but parsed zero entries"
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_distinguishes_parse_zero_with_results_heading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html><head><title>search</title></head><body>
+              <h2>מציג תוצאות בנושא</h2>
+              <article><div>ללא פריטים</div></article>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.SELECTOR_DRIFT_SUSPECTED
+    assert result.checks[0].summary == "Search results container was present but parsed zero entries"
+
+
+@pytest.mark.asyncio
+async def test_probe_haaretz_distinguishes_stale_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html><head><title>search</title></head><body>
+              <h2>מציג תוצאות בנושא</h2>
+              <article>
+                <h3><a href="/news/law/2025-01-06/ty-article/abc">המשטרה חשפה שירותי ליווי בדירה בתל אביב</a></h3>
+                <div>חשד להפעלת זנות במקום.</div>
+                <time>6 בינואר 2025</time>
+              </article>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_haaretz(days=21, sample_keywords=["ליווי"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.STALE_RESULTS
+    assert result.checks[0].summary == "Search page returned only out-of-window results"
+
+
 class _FakeSource(Source):
     def __init__(self, name: str, count: int) -> None:
         self._name = name
@@ -1437,11 +1572,15 @@ async def test_probe_source_dispatches_named_sources(monkeypatch: pytest.MonkeyP
     async def fake_ice(**_kwargs: object) -> SourceDiagnosticResult:
         return SourceDiagnosticResult(source_name="ice", status=DiagnosticStatus.OK)
 
+    async def fake_walla(**_kwargs: object) -> SourceDiagnosticResult:
+        return SourceDiagnosticResult(source_name="walla", status=DiagnosticStatus.OK)
+
     monkeypatch.setattr(source_health, "_probe_ynet", fake_ynet)
     monkeypatch.setattr(source_health, "_probe_maariv", fake_maariv)
     monkeypatch.setattr(source_health, "_probe_mako", fake_mako)
     monkeypatch.setattr(source_health, "_probe_haaretz", fake_haaretz)
     monkeypatch.setattr(source_health, "_probe_ice", fake_ice)
+    monkeypatch.setattr(source_health, "_probe_walla", fake_walla)
 
     assert (
         await source_health._probe_source(
@@ -1488,6 +1627,15 @@ async def test_probe_source_dispatches_named_sources(monkeypatch: pytest.MonkeyP
             sample_keywords=["זנות"],
         )
     ).source_name == "ice"
+    assert (
+        await source_health._probe_source(
+            source_name="walla",
+            source=_FakeSource("walla", 1),
+            source_cfg=SimpleNamespace(name="walla"),
+            days=21,
+            sample_keywords=["זנות"],
+        )
+    ).source_name == "walla"
 
 
 @pytest.mark.asyncio
@@ -1608,6 +1756,256 @@ async def test_probe_mako_reports_section_keyword_match(
 
     assert result.live_status == DiagnosticStatus.OK
     assert result.failure_bucket is None
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_skips_when_browser_runtime_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            raise RuntimeError("Chromium is not installed")
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.SKIP
+    assert result.failure_bucket is None
+    assert result.checks[0].name == "browser_session"
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_fails_on_unexpected_browser_start_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            raise ValueError("boom")
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.LIVE_PROBE_EXCEPTION
+    assert result.checks[0].name == "browser_session"
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_http_fetch_failed_when_search_and_section_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=SimpleNamespace(url="https://www.mako.co.il/Search"))
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> str:
+            session.page.url = self._build_search_url(keyword)
+            raise RuntimeError(f"search failed for {keyword}")
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            raise RuntimeError("section failed")
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
+    assert {check.name for check in result.checks} == {
+        "search:בית בושת",
+        "section:men-men_news",
+    }
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_unexpected_redirect_after_keyword_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakePage:
+        def __init__(self) -> None:
+            self.url = "https://www.mako.co.il/Search"
+
+        async def title(self) -> str:
+            return "search title"
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=FakePage())
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> str:
+            del keyword
+            session.page.url = "https://example.com/redirected-search"
+            return "<html><body>search</body></html>"
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://example.com/redirected-section"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return [article]
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> object:
+            del item, cutoff
+            return article
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del keywords
+            return candidate is article
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
+    assert any(check.summary == "Search page returned parsed keyword-matching articles" for check in result.checks)
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_keyword_zeroing_with_search_hits_and_section_parse_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakePage:
+        def __init__(self) -> None:
+            self.url = "https://www.mako.co.il/Search"
+
+        async def title(self) -> str:
+            return "search title"
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=FakePage())
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> str:
+            session.page.url = self._build_search_url(keyword)
+            return "<html><body>search</body></html>"
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return [article]
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> None:
+            del item, cutoff
+            return None
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del candidate, keywords
+            return False
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS
+    summaries = {check.name: check.summary for check in result.checks}
+    assert summaries["search:בית בושת"] == "Search page returned parsed articles"
+    assert summaries["section:men-men_news"] == (
+        "Section page contains candidates but parsing returned zero articles"
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_mako_reports_section_keyword_zeroing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakePage:
+        def __init__(self) -> None:
+            self.url = "https://www.mako.co.il/Search"
+
+        async def title(self) -> str:
+            return "page title"
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=FakePage())
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> None:
+            session.page.url = self._build_search_url(keyword)
+            return None
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return []
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> object:
+            del item, cutoff
+            return article
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del candidate, keywords
+            return False
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS
+    summaries = {check.name: check.summary for check in result.checks}
+    assert summaries["section:men-men_news"] == (
+        "Section page returned parsed articles but none match the sampled keywords"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -1496,7 +1496,7 @@ async def test_probe_source_uses_fallback_for_unknown_source(
 ) -> None:
     async def fake_fallback(**_kwargs: object) -> SourceDiagnosticResult:
         return SourceDiagnosticResult(
-            source_name="walla",
+            source_name="unknown-source",
             status=DiagnosticStatus.OK,
             live_status=DiagnosticStatus.OK,
             probe_mode="fallback_fetch",
@@ -1504,9 +1504,9 @@ async def test_probe_source_uses_fallback_for_unknown_source(
 
     monkeypatch.setattr(source_health, "_probe_via_fallback_fetch", fake_fallback)
     result = await source_health._probe_source(
-        source_name="walla",
-        source=_FakeSource("walla", 1),
-        source_cfg=SimpleNamespace(name="walla"),
+        source_name="unknown-source",
+        source=_FakeSource("unknown-source", 1),
+        source_cfg=SimpleNamespace(name="unknown-source"),
         days=21,
         sample_keywords=["זנות"],
     )


### PR DESCRIPTION
## Summary

This PR turns the recent source-investigation work into productized diagnostics and targeted source fixes across the news ingestion pipeline.

It does four main things:
- strengthens `diagnose-sources` with source-specific live probes instead of generic zero/non-zero checks
- improves ingest debug artifacts so future zero-result incidents preserve enough runtime evidence to debug them quickly
- fixes concrete discovery issues in Maariv and Ynet
- tightens weak/ambiguous source behavior in Mako, ICE, Walla, and Haaretz

## Why

This branch was driven by a full source-health pass after multiple suspicious misses in the daily state pipeline.

Key findings from the investigation:
- `ice` was being reported as parse-zero in cases where the search page actually returned only stale candidates outside the cutoff window
- `walla` was structurally healthy, but the old diagnostic could not distinguish parser drift from keyword coverage gaps
- `mako` could silently return zero articles when browser/session startup failed, which made state logs look deceptively healthy
- `maariv` missed a clearly relevant `breaking-news` article because the source only scraped the law section and search was returning `404`
- `ynet` was configured to use a shallow generic RSS feed instead of the much better `משפט ופלילים` feed
- `haaretz` looked `ok` under fallback diagnostics even when its live search results were low-quality after filtering

## Main changes

### 1. Source-health diagnostics

Expanded [source_health.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/diagnostics/source_health.py) with source-specific probes for:
- `mako`
- `walla`
- `haaretz`

Refined existing probes for:
- `ice`
- `maariv`
- `ynet`

Notable diagnostic improvements:
- add `stale_results` as a first-class failure bucket
- distinguish stale-only result sets from parse-zero failures
- inspect actual page/feed structure instead of only relying on `source.fetch()`
- expose per-check structured details such as:
  - entry counts
  - recent-entry counts
  - keyword-match counts
  - selector/container presence
  - page titles, URLs, payload sizes, and redirects

This makes `diagnose-sources` much more actionable for real triage.

### 2. Mako runtime telemetry in ingest debug logs

Added source runtime debug plumbing so the ingest debug payload can preserve structured source telemetry.

Changes:
- [base.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/sources/base.py): optional `get_debug_state()` hook for sources
- [mako.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/sources/mako.py): record runtime debug state for browser session, keyword searches, section fetches, and aggregate result counts
- [pipeline.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/pipeline.py): persist runtime debug in:
  - each `source_summaries[i].runtime_debug`
  - top-level `source_runtime_debug`

Also changed Mako browser-session startup failures to raise a real source error instead of silently returning `[]`, so future incidents do not look like clean zero-result days.

### 3. Maariv discovery fix

Updated [maariv.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/sources/maariv.py) so Maariv discovery now includes both:
- `https://www.maariv.co.il/news/law`
- `https://www.maariv.co.il/breaking-news`

Also tightened section parsing so `breaking-news` pages use targeted card selectors instead of generic wrappers.

This addresses a concrete miss where a relevant `breaking-news` article was not discoverable through the old source.

### 4. Ynet feed correction

Switched Ynet from the generic RSS feed to the better `משפט ופלילים` feed.

Updated:
- [rss.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/sources/rss.py)
- [agents/news/local.yaml](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/agents/news/local.yaml)
- [agents/news/github.yaml](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/agents/news/github.yaml)
- [agents/news.yaml](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/agents/news.yaml)
- [agents/news-github.yaml](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/agents/news-github.yaml)

New feed:
- `https://www.ynet.co.il/Integration/StoryRss190.xml`

This was motivated by live investigation showing:
- old generic feed span: about 12.7 hours
- `משפט ופלילים` feed span: about 182.6 hours

That makes Ynet much better aligned with once-daily ingestion.

### 5. Haaretz precision controls

Updated [haaretz.py](https://github.com/DataHackIL/tfht_enforce_idx/blob/codex/ice-diagnostic-stale-results/src/denbust/sources/haaretz.py) to reduce obvious low-signal matches:
- reject `talkback` article paths
- only allow bare `ליווי` when it appears in explicit sex-work phrases such as `שירותי ליווי`, `נערות ליווי`, `מכון ליווי`

Combined with the new Haaretz-specific probe, this changes Haaretz from a misleading generic `ok` to a more truthful warning state when current search results are structurally fine but low-quality after filtering.

## Follow-up issues opened

To capture the next Ynet steps, I opened:
- [#65 Add Ynet category-page backstop for משפט ופלילים discovery](https://github.com/DataHackIL/tfht_enforce_idx/issues/65)
- [#66 Add fixture-based Ynet end-to-end regression test after web-search source exists](https://github.com/DataHackIL/tfht_enforce_idx/issues/66)

## Validation

Tests run during this branch included:
- `pytest -q tests/integration/test_scrapers.py -k ice`
- `pytest -q tests/integration/test_scrapers.py -k Maariv`
- `pytest -q tests/integration/test_scrapers.py -k Haaretz`
- `pytest -q tests/unit/test_source_health.py -k ynet`
- `pytest -q tests/unit/test_source_health.py -k walla`
- `pytest -q tests/unit/test_source_health.py -k haaretz`
- `pytest -q tests/unit/test_pipeline_core.py -k 'machine_debug_helpers or records_debug_payload_for_rejected_articles'`
- `pytest -q tests/unit/test_run_snapshots.py -k 'write_run_debug_summary_creates_compact_machine_json or write_run_debug_log_creates_directory_and_json'`

Representative live diagnostic runs:
- `python -m denbust.cli diagnose-sources --config agents/news/local.yaml --source ice --live-only`
- `python -m denbust.cli diagnose-sources --config agents/news/local.yaml --source mako --live-only`
- `python -m denbust.cli diagnose-sources --config agents/news/local.yaml --source maariv --live-only`
- `python -m denbust.cli diagnose-sources --config agents/news/local.yaml --source ynet --live-only`
- `python -m denbust.cli diagnose-sources --config agents/news/local.yaml --source haaretz --live-only`

## Expected reviewer focus

The most important review areas are:
- source-health probe behavior and bucket semantics
- Mako runtime debug payload shape
- Maariv `breaking-news` discovery path
- Ynet feed switch to `StoryRss190.xml`
- Haaretz precision tradeoffs around `talkback` and contextual `ליווי`
