### PR TITLE
Implement DL-PR-05 Exa discovery engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ data jobs. Phase A introduced the shared platform spine. Phase B turns the first
 
 Today, the implemented dataset/jobs are:
 
-- `news_items / discover` (source-native + Brave candidate persistence)
+- `news_items / discover` (source-native + Brave + Exa candidate persistence)
 - `news_items / ingest`
 - `news_items / release`
 - `news_items / backup`
@@ -40,7 +40,7 @@ Planned future datasets:
 - Persists dataset/job-scoped seen state and per-run JSON snapshots
 - Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
   paths under `news_items/discover/`
-- Runs Brave as the first external discovery engine feeding the durable candidate layer
+- Runs Brave and Exa as external discovery engines feeding the durable candidate layer
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
 
 ## Quick Start
@@ -218,13 +218,13 @@ What is implemented now:
 Still intentionally deferred:
 
 - additional dataset implementations beyond `news_items`
-- Exa and Google CSE engine integrations
+- Google CSE engine integration
 - richer human review tooling / admin UI
 - more advanced privacy policies beyond the current pragmatic gate
 
 ## Discovery Layer Foundation
 
-DL-PR-04 now builds on the earlier discovery milestones:
+DL-PR-05 now builds on the earlier discovery milestones:
 
 - `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
   models
@@ -232,10 +232,11 @@ DL-PR-04 now builds on the earlier discovery milestones:
 - explicit state-repo path helpers for candidate-layer snapshots and queue files
 - source-native candidate normalization and merge/upsert persistence
 - a real `news_items / discover` job that persists source-native candidates and Brave-discovered
-  candidates into the same durable substrate
+  and Exa-discovered candidates into the same durable substrate
 - Brave query building for broad and source-targeted discovery searches
-- a dedicated `DENBUST_BRAVE_SEARCH_API_KEY` configuration path for the first external discovery
-  engine
+- Exa query execution for the same broad and source-targeted discovery searches
+- dedicated `DENBUST_BRAVE_SEARCH_API_KEY` and `DENBUST_EXA_API_KEY` configuration paths for
+  external discovery engines
 - candidate selection / queueing helpers for retryable scrape work
 - scrape-attempt persistence and candidate status transitions underneath the ingest path
 - a real `news_items / scrape_candidates` job that drains queued candidates into article ingest
@@ -247,10 +248,10 @@ DL-PR-04 now builds on the earlier discovery milestones:
   - `candidate_provenance`
   - `scrape_attempts`
 
-Exa and Google CSE are still intentionally deferred, and the generic fetch/extract fallback remains
+Google CSE is still intentionally deferred, and the generic fetch/extract fallback remains
 scaffolded structurally for retry bookkeeping. The current daily monitoring flow remains
-operational, but the durable candidate substrate now accepts both source-native discovery and Brave
-search results.
+operational, but the durable candidate substrate now accepts source-native discovery plus Brave and
+Exa search results.
 
 ## Config Layout
 

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -1183,8 +1183,8 @@ to distinguish them from GitHub PR numbers. For example: `DL-PR-01`, `DL-PR-02`,
 - final source-aware scraping from durable candidates
 
 ### Milestone 3 — Exa + Google CSE
-- add Exa
-- add Google CSE
+- add Exa (implemented)
+- add Google CSE (pending)
 - add overlap metrics
 - add queue health metrics
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -174,6 +174,9 @@ Search-engine discovery begins contributing durable candidates, starting with Br
 ### Goal
 Add Exa as a semantic/AI-native discovery engine.
 
+### Status
+Implemented.
+
 ### Scope
 - Add Exa adapter under `src/denbust/discovery/engines/exa.py`
 - Support:

--- a/src/denbust/discovery/engines/exa.py
+++ b/src/denbust/discovery/engines/exa.py
@@ -146,8 +146,12 @@ class ExaSearchEngine:
                     "result_id": result.get("id"),
                     "result_url": url,
                     "result_title": title if isinstance(title, str) else None,
-                    "result_published_date": published_date if isinstance(published_date, str) else None,
-                    "result_author": result.get("author") if isinstance(result.get("author"), str) else None,
+                    "result_published_date": published_date
+                    if isinstance(published_date, str)
+                    else None,
+                    "result_author": result.get("author")
+                    if isinstance(result.get("author"), str)
+                    else None,
                 },
             )
         except ValueError:

--- a/src/denbust/discovery/engines/exa.py
+++ b/src/denbust/discovery/engines/exa.py
@@ -1,0 +1,154 @@
+"""Exa search discovery adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import httpx
+from pydantic import HttpUrl
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.news_items.normalize import canonicalize_news_url
+
+
+class ExaSearchEngine:
+    """Exa Search API adapter for discovery candidates."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        max_results_per_query: int = 20,
+        client: httpx.AsyncClient | None = None,
+        base_url: str = "https://api.exa.ai/search",
+    ) -> None:
+        self._api_key = api_key
+        self._max_results_per_query = max_results_per_query
+        self._base_url = base_url
+        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._owns_client = client is None
+
+    @property
+    def name(self) -> str:
+        return "exa"
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def discover(
+        self,
+        queries: list[DiscoveryQuery],
+        context: DiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        candidates: list[DiscoveredCandidate] = []
+        for query in queries:
+            response = await self._client.post(
+                self._base_url,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "x-api-key": self._api_key,
+                },
+                json=self._build_payload(query, context),
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                continue
+            results = payload.get("results", [])
+            if not isinstance(results, list):
+                continue
+            request_id = payload.get("requestId")
+            for index, result in enumerate(results, start=1):
+                candidate = self._result_to_candidate(
+                    result,
+                    query=query,
+                    rank=index,
+                    request_id=request_id if isinstance(request_id, str) else None,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+        return candidates
+
+    def _build_payload(self, query: DiscoveryQuery, context: DiscoveryContext) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "query": query.query_text,
+            "type": "auto",
+            "numResults": min(
+                context.max_results_per_query or self._max_results_per_query,
+                self._max_results_per_query,
+            ),
+        }
+        if query.date_from is not None:
+            payload["startPublishedDate"] = query.date_from.date().isoformat()
+        if query.date_to is not None:
+            payload["endPublishedDate"] = query.date_to.date().isoformat()
+        if query.preferred_domains:
+            payload["includeDomains"] = query.preferred_domains
+        if query.excluded_domains:
+            payload["excludeDomains"] = query.excluded_domains
+        return payload
+
+    def _result_to_candidate(
+        self,
+        result: Any,
+        *,
+        query: DiscoveryQuery,
+        rank: int,
+        request_id: str | None,
+    ) -> DiscoveredCandidate | None:
+        if not isinstance(result, dict):
+            return None
+        url = result.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+        publication_datetime_hint: datetime | None = None
+        published_date = result.get("publishedDate")
+        if isinstance(published_date, str):
+            normalized = published_date.replace("Z", "+00:00")
+            try:
+                publication_datetime_hint = datetime.fromisoformat(normalized)
+            except ValueError:
+                publication_datetime_hint = None
+        try:
+            parsed_url = HttpUrl(url)
+            canonical_url = HttpUrl(canonicalize_news_url(url))
+            title = result.get("title")
+            snippet = result.get("text")
+            if not isinstance(snippet, str) or not snippet:
+                snippet = None
+            if not snippet:
+                highlights = result.get("highlights")
+                if isinstance(highlights, list):
+                    snippet = next(
+                        (value for value in highlights if isinstance(value, str) and value),
+                        None,
+                    )
+            return DiscoveredCandidate(
+                producer_name=self.name,
+                producer_kind=ProducerKind.SEARCH_ENGINE,
+                query_text=query.query_text,
+                candidate_url=parsed_url,
+                canonical_url=canonical_url,
+                title=title if isinstance(title, str) else None,
+                snippet=snippet,
+                publication_datetime_hint=publication_datetime_hint,
+                rank=rank,
+                source_hint=query.source_hint,
+                metadata={
+                    "engine": self.name,
+                    "query_kind": query.query_kind.value,
+                    "preferred_domains": query.preferred_domains,
+                    "request_id": request_id,
+                    "result_id": result.get("id"),
+                    "result_url": url,
+                    "result_title": title if isinstance(title, str) else None,
+                    "result_published_date": published_date if isinstance(published_date, str) else None,
+                    "result_author": result.get("author") if isinstance(result.get("author"), str) else None,
+                },
+            )
+        except ValueError:
+            return None

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -18,6 +18,7 @@ from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
 from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
+from denbust.discovery.engines.exa import ExaSearchEngine
 from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus, PersistentCandidate
 from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import (
@@ -214,6 +215,7 @@ def _write_discovery_engine_metrics(
     *,
     source_native_candidate_ids: set[str],
     brave_candidate_ids: set[str],
+    exa_candidate_ids: set[str],
 ) -> None:
     """Persist a lightweight engine overlap metrics snapshot."""
     write_metrics_snapshot(
@@ -221,7 +223,13 @@ def _write_discovery_engine_metrics(
         {
             "source_native": len(source_native_candidate_ids),
             "brave": len(brave_candidate_ids),
-            "shared_candidates": len(source_native_candidate_ids & brave_candidate_ids),
+            "exa": len(exa_candidate_ids),
+            "source_native_brave_shared": len(source_native_candidate_ids & brave_candidate_ids),
+            "source_native_exa_shared": len(source_native_candidate_ids & exa_candidate_ids),
+            "brave_exa_shared": len(brave_candidate_ids & exa_candidate_ids),
+            "shared_all_candidates": len(
+                source_native_candidate_ids & brave_candidate_ids & exa_candidate_ids
+            ),
         },
     )
 
@@ -357,6 +365,75 @@ async def _run_brave_discovery(
             )
         except Exception as exc:
             discovery_run.errors.append(f"brave: {type(exc).__name__}: {exc}")
+            discovered_candidates = []
+        return persist_discovered_candidates(
+            run=discovery_run,
+            discovered_candidates=discovered_candidates,
+            persistence=persistence,
+        )
+    finally:
+        await engine.aclose()
+        persistence.close()
+
+
+async def _run_exa_discovery(
+    *,
+    config: Config,
+    run_id: str,
+    days: int,
+) -> PersistedSourceDiscovery:
+    """Run Exa-powered discovery and persist candidates into the durable layer."""
+    queries = build_discovery_queries(config, days=days)
+    discovery_run = DiscoveryRun(
+        run_id=run_id,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=DiscoveryRunStatus.RUNNING,
+        query_count=len(queries),
+    )
+    persistence = create_discovery_persistence(config)
+    if not queries:
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    exa_api_key = config.exa_api_key
+    if not exa_api_key:
+        discovery_run.errors.append("exa: missing DENBUST_EXA_API_KEY")
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    engine = ExaSearchEngine(
+        api_key=exa_api_key,
+        max_results_per_query=config.discovery.engines.exa.max_results_per_query,
+    )
+    try:
+        try:
+            discovered_candidates = await engine.discover(
+                queries,
+                context=DiscoveryContext(
+                    run_id=run_id,
+                    max_results_per_query=config.discovery.engines.exa.max_results_per_query,
+                    metadata={
+                        "days": days,
+                        "engine": "exa",
+                        "allow_find_similar": config.discovery.engines.exa.allow_find_similar,
+                    },
+                ),
+            )
+        except Exception as exc:
+            discovery_run.errors.append(f"exa: {type(exc).__name__}: {exc}")
             discovered_candidates = []
         return persist_discovered_candidates(
             run=discovery_run,
@@ -1008,12 +1085,18 @@ async def run_news_discover_job(
     result.source_count = len(sources)
     source_native_requested = config.source_discovery.enabled
     brave_requested = config.discovery.enabled and config.discovery.engines.brave.enabled
+    exa_requested = config.discovery.enabled and config.discovery.engines.exa.enabled
     source_native_can_run = (
         source_native_requested and config.source_discovery.persist_candidates and bool(sources)
     )
     brave_can_run = brave_requested and config.discovery.persist_candidates
+    exa_can_run = exa_requested and config.discovery.persist_candidates
 
-    if brave_requested and not config.discovery.persist_candidates and not source_native_can_run:
+    if (
+        (brave_requested or exa_requested)
+        and not config.discovery.persist_candidates
+        and not source_native_can_run
+    ):
         result.fatal = True
         result.errors.append("discovery.persist_candidates is false")
         return result.finish("fatal: engine candidate persistence disabled")
@@ -1021,15 +1104,16 @@ async def run_news_discover_job(
         source_native_requested
         and not config.source_discovery.persist_candidates
         and not brave_can_run
+        and not exa_can_run
     ):
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
-    if not source_native_requested and not brave_can_run:
+    if not source_native_requested and not brave_can_run and not exa_can_run:
         result.fatal = True
         result.errors.append("source_discovery.enabled is false")
         return result.finish("fatal: source-native discovery disabled")
-    if not sources and not brave_can_run:
+    if not sources and not brave_can_run and not exa_can_run:
         result.fatal = True
         result.errors.append("No sources configured")
         return result.finish("fatal: no sources configured")
@@ -1066,8 +1150,21 @@ async def run_news_discover_job(
             )
         )
 
+    if exa_can_run:
+        persisted_runs.append(
+            (
+                "exa",
+                await _run_exa_discovery(
+                    config=config,
+                    run_id=f"{run_base}:exa",
+                    days=days,
+                ),
+            )
+        )
+
     source_native_candidate_ids: set[str] = set()
     brave_candidate_ids: set[str] = set()
+    exa_candidate_ids: set[str] = set()
     merged_candidate_ids: set[str] = set()
     failed_runs = 0
     for producer_name, persisted in persisted_runs:
@@ -1087,6 +1184,10 @@ async def run_news_discover_job(
             brave_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
             if persisted.run.status is DiscoveryRunStatus.PARTIAL:
                 result.warnings.append("brave discovery completed with partial engine failures")
+        if producer_name == "exa":
+            exa_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
+            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
+                result.warnings.append("exa discovery completed with partial engine failures")
         if persisted.run.status is DiscoveryRunStatus.FAILED:
             failed_runs += 1
 
@@ -1094,6 +1195,7 @@ async def run_news_discover_job(
         config,
         source_native_candidate_ids=source_native_candidate_ids,
         brave_candidate_ids=brave_candidate_ids,
+        exa_candidate_ids=exa_candidate_ids,
     )
     result.unified_item_count = len(merged_candidate_ids)
 

--- a/tests/unit/test_discovery_exa.py
+++ b/tests/unit/test_discovery_exa.py
@@ -1,0 +1,182 @@
+"""Unit tests for the Exa discovery adapter."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.engines.exa import ExaSearchEngine
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind, ProducerKind
+
+
+@pytest.mark.asyncio
+async def test_exa_search_engine_normalizes_results_and_renders_payload() -> None:
+    """Exa responses should become normalized discovery candidates."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = str(request.url)
+        captured["token"] = request.headers["x-api-key"]
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "requestId": "request-123",
+                "results": [
+                    {
+                        "id": "result-1",
+                        "url": "https://www.ynet.co.il/news/article/abc?utm_source=exa",
+                        "title": "פשיטה על בית בושת",
+                        "publishedDate": "2026-04-15T08:00:00Z",
+                        "author": "Reporter",
+                        "highlights": ["המשטרה פשטה על המקום."],
+                    }
+                ],
+            },
+        )
+
+    engine = ExaSearchEngine(
+        api_key="exa-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_results_per_query=20,
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="בית בושת",
+                query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                preferred_domains=["www.ynet.co.il"],
+                source_hint="ynet",
+                language="he",
+                date_from=datetime(2026, 4, 10, tzinfo=UTC),
+                date_to=datetime(2026, 4, 16, tzinfo=UTC),
+            )
+        ],
+        DiscoveryContext(run_id="run-1", max_results_per_query=5),
+    )
+    await engine.aclose()
+
+    assert captured["path"] == "https://api.exa.ai/search"
+    assert captured["token"] == "exa-key"
+    assert captured["payload"] == {
+        "query": "בית בושת",
+        "type": "auto",
+        "numResults": 5,
+        "startPublishedDate": "2026-04-10",
+        "endPublishedDate": "2026-04-16",
+        "includeDomains": ["www.ynet.co.il"],
+    }
+    assert len(candidates) == 1
+    assert candidates[0].producer_name == "exa"
+    assert candidates[0].producer_kind is ProducerKind.SEARCH_ENGINE
+    assert candidates[0].source_hint == "ynet"
+    assert candidates[0].rank == 1
+    assert str(candidates[0].candidate_url) == "https://www.ynet.co.il/news/article/abc?utm_source=exa"
+    assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
+    assert candidates[0].snippet == "המשטרה פשטה על המקום."
+    assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
+    assert candidates[0].metadata == {
+        "engine": "exa",
+        "query_kind": "source_targeted",
+        "preferred_domains": ["www.ynet.co.il"],
+        "request_id": "request-123",
+        "result_id": "result-1",
+        "result_url": "https://www.ynet.co.il/news/article/abc?utm_source=exa",
+        "result_title": "פשיטה על בית בושת",
+        "result_published_date": "2026-04-15T08:00:00Z",
+        "result_author": "Reporter",
+    }
+
+
+@pytest.mark.asyncio
+async def test_exa_search_engine_aclose_closes_owned_client() -> None:
+    """Owned async clients should be closed by `aclose()`."""
+    engine = ExaSearchEngine(api_key="exa-key")
+
+    await engine.aclose()
+
+    assert engine._client.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_exa_search_engine_skips_malformed_payloads_and_invalid_rows() -> None:
+    """Malformed payloads and invalid rows should be ignored without failing the whole call."""
+    responses = iter(
+        [
+            httpx.Response(200, json=[]),
+            httpx.Response(200, json={"results": "not-a-list"}),
+            httpx.Response(
+                200,
+                json={
+                    "results": [
+                        "bad-row",
+                        {"title": "missing url"},
+                        {"url": "not-a-url", "title": "bad"},
+                        {"url": "https://www.mako.co.il/news/article/xyz", "title": "ok"},
+                    ]
+                },
+            ),
+        ]
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    engine = ExaSearchEngine(
+        api_key="exa-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+        ],
+        DiscoveryContext(run_id="run-2"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://www.mako.co.il/news/article/xyz"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exa_search_engine_uses_text_snippet_and_ignores_invalid_published_date() -> None:
+    """Text should be used as snippet when present and bad published dates should be ignored."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "url": "https://www.maariv.co.il/news/article-1",
+                        "title": "כותרת",
+                        "publishedDate": "not-a-datetime",
+                        "text": "תקציר מלא",
+                    }
+                ]
+            },
+        )
+
+    engine = ExaSearchEngine(
+        api_key="exa-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-3"),
+    )
+    await engine.aclose()
+
+    assert len(candidates) == 1
+    assert candidates[0].snippet == "תקציר מלא"
+    assert candidates[0].publication_datetime_hint is None

--- a/tests/unit/test_discovery_exa.py
+++ b/tests/unit/test_discovery_exa.py
@@ -76,7 +76,9 @@ async def test_exa_search_engine_normalizes_results_and_renders_payload() -> Non
     assert candidates[0].producer_kind is ProducerKind.SEARCH_ENGINE
     assert candidates[0].source_hint == "ynet"
     assert candidates[0].rank == 1
-    assert str(candidates[0].candidate_url) == "https://www.ynet.co.il/news/article/abc?utm_source=exa"
+    assert (
+        str(candidates[0].candidate_url) == "https://www.ynet.co.il/news/article/abc?utm_source=exa"
+    )
     assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
     assert candidates[0].snippet == "המשטרה פשטה על המקום."
     assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -40,6 +40,7 @@ from denbust.pipeline import (
     _build_suspicions,
     _persist_source_native_candidates,
     _run_brave_discovery,
+    _run_exa_discovery,
     _run_job_from_config,
     _run_source_native_discovery,
     _source_name_from_error,
@@ -557,6 +558,142 @@ class TestRunPipelineAsync:
         assert captured["persistence_closed"] is True
         assert captured["engine_init"] == {"api_key": "brave-key", "max_results_per_query": 20}
         assert captured["context"].metadata == {"days": 6, "engine": "brave"}
+
+    @pytest.mark.asyncio
+    async def test_run_exa_discovery_persists_empty_when_no_queries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exa discovery should still persist an empty run when query building yields nothing."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr("denbust.pipeline.build_discovery_queries", lambda *_a, **_k: [])
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_exa_discovery(config=Config(), run_id="run-exa", days=4)
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).query_count == 0
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_exa_discovery_records_missing_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exa discovery should persist an error when enabled without an API key."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_exa_discovery(
+            config=Config(discovery={"enabled": True, "engines": {"exa": {"enabled": True}}}),
+            run_id="run-exa",
+            days=4,
+        )
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).errors == ["exa: missing DENBUST_EXA_API_KEY"]
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_exa_discovery_catches_engine_errors_and_closes_resources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exa engine failures should be recorded on the run and still close both engine and store."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["persistence_closed"] = True
+
+        class FakeEngine:
+            def __init__(self, **kwargs: object) -> None:
+                captured["engine_init"] = kwargs
+
+            async def discover(self, queries, context):
+                captured["queries"] = queries
+                captured["context"] = context
+                raise RuntimeError("boom")
+
+            async def aclose(self) -> None:
+                captured["engine_closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(Config, "exa_api_key", property(lambda _self: "exa-key"))
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr("denbust.pipeline.ExaSearchEngine", FakeEngine)
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_exa_discovery(
+            config=Config(discovery={"enabled": True, "engines": {"exa": {"enabled": True}}}),
+            run_id="run-exa",
+            days=6,
+        )
+
+        assert persisted.candidates == []
+        assert cast(DiscoveryRun, captured["run"]).errors == ["exa: RuntimeError: boom"]
+        assert captured["engine_closed"] is True
+        assert captured["persistence_closed"] is True
+        assert captured["engine_init"] == {"api_key": "exa-key", "max_results_per_query": 20}
+        assert captured["context"].metadata == {
+            "days": 6,
+            "engine": "exa",
+            "allow_find_similar": True,
+        }
 
     @pytest.mark.asyncio
     async def test_run_pipeline_async_requires_api_key(
@@ -1535,6 +1672,57 @@ class TestRunPipelineAsync:
         ).read_text(encoding="utf-8")
         assert '"brave": 2' in metrics_payload
         assert '"source_native": 0' in metrics_payload
+        assert '"exa": 0' in metrics_payload
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_supports_exa_only_and_writes_metrics(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Exa discovery should run without configured sources and persist engine metrics."""
+        exa_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:exa",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-exa-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                ),
+                build_persistent_candidate(
+                    "candidate-exa-2",
+                    current_url="https://www.mako.co.il/news/article/2",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_exa_discovery",
+            AsyncMock(return_value=exa_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"exa": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 2
+        assert result.unified_item_count == 2
+        metrics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+        ).read_text(encoding="utf-8")
+        assert '"exa": 2' in metrics_payload
+        assert '"source_native": 0' in metrics_payload
+        assert '"brave": 0' in metrics_payload
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_aggregates_brave_and_source_native_without_double_counting(
@@ -1607,6 +1795,108 @@ class TestRunPipelineAsync:
         assert result.unified_item_count == 3
 
     @pytest.mark.asyncio
+    async def test_run_news_discover_job_aggregates_brave_exa_and_source_native_overlaps(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Merged candidate counts and overlap metrics should include Exa alongside Brave."""
+        source_native = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:source_native",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                )
+            ],
+            provenance=[],
+        )
+        brave = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                ),
+                build_persistent_candidate(
+                    "candidate-brave-only",
+                    current_url="https://www.mako.co.il/news/article/brave-only",
+                ),
+            ],
+            provenance=[],
+        )
+        exa = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:exa",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                ),
+                build_persistent_candidate(
+                    "candidate-exa-only",
+                    current_url="https://www.maariv.co.il/news/article/exa-only",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [MagicMock(name="ynet")]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_source_native_discovery",
+            AsyncMock(return_value=source_native),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_exa_discovery",
+            AsyncMock(return_value=exa),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                discovery={
+                    "enabled": True,
+                    "engines": {"brave": {"enabled": True}, "exa": {"enabled": True}},
+                },
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 5
+        assert result.unified_item_count == 3
+        metrics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+        ).read_text(encoding="utf-8")
+        assert '"exa": 2' in metrics_payload
+        assert '"source_native_brave_shared": 1' in metrics_payload
+        assert '"source_native_exa_shared": 1' in metrics_payload
+        assert '"brave_exa_shared": 1' in metrics_payload
+        assert '"shared_all_candidates": 1' in metrics_payload
+
+    @pytest.mark.asyncio
     async def test_run_news_discover_job_marks_brave_failure_fatal_when_it_is_the_only_engine(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -1640,6 +1930,41 @@ class TestRunPipelineAsync:
 
         assert result.fatal is True
         assert result.errors == ["brave: missing DENBUST_BRAVE_SEARCH_API_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_marks_exa_failure_fatal_when_it_is_the_only_engine(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A failed Exa-only discovery run should surface as fatal."""
+        exa_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:exa",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.FAILED,
+                candidate_count=0,
+                merged_candidate_count=0,
+                errors=["exa: missing DENBUST_EXA_API_KEY"],
+            ),
+            candidates=[],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_exa_discovery",
+            AsyncMock(return_value=exa_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"exa": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is True
+        assert result.errors == ["exa: missing DENBUST_EXA_API_KEY"]
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_fails_when_engine_persistence_disabled_and_no_source_native(
@@ -1781,6 +2106,44 @@ class TestRunPipelineAsync:
         )
 
         assert "brave discovery completed with partial engine failures" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_warns_on_exa_partial(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Exa partial runs should surface as warnings and still write metrics."""
+        exa_partial = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:exa",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.PARTIAL,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-exa-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                )
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_exa_discovery",
+            AsyncMock(return_value=exa_partial),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"exa": {"enabled": True}}},
+            )
+        )
+
+        assert "exa discovery completed with partial engine failures" in result.warnings
 
 
 class TestRunPipeline:


### PR DESCRIPTION
## Summary

This PR implements **DL-PR-05 — Exa engine integration** for the persistent discovery/candidacy layer.

It adds Exa as the second external discovery engine, parallel to Brave, feeding the same durable candidate substrate and the existing `news_items / discover` job.

This PR stays intentionally narrow:
- standard Exa query search is operational
- `find similar` remains scaffold-only via config and is **not** wired into production discovery yet
- no scrape/backfill/self-healing behavior is changed
- no Google CSE work is included

## What changed

### 1. New Exa discovery adapter

Added a new adapter at `src/denbust/discovery/engines/exa.py`:
- `ExaSearchEngine`
- constructor shape mirrors the existing Brave adapter:
  - `api_key`
  - `max_results_per_query`
  - optional `httpx.AsyncClient`
  - configurable `base_url`
- exposes `name == "exa"`
- implements `discover(queries, context)`
- closes owned clients via `aclose()`

### 2. Exa result normalization into `DiscoveredCandidate`

Exa results are normalized using the same candidate rules already established for Brave:
- raw Exa result URL is preserved as `candidate_url`
- `canonical_url` is populated via `canonicalize_news_url(...)`
- `title`, `snippet`, and publication-date hints are extracted when available
- malformed rows are skipped safely instead of aborting the whole discovery run
- malformed JSON shapes are skipped safely instead of aborting the whole discovery run
- invalid URLs are skipped safely instead of aborting the whole discovery run

Persisted metadata is intentionally trimmed to a stable subset instead of storing the full raw Exa payload:
- `engine`
- `query_kind`
- `preferred_domains`
- `request_id`
- `result_id`
- `result_url`
- `result_title`
- `result_published_date`
- `result_author`

### 3. Discover job orchestration now supports Exa

Extended `src/denbust/pipeline.py` with an explicit Exa path, parallel to the current Brave implementation:
- added `_run_exa_discovery(...)`
- added `exa_requested` / `exa_can_run` logic in `run_news_discover_job()`
- `news_items / discover` now supports:
  - source-native only
  - Brave only
  - Exa only
  - Brave + Exa
  - source-native + Exa
  - source-native + Brave + Exa
- Exa partial/failure states are surfaced consistently with Brave
- Exa requires `DENBUST_EXA_API_KEY` when enabled

### 4. Discovery overlap metrics expanded

The discovery metrics snapshot now includes Exa alongside source-native and Brave.

The snapshot written under the discovery state paths now includes:
- `source_native`
- `brave`
- `exa`
- `source_native_brave_shared`
- `source_native_exa_shared`
- `brave_exa_shared`
- `shared_all_candidates`

This keeps the metrics additive without doing a larger multi-engine abstraction refactor in this PR.

### 5. Docs updated

Updated docs and README so the repo state matches the implementation:
- `README.md` now states that `news_items / discover` supports source-native + Brave + Exa candidate persistence
- `docs/tfht_discovery_layer_implementation_plan.md` marks DL-PR-05 as implemented
- `docs/tfht_discovery_layer_design_amended.md` marks Exa as implemented and Google CSE as pending in the milestone section

## What did not change

Still intentionally out of scope in this PR:
- Google CSE integration
- Exa `find similar` production wiring
- validated-example ingestion
- example-driven Exa producers
- backfill execution
- self-healing behavior
- scrape queue behavior
- generic fetch/extract fallback behavior
- broader multi-engine abstraction refactor

## Config / environment

This PR reuses the existing config surface:
- `discovery.engines.exa`
- `allow_find_similar`
- `Config.exa_api_key`

Required when Exa is enabled:
- `DENBUST_EXA_API_KEY`

`allow_find_similar` remains present as a **reserved/scaffolded** config option only. It is not operationally wired into `discover` in this PR.

## Tests added / updated

### New unit tests
- `tests/unit/test_discovery_exa.py`
  - normalizes Exa search responses into `DiscoveredCandidate`
  - canonicalizes URLs
  - verifies trimmed metadata only
  - skips malformed payloads and invalid rows safely
  - verifies owned-client close behavior
  - verifies text/highlight snippet handling and invalid published-date fallback

### Extended pipeline coverage
- `tests/unit/test_pipeline_core.py`
  - Exa-only discover success path
  - Exa-only fatal failure path
  - Exa partial warning path
  - `_run_exa_discovery()` empty-query path
  - `_run_exa_discovery()` missing API key path
  - `_run_exa_discovery()` engine-exception path with cleanup verification
  - Brave + Exa + source-native aggregation path
  - metrics payload now includes Exa overlap fields

## Validation run

Ran locally:

```bash
pytest -q tests/unit/test_discovery_exa.py tests/unit/test_pipeline_core.py tests/unit/test_config.py -k 'exa or discover'
pytest -q tests/unit/test_discovery_brave.py tests/unit/test_discovery_exa.py tests/unit/test_discovery_queries.py tests/unit/test_discovery_storage.py tests/unit/test_pipeline_core.py tests/unit/test_config.py -k 'discover or brave or exa or query or persistence'
ruff check src/denbust/discovery/engines/exa.py src/denbust/pipeline.py tests/unit/test_discovery_exa.py tests/unit/test_pipeline_core.py README.md docs/tfht_discovery_layer_implementation_plan.md docs/tfht_discovery_layer_design_amended.md
mypy src/denbust/discovery/engines/exa.py src/denbust/pipeline.py
```

All of the above passed locally.

## Follow-up

The next planned discovery PR after this is **DL-PR-06 — Google CSE integration**.

That PR can stay parallel to this one:
- add a Google CSE adapter
- reuse the same durable candidate layer
- keep discover orchestration additive
- preserve the current scrape/backfill boundaries
