### PR TITLE
Add candidate-driven scrape attempt layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Future-facing commands now exist as real `news_items` jobs:
 
 ```bash
 denbust run --dataset news_items --job discover --config agents/news/local.yaml
+denbust run --dataset news_items --job scrape_candidates --config agents/news/local.yaml
 denbust run --dataset news_items --job ingest --config agents/news/local.yaml
 denbust release --dataset news_items --config agents/release/news_items.yaml
 denbust backup --dataset news_items --config agents/backup/news_items.yaml
@@ -222,8 +223,8 @@ Still intentionally deferred:
 
 ## Discovery Layer Foundation
 
-PR 2 of the persistent multi-engine discovery work now adds the first operational slice on top of
-the PR 1 foundation:
+PR 3 of the persistent multi-engine discovery work now builds on the PR 1 foundation and the PR 2
+source-native persistence slice:
 
 - `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
   models
@@ -231,17 +232,21 @@ the PR 1 foundation:
 - explicit state-repo path helpers for candidate-layer snapshots and queue files
 - source-native candidate normalization and merge/upsert persistence
 - a real `news_items / discover` job that fetches source-native candidates only and persists them
-- best-effort source-native candidate persistence during `news_items / ingest`, without changing the
-  existing ingest/release/backup flow
+- candidate selection / queueing helpers for retryable scrape work
+- scrape-attempt persistence and candidate status transitions underneath the ingest path
+- a real `news_items / scrape_candidates` job that drains queued candidates into article ingest
+- `news_items / ingest` now uses the candidate scrape layer for source-native candidates while
+  preserving the existing direct-fetch convenience flow as a compatibility fallback
 - Supabase migrations for:
   - `discovery_runs`
   - `persistent_candidates`
   - `candidate_provenance`
   - `scrape_attempts`
 
-This PR does not yet call Brave, Exa, or Google CSE, and it does not yet route the live ingest
-pipeline through the durable candidate queue. The current daily monitoring flow remains behaviorally
-unchanged aside from persisting source-native candidate rows as an additive side effect.
+This PR still does not call Brave, Exa, or Google CSE, and the generic fetch/extract fallback is
+only scaffolded structurally for retry bookkeeping. The current daily monitoring flow remains
+operational, but candidate selection, scrape attempts, and retryable failure state now exist as a
+real substrate under source-native ingest.
 
 ## Config Layout
 

--- a/src/denbust/datasets/jobs.py
+++ b/src/denbust/datasets/jobs.py
@@ -58,6 +58,22 @@ async def _run_news_items_discover(
     )
 
 
