### PR TITLE
Add persistent discovery and candidacy foundation scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ data jobs. Phase A introduced the shared platform spine. Phase B turns the first
 
 Today, the implemented dataset/jobs are:
 
+- `news_items / discover` scaffold only
 - `news_items / ingest`
 - `news_items / release`
 - `news_items / backup`
@@ -37,6 +38,8 @@ Planned future datasets:
 - Publishes release bundles to Kaggle and Hugging Face when configured
 - Uploads the latest release bundle to Google Drive and S3-compatible object storage when configured
 - Persists dataset/job-scoped seen state and per-run JSON snapshots
+- Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
+  paths under `news_items/discover/`
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
 
 ## Quick Start
@@ -150,6 +153,22 @@ tfht_enforce_idx_state/
         └── publication/
 ```
 
+The new discovery/candidacy foundation adds a separate candidate-layer namespace alongside the
+existing ingest/release/backup state:
+
+```text
+tfht_enforce_idx_state/
+└── news_items/
+    └── discover/
+        ├── runs/
+        ├── candidates/
+        │   ├── latest_candidates.jsonl
+        │   ├── retry_queue.jsonl
+        │   └── backfill_queue.jsonl
+        └── metrics/
+            └── engine_overlap_latest.json
+```
+
 Bootstrap notes:
 
 - `seen.json` may be absent initially; it is created once a run marks at least one URL as seen
@@ -196,8 +215,26 @@ What is implemented now:
 Still intentionally deferred:
 
 - additional dataset implementations beyond `news_items`
+- operational wiring of the new multi-engine discovery layer into production ingest
 - richer human review tooling / admin UI
 - more advanced privacy policies beyond the current pragmatic gate
+
+## Discovery Layer Foundation
+
+PR 1 of the persistent multi-engine discovery work is now in place as scaffolding only. It adds:
+
+- `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
+  models
+- config sections for `discovery`, `source_discovery`, `candidates`, and `backfill`
+- explicit state-repo path helpers for candidate-layer snapshots and queue files
+- Supabase migrations for:
+  - `discovery_runs`
+  - `persistent_candidates`
+  - `candidate_provenance`
+  - `scrape_attempts`
+
+This PR does not yet call Brave, Exa, or Google CSE, and it does not yet route the live ingest
+pipeline through the durable candidate queue. The current daily monitoring flow remains unchanged.
 
 ## Config Layout
 

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -1,12 +1,15 @@
 """Configuration management for denbust."""
 
 import os
+from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
 
+from denbust.discovery.models import DiscoveryQueryKind
+from denbust.discovery.state_paths import DiscoveryStatePaths, resolve_discovery_state_paths
 from denbust.models.common import DatasetName, JobName, normalize_job_name
 from denbust.store.state_paths import DatasetStatePaths, resolve_dataset_state_paths
 
@@ -218,6 +221,127 @@ class BackupConfig(BaseModel):
     object_storage: ObjectStorageBackupConfig = Field(default_factory=ObjectStorageBackupConfig)
 
 
