### PR TITLE
DL-PR-04: integrate Brave discovery engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ data jobs. Phase A introduced the shared platform spine. Phase B turns the first
 
 Today, the implemented dataset/jobs are:
 
-- `news_items / discover` (source-native candidate persistence only)
+- `news_items / discover` (source-native + Brave candidate persistence)
 - `news_items / ingest`
 - `news_items / release`
 - `news_items / backup`
@@ -40,6 +40,7 @@ Planned future datasets:
 - Persists dataset/job-scoped seen state and per-run JSON snapshots
 - Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
   paths under `news_items/discover/`
+- Runs Brave as the first external discovery engine feeding the durable candidate layer
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
 
 ## Quick Start
@@ -217,21 +218,24 @@ What is implemented now:
 Still intentionally deferred:
 
 - additional dataset implementations beyond `news_items`
-- operational wiring of the new multi-engine discovery layer into production ingest
+- Exa and Google CSE engine integrations
 - richer human review tooling / admin UI
 - more advanced privacy policies beyond the current pragmatic gate
 
 ## Discovery Layer Foundation
 
-PR 3 of the persistent multi-engine discovery work now builds on the PR 1 foundation and the PR 2
-source-native persistence slice:
+DL-PR-04 now builds on the earlier discovery milestones:
 
 - `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
   models
 - config sections for `discovery`, `source_discovery`, `candidates`, and `backfill`
 - explicit state-repo path helpers for candidate-layer snapshots and queue files
 - source-native candidate normalization and merge/upsert persistence
-- a real `news_items / discover` job that fetches source-native candidates only and persists them
+- a real `news_items / discover` job that persists source-native candidates and Brave-discovered
+  candidates into the same durable substrate
+- Brave query building for broad and source-targeted discovery searches
+- a dedicated `DENBUST_BRAVE_SEARCH_API_KEY` configuration path for the first external discovery
+  engine
 - candidate selection / queueing helpers for retryable scrape work
 - scrape-attempt persistence and candidate status transitions underneath the ingest path
 - a real `news_items / scrape_candidates` job that drains queued candidates into article ingest
@@ -243,10 +247,10 @@ source-native persistence slice:
   - `candidate_provenance`
   - `scrape_attempts`
 
-This PR still does not call Brave, Exa, or Google CSE, and the generic fetch/extract fallback is
-only scaffolded structurally for retry bookkeeping. The current daily monitoring flow remains
-operational, but candidate selection, scrape attempts, and retryable failure state now exist as a
-real substrate under source-native ingest.
+Exa and Google CSE are still intentionally deferred, and the generic fetch/extract fallback remains
+scaffolded structurally for retry bookkeeping. The current daily monitoring flow remains
+operational, but the durable candidate substrate now accepts both source-native discovery and Brave
+search results.
 
 ## Config Layout
 

--- a/src/denbust/discovery/engines/__init__.py
+++ b/src/denbust/discovery/engines/__init__.py
@@ -1,0 +1,5 @@
+"""Discovery-engine adapters."""
+
+from denbust.discovery.engines.brave import BraveSearchEngine
+
+__all__ = ["BraveSearchEngine"]

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -1,0 +1,117 @@
+"""Brave Search discovery adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import httpx
+from pydantic import HttpUrl
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+
+
+class BraveSearchEngine:
+    """Brave Search API adapter for discovery candidates."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        max_results_per_query: int = 20,
+        client: httpx.AsyncClient | None = None,
+        base_url: str = "https://api.search.brave.com/res/v1/web/search",
+    ) -> None:
+        self._api_key = api_key
+        self._max_results_per_query = max_results_per_query
+        self._base_url = base_url
+        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._owns_client = client is None
+
+    @property
+    def name(self) -> str:
+        return "brave"
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def discover(
+        self,
+        queries: list[DiscoveryQuery],
+        context: DiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        candidates: list[DiscoveredCandidate] = []
+        for query in queries:
+            response = await self._client.get(
+                self._base_url,
+                headers={
+                    "Accept": "application/json",
+                    "X-Subscription-Token": self._api_key,
+                },
+                params={
+                    "q": self._render_query(query),
+                    "count": min(
+                        context.max_results_per_query or self._max_results_per_query,
+                        self._max_results_per_query,
+                    ),
+                    "search_lang": query.language or "he",
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            results = payload.get("web", {}).get("results", [])
+            if not isinstance(results, list):
+                continue
+            for index, result in enumerate(results, start=1):
+                candidate = self._result_to_candidate(result, query=query, rank=index)
+                if candidate is not None:
+                    candidates.append(candidate)
+        return candidates
+
+    def _render_query(self, query: DiscoveryQuery) -> str:
+        if not query.preferred_domains:
+            return query.query_text
+        site_filters = " OR ".join(f"site:{domain}" for domain in query.preferred_domains)
+        return f"({site_filters}) {query.query_text}"
+
+    def _result_to_candidate(
+        self,
+        result: Any,
+        *,
+        query: DiscoveryQuery,
+        rank: int,
+    ) -> DiscoveredCandidate | None:
+        if not isinstance(result, dict):
+            return None
+        url = result.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+        publication_datetime_hint: datetime | None = None
+        page_age = result.get("page_age")
+        if isinstance(page_age, str):
+            normalized = page_age.replace("Z", "+00:00")
+            try:
+                publication_datetime_hint = datetime.fromisoformat(normalized)
+            except ValueError:
+                publication_datetime_hint = None
+        parsed_url = HttpUrl(url)
+        return DiscoveredCandidate(
+            producer_name=self.name,
+            producer_kind=ProducerKind.SEARCH_ENGINE,
+            query_text=query.query_text,
+            candidate_url=parsed_url,
+            canonical_url=parsed_url,
+            title=result.get("title"),
+            snippet=result.get("description"),
+            publication_datetime_hint=publication_datetime_hint,
+            rank=rank,
+            source_hint=query.source_hint,
+            metadata={
+                "engine": self.name,
+                "query_kind": query.query_kind.value,
+                "preferred_domains": query.preferred_domains,
+                "raw_result": result,
+            },
+        )

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -10,6 +10,7 @@ from pydantic import HttpUrl
 
 from denbust.discovery.base import DiscoveryContext
 from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.news_items.normalize import canonicalize_news_url
 
 
 class BraveSearchEngine:
@@ -61,7 +62,12 @@ class BraveSearchEngine:
             )
             response.raise_for_status()
             payload = response.json()
-            results = payload.get("web", {}).get("results", [])
+            if not isinstance(payload, dict):
+                continue
+            web = payload.get("web", {})
+            if not isinstance(web, dict):
+                continue
+            results = web.get("results", [])
             if not isinstance(results, list):
                 continue
             for index, result in enumerate(results, start=1):
@@ -96,22 +102,30 @@ class BraveSearchEngine:
                 publication_datetime_hint = datetime.fromisoformat(normalized)
             except ValueError:
                 publication_datetime_hint = None
-        parsed_url = HttpUrl(url)
-        return DiscoveredCandidate(
-            producer_name=self.name,
-            producer_kind=ProducerKind.SEARCH_ENGINE,
-            query_text=query.query_text,
-            candidate_url=parsed_url,
-            canonical_url=parsed_url,
-            title=result.get("title"),
-            snippet=result.get("description"),
-            publication_datetime_hint=publication_datetime_hint,
-            rank=rank,
-            source_hint=query.source_hint,
-            metadata={
-                "engine": self.name,
-                "query_kind": query.query_kind.value,
-                "preferred_domains": query.preferred_domains,
-                "raw_result": result,
-            },
-        )
+        try:
+            parsed_url = HttpUrl(url)
+            canonical_url = HttpUrl(canonicalize_news_url(url))
+            return DiscoveredCandidate(
+                producer_name=self.name,
+                producer_kind=ProducerKind.SEARCH_ENGINE,
+                query_text=query.query_text,
+                candidate_url=parsed_url,
+                canonical_url=canonical_url,
+                title=result.get("title"),
+                snippet=result.get("description"),
+                publication_datetime_hint=publication_datetime_hint,
+                rank=rank,
+                source_hint=query.source_hint,
+                metadata={
+                    "engine": self.name,
+                    "query_kind": query.query_kind.value,
+                    "preferred_domains": query.preferred_domains,
+                    "result_url": url,
+                    "result_title": result.get("title"),
+                    "result_description": result.get("description"),
+                    "result_page_age": result.get("page_age"),
+                    "result_age": result.get("age"),
+                },
+            )
+        except ValueError:
+            return None

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -1,0 +1,107 @@
+"""Query builders for multi-engine discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from denbust.config import Config, SourceConfig, SourceType
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
+
+_SCRAPER_SOURCE_DOMAINS: dict[str, str] = {
+    "mako": "www.mako.co.il",
+    "maariv": "www.maariv.co.il",
+    "walla": "news.walla.co.il",
+    "haaretz": "www.haaretz.co.il",
+    "ice": "www.ice.co.il",
+}
+
+
+def _normalize_keywords(keywords: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for keyword in keywords:
+        value = keyword.strip()
+        if not value:
+            continue
+        if value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def _source_domain(source: SourceConfig) -> str | None:
+    if source.url:
+        return urlparse(str(source.url)).netloc or None
+    if source.type is SourceType.SCRAPER:
+        return _SCRAPER_SOURCE_DOMAINS.get(source.name)
+    return None
+
+
+def _enabled_source_domains(config: Config) -> list[tuple[str, str]]:
+    source_domains: list[tuple[str, str]] = []
+    for source in config.sources:
+        if not source.enabled:
+            continue
+        domain = _source_domain(source)
+        if domain is None:
+            continue
+        source_domains.append((source.name, domain))
+    return source_domains
+
+
+def build_discovery_queries(
+    config: Config,
+    *,
+    days: int,
+    now: datetime | None = None,
+) -> list[DiscoveryQuery]:
+    """Build normalized discovery queries for enabled discovery engines."""
+    keywords = _normalize_keywords(config.keywords)
+    if not keywords:
+        return []
+
+    current_time = now or datetime.now(UTC)
+    date_from = current_time - timedelta(days=days)
+    date_to = current_time
+    queries: list[DiscoveryQuery] = []
+    seen_keys: set[tuple[object, ...]] = set()
+    source_domains = _enabled_source_domains(config)
+
+    for keyword in keywords:
+        if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
+            broad_key = (DiscoveryQueryKind.BROAD, keyword)
+            if broad_key not in seen_keys:
+                queries.append(
+                    DiscoveryQuery(
+                        query_text=keyword,
+                        language="he",
+                        date_from=date_from,
+                        date_to=date_to,
+                        query_kind=DiscoveryQueryKind.BROAD,
+                    )
+                )
+                seen_keys.add(broad_key)
+
+        if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+            for source_name, domain in source_domains:
+                source_key = (DiscoveryQueryKind.SOURCE_TARGETED, keyword, source_name, domain)
+                if source_key in seen_keys:
+                    continue
+                queries.append(
+                    DiscoveryQuery(
+                        query_text=keyword,
+                        language="he",
+                        date_from=date_from,
+                        date_to=date_to,
+                        preferred_domains=[domain],
+                        source_hint=source_name,
+                        query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                        tags=[source_name],
+                    )
+                )
+                seen_keys.add(source_key)
+
+    return queries

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -35,7 +35,7 @@ def _normalize_keywords(keywords: Iterable[str]) -> list[str]:
 def _source_domain(source: SourceConfig) -> str | None:
     if source.url:
         return urlparse(str(source.url)).netloc or None
-    if source.type is SourceType.SCRAPER:
+    if source.type == SourceType.SCRAPER:
         return _SCRAPER_SOURCE_DOMAINS.get(source.name)
     return None
 

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -1009,9 +1009,7 @@ async def run_news_discover_job(
     source_native_requested = config.source_discovery.enabled
     brave_requested = config.discovery.enabled and config.discovery.engines.brave.enabled
     source_native_can_run = (
-        source_native_requested
-        and config.source_discovery.persist_candidates
-        and bool(sources)
+        source_native_requested and config.source_discovery.persist_candidates and bool(sources)
     )
     brave_can_run = brave_requested and config.discovery.persist_candidates
 
@@ -1019,7 +1017,11 @@ async def run_news_discover_job(
         result.fatal = True
         result.errors.append("source_discovery.enabled is false")
         return result.finish("fatal: source-native discovery disabled")
-    if source_native_requested and not config.source_discovery.persist_candidates and not brave_can_run:
+    if (
+        source_native_requested
+        and not config.source_discovery.persist_candidates
+        and not brave_can_run
+    ):
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
@@ -1079,7 +1081,9 @@ async def run_news_discover_job(
         merged_candidate_ids.update(candidate.candidate_id for candidate in persisted.candidates)
         result.errors.extend(persisted.run.errors)
         if producer_name == "source_native":
-            source_native_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
+            source_native_candidate_ids = {
+                candidate.candidate_id for candidate in persisted.candidates
+            }
             if persisted.run.status is DiscoveryRunStatus.PARTIAL:
                 result.warnings.append(
                     "source-native discovery completed with partial source failures"

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -1013,10 +1013,10 @@ async def run_news_discover_job(
     )
     brave_can_run = brave_requested and config.discovery.persist_candidates
 
-    if not source_native_requested and not brave_can_run:
+    if brave_requested and not config.discovery.persist_candidates and not source_native_can_run:
         result.fatal = True
-        result.errors.append("source_discovery.enabled is false")
-        return result.finish("fatal: source-native discovery disabled")
+        result.errors.append("discovery.persist_candidates is false")
+        return result.finish("fatal: engine candidate persistence disabled")
     if (
         source_native_requested
         and not config.source_discovery.persist_candidates
@@ -1025,10 +1025,10 @@ async def run_news_discover_job(
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
-    if brave_requested and not config.discovery.persist_candidates and not source_native_can_run:
+    if not source_native_requested and not brave_can_run:
         result.fatal = True
-        result.errors.append("discovery.persist_candidates is false")
-        return result.finish("fatal: engine candidate persistence disabled")
+        result.errors.append("source_discovery.enabled is false")
+        return result.finish("fatal: source-native discovery disabled")
     if not sources and not brave_can_run:
         result.fatal = True
         result.errors.append("No sources configured")
@@ -1065,11 +1065,6 @@ async def run_news_discover_job(
                 ),
             )
         )
-
-    if not persisted_runs:
-        result.fatal = True
-        result.errors.append("No discovery producers enabled")
-        return result.finish("fatal: no discovery producers enabled")
 
     source_native_candidate_ids: set[str] = set()
     brave_candidate_ids: set[str] = set()

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -16,8 +16,10 @@ from denbust.data_models import ClassifiedArticle, RawArticle, UnifiedItem
 from denbust.datasets.jobs import ensure_default_jobs_registered
 from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
-from denbust.discovery.base import SourceDiscoveryContext
+from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
+from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus, PersistentCandidate
+from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import (
     CandidateScrapeBatch,
     scrape_candidates,
@@ -29,6 +31,7 @@ from denbust.discovery.source_native import (
     persist_discovered_candidates,
     raw_article_to_discovered_candidate,
 )
+from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.discovery.storage import create_discovery_persistence
 from denbust.models.common import DatasetName, JobName
 from denbust.models.runs import RunSnapshot
@@ -206,6 +209,23 @@ def _group_articles_by_source(articles: list[RawArticle]) -> dict[str, list[RawA
     return dict(grouped)
 
 
+def _write_discovery_engine_metrics(
+    config: Config,
+    *,
+    source_native_candidate_ids: set[str],
+    brave_candidate_ids: set[str],
+) -> None:
+    """Persist a lightweight engine overlap metrics snapshot."""
+    write_metrics_snapshot(
+        config.discovery_state_paths.engine_overlap_latest_path,
+        {
+            "source_native": len(source_native_candidate_ids),
+            "brave": len(brave_candidate_ids),
+            "shared_candidates": len(source_native_candidate_ids & brave_candidate_ids),
+        },
+    )
+
+
 async def _persist_source_native_candidates(
     *,
     config: Config,
@@ -280,6 +300,71 @@ async def _run_source_native_discovery(
         )
         return persisted
     finally:
+        persistence.close()
+
+
+async def _run_brave_discovery(
+    *,
+    config: Config,
+    run_id: str,
+    days: int,
+) -> PersistedSourceDiscovery:
+    """Run Brave-powered discovery and persist candidates into the durable layer."""
+    queries = build_discovery_queries(config, days=days)
+    discovery_run = DiscoveryRun(
+        run_id=run_id,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=DiscoveryRunStatus.RUNNING,
+        query_count=len(queries),
+    )
+    persistence = create_discovery_persistence(config)
+    if not queries:
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    brave_api_key = config.brave_search_api_key
+    if not brave_api_key:
+        discovery_run.errors.append("brave: missing DENBUST_BRAVE_SEARCH_API_KEY")
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    engine = BraveSearchEngine(
+        api_key=brave_api_key,
+        max_results_per_query=config.discovery.engines.brave.max_results_per_query,
+    )
+    try:
+        try:
+            discovered_candidates = await engine.discover(
+                queries,
+                context=DiscoveryContext(
+                    run_id=run_id,
+                    max_results_per_query=config.discovery.engines.brave.max_results_per_query,
+                    metadata={"days": days, "engine": "brave"},
+                ),
+            )
+        except Exception as exc:
+            discovery_run.errors.append(f"brave: {type(exc).__name__}: {exc}")
+            discovered_candidates = []
+        return persist_discovered_candidates(
+            run=discovery_run,
+            discovered_candidates=discovered_candidates,
+            persistence=persistence,
+        )
+    finally:
+        await engine.aclose()
         persistence.close()
 
 
@@ -915,43 +1000,111 @@ async def run_news_discover_job(
     days_override: int | None = None,
     operational_store: OperationalStore | None = None,
 ) -> RunSnapshot:
-    """Run source-native discovery only and persist durable candidates."""
+    """Run configured discovery producers and persist durable candidates."""
     del operational_store
     days = days_override if days_override is not None else config.days
     result = _build_run_snapshot(config, config_path=config_path, days=days)
     sources = create_sources(config)
     result.source_count = len(sources)
-    if not config.source_discovery.enabled:
+    source_native_requested = config.source_discovery.enabled
+    brave_requested = config.discovery.enabled and config.discovery.engines.brave.enabled
+    source_native_can_run = (
+        source_native_requested
+        and config.source_discovery.persist_candidates
+        and bool(sources)
+    )
+    brave_can_run = brave_requested and config.discovery.persist_candidates
+
+    if not source_native_requested and not brave_can_run:
         result.fatal = True
         result.errors.append("source_discovery.enabled is false")
         return result.finish("fatal: source-native discovery disabled")
-    if not config.source_discovery.persist_candidates:
+    if source_native_requested and not config.source_discovery.persist_candidates and not brave_can_run:
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
-    if not sources:
+    if brave_requested and not config.discovery.persist_candidates and not source_native_can_run:
+        result.fatal = True
+        result.errors.append("discovery.persist_candidates is false")
+        return result.finish("fatal: engine candidate persistence disabled")
+    if not sources and not brave_can_run:
         result.fatal = True
         result.errors.append("No sources configured")
         return result.finish("fatal: no sources configured")
 
-    persisted = await _run_source_native_discovery(
-        config=config,
-        sources=sources,
-        run_id=result.run_timestamp.astimezone(UTC).isoformat(),
-        days=days,
-    )
-    result.raw_article_count = persisted.run.candidate_count
-    result.unseen_article_count = persisted.run.candidate_count
-    result.unified_item_count = persisted.run.merged_candidate_count
-    result.errors.extend(persisted.run.errors)
-    if persisted.run.status is DiscoveryRunStatus.FAILED:
+    persisted_runs: list[tuple[str, PersistedSourceDiscovery]] = []
+    run_base = result.run_timestamp.astimezone(UTC).isoformat()
+
+    if source_native_can_run:
+        persisted_runs.append(
+            (
+                "source_native",
+                await _run_source_native_discovery(
+                    config=config,
+                    sources=sources,
+                    run_id=f"{run_base}:source_native",
+                    days=days,
+                ),
+            )
+        )
+    elif source_native_requested and not config.source_discovery.persist_candidates:
+        result.warnings.append("source-native discovery skipped because persistence is disabled")
+    elif source_native_requested and not sources:
+        result.warnings.append("source-native discovery skipped because no sources are configured")
+
+    if brave_can_run:
+        persisted_runs.append(
+            (
+                "brave",
+                await _run_brave_discovery(
+                    config=config,
+                    run_id=f"{run_base}:brave",
+                    days=days,
+                ),
+            )
+        )
+
+    if not persisted_runs:
         result.fatal = True
-    if persisted.run.status is DiscoveryRunStatus.PARTIAL:
-        result.warnings.append("source-native discovery completed with partial source failures")
+        result.errors.append("No discovery producers enabled")
+        return result.finish("fatal: no discovery producers enabled")
+
+    source_native_candidate_ids: set[str] = set()
+    brave_candidate_ids: set[str] = set()
+    merged_candidate_ids: set[str] = set()
+    failed_runs = 0
+    for producer_name, persisted in persisted_runs:
+        result.raw_article_count += persisted.run.candidate_count
+        result.unseen_article_count += persisted.run.candidate_count
+        merged_candidate_ids.update(candidate.candidate_id for candidate in persisted.candidates)
+        result.errors.extend(persisted.run.errors)
+        if producer_name == "source_native":
+            source_native_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
+            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
+                result.warnings.append(
+                    "source-native discovery completed with partial source failures"
+                )
+        if producer_name == "brave":
+            brave_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
+            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
+                result.warnings.append("brave discovery completed with partial engine failures")
+        if persisted.run.status is DiscoveryRunStatus.FAILED:
+            failed_runs += 1
+
+    _write_discovery_engine_metrics(
+        config,
+        source_native_candidate_ids=source_native_candidate_ids,
+        brave_candidate_ids=brave_candidate_ids,
+    )
+    result.unified_item_count = len(merged_candidate_ids)
+
+    if failed_runs == len(persisted_runs):
+        result.fatal = True
+
     result.finish(
-        "source-native discovery persisted "
-        f"{persisted.run.merged_candidate_count} candidate(s) from "
-        f"{persisted.run.candidate_count} discovered result(s)"
+        "discovery persisted "
+        f"{result.unified_item_count} merged candidate(s) from "
+        f"{result.raw_article_count} discovered result(s)"
     )
     return result
 

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -70,8 +70,15 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
     assert candidates[0].producer_kind is ProducerKind.SEARCH_ENGINE
     assert candidates[0].source_hint == "ynet"
     assert candidates[0].rank == 1
+    assert str(candidates[0].candidate_url) == "https://www.ynet.co.il/news/article/abc"
+    assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
     assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
     assert candidates[0].metadata["query_kind"] == "source_targeted"
+    assert candidates[0].metadata["result_url"] == "https://www.ynet.co.il/news/article/abc"
+    assert candidates[0].metadata["result_title"] == "פשיטה על בית בושת"
+    assert candidates[0].metadata["result_description"] == "המשטרה פשטה על המקום."
+    assert candidates[0].metadata["result_page_age"] == "2026-04-15T08:00:00Z"
+    assert "raw_result" not in candidates[0].metadata
 
 
 @pytest.mark.asyncio
@@ -105,4 +112,51 @@ async def test_brave_search_engine_skips_invalid_results() -> None:
 
     assert [str(candidate.candidate_url) for candidate in candidates] == [
         "https://www.mako.co.il/news/article/xyz"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_skips_non_object_payloads_and_invalid_urls() -> None:
+    """Malformed payloads and bad URLs should be ignored without failing the whole discovery call."""
+    responses = iter(
+        [
+            httpx.Response(200, json=[]),
+            httpx.Response(200, json={"web": []}),
+            httpx.Response(
+                200,
+                json={
+                    "web": {
+                        "results": [
+                            {"url": "not-a-url", "title": "bad"},
+                            {"url": "https://www.walla.co.il/item?utm_source=test", "title": "ok"},
+                        ]
+                    }
+                },
+            ),
+        ]
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+        ],
+        DiscoveryContext(run_id="run-3"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://www.walla.co.il/item?utm_source=test"
+    ]
+    assert [str(candidate.canonical_url) for candidate in candidates] == [
+        "https://walla.co.il/item"
     ]

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -1,0 +1,108 @@
+"""Unit tests for the Brave discovery adapter."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.engines.brave import BraveSearchEngine
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind, ProducerKind
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_normalizes_results_and_renders_site_query() -> None:
+    """Brave responses should become normalized discovery candidates."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = request.url.params["q"]
+        captured["count"] = request.url.params["count"]
+        captured["token"] = request.headers["X-Subscription-Token"]
+        return httpx.Response(
+            200,
+            text=json.dumps(
+                {
+                    "web": {
+                        "results": [
+                            {
+                                "url": "https://www.ynet.co.il/news/article/abc",
+                                "title": "פשיטה על בית בושת",
+                                "description": "המשטרה פשטה על המקום.",
+                                "page_age": "2026-04-15T08:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            ),
+        )
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_results_per_query=20,
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="בית בושת",
+                query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                preferred_domains=["www.ynet.co.il"],
+                source_hint="ynet",
+                language="he",
+            )
+        ],
+        DiscoveryContext(run_id="run-1", max_results_per_query=5),
+    )
+    await engine.aclose()
+
+    assert captured == {
+        "query": "(site:www.ynet.co.il) בית בושת",
+        "count": "5",
+        "token": "brave-key",
+    }
+    assert len(candidates) == 1
+    assert candidates[0].producer_name == "brave"
+    assert candidates[0].producer_kind is ProducerKind.SEARCH_ENGINE
+    assert candidates[0].source_hint == "ynet"
+    assert candidates[0].rank == 1
+    assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
+    assert candidates[0].metadata["query_kind"] == "source_targeted"
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_skips_invalid_results() -> None:
+    """Malformed Brave payload rows should be ignored."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {"title": "missing url"},
+                        {"url": ""},
+                        {"url": "https://www.mako.co.il/news/article/xyz", "title": "ok"},
+                    ]
+                }
+            },
+        )
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-2"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://www.mako.co.il/news/article/xyz"
+    ]

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -178,7 +178,9 @@ async def test_brave_search_engine_skips_non_list_results_and_non_dict_rows() ->
     responses = iter(
         [
             httpx.Response(200, json={"web": {"results": "not-a-list"}}),
-            httpx.Response(200, json={"web": {"results": ["bad-row", {"url": "https://ice.co.il/a"}]}}),
+            httpx.Response(
+                200, json={"web": {"results": ["bad-row", {"url": "https://ice.co.il/a"}]}}
+            ),
         ]
     )
 

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -82,6 +82,16 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
 
 
 @pytest.mark.asyncio
+async def test_brave_search_engine_aclose_closes_owned_client() -> None:
+    """Owned async clients should be closed by `aclose()`."""
+    engine = BraveSearchEngine(api_key="brave-key")
+
+    await engine.aclose()
+
+    assert engine._client.is_closed is True
+
+
+@pytest.mark.asyncio
 async def test_brave_search_engine_skips_invalid_results() -> None:
     """Malformed Brave payload rows should be ignored."""
 
@@ -160,3 +170,68 @@ async def test_brave_search_engine_skips_non_object_payloads_and_invalid_urls() 
     assert [str(candidate.canonical_url) for candidate in candidates] == [
         "https://walla.co.il/item"
     ]
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_skips_non_list_results_and_non_dict_rows() -> None:
+    """Unexpected result container shapes should be skipped safely."""
+    responses = iter(
+        [
+            httpx.Response(200, json={"web": {"results": "not-a-list"}}),
+            httpx.Response(200, json={"web": {"results": ["bad-row", {"url": "https://ice.co.il/a"}]}}),
+        ]
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+        ],
+        DiscoveryContext(run_id="run-4"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == ["https://ice.co.il/a"]
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_ignores_invalid_page_age() -> None:
+    """Unparseable page-age values should produce a candidate with no publication hint."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://www.mako.co.il/news/article/xyz",
+                            "title": "ok",
+                            "page_age": "not-a-datetime",
+                        }
+                    ]
+                }
+            },
+        )
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-5"),
+    )
+    await engine.aclose()
+
+    assert len(candidates) == 1
+    assert candidates[0].publication_datetime_hint is None

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -1,0 +1,64 @@
+"""Unit tests for discovery query builders."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from denbust.config import Config, SourceConfig, SourceType
+from denbust.discovery.models import DiscoveryQueryKind
+from denbust.discovery.queries import build_discovery_queries
+
+
+def test_build_discovery_queries_creates_broad_and_source_targeted_queries() -> None:
+    """Query construction should include both broad and source-targeted variants by default."""
+    config = Config(
+        keywords=["בית בושת", "זנות"],
+        sources=[
+            SourceConfig(
+                name="ynet",
+                type=SourceType.RSS,
+                url="https://www.ynet.co.il/Integration/StoryRss2.xml",
+            ),
+            SourceConfig(name="mako", type=SourceType.SCRAPER),
+        ],
+        discovery={"enabled": True},
+    )
+
+    queries = build_discovery_queries(
+        config,
+        days=5,
+        now=datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+    )
+
+    broad_queries = [query for query in queries if query.query_kind is DiscoveryQueryKind.BROAD]
+    targeted_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    ]
+
+    assert len(broad_queries) == 2
+    assert len(targeted_queries) == 4
+    assert {query.query_text for query in broad_queries} == {"בית בושת", "זנות"}
+    assert {(query.source_hint, tuple(query.preferred_domains)) for query in targeted_queries} == {
+        ("ynet", ("www.ynet.co.il",)),
+        ("mako", ("www.mako.co.il",)),
+    }
+    assert all(query.language == "he" for query in queries)
+    assert all(query.date_from is not None and query.date_to is not None for query in queries)
+
+
+def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
+    """Only configured query kinds should be generated."""
+    config = Config(
+        keywords=["בית בושת"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={
+            "enabled": True,
+            "default_query_kinds": [DiscoveryQueryKind.SOURCE_TARGETED],
+        },
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    assert len(queries) == 1
+    assert queries[0].query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    assert queries[0].source_hint == "mako"

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -62,3 +62,64 @@ def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
     assert len(queries) == 1
     assert queries[0].query_kind is DiscoveryQueryKind.SOURCE_TARGETED
     assert queries[0].source_hint == "mako"
+
+
+def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() -> None:
+    """Blank/duplicate keywords and unusable sources should be skipped cleanly."""
+    config = Config(
+        keywords=["", "  ", "זנות", "זנות"],
+        sources=[
+            SourceConfig(name="disabled", type=SourceType.SCRAPER, enabled=False),
+            SourceConfig(name="unknown", type=SourceType.SCRAPER),
+            SourceConfig(name="rss-no-url", type=SourceType.RSS),
+            SourceConfig(name="mako", type=SourceType.SCRAPER),
+        ],
+        discovery={"enabled": True},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    broad_queries = [query for query in queries if query.query_kind is DiscoveryQueryKind.BROAD]
+    targeted_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    ]
+
+    assert len(broad_queries) == 1
+    assert len(targeted_queries) == 1
+    assert broad_queries[0].query_text == "זנות"
+    assert targeted_queries[0].source_hint == "mako"
+
+
+def test_build_discovery_queries_returns_empty_for_empty_keyword_set() -> None:
+    """If all keywords collapse away, no discovery queries should be built."""
+    config = Config(
+        keywords=["", "   "],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"enabled": True},
+    )
+
+    assert build_discovery_queries(config, days=3) == []
+
+
+def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> None:
+    """Duplicate source domains should not emit duplicate source-targeted queries."""
+    config = Config(
+        keywords=["זנות", "זנות"],
+        sources=[
+            SourceConfig(name="ynet", type=SourceType.RSS, url="https://www.ynet.co.il/feed.xml"),
+            SourceConfig(
+                name="ynet",
+                type=SourceType.RSS,
+                url="https://www.ynet.co.il/another-feed.xml",
+            ),
+        ],
+        discovery={"enabled": True},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+    targeted_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    ]
+
+    assert len(targeted_queries) == 1
+    assert targeted_queries[0].preferred_domains == ["www.ynet.co.il"]

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1704,6 +1704,47 @@ class TestRunPipelineAsync:
         )
 
     @pytest.mark.asyncio
+    async def test_run_news_discover_job_warns_when_source_native_persistence_disabled_but_brave_runs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Source-native persistence-disabled skips should degrade to a warning when Brave runs."""
+        brave_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-brave-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                )
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [MagicMock(name="ynet")]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"persist_candidates": False},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert "source-native discovery skipped because persistence is disabled" in result.warnings
+
+    @pytest.mark.asyncio
     async def test_run_news_discover_job_warns_on_brave_partial(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -21,7 +21,12 @@ from denbust.data_models import (
     SubCategory,
     UnifiedItem,
 )
-from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus
+from denbust.discovery.models import (
+    CandidateStatus,
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    PersistentCandidate,
+)
 from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
 from denbust.models.common import DatasetName, JobName
@@ -93,6 +98,27 @@ def build_unified_item(url: str = "https://example.com/article") -> UnifiedItem:
         date=datetime(2026, 3, 1, tzinfo=UTC),
         category=Category.BROTHEL,
         sub_category=SubCategory.CLOSURE,
+    )
+
+
+def build_persistent_candidate(
+    candidate_id: str,
+    *,
+    current_url: str,
+) -> PersistentCandidate:
+    """Create a sample persistent candidate."""
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        current_url=HttpUrl(current_url),
+        canonical_url=HttpUrl(current_url),
+        titles=["פשיטה על בית בושת"],
+        snippets=["המשטרה ביצעה פשיטה."],
+        discovered_via=["source_native"],
+        discovery_queries=["בית בושת"],
+        source_hints=["test"],
+        first_seen_at=datetime(2026, 4, 11, 8, 0, tzinfo=UTC),
+        last_seen_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        candidate_status=CandidateStatus.NEW,
     )
 
 
@@ -1282,7 +1308,7 @@ class TestRunPipelineAsync:
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_marks_failed_and_partial_runs(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Discover should surface failed runs as fatal and partial runs as warnings."""
         persisted = PersistedSourceDiscovery(
@@ -1305,7 +1331,7 @@ class TestRunPipelineAsync:
             AsyncMock(return_value=persisted),
         )
 
-        partial_result = await run_news_discover_job(Config())
+        partial_result = await run_news_discover_job(Config(store={"state_root": tmp_path}))
 
         assert partial_result.fatal is False
         assert (
@@ -1314,9 +1340,163 @@ class TestRunPipelineAsync:
         )
 
         persisted.run.status = DiscoveryRunStatus.FAILED
-        failed_result = await run_news_discover_job(Config())
+        failed_result = await run_news_discover_job(Config(store={"state_root": tmp_path}))
 
         assert failed_result.fatal is True
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_supports_brave_only_and_writes_metrics(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Brave discovery should run without configured sources and persist engine metrics."""
+        brave_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=3,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-brave-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                ),
+                build_persistent_candidate(
+                    "candidate-brave-2",
+                    current_url="https://www.mako.co.il/news/article/2",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 3
+        assert result.unified_item_count == 2
+        metrics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+        ).read_text(encoding="utf-8")
+        assert '"brave": 2' in metrics_payload
+        assert '"source_native": 0' in metrics_payload
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_aggregates_brave_and_source_native_without_double_counting(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Merged candidate counts should be deduplicated across discovery producers."""
+        source_native = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:source_native",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared",
+                    current_url="https://www.ynet.co.il/news/article/shared",
+                ),
+                build_persistent_candidate(
+                    "candidate-source-only",
+                    current_url="https://www.walla.co.il/news/article/source-only",
+                ),
+            ],
+            provenance=[],
+        )
+        brave = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=3,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared",
+                    current_url="https://www.ynet.co.il/news/article/shared",
+                ),
+                build_persistent_candidate(
+                    "candidate-brave-only",
+                    current_url="https://www.mako.co.il/news/article/brave-only",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [MagicMock(name="ynet")]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_source_native_discovery",
+            AsyncMock(return_value=source_native),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 5
+        assert result.unified_item_count == 3
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_marks_brave_failure_fatal_when_it_is_the_only_engine(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A failed Brave-only discovery run should surface as fatal."""
+        brave_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.FAILED,
+                candidate_count=0,
+                merged_candidate_count=0,
+                errors=["brave: missing DENBUST_BRAVE_SEARCH_API_KEY"],
+            ),
+            candidates=[],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is True
+        assert result.errors == ["brave: missing DENBUST_BRAVE_SEARCH_API_KEY"]
 
 
 class TestRunPipeline:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1699,7 +1699,9 @@ class TestRunPipelineAsync:
         )
 
         assert result.fatal is False
-        assert "source-native discovery skipped because no sources are configured" in result.warnings
+        assert (
+            "source-native discovery skipped because no sources are configured" in result.warnings
+        )
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_warns_on_brave_partial(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
@@ -38,6 +39,7 @@ from denbust.pipeline import (
     _build_source_summaries,
     _build_suspicions,
     _persist_source_native_candidates,
+    _run_brave_discovery,
     _run_job_from_config,
     _run_source_native_discovery,
     _source_name_from_error,
@@ -414,6 +416,147 @@ class TestFetchAndClassifyHelpers:
 
 class TestRunPipelineAsync:
     """Tests for async pipeline control flow."""
+
+    @pytest.mark.asyncio
+    async def test_run_brave_discovery_persists_empty_when_no_queries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Brave discovery should still persist an empty run when query building yields nothing."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_brave_discovery(config=Config(), run_id="run-brave", days=4)
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).query_count == 0
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_brave_discovery_records_missing_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Brave discovery should persist an error when enabled without an API key."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_brave_discovery(
+            config=Config(discovery={"enabled": True, "engines": {"brave": {"enabled": True}}}),
+            run_id="run-brave",
+            days=4,
+        )
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).errors == [
+            "brave: missing DENBUST_BRAVE_SEARCH_API_KEY"
+        ]
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_brave_discovery_catches_engine_errors_and_closes_resources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Engine failures should be recorded on the run and still close both engine and store."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["persistence_closed"] = True
+
+        class FakeEngine:
+            def __init__(self, **kwargs: object) -> None:
+                captured["engine_init"] = kwargs
+
+            async def discover(self, queries, context):
+                captured["queries"] = queries
+                captured["context"] = context
+                raise RuntimeError("boom")
+
+            async def aclose(self) -> None:
+                captured["engine_closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(
+            Config,
+            "brave_search_api_key",
+            property(lambda _self: "brave-key"),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr("denbust.pipeline.BraveSearchEngine", FakeEngine)
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_brave_discovery(
+            config=Config(discovery={"enabled": True, "engines": {"brave": {"enabled": True}}}),
+            run_id="run-brave",
+            days=6,
+        )
+
+        assert persisted.candidates == []
+        assert cast(DiscoveryRun, captured["run"]).errors == ["brave: RuntimeError: boom"]
+        assert captured["engine_closed"] is True
+        assert captured["persistence_closed"] is True
+        assert captured["engine_init"] == {"api_key": "brave-key", "max_results_per_query": 20}
+        assert captured["context"].metadata == {"days": 6, "engine": "brave"}
 
     @pytest.mark.asyncio
     async def test_run_pipeline_async_requires_api_key(
@@ -1497,6 +1640,104 @@ class TestRunPipelineAsync:
 
         assert result.fatal is True
         assert result.errors == ["brave: missing DENBUST_BRAVE_SEARCH_API_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_fails_when_engine_persistence_disabled_and_no_source_native(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Engine-backed discover should fail early when engine persistence is disabled."""
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+
+        result = await run_news_discover_job(
+            Config(
+                source_discovery={"enabled": True, "persist_candidates": True},
+                discovery={
+                    "enabled": True,
+                    "persist_candidates": False,
+                    "engines": {"brave": {"enabled": True}},
+                },
+            )
+        )
+
+        assert result.fatal is True
+        assert result.errors == ["discovery.persist_candidates is false"]
+        assert result.result_summary == "fatal: engine candidate persistence disabled"
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_warns_when_source_native_skipped_for_no_sources_but_brave_runs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Source-native no-source skips should degrade to a warning when Brave remains active."""
+        brave_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-brave-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                )
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert "source-native discovery skipped because no sources are configured" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_warns_on_brave_partial(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Brave partial runs should surface as warnings and still write metrics."""
+        brave_partial = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.PARTIAL,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-brave-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                )
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave_partial),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+            )
+        )
+
+        assert "brave discovery completed with partial engine failures" in result.warnings
 
 
 class TestRunPipeline:


### PR DESCRIPTION
## Summary

This implements `DL-PR-04` from the discovery-layer implementation plan: Brave becomes the first external discovery engine feeding the persistent candidate substrate.

The PR keeps the current ingest/release/backup flow intact and adds Brave only as an additive discovery path behind config gates.

## What changed

### 1. Brave engine adapter
- Added `src/denbust/discovery/engines/brave.py`
- Implements a `BraveSearchEngine` adapter using the Brave Search API
- Normalizes Brave web results into `DiscoveredCandidate`
- Preserves source-native discovery semantics by using the same persistence merge/provenance path already introduced in earlier discovery PRs

### 2. Discovery query builder
- Added `src/denbust/discovery/queries.py`
- Builds normalized `DiscoveryQuery` objects for:
  - broad keyword discovery
  - source-targeted discovery
- Resolves preferred domains from configured RSS URLs and known scraper-source domain mappings
- Uses the effective day window for `date_from` / `date_to`

### 3. Discover job wiring
- Updated `run_news_discover_job()` in `src/denbust/pipeline.py`
- `news_items / discover` can now run:
  - source-native only
  - Brave only
  - source-native + Brave together
- Aggregates results across producers while deduplicating merged candidate counts by `candidate_id`
- Writes lightweight engine overlap metrics into the discovery state namespace
- Preserves existing fatal behavior for source-native-only configurations, while allowing Brave-only discovery when source-native discovery is disabled or no news sources are configured

### 4. Docs
- Updated `README.md` to reflect that `news_items / discover` now supports source-native plus Brave discovery
- Clarified that Exa and Google CSE remain deferred

## Validation

Ran locally:

```bash
pytest -q tests/unit/test_config.py tests/unit/test_discovery_queries.py tests/unit/test_discovery_brave.py tests/unit/test_discovery_storage.py tests/unit/test_pipeline_core.py -k 'discover or brave or query or source_native or persistence'
ruff check src/denbust/discovery/queries.py src/denbust/discovery/engines/brave.py src/denbust/pipeline.py tests/unit/test_discovery_queries.py tests/unit/test_discovery_brave.py tests/unit/test_discovery_storage.py tests/unit/test_pipeline_core.py README.md
mypy src/denbust/discovery/queries.py src/denbust/discovery/engines/brave.py src/denbust/pipeline.py
```

## Scope intentionally deferred
- Exa integration
- Google CSE integration
- persistence-level server-side engine candidate selection for large discovery tables
- backfill / self-healing flows
- generic fetch/extract fallback execution

## Notes
- Brave remains fully gated by `discovery.enabled`, `discovery.persist_candidates`, and `discovery.engines.brave.enabled`
- The API key path remains `DENBUST_BRAVE_SEARCH_API_KEY`
- The current source-native monitoring flow remains available and unchanged when Brave is not enabled