+async def _run_news_items_scrape_candidates(
+    config: Config,
+    config_path: Path | None,
+    days_override: int | None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    from denbust.pipeline import run_news_scrape_candidates_job
+
+    return await run_news_scrape_candidates_job(
+        config,
+        config_path=config_path,
+        days_override=days_override,
+        operational_store=operational_store,
+    )
+
+
 async def _run_scaffolded_release(
     config: Config,
     config_path: Path | None,
@@ -116,7 +132,7 @@ def ensure_default_jobs_registered() -> None:
     register_job(
         DatasetName.NEWS_ITEMS,
         JobName.SCRAPE_CANDIDATES,
-        _run_unimplemented_scaffold_job,
+        _run_news_items_scrape_candidates,
     )
     register_job(
         DatasetName.NEWS_ITEMS,

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -51,7 +51,8 @@ def select_candidates_for_scrape(
     eligible = [
         candidate
         for candidate in candidates
-        if candidate.next_scrape_attempt_at is None or candidate.next_scrape_attempt_at <= current_time
+        if candidate.next_scrape_attempt_at is None
+        or candidate.next_scrape_attempt_at <= current_time
     ]
     ordered = sorted(
         eligible,
@@ -165,9 +166,7 @@ def _mark_attempt_failure(
         config.candidates.allow_retry_on_fetch_failure
         and status is not CandidateStatus.UNSUPPORTED_SOURCE
     ):
-        retry_at = finished_at + timedelta(
-            hours=config.candidates.default_retry_backoff_hours
-        )
+        retry_at = finished_at + timedelta(hours=config.candidates.default_retry_backoff_hours)
     return candidate.model_copy(
         update={
             "candidate_status": status,

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -1,0 +1,325 @@
+"""Candidate selection and scrape-attempt orchestration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from denbust.config import Config
+from denbust.data_models import RawArticle
+from denbust.discovery.models import (
+    CandidateStatus,
+    ContentBasis,
+    FetchStatus,
+    PersistentCandidate,
+    ScrapeAttempt,
+    ScrapeAttemptKind,
+)
+from denbust.discovery.storage import DiscoveryPersistence
+from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
+from denbust.sources.base import Source
+
+SCRAPEABLE_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (
+    CandidateStatus.NEW,
+    CandidateStatus.QUEUED,
+    CandidateStatus.SCRAPE_PENDING,
+    CandidateStatus.SCRAPE_FAILED,
+    CandidateStatus.PARTIALLY_SCRAPED,
+)
+
+
+@dataclass
+class CandidateScrapeBatch:
+    """Results from attempting to materialize candidates into raw articles."""
+
+    selected_candidates: list[PersistentCandidate]
+    updated_candidates: list[PersistentCandidate]
+    attempts: list[ScrapeAttempt]
+    raw_articles: list[RawArticle]
+    errors: list[str]
+
+
+def select_candidates_for_scrape(
+    persistence: DiscoveryPersistence,
+    *,
+    limit: int,
+    now: datetime | None = None,
+) -> list[PersistentCandidate]:
+    """Return eligible durable candidates for scraping."""
+    current_time = now or datetime.now(UTC)
+    candidates = persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+    eligible = [
+        candidate
+        for candidate in candidates
+        if candidate.next_scrape_attempt_at is None or candidate.next_scrape_attempt_at <= current_time
+    ]
+    ordered = sorted(
+        eligible,
+        key=lambda candidate: (
+            candidate.retry_priority,
+            candidate.next_scrape_attempt_at or datetime.min.replace(tzinfo=UTC),
+            candidate.last_seen_at,
+            candidate.candidate_id,
+        ),
+        reverse=True,
+    )
+    return ordered[:limit]
+
+
+def queue_candidates_for_scrape(candidates: list[PersistentCandidate]) -> list[PersistentCandidate]:
+    """Mark candidates as queued or pending for an immediate scrape pass."""
+    queued: list[PersistentCandidate] = []
+    for candidate in candidates:
+        next_status = (
+            CandidateStatus.QUEUED
+            if candidate.candidate_status is CandidateStatus.NEW
+            else CandidateStatus.SCRAPE_PENDING
+        )
+        queued.append(candidate.model_copy(update={"candidate_status": next_status}))
+    return queued
+
+
+def _candidate_urls(candidate: PersistentCandidate) -> set[str]:
+    urls = {canonicalize_news_url(str(candidate.current_url))}
+    if candidate.canonical_url is not None:
+        urls.add(canonicalize_news_url(str(candidate.canonical_url)))
+    return urls
+
+
+def _select_source_name(
+    candidate: PersistentCandidate,
+    sources_by_name: dict[str, Source],
+) -> str | None:
+    for name in [*candidate.source_hints, *candidate.discovered_via]:
+        if name in sources_by_name:
+            return name
+    return None
+
+
+def _build_attempt(
+    *,
+    candidate_id: str,
+    started_at: datetime,
+    finished_at: datetime,
+    attempt_kind: ScrapeAttemptKind,
+    fetch_status: FetchStatus,
+    source_adapter_name: str | None = None,
+    article: RawArticle | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    diagnostics: dict[str, object] | None = None,
+) -> ScrapeAttempt:
+    return ScrapeAttempt(
+        candidate_id=candidate_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        attempt_kind=attempt_kind,
+        fetch_status=fetch_status,
+        source_adapter_name=source_adapter_name,
+        extracted_title=article.title if article is not None else None,
+        extracted_publication_datetime=article.date if article is not None else None,
+        error_code=error_code,
+        error_message=error_message,
+        diagnostics=diagnostics or {},
+    )
+
+
+def _mark_attempt_success(
+    candidate: PersistentCandidate,
+    attempt: ScrapeAttempt,
+    article: RawArticle,
+) -> PersistentCandidate:
+    return candidate.model_copy(
+        update={
+            "candidate_status": CandidateStatus.SCRAPE_SUCCEEDED,
+            "scrape_attempt_count": candidate.scrape_attempt_count + 1,
+            "last_scrape_attempt_at": attempt.finished_at,
+            "next_scrape_attempt_at": None,
+            "last_scrape_error_code": None,
+            "last_scrape_error_message": None,
+            "content_basis": ContentBasis.PARTIAL_PAGE,
+            "titles": deduplicate_strings([*candidate.titles, article.title]),
+            "snippets": deduplicate_strings([*candidate.snippets, article.snippet]),
+            "metadata": {
+                **candidate.metadata,
+                "last_scraped_source_name": article.source_name,
+                "last_scraped_candidate_url": str(candidate.current_url),
+            },
+        }
+    )
+
+
+def _mark_attempt_failure(
+    candidate: PersistentCandidate,
+    *,
+    attempts: list[ScrapeAttempt],
+    status: CandidateStatus,
+    error_code: str,
+    error_message: str,
+    config: Config,
+) -> PersistentCandidate:
+    final_attempt = attempts[-1]
+    finished_at = final_attempt.finished_at or final_attempt.started_at
+    retry_at = None
+    if (
+        config.candidates.allow_retry_on_fetch_failure
+        and status is not CandidateStatus.UNSUPPORTED_SOURCE
+    ):
+        retry_at = finished_at + timedelta(
+            hours=config.candidates.default_retry_backoff_hours
+        )
+    return candidate.model_copy(
+        update={
+            "candidate_status": status,
+            "scrape_attempt_count": candidate.scrape_attempt_count + len(attempts),
+            "last_scrape_attempt_at": finished_at,
+            "next_scrape_attempt_at": retry_at,
+            "last_scrape_error_code": error_code,
+            "last_scrape_error_message": error_message,
+            "needs_review": candidate.needs_review or status is CandidateStatus.UNSUPPORTED_SOURCE,
+            "self_heal_eligible": status is CandidateStatus.SCRAPE_FAILED,
+        }
+    )
+
+
+async def scrape_candidates(
+    *,
+    config: Config,
+    persistence: DiscoveryPersistence,
+    candidates: list[PersistentCandidate],
+    sources: list[Source],
+    preloaded_source_articles: dict[str, list[RawArticle]] | None = None,
+) -> CandidateScrapeBatch:
+    """Attempt to materialize durable candidates into raw articles."""
+    if not candidates:
+        return CandidateScrapeBatch([], [], [], [], [])
+
+    queued_candidates = queue_candidates_for_scrape(candidates)
+    persistence.upsert_candidates(queued_candidates)
+
+    source_articles_cache = dict(preloaded_source_articles or {})
+    sources_by_name = {source.name: source for source in sources}
+    updated_candidates: list[PersistentCandidate] = []
+    attempts: list[ScrapeAttempt] = []
+    raw_articles: list[RawArticle] = []
+    errors: list[str] = []
+
+    for queued_candidate in queued_candidates:
+        in_progress = queued_candidate.model_copy(
+            update={"candidate_status": CandidateStatus.SCRAPE_IN_PROGRESS}
+        )
+        persistence.upsert_candidates([in_progress])
+
+        source_name = _select_source_name(in_progress, sources_by_name)
+        started_at = datetime.now(UTC)
+        article: RawArticle | None = None
+        candidate_attempts: list[ScrapeAttempt] = []
+
+        if source_name is not None:
+            source = sources_by_name[source_name]
+            articles = source_articles_cache.get(source_name)
+            if articles is None:
+                articles = await source.fetch(days=config.days, keywords=config.keywords)
+                source_articles_cache[source_name] = articles
+            candidate_urls = _candidate_urls(in_progress)
+            article = next(
+                (
+                    candidate_article
+                    for candidate_article in articles
+                    if canonicalize_news_url(str(candidate_article.url)) in candidate_urls
+                ),
+                None,
+            )
+            finished_at = datetime.now(UTC)
+            if article is not None:
+                candidate_attempts.append(
+                    _build_attempt(
+                        candidate_id=in_progress.candidate_id,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                        fetch_status=FetchStatus.SUCCESS,
+                        source_adapter_name=source_name,
+                        article=article,
+                        diagnostics={"matched_candidate_urls": sorted(candidate_urls)},
+                    )
+                )
+                updated_candidates.append(
+                    _mark_attempt_success(in_progress, candidate_attempts[-1], article)
+                )
+                raw_articles.append(article)
+                attempts.extend(candidate_attempts)
+                continue
+
+            candidate_attempts.append(
+                _build_attempt(
+                    candidate_id=in_progress.candidate_id,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                    fetch_status=FetchStatus.FAILED,
+                    source_adapter_name=source_name,
+                    error_code="candidate_not_found",
+                    error_message=f"{source_name} adapter did not return the candidate URL",
+                )
+            )
+        else:
+            finished_at = datetime.now(UTC)
+            candidate_attempts.append(
+                _build_attempt(
+                    candidate_id=in_progress.candidate_id,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                    fetch_status=FetchStatus.UNSUPPORTED,
+                    error_code="source_adapter_unavailable",
+                    error_message="No source adapter available for candidate source hints",
+                )
+            )
+
+        generic_started_at = datetime.now(UTC)
+        generic_finished_at = datetime.now(UTC)
+        generic_error_message = "generic fetch fallback not implemented yet"
+        candidate_attempts.append(
+            _build_attempt(
+                candidate_id=in_progress.candidate_id,
+                started_at=generic_started_at,
+                finished_at=generic_finished_at,
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.UNSUPPORTED,
+                error_code="generic_fetch_not_implemented",
+                error_message=generic_error_message,
+            )
+        )
+
+        if source_name is None:
+            status = CandidateStatus.UNSUPPORTED_SOURCE
+            error_code = "unsupported_source"
+            error_message = "No supported source adapter or generic fetch path is available"
+        else:
+            status = CandidateStatus.SCRAPE_FAILED
+            error_code = "generic_fetch_not_implemented"
+            error_message = generic_error_message
+
+        updated_candidates.append(
+            _mark_attempt_failure(
+                in_progress,
+                attempts=candidate_attempts,
+                status=status,
+                error_code=error_code,
+                error_message=error_message,
+                config=config,
+            )
+        )
+        attempts.extend(candidate_attempts)
+        errors.append(f"{in_progress.candidate_id}: {error_message}")
+
+    persistence.append_attempts(attempts)
+    persistence.upsert_candidates(updated_candidates)
+    return CandidateScrapeBatch(
+        selected_candidates=queued_candidates,
+        updated_candidates=updated_candidates,
+        attempts=attempts,
+        raw_articles=raw_articles,
+        errors=errors,
+    )

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -54,15 +54,16 @@ def select_candidates_for_scrape(
         if candidate.next_scrape_attempt_at is None
         or candidate.next_scrape_attempt_at <= current_time
     ]
+    max_datetime = datetime.max.replace(tzinfo=UTC)
     ordered = sorted(
         eligible,
         key=lambda candidate: (
-            candidate.retry_priority,
-            candidate.next_scrape_attempt_at or datetime.min.replace(tzinfo=UTC),
-            candidate.last_seen_at,
+            -candidate.retry_priority,
+            0 if candidate.next_scrape_attempt_at is None else 1,
+            candidate.next_scrape_attempt_at or max_datetime,
+            -candidate.last_seen_at.timestamp(),
             candidate.candidate_id,
         ),
-        reverse=True,
     )
     return ordered[:limit]
 
@@ -216,52 +217,81 @@ async def scrape_candidates(
 
         if source_name is not None:
             source = sources_by_name[source_name]
-            articles = source_articles_cache.get(source_name)
-            if articles is None:
-                articles = await source.fetch(days=config.days, keywords=config.keywords)
-                source_articles_cache[source_name] = articles
-            candidate_urls = _candidate_urls(in_progress)
-            article = next(
-                (
-                    candidate_article
-                    for candidate_article in articles
-                    if canonicalize_news_url(str(candidate_article.url)) in candidate_urls
-                ),
-                None,
-            )
-            finished_at = datetime.now(UTC)
-            if article is not None:
+            try:
+                articles = source_articles_cache.get(source_name)
+                if articles is None:
+                    articles = await source.fetch(days=config.days, keywords=config.keywords)
+                    source_articles_cache[source_name] = articles
+                candidate_urls = _candidate_urls(in_progress)
+                article = next(
+                    (
+                        candidate_article
+                        for candidate_article in articles
+                        if canonicalize_news_url(str(candidate_article.url)) in candidate_urls
+                    ),
+                    None,
+                )
+                finished_at = datetime.now(UTC)
+                if article is not None:
+                    candidate_attempts.append(
+                        _build_attempt(
+                            candidate_id=in_progress.candidate_id,
+                            started_at=started_at,
+                            finished_at=finished_at,
+                            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                            fetch_status=FetchStatus.SUCCESS,
+                            source_adapter_name=source_name,
+                            article=article,
+                            diagnostics={"matched_candidate_urls": sorted(candidate_urls)},
+                        )
+                    )
+                    updated_candidates.append(
+                        _mark_attempt_success(in_progress, candidate_attempts[-1], article)
+                    )
+                    raw_articles.append(article)
+                    attempts.extend(candidate_attempts)
+                    continue
+
                 candidate_attempts.append(
                     _build_attempt(
                         candidate_id=in_progress.candidate_id,
                         started_at=started_at,
                         finished_at=finished_at,
                         attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                        fetch_status=FetchStatus.SUCCESS,
+                        fetch_status=FetchStatus.FAILED,
                         source_adapter_name=source_name,
-                        article=article,
-                        diagnostics={"matched_candidate_urls": sorted(candidate_urls)},
+                        error_code="candidate_not_found",
+                        error_message=f"{source_name} adapter did not return the candidate URL",
+                    )
+                )
+            except Exception as exc:
+                finished_at = datetime.now(UTC)
+                error_message = f"{source_name} adapter failed: {type(exc).__name__}: {exc}"
+                candidate_attempts.append(
+                    _build_attempt(
+                        candidate_id=in_progress.candidate_id,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                        fetch_status=FetchStatus.FAILED,
+                        source_adapter_name=source_name,
+                        error_code="source_adapter_error",
+                        error_message=error_message,
                     )
                 )
                 updated_candidates.append(
-                    _mark_attempt_success(in_progress, candidate_attempts[-1], article)
+                    _mark_attempt_failure(
+                        in_progress,
+                        attempts=candidate_attempts,
+                        status=CandidateStatus.SCRAPE_FAILED,
+                        error_code="source_adapter_error",
+                        error_message=error_message,
+                        config=config,
+                    )
                 )
-                raw_articles.append(article)
                 attempts.extend(candidate_attempts)
+                errors.append(f"{in_progress.candidate_id}: {error_message}")
                 continue
-
-            candidate_attempts.append(
-                _build_attempt(
-                    candidate_id=in_progress.candidate_id,
-                    started_at=started_at,
-                    finished_at=finished_at,
-                    attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                    fetch_status=FetchStatus.FAILED,
-                    source_adapter_name=source_name,
-                    error_code="candidate_not_found",
-                    error_message=f"{source_name} adapter did not return the candidate URL",
-                )
-            )
         else:
             finished_at = datetime.now(UTC)
             candidate_attempts.append(

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -16,7 +16,12 @@ from denbust.datasets.jobs import ensure_default_jobs_registered
 from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
 from denbust.discovery.base import SourceDiscoveryContext
-from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus
+from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus, PersistentCandidate
+from denbust.discovery.scrape_queue import (
+    CandidateScrapeBatch,
+    scrape_candidates,
+    select_candidates_for_scrape,
+)
 from denbust.discovery.source_native import (
     PersistedSourceDiscovery,
     SourceDiscoveryAdapter,
@@ -66,6 +71,7 @@ logger = logging.getLogger(__name__)
 
 _OPERATIONAL_STORE_JOBS = {
     JobName.INGEST,
+    JobName.SCRAPE_CANDIDATES,
     JobName.RELEASE,
     JobName.BACKUP,
 }
@@ -266,6 +272,172 @@ async def _run_source_native_discovery(
         return persisted
     finally:
         persistence.close()
+
+
+async def _scrape_candidate_batch(
+    *,
+    config: Config,
+    candidates: list[PersistentCandidate],
+    sources: list[Source],
+    preloaded_source_articles: dict[str, list[RawArticle]] | None = None,
+) -> CandidateScrapeBatch:
+    """Materialize durable candidates into raw articles and record scrape attempts."""
+    persistence = create_discovery_persistence(config)
+    try:
+        return await scrape_candidates(
+            config=config,
+            persistence=persistence,
+            candidates=candidates,
+            sources=sources,
+            preloaded_source_articles=preloaded_source_articles,
+        )
+    finally:
+        persistence.close()
+
+
+async def _run_candidate_scrape_job(
+    *,
+    config: Config,
+    sources: list[Source],
+    limit: int,
+) -> CandidateScrapeBatch:
+    """Select queued candidates and run the scrape-attempt layer."""
+    persistence = create_discovery_persistence(config)
+    try:
+        selected_candidates = select_candidates_for_scrape(
+            persistence,
+            limit=limit,
+        )
+    finally:
+        persistence.close()
+
+    return await _scrape_candidate_batch(
+        config=config,
+        candidates=selected_candidates,
+        sources=sources,
+    )
+
+
+async def _process_ingest_articles(
+    *,
+    config: Config,
+    result: RunSnapshot,
+    source_names: list[str],
+    sources: list[Source],
+    all_articles: list[RawArticle],
+    seen_store: SeenStore,
+    classifier: Classifier,
+    deduplicator: Deduplicator,
+    operational_store: OperationalStore | None,
+) -> RunSnapshot:
+    """Run the classifier/dedup/store portion of ingest over fetched articles."""
+    unseen_articles: list[RawArticle] = []
+    classified_articles: list[ClassifiedArticle] = []
+    unified_items: list[UnifiedItem] = []
+
+    if not all_articles:
+        logger.info("No articles found from any source")
+        result.seen_count_after = seen_store.count
+        result.finish("no articles found")
+        result.set_debug_payload(
+            _build_ingest_debug_payload(
+                result=result,
+                sources=sources,
+                source_names=source_names,
+                raw_articles=all_articles,
+                unseen_articles=unseen_articles,
+                classified_articles=classified_articles,
+                unified_items=unified_items,
+            )
+        )
+        return result
+
+    unseen_articles = filter_seen(all_articles, seen_store)
+    result.unseen_article_count = len(unseen_articles)
+    if not unseen_articles:
+        logger.info("All articles were already seen")
+        result.seen_count_after = seen_store.count
+        result.finish("all fetched articles were already seen")
+        result.set_debug_payload(
+            _build_ingest_debug_payload(
+                result=result,
+                sources=sources,
+                source_names=source_names,
+                raw_articles=all_articles,
+                unseen_articles=unseen_articles,
+                classified_articles=classified_articles,
+                unified_items=unified_items,
+            )
+        )
+        return result
+
+    if len(unseen_articles) > config.max_articles:
+        warning = (
+            f"Article count ({len(unseen_articles)}) exceeds max_articles threshold "
+            f"({config.max_articles}). Consider adding a pre-filter stage or reducing "
+            f"the number of days/sources. Proceeding with classification anyway."
+        )
+        logger.warning(warning)
+        result.warnings.append(warning)
+
+    classified_articles = await classifier.classify_batch(unseen_articles)
+    relevant_articles = [
+        article for article in classified_articles if article.classification.relevant
+    ]
+    result.relevant_article_count = len(relevant_articles)
+    if not relevant_articles:
+        logger.info("No relevant articles found")
+        result.seen_count_after = seen_store.count
+        result.set_debug_payload(
+            _build_ingest_debug_payload(
+                result=result.finish("no relevant articles found"),
+                sources=sources,
+                source_names=source_names,
+                raw_articles=all_articles,
+                unseen_articles=unseen_articles,
+                classified_articles=classified_articles,
+                unified_items=unified_items,
+            )
+        )
+        return result
+
+    unified_items = deduplicate_articles(relevant_articles, deduplicator)
+    result.unified_item_count = len(unified_items)
+    result.items = unified_items
+
+    store = operational_store or create_operational_store(config)
+    records = await build_operational_records(
+        unified_items,
+        config=config,
+        operational_store=store,
+    )
+    store.upsert_records(
+        config.dataset_name.value,
+        [record.model_dump(mode="json") for record in records],
+    )
+    privacy_counts = summarize_privacy_mix(records)
+    if privacy_counts:
+        risk_summary = ", ".join(
+            f"{risk.value}:{count}"
+            for risk, count in sorted(privacy_counts.items(), key=lambda item: item[0].value)
+        )
+        result.warnings.append(f"privacy_risk_distribution={risk_summary}")
+
+    mark_seen(unified_items, seen_store)
+    result.seen_count_after = seen_store.count
+    result.finish(f"ingest completed with {len(unified_items)} unified item(s)")
+    result.set_debug_payload(
+        _build_ingest_debug_payload(
+            result=result,
+            sources=sources,
+            source_names=source_names,
+            raw_articles=all_articles,
+            unseen_articles=unseen_articles,
+            classified_articles=classified_articles,
+            unified_items=unified_items,
+        )
+    )
+    return result
 
 
 def mark_seen(items: list[UnifiedItem], seen_store: SeenStore) -> None:
@@ -654,14 +826,12 @@ async def run_news_ingest_job(
         days=days,
         keywords=config.keywords,
     )
-    unseen_articles: list[RawArticle] = []
-    classified_articles: list[ClassifiedArticle] = []
-    unified_items: list[UnifiedItem] = []
     result.raw_article_count = len(all_articles)
     result.errors.extend(source_errors)
     if source_errors:
         result.warnings.append(f"{len(source_errors)} source(s) reported errors")
 
+    ingest_articles = list(all_articles)
     if (
         config.source_discovery.enabled
         and config.source_discovery.persist_candidates
@@ -676,115 +846,63 @@ async def run_news_ingest_job(
             result.warnings.append(
                 f"source_native_candidates_persisted={len(persisted_source_discovery.candidates)}"
             )
+            try:
+                scrape_batch = await _scrape_candidate_batch(
+                    config=config,
+                    candidates=persisted_source_discovery.candidates,
+                    sources=sources,
+                    preloaded_source_articles={
+                        source_name: [
+                            article
+                            for article in all_articles
+                            if article.source_name == source_name
+                        ]
+                        for source_name in source_names
+                    },
+                )
+                if scrape_batch.errors:
+                    result.warnings.append(
+                        f"candidate_scrape_failures={len(scrape_batch.errors)}"
+                    )
+                passthrough_articles = [
+                    article
+                    for article in all_articles
+                    if not _source_discovery_enabled_for_source(config, article.source_name)
+                ]
+                ingest_articles = [
+                    *scrape_batch.raw_articles,
+                    *[
+                        article
+                        for article in passthrough_articles
+                        if article not in scrape_batch.raw_articles
+                    ],
+                ]
+                if not ingest_articles and all_articles:
+                    result.warnings.append("candidate_scrape_layer_fell_back_to_direct_articles")
+                    ingest_articles = list(all_articles)
+            except Exception as exc:
+                logger.warning("Candidate scrape layer failed during ingest: %s", exc)
+                result.warnings.append(
+                    f"candidate_scrape_layer_failed={type(exc).__name__}: {exc}"
+                )
         except Exception as exc:
             logger.warning("Source-native candidate persistence failed during ingest: %s", exc)
             result.warnings.append(
                 f"source_native_candidate_persistence_failed={type(exc).__name__}: {exc}"
             )
 
-    if not all_articles:
-        logger.info("No articles found from any source")
-        result.seen_count_after = seen_store.count
-        result.finish("no articles found")
-        result.set_debug_payload(
-            _build_ingest_debug_payload(
-                result=result,
-                sources=sources,
-                source_names=source_names,
-                raw_articles=all_articles,
-                unseen_articles=unseen_articles,
-                classified_articles=classified_articles,
-                unified_items=unified_items,
-            )
-        )
-        return result
-
-    unseen_articles = filter_seen(all_articles, seen_store)
-    result.unseen_article_count = len(unseen_articles)
-    if not unseen_articles:
-        logger.info("All articles were already seen")
-        result.seen_count_after = seen_store.count
-        result.finish("all fetched articles were already seen")
-        result.set_debug_payload(
-            _build_ingest_debug_payload(
-                result=result,
-                sources=sources,
-                source_names=source_names,
-                raw_articles=all_articles,
-                unseen_articles=unseen_articles,
-                classified_articles=classified_articles,
-                unified_items=unified_items,
-            )
-        )
-        return result
-
-    if len(unseen_articles) > config.max_articles:
-        warning = (
-            f"Article count ({len(unseen_articles)}) exceeds max_articles threshold "
-            f"({config.max_articles}). Consider adding a pre-filter stage or reducing "
-            f"the number of days/sources. Proceeding with classification anyway."
-        )
-        logger.warning(warning)
-        result.warnings.append(warning)
-
-    classified_articles = await classifier.classify_batch(unseen_articles)
-    relevant_articles = [
-        article for article in classified_articles if article.classification.relevant
-    ]
-    result.relevant_article_count = len(relevant_articles)
-    if not relevant_articles:
-        logger.info("No relevant articles found")
-        result.seen_count_after = seen_store.count
-        result.set_debug_payload(
-            _build_ingest_debug_payload(
-                result=result.finish("no relevant articles found"),
-                sources=sources,
-                source_names=source_names,
-                raw_articles=all_articles,
-                unseen_articles=unseen_articles,
-                classified_articles=classified_articles,
-                unified_items=unified_items,
-            )
-        )
-        return result
-
-    unified_items = deduplicate_articles(relevant_articles, deduplicator)
-    result.unified_item_count = len(unified_items)
-    result.items = unified_items
-
-    store = operational_store or create_operational_store(config)
-    records = await build_operational_records(
-        unified_items,
+    result.raw_article_count = len(ingest_articles)
+    return await _process_ingest_articles(
         config=config,
-        operational_store=store,
+        result=result,
+        source_names=source_names,
+        sources=sources,
+        all_articles=ingest_articles,
+        seen_store=seen_store,
+        classifier=classifier,
+        deduplicator=deduplicator,
+        operational_store=operational_store,
     )
-    store.upsert_records(
-        config.dataset_name.value,
-        [record.model_dump(mode="json") for record in records],
-    )
-    privacy_counts = summarize_privacy_mix(records)
-    if privacy_counts:
-        risk_summary = ", ".join(
-            f"{risk.value}:{count}"
-            for risk, count in sorted(privacy_counts.items(), key=lambda item: item[0].value)
-        )
-        result.warnings.append(f"privacy_risk_distribution={risk_summary}")
-
-    mark_seen(unified_items, seen_store)
-    result.seen_count_after = seen_store.count
-    result.finish(f"ingest completed with {len(unified_items)} unified item(s)")
-    result.set_debug_payload(
-        _build_ingest_debug_payload(
-            result=result,
-            sources=sources,
-            source_names=source_names,
-            raw_articles=all_articles,
-            unseen_articles=unseen_articles,
-            classified_articles=classified_articles,
-            unified_items=unified_items,
-        )
-    )
-    return result
 
 
 async def run_news_discover_job(
@@ -832,6 +950,66 @@ async def run_news_discover_job(
         f"{persisted.run.candidate_count} discovered result(s)"
     )
     return result
+
+
+async def run_news_scrape_candidates_job(
+    config: Config,
+    config_path: Path | None = None,
+    days_override: int | None = None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    """Scrape queued candidates and feed successful results into the ingest path."""
+    days = days_override if days_override is not None else config.days
+    result = _build_run_snapshot(config, config_path=config_path, days=days)
+
+    if not config.anthropic_api_key:
+        result.fatal = True
+        result.errors.append("ANTHROPIC_API_KEY not set")
+        return result.finish("fatal: missing anthropic api key")
+
+    sources = create_sources(config)
+    source_names = [source.name for source in sources]
+    result.source_count = len(sources)
+    if not sources:
+        result.fatal = True
+        result.errors.append("No sources configured")
+        return result.finish("fatal: no sources configured")
+
+    classifier = create_classifier(
+        api_key=config.anthropic_api_key,
+        model=config.classifier.model,
+        system_prompt=config.classifier.system_prompt,
+        user_prompt_template=config.classifier.user_prompt_template,
+    )
+    deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
+    seen_store = create_seen_store(config.state_paths.seen_path)
+    result.seen_count_before = seen_store.count
+
+    scrape_batch = await _run_candidate_scrape_job(
+        config=config,
+        sources=sources,
+        limit=config.max_articles,
+    )
+    result.raw_article_count = len(scrape_batch.raw_articles)
+    if scrape_batch.errors:
+        result.errors.extend(scrape_batch.errors)
+        result.warnings.append(
+            f"candidate_scrape_failures={len(scrape_batch.errors)}"
+        )
+    if not scrape_batch.selected_candidates:
+        return result.finish("no queued candidates eligible for scrape")
+
+    return await _process_ingest_articles(
+        config=config,
+        result=result,
+        source_names=source_names,
+        sources=sources,
+        all_articles=scrape_batch.raw_articles,
+        seen_store=seen_store,
+        classifier=classifier,
+        deduplicator=deduplicator,
+        operational_store=operational_store,
+    )
 
 
 async def run_pipeline_async(config: Config, days: int) -> RunSnapshot:

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import sys
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -195,6 +196,14 @@ def _source_discovery_enabled_for_source(config: Config, source_name: str) -> bo
     if source_config is None:
         return True
     return source_config.enabled
+
+
+def _group_articles_by_source(articles: list[RawArticle]) -> dict[str, list[RawArticle]]:
+    """Group fetched articles by source name in a single pass."""
+    grouped: defaultdict[str, list[RawArticle]] = defaultdict(list)
+    for article in articles:
+        grouped[article.source_name].append(article)
+    return dict(grouped)
 
 
 async def _persist_source_native_candidates(
@@ -852,12 +861,11 @@ async def run_news_ingest_job(
                     candidates=persisted_source_discovery.candidates,
                     sources=sources,
                     preloaded_source_articles={
-                        source_name: [
-                            article
-                            for article in all_articles
-                            if article.source_name == source_name
-                        ]
-                        for source_name in source_names
+                        source_name: grouped_articles
+                        for source_name, grouped_articles in _group_articles_by_source(
+                            all_articles
+                        ).items()
+                        if source_name in source_names
                     },
                 )
                 if scrape_batch.errors:

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -990,7 +990,7 @@ async def run_news_scrape_candidates_job(
     result.seen_count_before = seen_store.count
 
     scrape_batch = await _run_candidate_scrape_job(
-        config=config,
+        config=config.model_copy(update={"days": days}),
         sources=sources,
         limit=config.max_articles,
     )

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -861,9 +861,7 @@ async def run_news_ingest_job(
                     },
                 )
                 if scrape_batch.errors:
-                    result.warnings.append(
-                        f"candidate_scrape_failures={len(scrape_batch.errors)}"
-                    )
+                    result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
                 passthrough_articles = [
                     article
                     for article in all_articles
@@ -882,9 +880,7 @@ async def run_news_ingest_job(
                     ingest_articles = list(all_articles)
             except Exception as exc:
                 logger.warning("Candidate scrape layer failed during ingest: %s", exc)
-                result.warnings.append(
-                    f"candidate_scrape_layer_failed={type(exc).__name__}: {exc}"
-                )
+                result.warnings.append(f"candidate_scrape_layer_failed={type(exc).__name__}: {exc}")
         except Exception as exc:
             logger.warning("Source-native candidate persistence failed during ingest: %s", exc)
             result.warnings.append(
@@ -993,9 +989,7 @@ async def run_news_scrape_candidates_job(
     result.raw_article_count = len(scrape_batch.raw_articles)
     if scrape_batch.errors:
         result.errors.extend(scrape_batch.errors)
-        result.warnings.append(
-            f"candidate_scrape_failures={len(scrape_batch.errors)}"
-        )
+        result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
     if not scrape_batch.selected_candidates:
         return result.finish("no queued candidates eligible for scrape")
 

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -1437,7 +1437,9 @@ class TestIceScraper:
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_fetch_stops_when_next_page_has_only_old_results(self) -> None:
+    async def test_fetch_stops_when_next_page_has_only_old_results(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Fetch should stop paginating when the next page contains no recent articles."""
         page_one = load_fixture("html/ice_search.html")
         page_two = """
@@ -1464,6 +1466,14 @@ class TestIceScraper:
         scraper = self._create_scraper()
         keyword = "בית בושת"
         page_three_url = scraper._build_search_url(keyword, page_number=3)
+
+        class FrozenDateTime(datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> datetime:
+                del tz
+                return cls(2026, 4, 1, 12, 0, tzinfo=UTC)
+
+        monkeypatch.setattr("denbust.sources.ice.datetime", FrozenDateTime)
 
         respx.get(scraper._build_search_url(keyword)).mock(
             return_value=Response(200, text=page_one)

--- a/tests/unit/test_dataset_jobs.py
+++ b/tests/unit/test_dataset_jobs.py
@@ -10,6 +10,7 @@ import pytest
 from denbust.config import Config
 from denbust.datasets.jobs import (
     _run_news_items_ingest,
+    _run_news_items_scrape_candidates,
     _run_scaffolded_backup,
     _run_scaffolded_release,
 )
@@ -64,6 +65,33 @@ async def test_run_news_items_ingest_wrapper_passes_operational_store(
         config,
         config_path=Path("agents/news/local.yaml"),
         days_override=7,
+        operational_store=store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_news_items_scrape_candidates_wrapper_calls_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scrape-candidates wrapper should delegate to the pipeline handler."""
+    expected = build_snapshot()
+    mock = AsyncMock(return_value=expected)
+    monkeypatch.setattr("denbust.pipeline.run_news_scrape_candidates_job", mock)
+
+    config = Config(job_name="scrape_candidates")
+    store = object()
+    result = await _run_news_items_scrape_candidates(
+        config,
+        Path("agents/news/local.yaml"),
+        5,
+        operational_store=store,  # type: ignore[arg-type]
+    )
+
+    assert result is expected
+    mock.assert_awaited_once_with(
+        config,
+        config_path=Path("agents/news/local.yaml"),
+        days_override=5,
         operational_store=store,
     )
 

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -78,6 +78,19 @@ class FakeSource:
         return self.articles
 
 
+class FailingSource(FakeSource):
+    """Source stub that raises from fetch."""
+
+    def __init__(self, name: str, error: Exception) -> None:
+        super().__init__(name, [])
+        self.error = error
+
+    async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
+        del days, keywords
+        self.calls += 1
+        raise self.error
+
+
 def build_store(tmp_path: Path) -> StateRepoDiscoveryPersistence:
     """Create a state-repo persistence backend rooted in pytest temp storage."""
     return StateRepoDiscoveryPersistence(
@@ -115,6 +128,41 @@ def test_select_candidates_for_scrape_filters_retryable_due_candidates(tmp_path:
     assert all(
         candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES for candidate in selected
     )
+
+
+def test_select_candidates_for_scrape_prioritizes_none_and_earlier_retry_times(
+    tmp_path: Path,
+) -> None:
+    """Selection should prefer immediate candidates and earlier due retries."""
+    store = build_store(tmp_path)
+    due_time = datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    store.upsert_candidates(
+        [
+            build_candidate(
+                "later_due",
+                status=CandidateStatus.SCRAPE_FAILED,
+                next_scrape_attempt_at=due_time - timedelta(minutes=5),
+            ),
+            build_candidate(
+                "immediate",
+                status=CandidateStatus.NEW,
+                next_scrape_attempt_at=None,
+            ),
+            build_candidate(
+                "earlier_due",
+                status=CandidateStatus.SCRAPE_FAILED,
+                next_scrape_attempt_at=due_time - timedelta(hours=1),
+            ),
+        ]
+    )
+
+    selected = select_candidates_for_scrape(store, limit=10, now=due_time)
+
+    assert [candidate.candidate_id for candidate in selected] == [
+        "immediate",
+        "earlier_due",
+        "later_due",
+    ]
 
 
 @pytest.mark.asyncio
@@ -223,3 +271,50 @@ async def test_scrape_candidates_marks_unknown_sources_as_unsupported(tmp_path: 
     assert stored.next_scrape_attempt_at is None
     assert len(batch.attempts) == 2
     assert batch.attempts[0].fetch_status is FetchStatus.UNSUPPORTED
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_records_adapter_exceptions_and_continues(
+    tmp_path: Path,
+) -> None:
+    """Adapter exceptions should fail only the affected candidate and continue the batch."""
+    store = build_store(tmp_path)
+    failing_candidate = build_candidate("candidate-fail", status=CandidateStatus.NEW)
+    succeeding_candidate = build_candidate(
+        "candidate-ok",
+        status=CandidateStatus.NEW,
+        current_url="https://www.mako.co.il/news/article/ok?utm_source=test",
+        canonical_url="https://www.mako.co.il/news/article/ok",
+        source_hint="mako",
+    )
+    store.upsert_candidates([failing_candidate, succeeding_candidate])
+    sources = [
+        FailingSource("ynet", RuntimeError("adapter boom")),
+        FakeSource(
+            "mako",
+            [build_raw_article("https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako")],
+        ),
+    ]
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[failing_candidate, succeeding_candidate],
+        sources=sources,
+    )
+
+    failed = store.get_candidate("candidate-fail")
+    succeeded = store.get_candidate("candidate-ok")
+    assert failed is not None
+    assert failed.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert failed.next_scrape_attempt_at is not None
+    assert failed.last_scrape_error_code == "source_adapter_error"
+    assert "adapter boom" in (failed.last_scrape_error_message or "")
+    assert succeeded is not None
+    assert succeeded.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
+    assert len(batch.raw_articles) == 1
+    assert any(error == "candidate-fail: ynet adapter failed: RuntimeError: adapter boom" for error in batch.errors)
+    assert [attempt.fetch_status for attempt in batch.attempts] == [
+        FetchStatus.FAILED,
+        FetchStatus.SUCCESS,
+    ]

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -292,7 +292,11 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
         FailingSource("ynet", RuntimeError("adapter boom")),
         FakeSource(
             "mako",
-            [build_raw_article("https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako")],
+            [
+                build_raw_article(
+                    "https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako"
+                )
+            ],
         ),
     ]
 
@@ -313,7 +317,10 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
     assert succeeded is not None
     assert succeeded.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
     assert len(batch.raw_articles) == 1
-    assert any(error == "candidate-fail: ynet adapter failed: RuntimeError: adapter boom" for error in batch.errors)
+    assert any(
+        error == "candidate-fail: ynet adapter failed: RuntimeError: adapter boom"
+        for error in batch.errors
+    )
     assert [attempt.fetch_status for attempt in batch.attempts] == [
         FetchStatus.FAILED,
         FetchStatus.SUCCESS,

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -166,6 +166,25 @@ def test_select_candidates_for_scrape_prioritizes_none_and_earlier_retry_times(
 
 
 @pytest.mark.asyncio
+async def test_scrape_candidates_returns_empty_batch_for_no_candidates(tmp_path: Path) -> None:
+    """An empty scrape pass should return an empty batch without persistence writes."""
+    store = build_store(tmp_path)
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[],
+        sources=[],
+    )
+
+    assert batch.selected_candidates == []
+    assert batch.updated_candidates == []
+    assert batch.attempts == []
+    assert batch.raw_articles == []
+    assert batch.errors == []
+
+
+@pytest.mark.asyncio
 async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path: Path) -> None:
     """Successful source-adapter scrapes should yield raw articles and succeeded candidates."""
     store = build_store(tmp_path)

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -112,7 +112,9 @@ def test_select_candidates_for_scrape_filters_retryable_due_candidates(tmp_path:
     selected = select_candidates_for_scrape(store, limit=10, now=due_time)
 
     assert {candidate.candidate_id for candidate in selected} == {"new", "failed_due"}
-    assert all(candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES for candidate in selected)
+    assert all(
+        candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES for candidate in selected
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -1,0 +1,223 @@
+"""Unit tests for candidate-driven scrape orchestration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from pydantic import HttpUrl
+
+from denbust.config import Config
+from denbust.data_models import RawArticle
+from denbust.discovery.models import CandidateStatus, FetchStatus, PersistentCandidate
+from denbust.discovery.scrape_queue import (
+    SCRAPEABLE_CANDIDATE_STATUSES,
+    scrape_candidates,
+    select_candidates_for_scrape,
+)
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName
+
+
+def build_candidate(
+    candidate_id: str,
+    *,
+    status: CandidateStatus,
+    source_hint: str = "ynet",
+    current_url: str = "https://www.ynet.co.il/news/article/abc?utm_source=test",
+    canonical_url: str = "https://www.ynet.co.il/news/article/abc",
+    next_scrape_attempt_at: datetime | None = None,
+    scrape_attempt_count: int = 0,
+) -> PersistentCandidate:
+    """Build a persistent candidate fixture."""
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        canonical_url=HttpUrl(canonical_url),
+        current_url=HttpUrl(current_url),
+        titles=["title"],
+        snippets=["snippet"],
+        discovered_via=["source_native"],
+        discovery_queries=["בית בושת"],
+        source_hints=[source_hint],
+        first_seen_at=datetime(2026, 4, 10, 8, 0, tzinfo=UTC),
+        last_seen_at=datetime(2026, 4, 11, 8, 0, tzinfo=UTC),
+        candidate_status=status,
+        next_scrape_attempt_at=next_scrape_attempt_at,
+        scrape_attempt_count=scrape_attempt_count,
+    )
+
+
+def build_raw_article(
+    url: str = "https://www.ynet.co.il/news/article/abc?utm_source=test",
+    *,
+    source_name: str = "ynet",
+) -> RawArticle:
+    """Build a raw article fixture."""
+    return RawArticle(
+        url=HttpUrl(url),
+        title="פשיטה על בית בושת",
+        snippet="המשטרה ביצעה פשיטה.",
+        date=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        source_name=source_name,
+    )
+
+
+class FakeSource:
+    """Simple source stub used by the scrape queue tests."""
+
+    def __init__(self, name: str, articles: list[RawArticle]) -> None:
+        self.name = name
+        self.articles = articles
+        self.calls = 0
+
+    async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
+        del days, keywords
+        self.calls += 1
+        return self.articles
+
+
+def build_store(tmp_path: Path) -> StateRepoDiscoveryPersistence:
+    """Create a state-repo persistence backend rooted in pytest temp storage."""
+    return StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(
+            state_root=tmp_path,
+            dataset_name=DatasetName.NEWS_ITEMS,
+        )
+    )
+
+
+def test_select_candidates_for_scrape_filters_retryable_due_candidates(tmp_path: Path) -> None:
+    """Only retryable candidates whose retry window has elapsed should be selected."""
+    store = build_store(tmp_path)
+    due_time = datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    store.upsert_candidates(
+        [
+            build_candidate("new", status=CandidateStatus.NEW),
+            build_candidate(
+                "failed_due",
+                status=CandidateStatus.SCRAPE_FAILED,
+                next_scrape_attempt_at=due_time - timedelta(hours=1),
+            ),
+            build_candidate(
+                "failed_future",
+                status=CandidateStatus.SCRAPE_FAILED,
+                next_scrape_attempt_at=due_time + timedelta(hours=1),
+            ),
+            build_candidate("closed", status=CandidateStatus.CLOSED),
+        ]
+    )
+
+    selected = select_candidates_for_scrape(store, limit=10, now=due_time)
+
+    assert {candidate.candidate_id for candidate in selected} == {"new", "failed_due"}
+    assert all(candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES for candidate in selected)
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path: Path) -> None:
+    """Successful source-adapter scrapes should yield raw articles and succeeded candidates."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-1", status=CandidateStatus.NEW)
+    store.upsert_candidates([candidate])
+    source = FakeSource("ynet", [build_raw_article()])
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[candidate],
+        sources=[source],
+        preloaded_source_articles={"ynet": [build_raw_article()]},
+    )
+
+    stored = store.get_candidate("candidate-1")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
+    assert stored.scrape_attempt_count == 1
+    assert len(batch.raw_articles) == 1
+    assert len(batch.attempts) == 1
+    assert batch.attempts[0].fetch_status is FetchStatus.SUCCESS
+    assert source.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_retains_failed_candidate_for_retry(tmp_path: Path) -> None:
+    """Missing source matches should keep the candidate retryable with attempt history."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-2", status=CandidateStatus.SCRAPE_FAILED)
+    store.upsert_candidates([candidate])
+    source = FakeSource("ynet", [])
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[candidate],
+        sources=[source],
+    )
+
+    stored = store.get_candidate("candidate-2")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert stored.scrape_attempt_count == 2
+    assert stored.next_scrape_attempt_at is not None
+    assert [attempt.fetch_status for attempt in batch.attempts] == [
+        FetchStatus.FAILED,
+        FetchStatus.UNSUPPORTED,
+    ]
+    assert batch.raw_articles == []
+    assert len(store.list_attempts("candidate-2")) == 2
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_accumulates_attempt_count_across_retries(tmp_path: Path) -> None:
+    """Repeated scrape passes should append attempts rather than resetting candidate history."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-3",
+        status=CandidateStatus.SCRAPE_FAILED,
+        scrape_attempt_count=2,
+        next_scrape_attempt_at=datetime(2026, 4, 11, 8, 0, tzinfo=UTC),
+    )
+    store.upsert_candidates([candidate])
+    source = FakeSource("ynet", [])
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[candidate],
+        sources=[source],
+    )
+
+    stored = store.get_candidate("candidate-3")
+    assert stored is not None
+    assert stored.scrape_attempt_count == 4
+    assert len(batch.attempts) == 2
+    assert len(store.list_attempts("candidate-3")) == 2
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_marks_unknown_sources_as_unsupported(tmp_path: Path) -> None:
+    """Candidates without a matching source adapter should become unsupported."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-4",
+        status=CandidateStatus.NEW,
+        source_hint="unknown-source",
+        current_url="https://unknown.example.com/article",
+        canonical_url="https://unknown.example.com/article",
+    )
+
+    batch = await scrape_candidates(
+        config=Config(store={"state_root": tmp_path}),
+        persistence=store,
+        candidates=[candidate],
+        sources=[],
+    )
+
+    stored = store.get_candidate("candidate-4")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
+    assert stored.next_scrape_attempt_at is None
+    assert len(batch.attempts) == 2
+    assert batch.attempts[0].fetch_status is FetchStatus.UNSUPPORTED

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -21,6 +21,7 @@ from denbust.data_models import (
     UnifiedItem,
 )
 from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus
+from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
 from denbust.models.common import DatasetName, JobName
 from denbust.models.policies import PrivacyRisk
@@ -45,6 +46,7 @@ from denbust.pipeline import (
     run_job_async,
     run_news_discover_job,
     run_news_ingest_job,
+    run_news_scrape_candidates_job,
     run_pipeline,
     run_pipeline_async,
     run_release,
@@ -702,7 +704,7 @@ class TestRunPipelineAsync:
 
     @pytest.mark.asyncio
     async def test_run_news_ingest_job_records_privacy_mix_warning(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Successful ingest runs should summarize the privacy-risk mix."""
 
@@ -754,7 +756,10 @@ class TestRunPipelineAsync:
         monkeypatch.setattr("denbust.pipeline.mark_seen", fake_mark_seen)
 
         result = await run_news_ingest_job(
-            Config(output=OutputConfig(formats=[OutputFormat.CLI])),
+            Config(
+                output=OutputConfig(formats=[OutputFormat.CLI]),
+                store={"state_root": tmp_path},
+            ),
             operational_store=fake_store,
         )
 
@@ -879,6 +884,149 @@ class TestRunPipelineAsync:
         result = await run_news_ingest_job(Config(), operational_store=MagicMock())
 
         assert "source_native_candidate_persistence_failed=RuntimeError: boom" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_run_news_ingest_job_uses_candidate_scrape_results_and_passthrough_sources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ingest should use candidate-driven results while preserving disabled-source passthrough."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        seen_store = MagicMock(count=1)
+        source_scraped = RawArticle(
+            url=HttpUrl("https://www.ynet.co.il/news/article/1"),
+            title="כותרת ינט",
+            snippet="תקציר ינט",
+            date=datetime(2026, 4, 11, tzinfo=UTC),
+            source_name="ynet",
+        )
+        disabled_passthrough = RawArticle(
+            url=HttpUrl("https://www.walla.co.il/item/1"),
+            title="כותרת וואלה",
+            snippet="תקציר וואלה",
+            date=datetime(2026, 4, 11, tzinfo=UTC),
+            source_name="walla",
+        )
+        persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-ingest",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.INGEST,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[],
+            provenance=[],
+        )
+        scrape_batch = CandidateScrapeBatch(
+            selected_candidates=[],
+            updated_candidates=[],
+            attempts=[],
+            raw_articles=[source_scraped],
+            errors=[],
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            side_effect=lambda articles: [
+                build_classified_article(str(article.url), relevant=True) for article in articles
+            ]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources",
+            lambda _config: [FakeSource("ynet", []), FakeSource("walla", [])],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline.fetch_all_sources",
+            AsyncMock(return_value=([source_scraped, disabled_passthrough], [])),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._persist_source_native_candidates",
+            AsyncMock(return_value=persisted),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._scrape_candidate_batch",
+            AsyncMock(return_value=scrape_batch),
+        )
+        monkeypatch.setattr("denbust.pipeline.filter_seen", lambda articles, _store: articles)
+        monkeypatch.setattr(
+            "denbust.pipeline.deduplicate_articles",
+            lambda articles, _deduplicator: [
+                build_unified_item(str(article.article.url)) for article in articles
+            ],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.build_operational_records",
+            AsyncMock(return_value=[]),
+        )
+        mark_seen_mock = MagicMock()
+        monkeypatch.setattr("denbust.pipeline.mark_seen", mark_seen_mock)
+        operational_store = MagicMock()
+
+        result = await run_news_ingest_job(
+            Config(source_discovery={"sources": {"walla": False}}),
+            operational_store=operational_store,
+        )
+
+        assert result.raw_article_count == 2
+        classifier.classify_batch.assert_awaited_once()
+        classified_input = classifier.classify_batch.await_args.args[0]
+        assert [article.source_name for article in classified_input] == ["ynet", "walla"]
+        mark_seen_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_processes_scraped_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scrape-candidates job should feed successful scraped articles into ingest processing."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        seen_store = MagicMock(count=0)
+        raw_article = build_raw_article("https://example.com/queued")
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[build_classified_article("https://example.com/queued", relevant=True)]
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])])
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            AsyncMock(
+                return_value=CandidateScrapeBatch(
+                    selected_candidates=[MagicMock()],
+                    updated_candidates=[],
+                    attempts=[],
+                    raw_articles=[raw_article],
+                    errors=["candidate-1: generic fetch fallback not implemented yet"],
+                )
+            ),
+        )
+        monkeypatch.setattr("denbust.pipeline.filter_seen", lambda articles, _store: articles)
+        monkeypatch.setattr(
+            "denbust.pipeline.deduplicate_articles",
+            lambda _articles, _deduplicator: [build_unified_item("https://example.com/queued")],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.build_operational_records",
+            AsyncMock(return_value=[]),
+        )
+        operational_store = MagicMock()
+        mark_seen_mock = MagicMock()
+        monkeypatch.setattr("denbust.pipeline.mark_seen", mark_seen_mock)
+
+        result = await run_news_scrape_candidates_job(
+            Config(job_name=JobName.SCRAPE_CANDIDATES),
+            operational_store=operational_store,
+        )
+
+        assert result.raw_article_count == 1
+        assert result.errors == ["candidate-1: generic fetch fallback not implemented yet"]
+        assert "candidate_scrape_failures=1" in result.warnings
+        assert result.unified_item_count == 1
+        mark_seen_mock.assert_called_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 import pytest
 from pydantic import HttpUrl
 
