### PR TITLE
Implement DL-PR-06 Google CSE discovery engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ data jobs. Phase A introduced the shared platform spine. Phase B turns the first
 
 Today, the implemented dataset/jobs are:
 
-- `news_items / discover` (source-native + Brave + Exa candidate persistence)
+- `news_items / discover` (source-native + Brave + Exa + Google CSE candidate persistence)
 - `news_items / ingest`
 - `news_items / release`
 - `news_items / backup`
@@ -40,7 +40,7 @@ Planned future datasets:
 - Persists dataset/job-scoped seen state and per-run JSON snapshots
 - Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
   paths under `news_items/discover/`
-- Runs Brave and Exa as external discovery engines feeding the durable candidate layer
+- Runs Brave, Exa, and Google CSE as external discovery engines feeding the durable candidate layer
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
 
 ## Quick Start
@@ -218,13 +218,12 @@ What is implemented now:
 Still intentionally deferred:
 
 - additional dataset implementations beyond `news_items`
-- Google CSE engine integration
 - richer human review tooling / admin UI
 - more advanced privacy policies beyond the current pragmatic gate
 
 ## Discovery Layer Foundation
 
-DL-PR-05 now builds on the earlier discovery milestones:
+DL-PR-06 now builds on the earlier discovery milestones:
 
 - `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
   models
@@ -232,11 +231,13 @@ DL-PR-05 now builds on the earlier discovery milestones:
 - explicit state-repo path helpers for candidate-layer snapshots and queue files
 - source-native candidate normalization and merge/upsert persistence
 - a real `news_items / discover` job that persists source-native candidates and Brave-discovered
-  and Exa-discovered candidates into the same durable substrate
+  plus Exa-discovered and Google CSE-discovered candidates into the same durable substrate
 - Brave query building for broad and source-targeted discovery searches
 - Exa query execution for the same broad and source-targeted discovery searches
-- dedicated `DENBUST_BRAVE_SEARCH_API_KEY` and `DENBUST_EXA_API_KEY` configuration paths for
-  external discovery engines
+- Google CSE query execution for the same broad and source-targeted discovery searches
+- dedicated `DENBUST_BRAVE_SEARCH_API_KEY`, `DENBUST_EXA_API_KEY`, and
+  `DENBUST_GOOGLE_CSE_API_KEY` / `DENBUST_GOOGLE_CSE_ID` configuration paths for external
+  discovery engines
 - candidate selection / queueing helpers for retryable scrape work
 - scrape-attempt persistence and candidate status transitions underneath the ingest path
 - a real `news_items / scrape_candidates` job that drains queued candidates into article ingest
@@ -248,10 +249,9 @@ DL-PR-05 now builds on the earlier discovery milestones:
   - `candidate_provenance`
   - `scrape_attempts`
 
-Google CSE is still intentionally deferred, and the generic fetch/extract fallback remains
-scaffolded structurally for retry bookkeeping. The current daily monitoring flow remains
-operational, but the durable candidate substrate now accepts source-native discovery plus Brave and
-Exa search results.
+The generic fetch/extract fallback remains scaffolded structurally for retry bookkeeping. The
+current daily monitoring flow remains operational, and the durable candidate substrate now accepts
+source-native discovery plus Brave, Exa, and Google CSE search results.
 
 ## Config Layout
 

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -1184,7 +1184,7 @@ to distinguish them from GitHub PR numbers. For example: `DL-PR-01`, `DL-PR-02`,
 
 ### Milestone 3 — Exa + Google CSE
 - add Exa (implemented)
-- add Google CSE (pending)
+- add Google CSE (implemented)
 - add overlap metrics
 - add queue health metrics
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -203,6 +203,9 @@ A second complementary discovery engine is integrated cleanly.
 ### Goal
 Add recall-oriented search discovery via Google CSE.
 
+### Status
+Implemented.
+
 ### Scope
 - Add Google CSE adapter under `src/denbust/discovery/engines/google_cse.py`
 - Support:

--- a/src/denbust/discovery/engines/google_cse.py
+++ b/src/denbust/discovery/engines/google_cse.py
@@ -135,7 +135,9 @@ class GoogleCseSearchEngine:
                     "result_title": title if isinstance(title, str) else None,
                     "result_snippet": snippet if isinstance(snippet, str) else None,
                     "result_display_link": (
-                        result.get("displayLink") if isinstance(result.get("displayLink"), str) else None
+                        result.get("displayLink")
+                        if isinstance(result.get("displayLink"), str)
+                        else None
                     ),
                     "result_cache_id": (
                         result.get("cacheId") if isinstance(result.get("cacheId"), str) else None

--- a/src/denbust/discovery/engines/google_cse.py
+++ b/src/denbust/discovery/engines/google_cse.py
@@ -26,6 +26,8 @@ class GoogleCseSearchEngine:
         client: httpx.AsyncClient | None = None,
         base_url: str = "https://customsearch.googleapis.com/customsearch/v1",
     ) -> None:
+        if max_results_per_query > 10:
+            raise ValueError("Google CSE supports at most 10 results per query")
         self._api_key = api_key
         self._cse_id = cse_id
         self._max_results_per_query = max_results_per_query
@@ -88,6 +90,7 @@ class GoogleCseSearchEngine:
             "num": min(
                 context.max_results_per_query or self._max_results_per_query,
                 self._max_results_per_query,
+                10,
             ),
         }
         if query.language == "he":

--- a/src/denbust/discovery/engines/google_cse.py
+++ b/src/denbust/discovery/engines/google_cse.py
@@ -1,0 +1,175 @@
+"""Google Custom Search JSON API discovery adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+import httpx
+from pydantic import HttpUrl
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.news_items.normalize import canonicalize_news_url
+
+
+class GoogleCseSearchEngine:
+    """Google Custom Search JSON API adapter for discovery candidates."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        cse_id: str,
+        max_results_per_query: int = 10,
+        client: httpx.AsyncClient | None = None,
+        base_url: str = "https://customsearch.googleapis.com/customsearch/v1",
+    ) -> None:
+        self._api_key = api_key
+        self._cse_id = cse_id
+        self._max_results_per_query = max_results_per_query
+        self._base_url = base_url
+        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._owns_client = client is None
+
+    @property
+    def name(self) -> str:
+        return "google_cse"
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def discover(
+        self,
+        queries: list[DiscoveryQuery],
+        context: DiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        candidates: list[DiscoveredCandidate] = []
+        for query in queries:
+            response = await self._client.get(
+                self._base_url,
+                params=self._build_params(query, context),
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                continue
+            items = payload.get("items", [])
+            if not isinstance(items, list):
+                continue
+            search_information = payload.get("searchInformation")
+            total_results = None
+            if isinstance(search_information, dict):
+                total_results_value = search_information.get("totalResults")
+                if isinstance(total_results_value, str):
+                    total_results = total_results_value
+            for index, item in enumerate(items, start=1):
+                candidate = self._result_to_candidate(
+                    item,
+                    query=query,
+                    rank=index,
+                    total_results=total_results,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+        return candidates
+
+    def _build_params(
+        self,
+        query: DiscoveryQuery,
+        context: DiscoveryContext,
+    ) -> Mapping[str, str | int]:
+        params: dict[str, str | int] = {
+            "key": self._api_key,
+            "cx": self._cse_id,
+            "q": query.query_text,
+            "num": min(
+                context.max_results_per_query or self._max_results_per_query,
+                self._max_results_per_query,
+            ),
+        }
+        if query.language == "he":
+            params["lr"] = "lang_he"
+        if len(query.preferred_domains) == 1:
+            params["siteSearch"] = query.preferred_domains[0]
+            params["siteSearchFilter"] = "i"
+        return params
+
+    def _result_to_candidate(
+        self,
+        result: Any,
+        *,
+        query: DiscoveryQuery,
+        rank: int,
+        total_results: str | None,
+    ) -> DiscoveredCandidate | None:
+        if not isinstance(result, dict):
+            return None
+        url = result.get("link")
+        if not isinstance(url, str) or not url:
+            return None
+        try:
+            parsed_url = HttpUrl(url)
+            canonical_url = HttpUrl(canonicalize_news_url(url))
+            title = result.get("title")
+            snippet = result.get("snippet")
+            publication_datetime_hint = _extract_google_publication_datetime(result)
+            return DiscoveredCandidate(
+                producer_name=self.name,
+                producer_kind=ProducerKind.SEARCH_ENGINE,
+                query_text=query.query_text,
+                candidate_url=parsed_url,
+                canonical_url=canonical_url,
+                title=title if isinstance(title, str) else None,
+                snippet=snippet if isinstance(snippet, str) else None,
+                publication_datetime_hint=publication_datetime_hint,
+                rank=rank,
+                source_hint=query.source_hint,
+                metadata={
+                    "engine": self.name,
+                    "query_kind": query.query_kind.value,
+                    "preferred_domains": query.preferred_domains,
+                    "result_url": url,
+                    "result_title": title if isinstance(title, str) else None,
+                    "result_snippet": snippet if isinstance(snippet, str) else None,
+                    "result_display_link": (
+                        result.get("displayLink") if isinstance(result.get("displayLink"), str) else None
+                    ),
+                    "result_cache_id": (
+                        result.get("cacheId") if isinstance(result.get("cacheId"), str) else None
+                    ),
+                    "total_results": total_results,
+                },
+            )
+        except ValueError:
+            return None
+
+
+def _extract_google_publication_datetime(result: dict[str, Any]) -> datetime | None:
+    """Extract a best-effort publication hint from Google result metadata."""
+    pagemap = result.get("pagemap")
+    if not isinstance(pagemap, dict):
+        return None
+    metatags = pagemap.get("metatags")
+    if not isinstance(metatags, list):
+        return None
+    for metatag in metatags:
+        if not isinstance(metatag, dict):
+            continue
+        for key in (
+            "article:published_time",
+            "og:published_time",
+            "article:modified_time",
+            "og:updated_time",
+        ):
+            value = metatag.get(key)
+            if not isinstance(value, str):
+                continue
+            normalized = value.replace("Z", "+00:00")
+            try:
+                return datetime.fromisoformat(normalized)
+            except ValueError:
+                continue
+    return None

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -1200,7 +1200,12 @@ async def run_news_discover_job(
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
-    if not source_native_requested and not brave_can_run and not exa_can_run and not google_cse_can_run:
+    if (
+        not source_native_requested
+        and not brave_can_run
+        and not exa_can_run
+        and not google_cse_can_run
+    ):
         result.fatal = True
         result.errors.append("source_discovery.enabled is false")
         return result.finish("fatal: source-native discovery disabled")

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -19,6 +19,7 @@ from denbust.dedup.similarity import Deduplicator, create_deduplicator
 from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.engines.exa import ExaSearchEngine
+from denbust.discovery.engines.google_cse import GoogleCseSearchEngine
 from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus, PersistentCandidate
 from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import (
@@ -216,6 +217,7 @@ def _write_discovery_engine_metrics(
     source_native_candidate_ids: set[str],
     brave_candidate_ids: set[str],
     exa_candidate_ids: set[str],
+    google_cse_candidate_ids: set[str],
 ) -> None:
     """Persist a lightweight engine overlap metrics snapshot."""
     write_metrics_snapshot(
@@ -224,11 +226,20 @@ def _write_discovery_engine_metrics(
             "source_native": len(source_native_candidate_ids),
             "brave": len(brave_candidate_ids),
             "exa": len(exa_candidate_ids),
+            "google_cse": len(google_cse_candidate_ids),
             "source_native_brave_shared": len(source_native_candidate_ids & brave_candidate_ids),
             "source_native_exa_shared": len(source_native_candidate_ids & exa_candidate_ids),
+            "source_native_google_cse_shared": len(
+                source_native_candidate_ids & google_cse_candidate_ids
+            ),
             "brave_exa_shared": len(brave_candidate_ids & exa_candidate_ids),
+            "brave_google_cse_shared": len(brave_candidate_ids & google_cse_candidate_ids),
+            "exa_google_cse_shared": len(exa_candidate_ids & google_cse_candidate_ids),
             "shared_all_candidates": len(
-                source_native_candidate_ids & brave_candidate_ids & exa_candidate_ids
+                source_native_candidate_ids
+                & brave_candidate_ids
+                & exa_candidate_ids
+                & google_cse_candidate_ids
             ),
         },
     )
@@ -434,6 +445,83 @@ async def _run_exa_discovery(
             )
         except Exception as exc:
             discovery_run.errors.append(f"exa: {type(exc).__name__}: {exc}")
+            discovered_candidates = []
+        return persist_discovered_candidates(
+            run=discovery_run,
+            discovered_candidates=discovered_candidates,
+            persistence=persistence,
+        )
+    finally:
+        await engine.aclose()
+        persistence.close()
+
+
+async def _run_google_cse_discovery(
+    *,
+    config: Config,
+    run_id: str,
+    days: int,
+) -> PersistedSourceDiscovery:
+    """Run Google CSE-powered discovery and persist candidates into the durable layer."""
+    queries = build_discovery_queries(config, days=days)
+    discovery_run = DiscoveryRun(
+        run_id=run_id,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=DiscoveryRunStatus.RUNNING,
+        query_count=len(queries),
+    )
+    persistence = create_discovery_persistence(config)
+    if not queries:
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    google_api_key = config.google_cse_api_key
+    google_cse_id = config.google_cse_id
+    if not google_api_key:
+        discovery_run.errors.append("google_cse: missing DENBUST_GOOGLE_CSE_API_KEY")
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+    if not google_cse_id:
+        discovery_run.errors.append("google_cse: missing DENBUST_GOOGLE_CSE_ID")
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    engine = GoogleCseSearchEngine(
+        api_key=google_api_key,
+        cse_id=google_cse_id,
+        max_results_per_query=config.discovery.engines.google_cse.max_results_per_query,
+    )
+    try:
+        try:
+            discovered_candidates = await engine.discover(
+                queries,
+                context=DiscoveryContext(
+                    run_id=run_id,
+                    max_results_per_query=config.discovery.engines.google_cse.max_results_per_query,
+                    metadata={"days": days, "engine": "google_cse"},
+                ),
+            )
+        except Exception as exc:
+            discovery_run.errors.append(f"google_cse: {type(exc).__name__}: {exc}")
             discovered_candidates = []
         return persist_discovered_candidates(
             run=discovery_run,
@@ -1086,14 +1174,16 @@ async def run_news_discover_job(
     source_native_requested = config.source_discovery.enabled
     brave_requested = config.discovery.enabled and config.discovery.engines.brave.enabled
     exa_requested = config.discovery.enabled and config.discovery.engines.exa.enabled
+    google_cse_requested = config.discovery.enabled and config.discovery.engines.google_cse.enabled
     source_native_can_run = (
         source_native_requested and config.source_discovery.persist_candidates and bool(sources)
     )
     brave_can_run = brave_requested and config.discovery.persist_candidates
     exa_can_run = exa_requested and config.discovery.persist_candidates
+    google_cse_can_run = google_cse_requested and config.discovery.persist_candidates
 
     if (
-        (brave_requested or exa_requested)
+        (brave_requested or exa_requested or google_cse_requested)
         and not config.discovery.persist_candidates
         and not source_native_can_run
     ):
@@ -1105,15 +1195,16 @@ async def run_news_discover_job(
         and not config.source_discovery.persist_candidates
         and not brave_can_run
         and not exa_can_run
+        and not google_cse_can_run
     ):
         result.fatal = True
         result.errors.append("source_discovery.persist_candidates is false")
         return result.finish("fatal: source-native candidate persistence disabled")
-    if not source_native_requested and not brave_can_run and not exa_can_run:
+    if not source_native_requested and not brave_can_run and not exa_can_run and not google_cse_can_run:
         result.fatal = True
         result.errors.append("source_discovery.enabled is false")
         return result.finish("fatal: source-native discovery disabled")
-    if not sources and not brave_can_run and not exa_can_run:
+    if not sources and not brave_can_run and not exa_can_run and not google_cse_can_run:
         result.fatal = True
         result.errors.append("No sources configured")
         return result.finish("fatal: no sources configured")
@@ -1162,9 +1253,22 @@ async def run_news_discover_job(
             )
         )
 
+    if google_cse_can_run:
+        persisted_runs.append(
+            (
+                "google_cse",
+                await _run_google_cse_discovery(
+                    config=config,
+                    run_id=f"{run_base}:google_cse",
+                    days=days,
+                ),
+            )
+        )
+
     source_native_candidate_ids: set[str] = set()
     brave_candidate_ids: set[str] = set()
     exa_candidate_ids: set[str] = set()
+    google_cse_candidate_ids: set[str] = set()
     merged_candidate_ids: set[str] = set()
     failed_runs = 0
     for producer_name, persisted in persisted_runs:
@@ -1188,6 +1292,14 @@ async def run_news_discover_job(
             exa_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
             if persisted.run.status is DiscoveryRunStatus.PARTIAL:
                 result.warnings.append("exa discovery completed with partial engine failures")
+        if producer_name == "google_cse":
+            google_cse_candidate_ids = {
+                candidate.candidate_id for candidate in persisted.candidates
+            }
+            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
+                result.warnings.append(
+                    "google_cse discovery completed with partial engine failures"
+                )
         if persisted.run.status is DiscoveryRunStatus.FAILED:
             failed_runs += 1
 
@@ -1196,6 +1308,7 @@ async def run_news_discover_job(
         source_native_candidate_ids=source_native_candidate_ids,
         brave_candidate_ids=brave_candidate_ids,
         exa_candidate_ids=exa_candidate_ids,
+        google_cse_candidate_ids=google_cse_candidate_ids,
     )
     result.unified_item_count = len(merged_candidate_ids)
 

--- a/tests/unit/test_discovery_google_cse.py
+++ b/tests/unit/test_discovery_google_cse.py
@@ -93,6 +93,16 @@ async def test_google_cse_search_engine_normalizes_results_and_renders_params() 
     }
 
 
+def test_google_cse_search_engine_rejects_max_results_over_api_limit() -> None:
+    """Engine config should fail clearly when exceeding the Google CSE API cap."""
+    with pytest.raises(ValueError, match="at most 10 results per query"):
+        GoogleCseSearchEngine(
+            api_key="google-key",
+            cse_id="search-engine-id",
+            max_results_per_query=11,
+        )
+
+
 @pytest.mark.asyncio
 async def test_google_cse_search_engine_aclose_closes_owned_client() -> None:
     """Owned async clients should be closed by `aclose()`."""
@@ -223,3 +233,35 @@ async def test_google_cse_search_engine_skips_non_dict_metatags_before_valid_pub
 
     assert len(candidates) == 1
     assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 10, 30, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_defensively_caps_request_num_to_api_limit() -> None:
+    """Request params should stay within the API limit even if internal state drifts."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(200, json={"items": []})
+
+    engine = GoogleCseSearchEngine(
+        api_key="google-key",
+        cse_id="search-engine-id",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_results_per_query=10,
+    )
+    engine._max_results_per_query = 25
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-5", max_results_per_query=50),
+    )
+    await engine.aclose()
+
+    assert candidates == []
+    assert captured["query"] == {
+        "key": "google-key",
+        "cx": "search-engine-id",
+        "q": "זנות",
+        "num": "10",
+    }

--- a/tests/unit/test_discovery_google_cse.py
+++ b/tests/unit/test_discovery_google_cse.py
@@ -1,0 +1,183 @@
+"""Unit tests for the Google CSE discovery adapter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.engines.google_cse import GoogleCseSearchEngine
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind, ProducerKind
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_normalizes_results_and_renders_params() -> None:
+    """Google CSE responses should become normalized discovery candidates."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "searchInformation": {"totalResults": "123"},
+                "items": [
+                    {
+                        "link": "https://www.ynet.co.il/news/article/abc?utm_source=google",
+                        "title": "פשיטה על בית בושת",
+                        "snippet": "המשטרה פשטה על המקום.",
+                        "displayLink": "www.ynet.co.il",
+                        "cacheId": "cache-1",
+                        "pagemap": {
+                            "metatags": [
+                                {
+                                    "article:published_time": "2026-04-15T08:00:00Z",
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        )
+
+    engine = GoogleCseSearchEngine(
+        api_key="google-key",
+        cse_id="search-engine-id",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_results_per_query=10,
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="בית בושת",
+                query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                preferred_domains=["www.ynet.co.il"],
+                source_hint="ynet",
+                language="he",
+            )
+        ],
+        DiscoveryContext(run_id="run-1", max_results_per_query=5),
+    )
+    await engine.aclose()
+
+    assert captured["query"] == {
+        "key": "google-key",
+        "cx": "search-engine-id",
+        "q": "בית בושת",
+        "num": "5",
+        "lr": "lang_he",
+        "siteSearch": "www.ynet.co.il",
+        "siteSearchFilter": "i",
+    }
+    assert len(candidates) == 1
+    assert candidates[0].producer_name == "google_cse"
+    assert candidates[0].producer_kind is ProducerKind.SEARCH_ENGINE
+    assert str(candidates[0].candidate_url) == (
+        "https://www.ynet.co.il/news/article/abc?utm_source=google"
+    )
+    assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
+    assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
+    assert candidates[0].metadata == {
+        "engine": "google_cse",
+        "query_kind": "source_targeted",
+        "preferred_domains": ["www.ynet.co.il"],
+        "result_url": "https://www.ynet.co.il/news/article/abc?utm_source=google",
+        "result_title": "פשיטה על בית בושת",
+        "result_snippet": "המשטרה פשטה על המקום.",
+        "result_display_link": "www.ynet.co.il",
+        "result_cache_id": "cache-1",
+        "total_results": "123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_aclose_closes_owned_client() -> None:
+    """Owned async clients should be closed by `aclose()`."""
+    engine = GoogleCseSearchEngine(api_key="google-key", cse_id="search-engine-id")
+
+    await engine.aclose()
+
+    assert engine._client.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_skips_malformed_payloads_and_invalid_rows() -> None:
+    """Malformed payloads and invalid rows should be ignored without failing the whole call."""
+    responses = iter(
+        [
+            httpx.Response(200, json=[]),
+            httpx.Response(200, json={"items": "not-a-list"}),
+            httpx.Response(
+                200,
+                json={
+                    "items": [
+                        "bad-row",
+                        {"title": "missing link"},
+                        {"link": "not-a-url", "title": "bad"},
+                        {"link": "https://www.mako.co.il/news/article/xyz", "title": "ok"},
+                    ]
+                },
+            ),
+        ]
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    engine = GoogleCseSearchEngine(
+        api_key="google-key",
+        cse_id="search-engine-id",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+            DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD),
+        ],
+        DiscoveryContext(run_id="run-2"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://www.mako.co.il/news/article/xyz"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_ignores_invalid_publication_hints() -> None:
+    """Bad publication metadata should not prevent candidate creation."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "link": "https://www.maariv.co.il/news/article-1",
+                        "title": "כותרת",
+                        "snippet": "תקציר",
+                        "pagemap": {"metatags": [{"article:published_time": "not-a-datetime"}]},
+                    }
+                ]
+            },
+        )
+
+    engine = GoogleCseSearchEngine(
+        api_key="google-key",
+        cse_id="search-engine-id",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-3"),
+    )
+    await engine.aclose()
+
+    assert len(candidates) == 1
+    assert candidates[0].publication_datetime_hint is None

--- a/tests/unit/test_discovery_google_cse.py
+++ b/tests/unit/test_discovery_google_cse.py
@@ -181,3 +181,43 @@ async def test_google_cse_search_engine_ignores_invalid_publication_hints() -> N
 
     assert len(candidates) == 1
     assert candidates[0].publication_datetime_hint is None
+
+
+@pytest.mark.asyncio
+async def test_google_cse_search_engine_skips_non_dict_metatags_before_valid_publication_time() -> None:
+    """Mixed metatag lists should ignore invalid entries and still extract publication time."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "link": "https://www.ynet.co.il/news/article/def",
+                        "title": "כותרת",
+                        "snippet": "תקציר",
+                        "pagemap": {
+                            "metatags": [
+                                "not-a-dict",
+                                {"article:published_time": "2026-04-15T10:30:00Z"},
+                            ]
+                        },
+                    }
+                ]
+            },
+        )
+
+    engine = GoogleCseSearchEngine(
+        api_key="google-key",
+        cse_id="search-engine-id",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [DiscoveryQuery(query_text="זנות", query_kind=DiscoveryQueryKind.BROAD)],
+        DiscoveryContext(run_id="run-4"),
+    )
+    await engine.aclose()
+
+    assert len(candidates) == 1
+    assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 10, 30, tzinfo=UTC)

--- a/tests/unit/test_discovery_google_cse.py
+++ b/tests/unit/test_discovery_google_cse.py
@@ -184,7 +184,9 @@ async def test_google_cse_search_engine_ignores_invalid_publication_hints() -> N
 
 
 @pytest.mark.asyncio
-async def test_google_cse_search_engine_skips_non_dict_metatags_before_valid_publication_time() -> None:
+async def test_google_cse_search_engine_skips_non_dict_metatags_before_valid_publication_time() -> (
+    None
+):
     """Mixed metatag lists should ignore invalid entries and still extract publication time."""
 
     def handler(_request: httpx.Request) -> httpx.Response:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -41,6 +41,7 @@ from denbust.pipeline import (
     _persist_source_native_candidates,
     _run_brave_discovery,
     _run_exa_discovery,
+    _run_google_cse_discovery,
     _run_job_from_config,
     _run_source_native_discovery,
     _source_name_from_error,
@@ -694,6 +695,196 @@ class TestRunPipelineAsync:
             "engine": "exa",
             "allow_find_similar": True,
         }
+
+    @pytest.mark.asyncio
+    async def test_run_google_cse_discovery_persists_empty_when_no_queries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Google CSE discovery should still persist an empty run when query building yields nothing."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr("denbust.pipeline.build_discovery_queries", lambda *_a, **_k: [])
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_google_cse_discovery(config=Config(), run_id="run-google", days=4)
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).query_count == 0
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_google_cse_discovery_records_missing_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Google CSE discovery should persist an error when enabled without required credentials."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_google_cse_discovery(
+            config=Config(
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}}
+            ),
+            run_id="run-google",
+            days=4,
+        )
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).errors == [
+            "google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"
+        ]
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_google_cse_discovery_records_missing_cse_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Google CSE discovery should persist an error when the search engine id is missing."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(Config, "google_cse_api_key", property(lambda _self: "google-key"))
+        monkeypatch.setattr(Config, "google_cse_id", property(lambda _self: None))
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_google_cse_discovery(
+            config=Config(
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}}
+            ),
+            run_id="run-google",
+            days=4,
+        )
+
+        assert persisted.candidates == []
+        assert captured["candidates"] == []
+        assert cast(DiscoveryRun, captured["run"]).errors == [
+            "google_cse: missing DENBUST_GOOGLE_CSE_ID"
+        ]
+        assert captured["closed"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_google_cse_discovery_catches_engine_errors_and_closes_resources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Google CSE engine failures should be recorded on the run and still close both engine and store."""
+        captured: dict[str, object] = {}
+
+        class FakePersistence:
+            def close(self) -> None:
+                captured["persistence_closed"] = True
+
+        class FakeEngine:
+            def __init__(self, **kwargs: object) -> None:
+                captured["engine_init"] = kwargs
+
+            async def discover(self, queries, context):
+                captured["queries"] = queries
+                captured["context"] = context
+                raise RuntimeError("boom")
+
+            async def aclose(self) -> None:
+                captured["engine_closed"] = True
+
+        def fake_persist_discovered_candidates(*, run, discovered_candidates, persistence):
+            del persistence
+            captured["run"] = run
+            captured["candidates"] = discovered_candidates
+            return PersistedSourceDiscovery(run=run, candidates=[], provenance=[])
+
+        monkeypatch.setattr(Config, "google_cse_api_key", property(lambda _self: "google-key"))
+        monkeypatch.setattr(Config, "google_cse_id", property(lambda _self: "search-engine-id"))
+        monkeypatch.setattr(
+            "denbust.pipeline.build_discovery_queries",
+            lambda *_args, **_kwargs: [MagicMock()],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_discovery_persistence",
+            lambda _config: FakePersistence(),
+        )
+        monkeypatch.setattr("denbust.pipeline.GoogleCseSearchEngine", FakeEngine)
+        monkeypatch.setattr(
+            "denbust.pipeline.persist_discovered_candidates",
+            fake_persist_discovered_candidates,
+        )
+
+        persisted = await _run_google_cse_discovery(
+            config=Config(
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}}
+            ),
+            run_id="run-google",
+            days=6,
+        )
+
+        assert persisted.candidates == []
+        assert cast(DiscoveryRun, captured["run"]).errors == ["google_cse: RuntimeError: boom"]
+        assert captured["engine_closed"] is True
+        assert captured["persistence_closed"] is True
+        assert captured["engine_init"] == {
+            "api_key": "google-key",
+            "cse_id": "search-engine-id",
+            "max_results_per_query": 10,
+        }
+        assert captured["context"].metadata == {"days": 6, "engine": "google_cse"}
 
     @pytest.mark.asyncio
     async def test_run_pipeline_async_requires_api_key(
@@ -1723,6 +1914,58 @@ class TestRunPipelineAsync:
         assert '"exa": 2' in metrics_payload
         assert '"source_native": 0' in metrics_payload
         assert '"brave": 0' in metrics_payload
+        assert '"google_cse": 0' in metrics_payload
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_supports_google_cse_only_and_writes_metrics(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Google CSE discovery should run without configured sources and persist engine metrics."""
+        google_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:google_cse",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-google-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                ),
+                build_persistent_candidate(
+                    "candidate-google-2",
+                    current_url="https://www.mako.co.il/news/article/2",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_google_cse_discovery",
+            AsyncMock(return_value=google_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 2
+        assert result.unified_item_count == 2
+        metrics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+        ).read_text(encoding="utf-8")
+        assert '"google_cse": 2' in metrics_payload
+        assert '"source_native": 0' in metrics_payload
+        assert '"brave": 0' in metrics_payload
+        assert '"exa": 0' in metrics_payload
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_aggregates_brave_and_source_native_without_double_counting(
@@ -1894,6 +2137,137 @@ class TestRunPipelineAsync:
         assert '"source_native_brave_shared": 1' in metrics_payload
         assert '"source_native_exa_shared": 1' in metrics_payload
         assert '"brave_exa_shared": 1' in metrics_payload
+        assert '"shared_all_candidates": 0' in metrics_payload
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_aggregates_all_engines_and_source_native_overlaps(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Merged candidate counts and overlap metrics should include Google CSE too."""
+        source_native = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:source_native",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                )
+            ],
+            provenance=[],
+        )
+        brave = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:brave",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                ),
+                build_persistent_candidate(
+                    "candidate-brave-only",
+                    current_url="https://www.mako.co.il/news/article/brave-only",
+                ),
+            ],
+            provenance=[],
+        )
+        exa = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:exa",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                ),
+                build_persistent_candidate(
+                    "candidate-exa-only",
+                    current_url="https://www.maariv.co.il/news/article/exa-only",
+                ),
+            ],
+            provenance=[],
+        )
+        google_cse = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:google_cse",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                candidate_count=2,
+                merged_candidate_count=2,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-shared-all",
+                    current_url="https://www.ynet.co.il/news/article/shared-all",
+                ),
+                build_persistent_candidate(
+                    "candidate-google-only",
+                    current_url="https://www.walla.co.il/news/article/google-only",
+                ),
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [MagicMock(name="ynet")]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_source_native_discovery",
+            AsyncMock(return_value=source_native),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            AsyncMock(return_value=brave),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_exa_discovery",
+            AsyncMock(return_value=exa),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_google_cse_discovery",
+            AsyncMock(return_value=google_cse),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                discovery={
+                    "enabled": True,
+                    "engines": {
+                        "brave": {"enabled": True},
+                        "exa": {"enabled": True},
+                        "google_cse": {"enabled": True},
+                    },
+                },
+            )
+        )
+
+        assert result.fatal is False
+        assert result.raw_article_count == 7
+        assert result.unified_item_count == 4
+        metrics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+        ).read_text(encoding="utf-8")
+        assert '"google_cse": 2' in metrics_payload
+        assert '"source_native_google_cse_shared": 1' in metrics_payload
+        assert '"brave_google_cse_shared": 1' in metrics_payload
+        assert '"exa_google_cse_shared": 1' in metrics_payload
         assert '"shared_all_candidates": 1' in metrics_payload
 
     @pytest.mark.asyncio
@@ -1965,6 +2339,41 @@ class TestRunPipelineAsync:
 
         assert result.fatal is True
         assert result.errors == ["exa: missing DENBUST_EXA_API_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_marks_google_cse_failure_fatal_when_it_is_the_only_engine(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A failed Google CSE-only discovery run should surface as fatal."""
+        google_persisted = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:google_cse",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.FAILED,
+                candidate_count=0,
+                merged_candidate_count=0,
+                errors=["google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"],
+            ),
+            candidates=[],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_google_cse_discovery",
+            AsyncMock(return_value=google_persisted),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}},
+            )
+        )
+
+        assert result.fatal is True
+        assert result.errors == ["google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"]
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_fails_when_engine_persistence_disabled_and_no_source_native(
@@ -2144,6 +2553,44 @@ class TestRunPipelineAsync:
         )
 
         assert "exa discovery completed with partial engine failures" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_warns_on_google_cse_partial(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Google CSE partial runs should surface as warnings and still write metrics."""
+        google_partial = PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-discover:google_cse",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.DISCOVER,
+                status=DiscoveryRunStatus.PARTIAL,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[
+                build_persistent_candidate(
+                    "candidate-google-1",
+                    current_url="https://www.ynet.co.il/news/article/1",
+                )
+            ],
+            provenance=[],
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr(
+            "denbust.pipeline._run_google_cse_discovery",
+            AsyncMock(return_value=google_partial),
+        )
+
+        result = await run_news_discover_job(
+            Config(
+                store={"state_root": tmp_path},
+                source_discovery={"enabled": False},
+                discovery={"enabled": True, "engines": {"google_cse": {"enabled": True}}},
+            )
+        )
+
+        assert "google_cse discovery completed with partial engine failures" in result.warnings
 
 
 class TestRunPipeline:


### PR DESCRIPTION
## Summary

This PR implements **DL-PR-06 — Google CSE integration** for the persistent discovery/candidacy layer.

It adds Google Custom Search JSON API as the third external discovery engine, parallel to Brave and Exa, feeding the same durable candidate substrate and the existing `news_items / discover` job.

This PR keeps the scope additive and narrow:
- Google CSE standard query search is operational
- it reuses the existing discovery query builder for broad and source-targeted searches
- it does not change scrape, backfill, or self-healing behavior
- it completes the initial three-engine discovery layer planned in the rollout docs

## What changed

### 1. New Google CSE discovery adapter

Added a new adapter at `src/denbust/discovery/engines/google_cse.py`:
- `GoogleCseSearchEngine`
- constructor shape mirrors the existing engine adapters:
  - `api_key`
  - `cse_id`
  - `max_results_per_query`
  - optional `httpx.AsyncClient`
  - configurable `base_url`
- exposes `name == "google_cse"`
- implements `discover(queries, context)`
- closes owned clients via `aclose()`

### 2. Google CSE result normalization into `DiscoveredCandidate`

Google CSE results are normalized using the same candidate rules already established for Brave and Exa:
- raw Google result URL is preserved as `candidate_url`
- `canonical_url` is populated via `canonicalize_news_url(...)`
- `title`, `snippet`, and publication-date hints are extracted when available
- malformed rows are skipped safely instead of aborting the whole discovery run
- malformed JSON shapes are skipped safely instead of aborting the whole discovery run
- invalid URLs are skipped safely instead of aborting the whole discovery run

Publication hints are extracted best-effort from `pagemap.metatags` when Google provides article metadata.

Persisted metadata is intentionally trimmed to a stable subset instead of storing the full raw Google payload:
- `engine`
- `query_kind`
- `preferred_domains`
- `result_url`
- `result_title`
- `result_snippet`
- `result_display_link`
- `result_cache_id`
- `total_results`

### 3. Discover job orchestration now supports Google CSE

Extended `src/denbust/pipeline.py` with an explicit Google CSE path, parallel to Brave and Exa:
- added `_run_google_cse_discovery(...)`
- added `google_cse_requested` / `google_cse_can_run` logic in `run_news_discover_job()`
- `news_items / discover` now supports all combinations of:
  - source-native
  - Brave
  - Exa
  - Google CSE
- Google CSE partial/failure states are surfaced consistently with Brave and Exa
- Google CSE requires both:
  - `DENBUST_GOOGLE_CSE_API_KEY`
  - `DENBUST_GOOGLE_CSE_ID`

### 4. Discovery overlap metrics expanded to the full initial engine set

The discovery metrics snapshot now includes Google CSE alongside source-native, Brave, and Exa.

The snapshot written under the discovery state paths now includes:
- `source_native`
- `brave`
- `exa`
- `google_cse`
- `source_native_brave_shared`
- `source_native_exa_shared`
- `source_native_google_cse_shared`
- `brave_exa_shared`
- `brave_google_cse_shared`
- `exa_google_cse_shared`
- `shared_all_candidates`

This keeps the observability additive without introducing a broader engine-abstraction refactor in this PR.

### 5. Docs updated

Updated docs and README so the repo state matches the implementation:
- `README.md` now states that `news_items / discover` supports source-native + Brave + Exa + Google CSE candidate persistence
- `docs/tfht_discovery_layer_implementation_plan.md` marks DL-PR-06 as implemented
- `docs/tfht_discovery_layer_design_amended.md` now marks both Exa and Google CSE as implemented in Milestone 3

## What did not change

Still intentionally out of scope in this PR:
- backfill execution
- self-healing behavior
- scrape queue behavior
- generic fetch/extract fallback behavior
- broader multi-engine abstraction refactor
- source suggestion / social-targeted discovery support

## Config / environment

This PR reuses the existing config surface:
- `discovery.engines.google_cse`
- `Config.google_cse_api_key`
- `Config.google_cse_id`

Required when Google CSE is enabled:
- `DENBUST_GOOGLE_CSE_API_KEY`
- `DENBUST_GOOGLE_CSE_ID`

No new top-level config sections were introduced.

## Tests added / updated

### New unit tests
- `tests/unit/test_discovery_google_cse.py`
  - normalizes Google CSE search responses into `DiscoveredCandidate`
  - canonicalizes URLs
  - verifies trimmed metadata only
  - verifies `siteSearch` / source-targeted request construction
  - skips malformed payloads and invalid rows safely
  - verifies owned-client close behavior
  - verifies invalid publication metadata fallback

### Extended pipeline coverage
- `tests/unit/test_pipeline_core.py`
  - Google CSE-only discover success path
  - Google CSE-only fatal failure path
  - Google CSE partial warning path
  - `_run_google_cse_discovery()` empty-query path
  - `_run_google_cse_discovery()` missing API key path
  - `_run_google_cse_discovery()` missing CSE ID path
  - `_run_google_cse_discovery()` engine-exception path with cleanup verification
  - all-engine aggregation path including Google overlap metrics

## Validation run

Ran locally:

```bash
pytest -q tests/unit/test_discovery_google_cse.py tests/unit/test_pipeline_core.py tests/unit/test_config.py -k 'google or discover'
pytest -q tests/unit/test_discovery_brave.py tests/unit/test_discovery_exa.py tests/unit/test_discovery_google_cse.py tests/unit/test_discovery_queries.py tests/unit/test_discovery_storage.py tests/unit/test_pipeline_core.py tests/unit/test_config.py -k 'discover or brave or exa or google or query or persistence'
ruff check src/denbust/discovery/engines/google_cse.py src/denbust/pipeline.py tests/unit/test_discovery_google_cse.py tests/unit/test_pipeline_core.py README.md docs/tfht_discovery_layer_implementation_plan.md docs/tfht_discovery_layer_design_amended.md
mypy src/denbust/discovery/engines/google_cse.py src/denbust/pipeline.py
```

All of the above passed locally.

## Resulting state after this PR

With this PR merged, the initial multi-engine discovery layer is functionally complete:
- source-native discovery persists into the durable candidate substrate
- Brave contributes external search-engine candidates
- Exa contributes semantic external search candidates
- Google CSE contributes recall-oriented external search candidates
- `news_items / discover` can orchestrate all of them together against the same persistent candidate layer

## Follow-up

The next discovery-layer work should move to the later rollout items, such as:
- observability / overlap reporting improvements
- backfill discover/scrape flows
- self-healing / retry feedback loops
- source suggestion and social-targeted discovery support