+class DiscoveryEngineConfig(BaseModel):
+    """Base configuration for a discovery engine."""
+
+    enabled: bool = False
+    api_key_env: str | None = None
+    max_results_per_query: int = Field(default=20, ge=1)
+
+
+class ExaDiscoveryEngineConfig(DiscoveryEngineConfig):
+    """Exa-specific discovery configuration."""
+
+    allow_find_similar: bool = True
+
+
+class GoogleCseDiscoveryEngineConfig(DiscoveryEngineConfig):
+    """Google Custom Search Engine configuration."""
+
+    cse_id_env: str | None = None
+    max_results_per_query: int = Field(default=10, ge=1)
+
+
+class DiscoveryEnginesConfig(BaseModel):
+    """Search-engine configuration for durable discovery."""
+
+    brave: DiscoveryEngineConfig = Field(
+        default_factory=lambda: DiscoveryEngineConfig(
+            enabled=False,
+            api_key_env="DENBUST_BRAVE_SEARCH_API_KEY",
+            max_results_per_query=20,
+        )
+    )
+    exa: ExaDiscoveryEngineConfig = Field(
+        default_factory=lambda: ExaDiscoveryEngineConfig(
+            enabled=False,
+            api_key_env="DENBUST_EXA_API_KEY",
+            max_results_per_query=20,
+            allow_find_similar=True,
+        )
+    )
+    google_cse: GoogleCseDiscoveryEngineConfig = Field(
+        default_factory=lambda: GoogleCseDiscoveryEngineConfig(
+            enabled=False,
+            api_key_env="DENBUST_GOOGLE_CSE_API_KEY",
+            cse_id_env="DENBUST_GOOGLE_CSE_ID",
+            max_results_per_query=10,
+        )
+    )
+
+
+class DiscoveryConfig(BaseModel):
+    """Top-level durable discovery configuration."""
+
+    enabled: bool = False
+    persist_candidates: bool = True
+    engines: DiscoveryEnginesConfig = Field(default_factory=DiscoveryEnginesConfig)
+    default_query_kinds: list[DiscoveryQueryKind] = Field(
+        default_factory=lambda: [
+            DiscoveryQueryKind.BROAD,
+            DiscoveryQueryKind.SOURCE_TARGETED,
+        ]
+    )
+
+
+class SourceDiscoveryProducerConfig(BaseModel):
+    """Per-source source-native candidacy configuration."""
+
+    enabled: bool = True
+
+
+class SourceDiscoveryConfig(BaseModel):
+    """Configuration for source-native candidate persistence."""
+
+    enabled: bool = True
+    persist_candidates: bool = True
+    sources: dict[str, SourceDiscoveryProducerConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_sources(cls, data: object) -> object:
+        if data is None or not isinstance(data, Mapping):
+            return data
+
+        normalized = dict(data)
+        sources = normalized.get("sources")
+        if not isinstance(sources, Mapping):
+            return normalized
+
+        normalized["sources"] = {
+            str(name): (
+                value
+                if isinstance(value, Mapping)
+                else {"enabled": bool(value)}
+            )
+            for name, value in sources.items()
+        }
+        return normalized
+
+
+class CandidatesConfig(BaseModel):
+    """Configuration for durable candidate persistence and retry semantics."""
+
+    discovery_runs_table: str = "discovery_runs"
+    supabase_table: str = "persistent_candidates"
+    provenance_table: str = "candidate_provenance"
+    scrape_attempts_table: str = "scrape_attempts"
+    keep_search_only_fallbacks: bool = True
+    require_review_for_search_only: bool = True
+    allow_retry_on_fetch_failure: bool = True
+    default_retry_backoff_hours: int = Field(default=24, ge=1)
+    max_retry_attempts: int = Field(default=10, ge=1)
+
+
+class BackfillConfig(BaseModel):
+    """Optional backfill orchestration configuration."""
+
+    enabled: bool = False
+    batch_window_days: int = Field(default=7, ge=1)
+    max_candidates_per_run: int = Field(default=500, ge=1)
+    max_scrape_attempts_per_run: int = Field(default=100, ge=1)
+
+
 # Default keywords for searching news articles (Hebrew)
 DEFAULT_KEYWORDS: list[str] = [
     "זנות",  # prostitution
@@ -248,6 +372,10 @@ class Config(BaseModel):
     output: OutputConfig = Field(default_factory=OutputConfig)
     store: StoreConfig = Field(default_factory=StoreConfig)
     operational: OperationalConfig = Field(default_factory=OperationalConfig)
+    discovery: DiscoveryConfig = Field(default_factory=DiscoveryConfig)
+    source_discovery: SourceDiscoveryConfig = Field(default_factory=SourceDiscoveryConfig)
+    candidates: CandidatesConfig = Field(default_factory=CandidatesConfig)
+    backfill: BackfillConfig = Field(default_factory=BackfillConfig)
     release: ReleaseConfig = Field(default_factory=ReleaseConfig)
     backup: BackupConfig = Field(default_factory=BackupConfig)
 
@@ -274,6 +402,14 @@ class Config(BaseModel):
             seen_path=self.store.seen_path,
             runs_dir=self.store.runs_dir,
             publication_dir=self.store.publication_dir,
+        )
+
+    @property
+    def discovery_state_paths(self) -> DiscoveryStatePaths:
+        """Resolve candidate-layer state paths for this dataset."""
+        return resolve_discovery_state_paths(
+            state_root=self.store.state_root,
+            dataset_name=self.dataset_name,
         )
 
     @property
@@ -346,6 +482,30 @@ class Config(BaseModel):
     def supabase_service_role_key(self) -> str | None:
         """Get the Supabase service role key from the environment."""
         return os.environ.get("DENBUST_SUPABASE_SERVICE_ROLE_KEY")
+
+    @property
+    def brave_search_api_key(self) -> str | None:
+        """Get the Brave Search API key from the configured environment variable."""
+        env_name = self.discovery.engines.brave.api_key_env
+        return os.environ.get(env_name) if env_name else None
+
+    @property
+    def exa_api_key(self) -> str | None:
+        """Get the Exa API key from the configured environment variable."""
+        env_name = self.discovery.engines.exa.api_key_env
+        return os.environ.get(env_name) if env_name else None
+
+    @property
+    def google_cse_api_key(self) -> str | None:
+        """Get the Google CSE API key from the configured environment variable."""
+        env_name = self.discovery.engines.google_cse.api_key_env
+        return os.environ.get(env_name) if env_name else None
+
+    @property
+    def google_cse_id(self) -> str | None:
+        """Get the Google CSE identifier from the configured environment variable."""
+        env_name = self.discovery.engines.google_cse.cse_id_env
+        return os.environ.get(env_name) if env_name else None
 
     @property
     def huggingface_token(self) -> str | None:

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -308,10 +308,19 @@ class SourceDiscoveryConfig(BaseModel):
         if not isinstance(sources, Mapping):
             return normalized
 
-        normalized["sources"] = {
-            str(name): (value if isinstance(value, Mapping) else {"enabled": bool(value)})
-            for name, value in sources.items()
-        }
+        normalized_sources: dict[str, Mapping[str, object] | dict[str, bool]] = {}
+        for name, value in sources.items():
+            if isinstance(value, Mapping):
+                normalized_sources[str(name)] = value
+            elif isinstance(value, bool):
+                normalized_sources[str(name)] = {"enabled": value}
+            else:
+                raise ValueError(
+                    "sources entries must be mappings or booleans for shorthand "
+                    f"(got {type(value).__name__} for source {name!r})"
+                )
+
+        normalized["sources"] = normalized_sources
         return normalized
 
 

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -309,11 +309,7 @@ class SourceDiscoveryConfig(BaseModel):
             return normalized
 
         normalized["sources"] = {
-            str(name): (
-                value
-                if isinstance(value, Mapping)
-                else {"enabled": bool(value)}
-            )
+            str(name): (value if isinstance(value, Mapping) else {"enabled": bool(value)})
             for name, value in sources.items()
         }
         return normalized

--- a/src/denbust/datasets/jobs.py
+++ b/src/denbust/datasets/jobs.py
@@ -13,6 +13,13 @@ from denbust.ops.storage import OperationalStore
 _REGISTERED = False
 
 
+def _scaffolded_job_error(config: Config) -> ValueError:
+    """Build a clear placeholder error for scaffold-only jobs."""
+    return ValueError(
+        f"{config.dataset_name.value}/{config.job_name.value} is scaffolded but not implemented yet"
+    )
+
+
 async def _run_news_items_ingest(
     config: Config,
     config_path: Path | None,
@@ -71,6 +78,17 @@ async def _run_scaffolded_backup(
     )
 
 
+async def _run_unimplemented_scaffold_job(
+    config: Config,
+    config_path: Path | None,
+    days_override: int | None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    """Fail scaffold-only jobs with a purpose-built message."""
+    del config_path, days_override, operational_store
+    raise _scaffolded_job_error(config)
+
+
 def ensure_default_jobs_registered() -> None:
     """Register Phase A dataset jobs exactly once."""
     global _REGISTERED
@@ -78,6 +96,22 @@ def ensure_default_jobs_registered() -> None:
         return
 
     register_job(DatasetName.NEWS_ITEMS, JobName.INGEST, _run_news_items_ingest)
+    register_job(DatasetName.NEWS_ITEMS, JobName.DISCOVER, _run_unimplemented_scaffold_job)
+    register_job(
+        DatasetName.NEWS_ITEMS,
+        JobName.SCRAPE_CANDIDATES,
+        _run_unimplemented_scaffold_job,
+    )
+    register_job(
+        DatasetName.NEWS_ITEMS,
+        JobName.BACKFILL_DISCOVER,
+        _run_unimplemented_scaffold_job,
+    )
+    register_job(
+        DatasetName.NEWS_ITEMS,
+        JobName.BACKFILL_SCRAPE,
+        _run_unimplemented_scaffold_job,
+    )
     register_job(DatasetName.NEWS_ITEMS, JobName.RELEASE, _run_scaffolded_release)
     register_job(DatasetName.NEWS_ITEMS, JobName.BACKUP, _run_scaffolded_backup)
     _REGISTERED = True

--- a/src/denbust/datasets/jobs.py
+++ b/src/denbust/datasets/jobs.py
@@ -90,7 +90,7 @@ async def _run_unimplemented_scaffold_job(
 
 
 def ensure_default_jobs_registered() -> None:
-    """Register Phase A dataset jobs exactly once."""
+    """Register default dataset jobs exactly once."""
     global _REGISTERED
     if _REGISTERED:
         return

--- a/src/denbust/discovery/__init__.py
+++ b/src/denbust/discovery/__init__.py
@@ -1,0 +1,67 @@
+"""Persistent discovery and candidacy layer scaffolding."""
+
+from denbust.discovery.base import (
+    DiscoveryContext,
+    DiscoveryEngine,
+    SourceCandidateProducer,
+    SourceDiscoveryContext,
+)
+from denbust.discovery.models import (
+    CandidateProvenance,
+    CandidateStatus,
+    ContentBasis,
+    DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    FetchStatus,
+    PersistentCandidate,
+    ProducerKind,
+    ScrapeAttempt,
+    ScrapeAttemptKind,
+)
+from denbust.discovery.persistence import (
+    CandidateStore,
+    DiscoveryRunStore,
+    ProvenanceStore,
+    ScrapeAttemptStore,
+)
+from denbust.discovery.state_paths import (
+    DiscoveryStatePaths,
+    discovery_snapshot_filename,
+    resolve_discovery_state_paths,
+    write_candidate_jsonl,
+    write_discovery_run_snapshot,
+    write_metrics_snapshot,
+)
+
+__all__ = [
+    "CandidateProvenance",
+    "CandidateStatus",
+    "CandidateStore",
+    "ContentBasis",
+    "DiscoveredCandidate",
+    "DiscoveryContext",
+    "DiscoveryEngine",
+    "DiscoveryQuery",
+    "DiscoveryQueryKind",
+    "DiscoveryRun",
+    "DiscoveryRunStatus",
+    "DiscoveryRunStore",
+    "DiscoveryStatePaths",
+    "FetchStatus",
+    "PersistentCandidate",
+    "ProducerKind",
+    "ProvenanceStore",
+    "ScrapeAttempt",
+    "ScrapeAttemptKind",
+    "ScrapeAttemptStore",
+    "SourceCandidateProducer",
+    "SourceDiscoveryContext",
+    "discovery_snapshot_filename",
+    "resolve_discovery_state_paths",
+    "write_candidate_jsonl",
+    "write_discovery_run_snapshot",
+    "write_metrics_snapshot",
+]

--- a/src/denbust/discovery/base.py
+++ b/src/denbust/discovery/base.py
@@ -1,0 +1,53 @@
+"""Base protocols and shared contexts for discovery producers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery
+
+
+class DiscoveryContext(BaseModel):
+    """Shared execution context for a discovery-engine run."""
+
+    run_id: str
+    max_results_per_query: int | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SourceDiscoveryContext(BaseModel):
+    """Shared execution context for source-native candidate producers."""
+
+    run_id: str
+    source_names: list[str] = Field(default_factory=list)
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class DiscoveryEngine(Protocol):
+    """Protocol for search-engine discovery adapters."""
+
+    name: str
+
+    async def discover(
+        self,
+        queries: list[DiscoveryQuery],
+        context: DiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        """Return normalized candidates for one or more search queries."""
+
+
+class SourceCandidateProducer(Protocol):
+    """Protocol for source-native candidate producers."""
+
+    name: str
+
+    async def discover_candidates(
+        self,
+        context: SourceDiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        """Return normalized candidates discovered directly from known sources."""

--- a/src/denbust/discovery/models.py
+++ b/src/denbust/discovery/models.py
@@ -1,0 +1,268 @@
+"""Core models for the persistent discovery and candidacy layer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, HttpUrl, model_validator
+
+from denbust.models.common import DatasetName, JobName
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _uuid_str() -> str:
+    return str(uuid4())
+
+
+def _domain_from_url(value: HttpUrl | None) -> str | None:
+    if value is None:
+        return None
+    return urlparse(str(value)).netloc or None
+
+
+class DiscoveryQueryKind(StrEnum):
+    """Supported query families for candidate discovery."""
+
+    BROAD = "broad"
+    SOURCE_TARGETED = "source_targeted"
+    TAXONOMY_TARGETED = "taxonomy_targeted"
+    SOCIAL_TARGETED = "social_targeted"
+
+
+class ProducerKind(StrEnum):
+    """Producer families that can emit discovery candidates."""
+
+    SEARCH_ENGINE = "search_engine"
+    SOURCE_NATIVE = "source_native"
+    SOCIAL_SEARCH = "social_search"
+
+
+class CandidateStatus(StrEnum):
+    """Lifecycle states for a persistent candidate."""
+
+    NEW = "new"
+    QUEUED = "queued"
+    SCRAPE_PENDING = "scrape_pending"
+    SCRAPE_IN_PROGRESS = "scrape_in_progress"
+    SCRAPE_SUCCEEDED = "scrape_succeeded"
+    SCRAPE_FAILED = "scrape_failed"
+    PARTIALLY_SCRAPED = "partially_scraped"
+    UNSUPPORTED_SOURCE = "unsupported_source"
+    SUPPRESSED = "suppressed"
+    CLOSED = "closed"
+
+
+class ContentBasis(StrEnum):
+    """Content quality basis for the current candidate state."""
+
+    CANDIDATE_ONLY = "candidate_only"
+    SEARCH_RESULT_ONLY = "search_result_only"
+    PARTIAL_PAGE = "partial_page"
+    FULL_ARTICLE_PAGE = "full_article_page"
+
+
+class ScrapeAttemptKind(StrEnum):
+    """Kinds of scrape attempt supported by the candidate layer."""
+
+    SOURCE_ADAPTER = "source_adapter"
+    GENERIC_FETCH = "generic_fetch"
+    GENERIC_EXTRACT = "generic_extract"
+    SELF_HEAL_RETRY = "self_heal_retry"
+    MANUAL_RETRY = "manual_retry"
+    BACKFILL_RETRY = "backfill_retry"
+
+
+class FetchStatus(StrEnum):
+    """Outcomes for a scrape attempt."""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"
+    BLOCKED = "blocked"
+    TIMEOUT = "timeout"
+
+
+class DiscoveryRunStatus(StrEnum):
+    """Status values for discovery-run bookkeeping."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+class DiscoveryQuery(BaseModel):
+    """Normalized search query definition for a discovery engine."""
+
+    query_text: str
+    language: str | None = None
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+    preferred_domains: list[str] = Field(default_factory=list)
+    excluded_domains: list[str] = Field(default_factory=list)
+    source_hint: str | None = None
+    query_kind: DiscoveryQueryKind = DiscoveryQueryKind.BROAD
+    tags: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_date_window(self) -> DiscoveryQuery:
+        if self.date_from and self.date_to and self.date_from > self.date_to:
+            raise ValueError("date_from must be earlier than or equal to date_to")
+        return self
+
+
+class DiscoveredCandidate(BaseModel):
+    """A candidate emitted directly by a discovery producer."""
+
+    discovery_id: str = Field(default_factory=_uuid_str)
+    producer_name: str
+    producer_kind: ProducerKind
+    query_text: str | None = None
+    candidate_url: HttpUrl
+    canonical_url: HttpUrl | None = None
+    title: str | None = None
+    snippet: str | None = None
+    discovered_at: datetime = Field(default_factory=_utc_now)
+    publication_datetime_hint: datetime | None = None
+    domain: str | None = None
+    rank: int | None = Field(default=None, ge=1)
+    producer_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    source_hint: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _normalize_domain(self) -> DiscoveredCandidate:
+        if self.domain is None:
+            self.domain = _domain_from_url(self.canonical_url or self.candidate_url)
+        return self
+
+
+class PersistentCandidate(BaseModel):
+    """Durable queue/history record for a candidate URL."""
+
+    candidate_id: str = Field(default_factory=_uuid_str)
+    canonical_url: HttpUrl | None = None
+    current_url: HttpUrl
+    domain: str | None = None
+    titles: list[str] = Field(default_factory=list)
+    snippets: list[str] = Field(default_factory=list)
+    discovered_via: list[str] = Field(default_factory=list)
+    discovery_queries: list[str] = Field(default_factory=list)
+    source_hints: list[str] = Field(default_factory=list)
+    first_seen_at: datetime = Field(default_factory=_utc_now)
+    last_seen_at: datetime = Field(default_factory=_utc_now)
+    candidate_status: CandidateStatus = CandidateStatus.NEW
+    scrape_attempt_count: int = Field(default=0, ge=0)
+    last_scrape_attempt_at: datetime | None = None
+    next_scrape_attempt_at: datetime | None = None
+    last_scrape_error_code: str | None = None
+    last_scrape_error_message: str | None = None
+    content_basis: ContentBasis = ContentBasis.CANDIDATE_ONLY
+    retry_priority: int = 0
+    needs_review: bool = False
+    backfill_batch_id: str | None = None
+    self_heal_eligible: bool = False
+    source_discovery_only: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _normalize_candidate(self) -> PersistentCandidate:
+        if self.domain is None:
+            self.domain = _domain_from_url(self.canonical_url or self.current_url)
+        if self.last_seen_at < self.first_seen_at:
+            raise ValueError("last_seen_at must be later than or equal to first_seen_at")
+        if (
+            self.last_scrape_attempt_at is not None
+            and self.last_scrape_attempt_at < self.first_seen_at
+        ):
+            raise ValueError("last_scrape_attempt_at cannot be earlier than first_seen_at")
+        if (
+            self.next_scrape_attempt_at is not None
+            and self.last_scrape_attempt_at is not None
+            and self.next_scrape_attempt_at < self.last_scrape_attempt_at
+        ):
+            raise ValueError(
+                "next_scrape_attempt_at cannot be earlier than last_scrape_attempt_at"
+            )
+        return self
+
+
+class CandidateProvenance(BaseModel):
+    """Append-only provenance event for durable candidate discovery."""
+
+    provenance_id: str = Field(default_factory=_uuid_str)
+    run_id: str
+    candidate_id: str
+    producer_name: str
+    producer_kind: ProducerKind
+    query_text: str | None = None
+    raw_url: HttpUrl
+    normalized_url: HttpUrl | None = None
+    title: str | None = None
+    snippet: str | None = None
+    publication_datetime_hint: datetime | None = None
+    rank: int | None = Field(default=None, ge=1)
+    domain: str | None = None
+    discovered_at: datetime = Field(default_factory=_utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _normalize_domain(self) -> CandidateProvenance:
+        if self.domain is None:
+            self.domain = _domain_from_url(self.normalized_url or self.raw_url)
+        return self
+
+
+class ScrapeAttempt(BaseModel):
+    """Audit record for each attempt to fetch or extract a candidate."""
+
+    attempt_id: str = Field(default_factory=_uuid_str)
+    candidate_id: str
+    started_at: datetime = Field(default_factory=_utc_now)
+    finished_at: datetime | None = None
+    attempt_kind: ScrapeAttemptKind
+    fetch_status: FetchStatus
+    source_adapter_name: str | None = None
+    extracted_title: str | None = None
+    extracted_publication_datetime: datetime | None = None
+    extracted_body_hash: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_finished_at(self) -> ScrapeAttempt:
+        if self.finished_at is not None and self.finished_at < self.started_at:
+            raise ValueError("finished_at must be later than or equal to started_at")
+        return self
+
+
+class DiscoveryRun(BaseModel):
+    """Run-level bookkeeping row for durable discovery executions."""
+
+    run_id: str = Field(default_factory=_uuid_str)
+    started_at: datetime = Field(default_factory=_utc_now)
+    finished_at: datetime | None = None
+    dataset_name: DatasetName = DatasetName.NEWS_ITEMS
+    job_name: JobName = JobName.DISCOVER
+    status: DiscoveryRunStatus = DiscoveryRunStatus.PENDING
+    query_count: int = Field(default=0, ge=0)
+    candidate_count: int = Field(default=0, ge=0)
+    merged_candidate_count: int = Field(default=0, ge=0)
+    queued_for_scrape_count: int = Field(default=0, ge=0)
+    errors: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_finished_at(self) -> DiscoveryRun:
+        if self.finished_at is not None and self.finished_at < self.started_at:
+            raise ValueError("finished_at must be later than or equal to started_at")
+        return self

--- a/src/denbust/discovery/models.py
+++ b/src/denbust/discovery/models.py
@@ -190,9 +190,7 @@ class PersistentCandidate(BaseModel):
             and self.last_scrape_attempt_at is not None
             and self.next_scrape_attempt_at < self.last_scrape_attempt_at
         ):
-            raise ValueError(
-                "next_scrape_attempt_at cannot be earlier than last_scrape_attempt_at"
-            )
+            raise ValueError("next_scrape_attempt_at cannot be earlier than last_scrape_attempt_at")
         return self
 
 

--- a/src/denbust/discovery/persistence.py
+++ b/src/denbust/discovery/persistence.py
@@ -1,0 +1,77 @@
+"""Persistence interfaces for the durable discovery layer."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from denbust.discovery.models import (
+    CandidateProvenance,
+    CandidateStatus,
+    DiscoveryRun,
+    PersistentCandidate,
+    ScrapeAttempt,
+)
+
+
+class DiscoveryRunStore(ABC):
+    """Persistence interface for discovery-run bookkeeping."""
+
+    @abstractmethod
+    def write_run(self, run: DiscoveryRun) -> None:
+        """Persist a discovery-run record."""
+
+
+class CandidateStore(ABC):
+    """Persistence interface for durable candidate rows."""
+
+    @abstractmethod
+    def upsert_candidates(self, candidates: Sequence[PersistentCandidate]) -> None:
+        """Insert or update durable candidate rows."""
+
+    @abstractmethod
+    def get_candidate(self, candidate_id: str) -> PersistentCandidate | None:
+        """Fetch a single durable candidate by id."""
+
+    @abstractmethod
+    def list_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[PersistentCandidate]:
+        """List durable candidates, optionally filtered by status."""
+
+
+class ProvenanceStore(ABC):
+    """Persistence interface for append-only candidate provenance."""
+
+    @abstractmethod
+    def append_provenance(self, events: Sequence[CandidateProvenance]) -> None:
+        """Append provenance events for discovered candidates."""
+
+    @abstractmethod
+    def list_provenance(
+        self,
+        candidate_id: str,
+        *,
+        limit: int | None = None,
+    ) -> list[CandidateProvenance]:
+        """Return provenance history for a candidate."""
+
+
+class ScrapeAttemptStore(ABC):
+    """Persistence interface for scrape-attempt history."""
+
+    @abstractmethod
+    def append_attempts(self, attempts: Sequence[ScrapeAttempt]) -> None:
+        """Append scrape-attempt records."""
+
+    @abstractmethod
+    def list_attempts(
+        self,
+        candidate_id: str,
+        *,
+        limit: int | None = None,
+    ) -> list[ScrapeAttempt]:
+        """Return scrape attempts for a candidate."""

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from denbust.discovery.models import PersistentCandidate
 from denbust.models.common import DatasetName, JobName
+from denbust.store.run_snapshots import snapshot_filename
 
 
 class DiscoveryStatePaths(BaseModel):
@@ -56,9 +57,8 @@ def resolve_discovery_state_paths(
 
 
 def discovery_snapshot_filename(run_timestamp: datetime) -> str:
-    """Build a git-safe filename for discovery-layer snapshots."""
-    safe_timestamp = run_timestamp.astimezone(UTC).strftime("%Y-%m-%dT%H-%M-%S-%fZ")
-    return f"{safe_timestamp}.json"
+    """Build a discovery-layer snapshot filename using the shared run format."""
+    return snapshot_filename(run_timestamp)
 
 
 def write_discovery_run_snapshot(

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -1,0 +1,90 @@
+"""State-repo path helpers for the durable discovery layer."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from denbust.discovery.models import PersistentCandidate
+from denbust.models.common import DatasetName, JobName
+
+
+class DiscoveryStatePaths(BaseModel):
+    """Resolved candidate-layer paths under the state root."""
+
+    state_root: Path
+    dataset_name: DatasetName
+    job_name: JobName
+    namespace_dir: Path
+    runs_dir: Path
+    candidates_dir: Path
+    metrics_dir: Path
+    latest_candidates_path: Path
+    retry_queue_path: Path
+    backfill_queue_path: Path
+    engine_overlap_latest_path: Path
+
+
+def resolve_discovery_state_paths(
+    *,
+    state_root: Path,
+    dataset_name: DatasetName,
+    job_name: JobName = JobName.DISCOVER,
+) -> DiscoveryStatePaths:
+    """Resolve the candidate-layer state layout for a dataset."""
+    namespace_dir = state_root / dataset_name / job_name
+    runs_dir = namespace_dir / "runs"
+    candidates_dir = namespace_dir / "candidates"
+    metrics_dir = namespace_dir / "metrics"
+    return DiscoveryStatePaths(
+        state_root=state_root,
+        dataset_name=dataset_name,
+        job_name=job_name,
+        namespace_dir=namespace_dir,
+        runs_dir=runs_dir,
+        candidates_dir=candidates_dir,
+        metrics_dir=metrics_dir,
+        latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
+        retry_queue_path=candidates_dir / "retry_queue.jsonl",
+        backfill_queue_path=candidates_dir / "backfill_queue.jsonl",
+        engine_overlap_latest_path=metrics_dir / "engine_overlap_latest.json",
+    )
+
+
+def discovery_snapshot_filename(run_timestamp: datetime) -> str:
+    """Build a git-safe filename for discovery-layer snapshots."""
+    safe_timestamp = run_timestamp.astimezone(UTC).strftime("%Y-%m-%dT%H-%M-%S-%fZ")
+    return f"{safe_timestamp}.json"
+
+
+def write_discovery_run_snapshot(runs_dir: Path, payload: dict[str, Any], *, run_timestamp: datetime) -> Path:
+    """Write a per-run discovery artifact to disk."""
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    path = runs_dir / discovery_snapshot_filename(run_timestamp)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return path
+
+
+def write_candidate_jsonl(path: Path, candidates: list[PersistentCandidate]) -> Path:
+    """Write candidate rows to a JSONL file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for candidate in candidates:
+            handle.write(candidate.model_dump_json())
+            handle.write("\n")
+    return path
+
+
+def write_metrics_snapshot(path: Path, payload: dict[str, Any]) -> Path:
+    """Write a JSON metrics artifact for discovery diagnostics."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return path

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -61,7 +61,9 @@ def discovery_snapshot_filename(run_timestamp: datetime) -> str:
     return f"{safe_timestamp}.json"
 
 
-def write_discovery_run_snapshot(runs_dir: Path, payload: dict[str, Any], *, run_timestamp: datetime) -> Path:
+def write_discovery_run_snapshot(
+    runs_dir: Path, payload: dict[str, Any], *, run_timestamp: datetime
+) -> Path:
     """Write a per-run discovery artifact to disk."""
     runs_dir.mkdir(parents=True, exist_ok=True)
     path = runs_dir / discovery_snapshot_filename(run_timestamp)

--- a/src/denbust/models/common.py
+++ b/src/denbust/models/common.py
@@ -19,9 +19,13 @@ class DatasetName(StrEnum):
 class JobName(StrEnum):
     """Supported dataset job identifiers."""
 
+    DISCOVER = "discover"
+    SCRAPE_CANDIDATES = "scrape_candidates"
     INGEST = "ingest"
     RELEASE = "release"
     BACKUP = "backup"
+    BACKFILL_DISCOVER = "backfill_discover"
+    BACKFILL_SCRAPE = "backfill_scrape"
 
 
 def normalize_job_name(value: JobName | str | None) -> JobName:

--- a/supabase/migrations/20260410_discovery_candidacy_foundation.sql
+++ b/supabase/migrations/20260410_discovery_candidacy_foundation.sql
@@ -9,7 +9,7 @@ create table if not exists public.discovery_runs (
     candidate_count integer not null default 0,
     merged_candidate_count integer not null default 0,
     queued_for_scrape_count integer not null default 0,
-    errors_json jsonb not null default '[]'::jsonb
+    errors jsonb not null default '[]'::jsonb
 );
 
 create index if not exists discovery_runs_dataset_job_idx
@@ -34,7 +34,7 @@ create table if not exists public.persistent_candidates (
     needs_review boolean not null default false,
     backfill_batch_id text,
     self_heal_eligible boolean not null default false,
-    metadata_json jsonb not null default '{}'::jsonb
+    metadata jsonb not null default '{}'::jsonb
 );
 
 create index if not exists persistent_candidates_status_idx
@@ -62,7 +62,7 @@ create table if not exists public.candidate_provenance (
     rank integer,
     domain text,
     discovered_at timestamptz not null,
-    metadata_json jsonb not null default '{}'::jsonb
+    metadata jsonb not null default '{}'::jsonb
 );
 
 create index if not exists candidate_provenance_candidate_idx
@@ -84,7 +84,7 @@ create table if not exists public.scrape_attempts (
     extracted_body_hash text,
     error_code text,
     error_message text,
-    diagnostics_json jsonb not null default '{}'::jsonb
+    diagnostics jsonb not null default '{}'::jsonb
 );
 
 create index if not exists scrape_attempts_candidate_idx

--- a/supabase/migrations/20260410_discovery_candidacy_foundation.sql
+++ b/supabase/migrations/20260410_discovery_candidacy_foundation.sql
@@ -1,0 +1,94 @@
+create table if not exists public.discovery_runs (
+    run_id text primary key,
+    started_at timestamptz not null,
+    finished_at timestamptz,
+    dataset_name text not null,
+    job_name text not null,
+    status text not null,
+    query_count integer not null default 0,
+    candidate_count integer not null default 0,
+    merged_candidate_count integer not null default 0,
+    queued_for_scrape_count integer not null default 0,
+    errors_json jsonb not null default '[]'::jsonb
+);
+
+create index if not exists discovery_runs_dataset_job_idx
+    on public.discovery_runs (dataset_name, job_name, started_at desc);
+
+create table if not exists public.persistent_candidates (
+    candidate_id text primary key,
+    canonical_url text,
+    current_url text not null,
+    domain text,
+    source_discovery_only boolean not null default false,
+    first_seen_at timestamptz not null,
+    last_seen_at timestamptz not null,
+    candidate_status text not null,
+    scrape_attempt_count integer not null default 0,
+    last_scrape_attempt_at timestamptz,
+    next_scrape_attempt_at timestamptz,
+    last_scrape_error_code text,
+    last_scrape_error_message text,
+    content_basis text not null,
+    retry_priority integer not null default 0,
+    needs_review boolean not null default false,
+    backfill_batch_id text,
+    self_heal_eligible boolean not null default false,
+    metadata_json jsonb not null default '{}'::jsonb
+);
+
+create index if not exists persistent_candidates_status_idx
+    on public.persistent_candidates (candidate_status, next_scrape_attempt_at);
+
+create index if not exists persistent_candidates_domain_idx
+    on public.persistent_candidates (domain, last_seen_at desc);
+
+create index if not exists persistent_candidates_canonical_url_idx
+    on public.persistent_candidates (canonical_url)
+    where canonical_url is not null;
+
+create table if not exists public.candidate_provenance (
+    provenance_id text primary key,
+    run_id text not null references public.discovery_runs (run_id) on delete cascade,
+    candidate_id text not null references public.persistent_candidates (candidate_id) on delete cascade,
+    producer_name text not null,
+    producer_kind text not null,
+    query_text text,
+    raw_url text not null,
+    normalized_url text,
+    title text,
+    snippet text,
+    publication_datetime_hint timestamptz,
+    rank integer,
+    domain text,
+    discovered_at timestamptz not null,
+    metadata_json jsonb not null default '{}'::jsonb
+);
+
+create index if not exists candidate_provenance_candidate_idx
+    on public.candidate_provenance (candidate_id, discovered_at desc);
+
+create index if not exists candidate_provenance_run_idx
+    on public.candidate_provenance (run_id, producer_name);
+
+create table if not exists public.scrape_attempts (
+    attempt_id text primary key,
+    candidate_id text not null references public.persistent_candidates (candidate_id) on delete cascade,
+    started_at timestamptz not null,
+    finished_at timestamptz,
+    attempt_kind text not null,
+    fetch_status text not null,
+    source_adapter_name text,
+    extracted_title text,
+    extracted_publication_datetime timestamptz,
+    extracted_body_hash text,
+    error_code text,
+    error_message text,
+    diagnostics_json jsonb not null default '{}'::jsonb
+);
+
+create index if not exists scrape_attempts_candidate_idx
+    on public.scrape_attempts (candidate_id, started_at desc);
+
+create index if not exists scrape_attempts_status_idx
+    on public.scrape_attempts (fetch_status, started_at desc);

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,7 @@ from denbust.config import (
     OutputFormat,
     ReleaseConfig,
     SourceConfig,
+    SourceDiscoveryConfig,
     SourceType,
     StoreConfig,
     load_config,
@@ -248,6 +249,13 @@ class TestConfig:
 
         assert config.source_discovery.sources["ynet"].enabled is True
         assert config.source_discovery.sources["mako"].enabled is False
+
+    def test_source_discovery_normalizer_passthrough_for_non_mapping(self) -> None:
+        """SourceDiscoveryConfig's pre-validator should leave non-mapping values untouched."""
+        sentinel = object()
+
+        assert SourceDiscoveryConfig._normalize_sources(sentinel) is sentinel
+        assert SourceDiscoveryConfig._normalize_sources(None) is None
 
     def test_discovery_config_parses_engine_blocks(self) -> None:
         """Discovery engine settings should parse from YAML-like mappings."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,8 +5,12 @@ from pathlib import Path
 import pytest
 
 from denbust.config import (
+    BackfillConfig,
+    CandidatesConfig,
     Config,
     DedupConfig,
+    DiscoveryConfig,
+    DiscoveryQueryKind,
     GoogleDriveBackupConfig,
     ObjectStorageBackupConfig,
     OutputConfig,
@@ -40,9 +44,22 @@ class TestConfig:
         assert config.store.seen_path is None
         assert config.store.runs_dir is None
         assert config.store.publication_dir is None
+        assert config.discovery.enabled is False
+        assert config.discovery.persist_candidates is True
+        assert config.discovery.default_query_kinds == [
+            DiscoveryQueryKind.BROAD,
+            DiscoveryQueryKind.SOURCE_TARGETED,
+        ]
+        assert config.source_discovery.enabled is True
+        assert config.candidates.discovery_runs_table == "discovery_runs"
+        assert config.backfill.enabled is False
         assert config.state_paths.seen_path == Path("data/news_items/ingest/seen.json")
         assert config.state_paths.runs_dir == Path("data/news_items/ingest/runs")
         assert config.state_paths.publication_dir == Path("data/news_items/ingest/publication")
+        assert config.discovery_state_paths.namespace_dir == Path("data/news_items/discover")
+        assert config.discovery_state_paths.latest_candidates_path == Path(
+            "data/news_items/discover/candidates/latest_candidates.jsonl"
+        )
 
     def test_custom_days(self) -> None:
         """Test custom days configuration."""
@@ -216,6 +233,63 @@ class TestConfig:
         assert config.state_paths.runs_dir == Path("custom/runs")
         assert config.state_paths.publication_dir == Path("custom/publication")
 
+    def test_source_discovery_config_normalizes_boolean_source_toggles(self) -> None:
+        """Per-source discovery config should accept shorthand booleans."""
+        config = Config.model_validate(
+            {
+                "source_discovery": {
+                    "sources": {
+                        "ynet": True,
+                        "mako": {"enabled": False},
+                    }
+                }
+            }
+        )
+
+        assert config.source_discovery.sources["ynet"].enabled is True
+        assert config.source_discovery.sources["mako"].enabled is False
+
+    def test_discovery_config_parses_engine_blocks(self) -> None:
+        """Discovery engine settings should parse from YAML-like mappings."""
+        config = DiscoveryConfig.model_validate(
+            {
+                "enabled": True,
+                "engines": {
+                    "brave": {"enabled": True, "max_results_per_query": 25},
+                    "exa": {"enabled": True, "allow_find_similar": False},
+                    "google_cse": {"enabled": True, "cse_id_env": "CUSTOM_GOOGLE_CSE_ID"},
+                },
+            }
+        )
+
+        assert config.enabled is True
+        assert config.engines.brave.enabled is True
+        assert config.engines.brave.max_results_per_query == 25
+        assert config.engines.exa.allow_find_similar is False
+        assert config.engines.google_cse.cse_id_env == "CUSTOM_GOOGLE_CSE_ID"
+
+    def test_candidates_config_defaults(self) -> None:
+        """Candidate persistence defaults should match the design doc scaffolding."""
+        config = CandidatesConfig()
+
+        assert config.discovery_runs_table == "discovery_runs"
+        assert config.supabase_table == "persistent_candidates"
+        assert config.provenance_table == "candidate_provenance"
+        assert config.scrape_attempts_table == "scrape_attempts"
+        assert config.default_retry_backoff_hours == 24
+        assert config.max_retry_attempts == 10
+
+    def test_backfill_config_validation(self) -> None:
+        """Backfill settings should enforce positive queue limits."""
+        config = BackfillConfig()
+
+        assert config.batch_window_days == 7
+        assert config.max_candidates_per_run == 500
+        assert config.max_scrape_attempts_per_run == 100
+
+        with pytest.raises(ValueError):
+            BackfillConfig(batch_window_days=0)
+
     def test_store_normalizer_passthrough_for_non_mapping(self) -> None:
         """The pre-validator should pass through non-mapping values unchanged."""
         sentinel = object()
@@ -259,6 +333,20 @@ class TestConfig:
 
         assert GoogleDriveBackupConfig._apply_env_overrides(sentinel) is sentinel
         assert ObjectStorageBackupConfig._apply_env_overrides(sentinel) is sentinel
+
+    def test_discovery_env_properties(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Discovery API key helpers should honor configured env names."""
+        monkeypatch.setenv("DENBUST_BRAVE_SEARCH_API_KEY", "brave-key")
+        monkeypatch.setenv("DENBUST_EXA_API_KEY", "exa-key")
+        monkeypatch.setenv("DENBUST_GOOGLE_CSE_API_KEY", "google-key")
+        monkeypatch.setenv("DENBUST_GOOGLE_CSE_ID", "search-engine-id")
+
+        config = Config()
+
+        assert config.brave_search_api_key == "brave-key"
+        assert config.exa_api_key == "exa-key"
+        assert config.google_cse_api_key == "google-key"
+        assert config.google_cse_id == "search-engine-id"
 
     def test_phase_b_env_properties(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Phase B service credentials should be exposed through config properties."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -257,6 +257,17 @@ class TestConfig:
         assert SourceDiscoveryConfig._normalize_sources(sentinel) is sentinel
         assert SourceDiscoveryConfig._normalize_sources(None) is None
 
+    def test_source_discovery_rejects_non_boolean_shorthand(self) -> None:
+        """Source shorthand should only accept actual booleans, not truthy strings."""
+        with pytest.raises(ValueError, match="sources entries must be mappings or booleans"):
+            SourceDiscoveryConfig.model_validate(
+                {
+                    "sources": {
+                        "ynet": "false",
+                    }
+                }
+            )
+
     def test_discovery_config_parses_engine_blocks(self) -> None:
         """Discovery engine settings should parse from YAML-like mappings."""
         config = DiscoveryConfig.model_validate(

--- a/tests/unit/test_discovery_migration.py
+++ b/tests/unit/test_discovery_migration.py
@@ -1,0 +1,27 @@
+"""Unit tests for the discovery-layer Supabase migration scaffold."""
+
+from pathlib import Path
+
+MIGRATION_PATH = Path("supabase/migrations/20260410_discovery_candidacy_foundation.sql")
+
+
+def test_discovery_migration_defines_required_tables() -> None:
+    """The foundation migration should create the durable candidate-layer tables."""
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "create table if not exists public.discovery_runs" in sql
+    assert "create table if not exists public.persistent_candidates" in sql
+    assert "create table if not exists public.candidate_provenance" in sql
+    assert "create table if not exists public.scrape_attempts" in sql
+
+
+def test_discovery_migration_includes_core_columns() -> None:
+    """The migration should cover the core queueing and retry columns from the design."""
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "candidate_status text not null" in sql
+    assert "content_basis text not null" in sql
+    assert "next_scrape_attempt_at timestamptz" in sql
+    assert "metadata_json jsonb not null default '{}'::jsonb" in sql
+    assert "errors_json jsonb not null default '[]'::jsonb" in sql
+    assert "diagnostics_json jsonb not null default '{}'::jsonb" in sql

--- a/tests/unit/test_discovery_migration.py
+++ b/tests/unit/test_discovery_migration.py
@@ -22,6 +22,6 @@ def test_discovery_migration_includes_core_columns() -> None:
     assert "candidate_status text not null" in sql
     assert "content_basis text not null" in sql
     assert "next_scrape_attempt_at timestamptz" in sql
-    assert "metadata_json jsonb not null default '{}'::jsonb" in sql
-    assert "errors_json jsonb not null default '[]'::jsonb" in sql
-    assert "diagnostics_json jsonb not null default '{}'::jsonb" in sql
+    assert "metadata jsonb not null default '{}'::jsonb" in sql
+    assert "errors jsonb not null default '[]'::jsonb" in sql
+    assert "diagnostics jsonb not null default '{}'::jsonb" in sql

--- a/tests/unit/test_discovery_models.py
+++ b/tests/unit/test_discovery_models.py
@@ -1,0 +1,131 @@
+"""Unit tests for persistent discovery-layer models."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from denbust.discovery.models import (
+    CandidateProvenance,
+    CandidateStatus,
+    ContentBasis,
+    DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    FetchStatus,
+    PersistentCandidate,
+    ProducerKind,
+    ScrapeAttempt,
+    ScrapeAttemptKind,
+)
+from denbust.models.common import JobName
+
+
+def test_discovery_query_validates_date_window() -> None:
+    """Discovery queries should reject inverted date windows."""
+    query = DiscoveryQuery(
+        query_text='site:example.com "בית בושת"',
+        date_from=datetime(2026, 4, 1, tzinfo=UTC),
+        date_to=datetime(2026, 4, 2, tzinfo=UTC),
+        query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+    )
+
+    assert query.query_kind == DiscoveryQueryKind.SOURCE_TARGETED
+
+    with pytest.raises(ValueError):
+        DiscoveryQuery(
+            query_text="bad",
+            date_from=datetime(2026, 4, 3, tzinfo=UTC),
+            date_to=datetime(2026, 4, 2, tzinfo=UTC),
+        )
+
+
+def test_discovered_candidate_serializes_with_inferred_domain() -> None:
+    """Discovered candidates should infer domains from their URL."""
+    candidate = DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        candidate_url="https://news.example.com/item/123",
+        title="Candidate title",
+    )
+
+    assert candidate.domain == "news.example.com"
+    payload = candidate.model_dump(mode="json")
+    assert payload["candidate_url"] == "https://news.example.com/item/123"
+    assert payload["producer_kind"] == "search_engine"
+
+
+def test_persistent_candidate_validates_scrape_timestamps() -> None:
+    """Persistent candidates should enforce coherent retry timestamps."""
+    first_seen = datetime(2026, 4, 10, 8, 0, tzinfo=UTC)
+    last_attempt = first_seen + timedelta(hours=1)
+    next_attempt = last_attempt + timedelta(hours=12)
+    candidate = PersistentCandidate(
+        current_url="https://mako.co.il/news/123",
+        canonical_url="https://mako.co.il/news/123",
+        titles=["Example"],
+        discovered_via=["source_native"],
+        first_seen_at=first_seen,
+        last_seen_at=first_seen,
+        last_scrape_attempt_at=last_attempt,
+        next_scrape_attempt_at=next_attempt,
+        candidate_status=CandidateStatus.SCRAPE_FAILED,
+        content_basis=ContentBasis.PARTIAL_PAGE,
+        scrape_attempt_count=1,
+    )
+
+    assert candidate.domain == "mako.co.il"
+    assert candidate.candidate_status == CandidateStatus.SCRAPE_FAILED
+
+    with pytest.raises(ValueError):
+        PersistentCandidate(
+            current_url="https://mako.co.il/news/123",
+            first_seen_at=first_seen,
+            last_seen_at=first_seen - timedelta(minutes=1),
+        )
+
+
+def test_candidate_provenance_uses_normalized_url_for_domain() -> None:
+    """Provenance should prefer normalized URLs when inferring domains."""
+    provenance = CandidateProvenance(
+        run_id="run-1",
+        candidate_id="candidate-1",
+        producer_name="google_cse",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        raw_url="https://google.com/url?q=https://www.ynet.co.il/item",
+        normalized_url="https://www.ynet.co.il/item",
+    )
+
+    assert provenance.domain == "www.ynet.co.il"
+
+
+def test_scrape_attempt_validates_finished_at() -> None:
+    """Scrape attempts should reject finish times before the start."""
+    started_at = datetime(2026, 4, 10, 10, 0, tzinfo=UTC)
+    attempt = ScrapeAttempt(
+        candidate_id="candidate-1",
+        started_at=started_at,
+        finished_at=started_at + timedelta(minutes=1),
+        attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+        fetch_status=FetchStatus.SUCCESS,
+    )
+
+    assert attempt.fetch_status == FetchStatus.SUCCESS
+
+    with pytest.raises(ValueError):
+        ScrapeAttempt(
+            candidate_id="candidate-1",
+            started_at=started_at,
+            finished_at=started_at - timedelta(minutes=1),
+            attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+            fetch_status=FetchStatus.FAILED,
+        )
+
+
+def test_discovery_run_defaults_to_discover_job() -> None:
+    """Discovery runs should default to the new discover job identity."""
+    run = DiscoveryRun(status=DiscoveryRunStatus.RUNNING)
+
+    assert run.job_name == JobName.DISCOVER
+    assert run.status == DiscoveryRunStatus.RUNNING

--- a/tests/unit/test_discovery_models.py
+++ b/tests/unit/test_discovery_models.py
@@ -18,6 +18,7 @@ from denbust.discovery.models import (
     ProducerKind,
     ScrapeAttempt,
     ScrapeAttemptKind,
+    _domain_from_url,
 )
 from denbust.models.common import JobName
 
@@ -56,6 +57,11 @@ def test_discovered_candidate_serializes_with_inferred_domain() -> None:
     assert payload["producer_kind"] == "search_engine"
 
 
+def test_domain_from_url_none_passthrough() -> None:
+    """The internal domain helper should preserve a missing URL as None."""
+    assert _domain_from_url(None) is None
+
+
 def test_persistent_candidate_validates_scrape_timestamps() -> None:
     """Persistent candidates should enforce coherent retry timestamps."""
     first_seen = datetime(2026, 4, 10, 8, 0, tzinfo=UTC)
@@ -83,6 +89,23 @@ def test_persistent_candidate_validates_scrape_timestamps() -> None:
             current_url="https://mako.co.il/news/123",
             first_seen_at=first_seen,
             last_seen_at=first_seen - timedelta(minutes=1),
+        )
+
+    with pytest.raises(ValueError):
+        PersistentCandidate(
+            current_url="https://mako.co.il/news/123",
+            first_seen_at=first_seen,
+            last_seen_at=first_seen,
+            last_scrape_attempt_at=first_seen - timedelta(minutes=1),
+        )
+
+    with pytest.raises(ValueError):
+        PersistentCandidate(
+            current_url="https://mako.co.il/news/123",
+            first_seen_at=first_seen,
+            last_seen_at=first_seen,
+            last_scrape_attempt_at=last_attempt,
+            next_scrape_attempt_at=last_attempt - timedelta(minutes=1),
         )
 
 
@@ -129,3 +152,14 @@ def test_discovery_run_defaults_to_discover_job() -> None:
 
     assert run.job_name == JobName.DISCOVER
     assert run.status == DiscoveryRunStatus.RUNNING
+
+
+def test_discovery_run_rejects_finished_at_before_started_at() -> None:
+    """Discovery runs should reject inverted timestamps."""
+    started_at = datetime(2026, 4, 10, 10, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError):
+        DiscoveryRun(
+            started_at=started_at,
+            finished_at=started_at - timedelta(minutes=1),
+        )

--- a/tests/unit/test_discovery_state_paths.py
+++ b/tests/unit/test_discovery_state_paths.py
@@ -1,0 +1,65 @@
+"""Unit tests for discovery-layer state path helpers."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from denbust.discovery.models import PersistentCandidate
+from denbust.discovery.state_paths import (
+    discovery_snapshot_filename,
+    resolve_discovery_state_paths,
+    write_candidate_jsonl,
+    write_discovery_run_snapshot,
+    write_metrics_snapshot,
+)
+from denbust.models.common import DatasetName
+
+
+def test_resolve_discovery_state_paths_uses_discover_namespace() -> None:
+    """Discovery-layer state files should live under dataset/discover."""
+    paths = resolve_discovery_state_paths(
+        state_root=Path("state_repo"),
+        dataset_name=DatasetName.NEWS_ITEMS,
+    )
+
+    assert paths.namespace_dir == Path("state_repo/news_items/discover")
+    assert paths.runs_dir == Path("state_repo/news_items/discover/runs")
+    assert paths.latest_candidates_path == Path(
+        "state_repo/news_items/discover/candidates/latest_candidates.jsonl"
+    )
+    assert paths.engine_overlap_latest_path == Path(
+        "state_repo/news_items/discover/metrics/engine_overlap_latest.json"
+    )
+
+
+def test_discovery_snapshot_filename_is_git_safe() -> None:
+    """Discovery snapshots should use the shared timestamp-safe filename format."""
+    filename = discovery_snapshot_filename(datetime(2026, 4, 10, 12, 0, 1, tzinfo=UTC))
+
+    assert filename == "2026-04-10T12-00-01-000000Z.json"
+
+
+def test_write_discovery_layer_artifacts(tmp_path: Path) -> None:
+    """Helpers should write JSON and JSONL candidate artifacts."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    candidate = PersistentCandidate(
+        current_url="https://www.ynet.co.il/item",
+        titles=["Example candidate"],
+        discovered_via=["brave"],
+    )
+
+    run_path = write_discovery_run_snapshot(
+        paths.runs_dir,
+        {"run_id": "run-1", "status": "running"},
+        run_timestamp=datetime(2026, 4, 10, 12, 0, 1, tzinfo=UTC),
+    )
+    candidates_path = write_candidate_jsonl(paths.latest_candidates_path, [candidate])
+    metrics_path = write_metrics_snapshot(paths.engine_overlap_latest_path, {"brave": 3})
+
+    assert run_path.exists()
+    assert candidates_path.exists()
+    assert metrics_path.exists()
+    assert json.loads(metrics_path.read_text(encoding="utf-8")) == {"brave": 3}
+    candidate_lines = candidates_path.read_text(encoding="utf-8").splitlines()
+    assert len(candidate_lines) == 1
+    assert '"current_url":"https://www.ynet.co.il/item"' in candidate_lines[0]

--- a/tests/unit/test_discovery_state_paths.py
+++ b/tests/unit/test_discovery_state_paths.py
@@ -62,4 +62,5 @@ def test_write_discovery_layer_artifacts(tmp_path: Path) -> None:
     assert json.loads(metrics_path.read_text(encoding="utf-8")) == {"brave": 3}
     candidate_lines = candidates_path.read_text(encoding="utf-8").splitlines()
     assert len(candidate_lines) == 1
-    assert '"current_url":"https://www.ynet.co.il/item"' in candidate_lines[0]
+    candidate_record = json.loads(candidate_lines[0])
+    assert candidate_record["current_url"] == "https://www.ynet.co.il/item"

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -993,7 +993,9 @@ class TestRunPipeline:
         """Scaffolded but unimplemented jobs should fail with a specific placeholder message."""
         config = Config(dataset_name="news_items", job_name="discover")
 
-        with pytest.raises(ValueError, match="news_items/discover is scaffolded but not implemented yet"):
+        with pytest.raises(
+            ValueError, match="news_items/discover is scaffolded but not implemented yet"
+        ):
             await run_job_async(config)
 
     @pytest.mark.asyncio

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -989,6 +989,14 @@ class TestRunPipeline:
             await run_job_async(config)
 
     @pytest.mark.asyncio
+    async def test_run_job_async_rejects_scaffolded_discover_job_with_clear_message(self) -> None:
+        """Scaffolded but unimplemented jobs should fail with a specific placeholder message."""
+        config = Config(dataset_name="news_items", job_name="discover")
+
+        with pytest.raises(ValueError, match="news_items/discover is scaffolded but not implemented yet"):
+            await run_job_async(config)
+
+    @pytest.mark.asyncio
     async def test_run_job_async_writes_run_metadata_via_operational_store(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

This PR implements **PR 1 — Discovery/Candidacy foundation (models, config, persistence scaffolding)** from [`docs/tfht_discovery_layer_implementation_plan.md`](../blob/main/docs/tfht_discovery_layer_implementation_plan.md), using [`docs/tfht_discovery_layer_design_amended.md`](../blob/main/docs/tfht_discovery_layer_design_amended.md) as the source of truth.

The goal here is to introduce the durable candidate-layer foundation without changing the current production ingest behavior.

## What this PR adds

### 1. New `denbust.discovery` package scaffolding

Adds a new package under `src/denbust/discovery/` with:

- core discovery/candidacy models
- producer protocols for future search-engine and source-native discovery adapters
- persistence abstractions for candidate/provenance/scrape-attempt stores
- state-repo path and file helpers for discovery-layer artifacts

### 2. Core durable discovery models

Adds explicit Pydantic models for:

- `DiscoveryQuery`
- `DiscoveredCandidate`
- `PersistentCandidate`
- `CandidateProvenance`
- `ScrapeAttempt`
- `DiscoveryRun`

These models encode the durable candidate substrate described in the amended design, including:

- source-native and search-engine candidacy
- retryable candidate states
- scrape-attempt auditability
- candidate-layer metadata suitable for later backfill, self-healing, and source-suggestion work

### 3. Config scaffolding for the new layer

Extends `Config` with additive sections for:

- `discovery`
- `source_discovery`
- `candidates`
- `backfill`

This includes initial engine config scaffolding for:

- Brave Search API
- Exa
- Google Custom Search JSON API

No engine calls are implemented in this PR. This is config and structural groundwork only.

### 4. State-repo path conventions for discovery artifacts

Adds a dedicated candidate-layer namespace under the dataset state root:

```text
<state_root>/news_items/discover/
  runs/
  candidates/
    latest_candidates.jsonl
    retry_queue.jsonl
    backfill_queue.jsonl
  metrics/
    engine_overlap_latest.json
```

This keeps candidate-layer state separate from the current ingest `seen.json` and run-snapshot layout while staying consistent with the repo’s dataset/job namespacing approach.

### 5. Supabase migration for durable candidate-layer tables

Adds a new migration creating:

- `discovery_runs`
- `persistent_candidates`
- `candidate_provenance`
- `scrape_attempts`

The schema is intentionally boring and explicit. It supports candidate durability, provenance, and scrape-attempt bookkeeping without yet wiring any runtime ingestion behavior to it.

### 6. Test coverage for the foundation layer

Adds focused unit coverage for:

- discovery-model validation and serialization
- config parsing/defaults for new sections
- discovery-layer state-path resolution and artifact writers
- migration/schema expectations at the SQL-text level

## What this PR does **not** do

Per the requested scope, this PR intentionally does **not** implement:

- Brave engine calls
- Exa engine calls
- Google CSE engine calls
- source-native candidacy persistence
- candidate merge/upsert execution flow
- scrape queue execution
- retry scheduling
- backfill jobs
- self-healing logic
- source suggestion logic
- social-targeted discovery behavior
- event-layer logic

## Compatibility / risk profile

This is designed as an additive, mergeable first step:

- the current `news_items / ingest` flow remains intact
- the current daily email monitoring flow remains intact
- no existing ingest/release/backup behavior is rerouted through the new candidate layer yet
- new job identities and config sections are present for future PRs, but not operationally wired into production behavior in this change

## Key files

- `src/denbust/discovery/models.py`
- `src/denbust/discovery/base.py`
- `src/denbust/discovery/persistence.py`
- `src/denbust/discovery/state_paths.py`
- `src/denbust/config.py`
- `src/denbust/models/common.py`
- `supabase/migrations/20260410_discovery_candidacy_foundation.sql`
- `tests/unit/test_discovery_models.py`
- `tests/unit/test_discovery_state_paths.py`
- `tests/unit/test_discovery_migration.py`

## Validation

Ran:

```bash
ruff check src/denbust/config.py src/denbust/models/common.py src/denbust/discovery tests/unit/test_discovery_models.py tests/unit/test_discovery_state_paths.py tests/unit/test_discovery_migration.py tests/unit/test_config.py
pytest -q tests/unit/test_discovery_models.py tests/unit/test_discovery_state_paths.py tests/unit/test_discovery_migration.py tests/unit/test_config.py tests/unit/test_state_paths.py
```

Both passed locally.

## Follow-on work enabled by this PR

This lays the groundwork for the next PRs in the implementation plan, especially:

- source-native candidacy persistence
- candidate merge/upsert logic
- candidate-driven scrape attempts and retry state
- Brave/Exa/Google CSE engine integration
- later backfill and self-healing workflows