+import denbust.pipeline as pipeline_module
 from denbust.config import Config, OutputConfig, OutputFormat, SourceConfig, SourceType
 from denbust.data_models import (
     Category,
@@ -1029,6 +1030,173 @@ class TestRunPipelineAsync:
         assert "candidate_scrape_failures=1" in result.warnings
         assert result.unified_item_count == 1
         mark_seen_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_candidate_scrape_job_selects_candidates_and_closes_persistence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Queued candidate selection should close persistence before scraping."""
+
+        class FakePersistence:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        config = Config()
+        persistence = FakePersistence()
+        selected_candidates = [MagicMock(name="candidate-1"), MagicMock(name="candidate-2")]
+        scrape_mock = AsyncMock(
+            return_value=CandidateScrapeBatch(
+                selected_candidates=selected_candidates,
+                updated_candidates=[],
+                attempts=[],
+                raw_articles=[],
+                errors=[],
+            )
+        )
+        select_mock = MagicMock(return_value=selected_candidates)
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: persistence,
+        )
+        monkeypatch.setattr("denbust.pipeline.select_candidates_for_scrape", select_mock)
+        monkeypatch.setattr("denbust.pipeline._scrape_candidate_batch", scrape_mock)
+
+        sources = [FakeSource("ynet", [])]
+        result = await pipeline_module._run_candidate_scrape_job(
+            config=config,
+            sources=sources,
+            limit=3,
+        )
+
+        assert result.selected_candidates == selected_candidates
+        assert persistence.closed is True
+        select_mock.assert_called_once_with(persistence, limit=3)
+        scrape_mock.assert_awaited_once_with(
+            config=config,
+            candidates=selected_candidates,
+            sources=sources,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_news_ingest_job_warns_when_candidate_scrape_layer_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ingest should continue and warn when candidate scrape orchestration raises."""
+        source_article = build_raw_article("https://example.com/source-layer")
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[build_classified_article("https://example.com/source-layer")]
+        )
+        persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-ingest",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[MagicMock(name="candidate-1")],
+            provenance=[],
+        )
+        seen_store = MagicMock(count=0)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources",
+            lambda _config: [FakeSource("ynet", [source_article])],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline.fetch_all_sources",
+            AsyncMock(return_value=([source_article], [])),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._persist_source_native_candidates",
+            AsyncMock(return_value=persisted),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._scrape_candidate_batch",
+            AsyncMock(side_effect=RuntimeError("scrape boom")),
+        )
+        monkeypatch.setattr("denbust.pipeline.filter_seen", lambda articles, _store: articles)
+        monkeypatch.setattr(
+            "denbust.pipeline.deduplicate_articles",
+            lambda articles, _deduplicator: [
+                build_unified_item(str(article.article.url)) for article in articles
+            ],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.build_operational_records",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr("denbust.pipeline.mark_seen", MagicMock())
+
+        result = await run_news_ingest_job(Config())
+
+        assert (
+            "candidate_scrape_layer_failed=RuntimeError: scrape boom" in result.warnings
+        )
+        assert result.raw_article_count == 1
+        assert result.unified_item_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_rejects_missing_api_key(self) -> None:
+        """The scrape-candidates job should fail clearly without an API key."""
+        result = await run_news_scrape_candidates_job(Config(job_name=JobName.SCRAPE_CANDIDATES))
+
+        assert result.fatal is True
+        assert result.errors == ["ANTHROPIC_API_KEY not set"]
+        assert result.result_summary == "fatal: missing anthropic api key"
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_rejects_missing_sources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scrape-candidates job should fail clearly when no sources are configured."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+
+        result = await run_news_scrape_candidates_job(Config(job_name=JobName.SCRAPE_CANDIDATES))
+
+        assert result.fatal is True
+        assert result.errors == ["No sources configured"]
+        assert result.result_summary == "fatal: no sources configured"
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_finishes_when_queue_is_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scrape-candidates job should finish cleanly when nothing is eligible."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            AsyncMock(
+                return_value=CandidateScrapeBatch(
+                    selected_candidates=[],
+                    updated_candidates=[],
+                    attempts=[],
+                    raw_articles=[],
+                    errors=[],
+                )
+            ),
+        )
+
+        result = await run_news_scrape_candidates_job(Config(job_name=JobName.SCRAPE_CANDIDATES))
+
+        assert result.fatal is False
+        assert result.raw_article_count == 0
+        assert result.result_summary == "no queued candidates eligible for scrape"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1197,6 +1197,53 @@ class TestRunPipelineAsync:
         assert result.result_summary == "no queued candidates eligible for scrape"
 
     @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_passes_days_override_to_scrape_layer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scrape layer should receive the effective days override, not the base config days."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(return_value=[])
+        seen_store = MagicMock(count=0)
+        captured: dict[str, object] = {}
+
+        async def fake_run_candidate_scrape_job(
+            *,
+            config: Config,
+            sources: list[FakeSource],
+            limit: int,
+        ) -> CandidateScrapeBatch:
+            captured["days"] = config.days
+            captured["limit"] = limit
+            captured["sources"] = [source.name for source in sources]
+            return CandidateScrapeBatch(
+                selected_candidates=[],
+                updated_candidates=[],
+                attempts=[],
+                raw_articles=[],
+                errors=[],
+            )
+
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            fake_run_candidate_scrape_job,
+        )
+
+        result = await run_news_scrape_candidates_job(
+            Config(job_name=JobName.SCRAPE_CANDIDATES, days=3, max_articles=7),
+            days_override=11,
+        )
+
+        assert result.result_summary == "no queued candidates eligible for scrape"
+        assert captured == {"days": 11, "limit": 7, "sources": ["test"]}
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("config", "error", "summary"),
         [

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -988,7 +988,9 @@ class TestRunPipelineAsync:
         classifier.classify_batch = AsyncMock(
             return_value=[build_classified_article("https://example.com/queued", relevant=True)]
         )
-        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])])
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
         monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
         monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
         monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1138,9 +1138,7 @@ class TestRunPipelineAsync:
 
         result = await run_news_ingest_job(Config())
 
-        assert (
-            "candidate_scrape_layer_failed=RuntimeError: scrape boom" in result.warnings
-        )
+        assert "candidate_scrape_layer_failed=RuntimeError: scrape boom" in result.warnings
         assert result.raw_article_count == 1
         assert result.unified_item_count == 1
 


### PR DESCRIPTION
## Summary

This PR implements **PR 3 — Separate scrape-attempt layer and candidate-driven ingest** from the discovery-layer implementation plan.

It introduces a real durable scrape-attempt substrate under the existing `news_items` flow:

- candidates can now be selected from the durable candidate store for scraping
- scrape attempts are recorded as first-class state
- failed scraping remains retryable at the candidate layer
- `news_items / scrape_candidates` is now a real job
- `news_items / ingest` now routes source-native candidates through the scrape-attempt layer while preserving compatibility fallback behavior

This keeps the current ingest/release/backup workflow operational while moving the repository onto the new candidate queue model.

## What changed

### 1. Added candidate-driven scrape orchestration

New module:
- `src/denbust/discovery/scrape_queue.py`

This adds:
- candidate selection from the durable store
- queue eligibility filtering using candidate status and `next_scrape_attempt_at`
- queue transitions:
  - `new -> queued`
  - retryable candidates -> `scrape_pending`
  - selected candidates -> `scrape_in_progress`
- scrape-attempt creation for:
  - `source_adapter`
  - `generic_fetch` placeholder fallback
- candidate status updates for:
  - `scrape_succeeded`
  - `scrape_failed`
  - `unsupported_source`
- retry bookkeeping:
  - incrementing `scrape_attempt_count`
  - updating `last_scrape_attempt_at`
  - scheduling `next_scrape_attempt_at` for retryable failures
  - preserving `last_scrape_error_code` / `last_scrape_error_message`

### 2. Added a real `news_items / scrape_candidates` job

Updated:
- `src/denbust/datasets/jobs.py`
- `src/denbust/pipeline.py`

`JobName.SCRAPE_CANDIDATES` is no longer a scaffold-only placeholder. It now:
- selects eligible durable candidates
- runs them through the scrape-attempt layer
- feeds successful raw articles into the existing classifier/dedup/operational ingest path
- preserves failure state on candidates that could not be materialized

### 3. Refactored ingest to use the candidate layer underneath

Updated:
- `src/denbust/pipeline.py`

`news_items / ingest` now does the following when source-native candidate persistence is enabled:

1. fetch raw source-native articles as before
2. persist them into the durable candidate layer as before
3. immediately run those candidates through the scrape-attempt layer
4. continue ingest using the successfully scraped raw articles

Compatibility behavior is preserved:
- if source-native candidate persistence fails, ingest still degrades to warnings
- if the scrape layer produces no usable articles, ingest falls back to the directly fetched articles so the current end-to-end monitoring flow keeps working
- sources disabled under `source_discovery.sources` still bypass source-native candidacy and continue through passthrough ingest behavior

### 4. Shared ingest processing extracted

To avoid duplicating the classifier/dedup/store path, the common article-to-news-item pipeline was pulled into an internal helper in `src/denbust/pipeline.py`.

This keeps:
- `ingest`
- `scrape_candidates`

on the same downstream behavior for:
- seen filtering
- classification
- deduplication
- operational row creation
- privacy summary warnings
- seen-store updates
- debug payload creation

### 5. README updated for PR 3

Updated:
- `README.md`

The README now reflects:
- the new `news_items / scrape_candidates` job
- that PR 3 is the current discovery milestone
- that the candidate queue / scrape-attempt substrate now exists underneath source-native ingest
- that generic fetch/extract remains scaffolded rather than fully implemented

## Behavior in scope for this PR

This PR intentionally implements the PR-3-sized milestone only:

- durable candidate queue selection
- scrape-attempt persistence and candidate transitions
- candidate-driven ingest wiring
- retryable failure retention
- source-adapter-first scraping path
- compatibility fallback for the current ingest flow

## Still intentionally out of scope

This PR does **not** yet implement:

- Brave engine integration
- Exa engine integration
- Google CSE integration
- a real generic fetch/extract article fallback
- backfill job execution
- self-healing logic
- source suggestion logic
- social-targeted discovery behavior
- event-layer logic

The generic fetch path is represented in attempt history so retry bookkeeping and future extension points are present, but it is still a structural placeholder in this PR.

## Tests

Added:
- `tests/unit/test_discovery_scrape_queue.py`

Updated:
- `tests/unit/test_pipeline_core.py`
- existing discovery storage tests continue to exercise candidate persistence behavior

Coverage added for:
- candidate queue selection based on status and retry timing
- successful source-adapter scrape attempts
- retained failed candidates with retry scheduling
- repeated scrape-attempt bookkeeping
- unsupported-source candidate handling
- ingest using candidate scrape results plus passthrough sources
- the new `news_items / scrape_candidates` job feeding into the ingest path

## Validation

Ran locally:

```bash
ruff check src/denbust/discovery/scrape_queue.py src/denbust/pipeline.py src/denbust/datasets/jobs.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_pipeline_core.py
mypy src/denbust/discovery/scrape_queue.py src/denbust/pipeline.py src/denbust/datasets/jobs.py
pytest -q tests/unit/test_discovery_scrape_queue.py tests/unit/test_discovery_storage.py tests/unit/test_pipeline_core.py -k 'scrape or source_native or ingest or discover'
```

## Files of interest

- `src/denbust/discovery/scrape_queue.py`
- `src/denbust/pipeline.py`
- `src/denbust/datasets/jobs.py`
- `tests/unit/test_discovery_scrape_queue.py`
- `tests/unit/test_pipeline_core.py`
- `README.md`

## Why this PR is mergeable

This is still an additive milestone:
- the current daily ingest path remains operational
- release and backup are untouched
- the new candidate-driven substrate is structurally real but still bounded to source-native producers only
- future engine PRs can now plug into a working durable scrape queue rather than inventing one later