### PR TITLE
Refactor in-repo agent context files

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -1,0 +1,24 @@
+# .agent-plan.md
+
+## Current System State
+
+- Active branch: `codex/refactor-agent-context-architecture`
+- Last action taken: agent-context cleanup branch created; `AGENTS.md` condensed; `llms.txt` added.
+- Current blockers: no explicit repo-tracked blocker, but the next implementation slice is split between unfinished Phase C follow-through and post-`DL-PR-06` discovery work. Prioritization should be explicit before larger feature work starts.
+
+## Active Task Breakdown
+
+- [ ] Finish Phase C test/validation follow-through from `C-7`
+- [ ] Wire the monthly report command/workflow from `C-6`
+- [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
+- [ ] Start `DL-PR-07` discovery observability and overlap reporting
+- [ ] Queue `DL-PR-09` backfill foundation after observability is in place
+- [ ] Keep `DL-PR-11` workflow rollout scoped to docs/workflows only; do not mix in self-healing or event-table work
+
+## Context Pointers
+
+- Phase C plan: [docs/PHASE_C_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/PHASE_C_PLAN.md)
+- Discovery rollout plan: [docs/tfht_discovery_layer_implementation_plan.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/tfht_discovery_layer_implementation_plan.md)
+- Broader implementation backlog: [docs/IMPLEMENTATION_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/IMPLEMENTATION_PLAN.md)
+- Current state report: [docs/2026_04_04_tfht_state_of_project_report.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/2026_04_04_tfht_state_of_project_report.md)
+- Supplemental product/taxonomy direction: [docs/CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/CHATGPT_26_04_PLAN.md)

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -17,8 +17,8 @@
 
 ## Context Pointers
 
-- Phase C plan: [docs/PHASE_C_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/PHASE_C_PLAN.md)
-- Discovery rollout plan: [docs/tfht_discovery_layer_implementation_plan.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/tfht_discovery_layer_implementation_plan.md)
-- Broader implementation backlog: [docs/IMPLEMENTATION_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/IMPLEMENTATION_PLAN.md)
-- Current state report: [docs/2026_04_04_tfht_state_of_project_report.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/2026_04_04_tfht_state_of_project_report.md)
-- Supplemental product/taxonomy direction: [docs/CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clones/tfht_enforce_idx/docs/CHATGPT_26_04_PLAN.md)
+- Phase C plan: [docs/PHASE_C_PLAN.md](docs/PHASE_C_PLAN.md)
+- Discovery rollout plan: [docs/tfht_discovery_layer_implementation_plan.md](docs/tfht_discovery_layer_implementation_plan.md)
+- Broader implementation backlog: [docs/IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)
+- Current state report: [docs/2026_04_04_tfht_state_of_project_report.md](docs/2026_04_04_tfht_state_of_project_report.md)
+- Supplemental product/taxonomy direction: [docs/CHATGPT_26_04_PLAN.md](docs/CHATGPT_26_04_PLAN.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,262 +1,104 @@
 # AGENTS.md
 
-> **SYNC NOTE:** `CLAUDE.md` mirrors this file. Keep them in sync when updating repository guidance.
+`CLAUDE.md` must remain a symlink to this file.
 
----
+## Repo Rules
 
-## Project Overview
+- Use the repo-specific GitHub MCP when available; use local `git` only if no MCP for this repo is exposed.
+- Do not commit secrets, tokens, browser state, or personal config.
+- Keep `LOCAL_AGENTS.md` untracked; treat it as additive only.
+- Prefer editing checked-in agent context in `AGENTS.md`, `llms.txt`, and `.agent-plan.md`; do not move dynamic state back into `AGENTS.md`.
 
-**denbust** (מדד האכיפה) is a Python tool for monitoring enforcement of anti-brothel laws in Israel.
+## Branch And PR Rules
 
-### Project Phases
+- Default branch prefix for agent work: `codex/`.
+- Keep branches single-purpose.
+- Open PRs against `main`.
+- Preserve `CLAUDE.md -> AGENTS.md` when changing repo guidance.
 
-**Phase 1 (Current):** News monitoring
-- 4 sources: 2 RSS feeds (Ynet, Walla) + 2 scrapers (Mako, Maariv)
-- Scan the last X days for reports about brothel raids, prostitution arrests, pimping cases, trafficking, and closure orders
-- Classify relevance with an LLM, deduplicate the same story across sources, and output unified items
-- Output is currently available via CLI and SMTP email, with multi-output fanout through `output.formats`
+## Environment
 
-**Phase 2 (Future):** Court records
-- Scrape Israeli Courts for related proceedings
-- Correlate news stories with court cases
-- Track closure orders and reopenings
+- Python `>=3.11`
+- Install dev dependencies:
 
-**Phase 3 (Future):** Analytics
-- Historical enforcement database
-- Regional enforcement gap analysis
-- Web dashboard with statistics
-
----
-
-## Current Architecture
-
-```text
-┌─────────────────┐     ┌─────────────────────────┐
-│   RSS Sources   │     │   Scraper Sources       │
-│  (Ynet, Walla)  │     │ Mako, Maariv            │
-└────────┬────────┘     └────────┬────────────────┘
-         │ HTTP/RSS               │ Playwright + HTML parsing (Mako)
-         │ keyword + date filter  │ HTML parsing (Maariv)
-         └──────────┬─────────────┘
-                    ▼
-         LLM Classifier (relevance + category)
-                    │
-                    ▼
-         Deduplicator (cross-source grouping)
-                    │
-                    ▼
-         Output fanout (`cli`, `email`)
+```bash
+pip install -e ".[dev]"
 ```
 
-- **Primary language:** Python 3.11+
-- **Runtime:** CLI (`denbust scan`), cron or GitHub Actions for automation
-- **Current outputs:** `cli`, `email`
-- **Telegram note:** `telegram` still exists in config as an enum but is not implemented; the pipeline currently logs a warning and falls back to CLI output
-- **No secrets in repo:** all credentials stay in environment variables
+- Install browser runtime before live Mako runs:
 
----
-
-## What We Monitor
-
-### Primary Topics
-- Brothel raids and closures
-- Prostitution-related arrests
-- Pimp (סרסור) arrests and sentencing
-- Human trafficking cases
-- Administrative closure orders
-
-### Secondary Topics
-- Massage parlor / spa busts (fronts)
-- Online platform takedowns
-- Police operations targeting prostitution
-- Court sentences in related cases
-- Trafficking victim rescues
-
----
-
-## Repository Structure
-
-```text
-denbust/
-├── src/denbust/
-│   ├── __init__.py
-│   ├── cli.py                 # Typer CLI entry point
-│   ├── config.py              # Config model + env-backed properties
-│   ├── data_models.py         # RawArticle, ClassifiedArticle, UnifiedItem
-│   ├── pipeline.py            # Orchestration + output fanout
-│   ├── sources/
-│   │   ├── base.py            # Source protocol
-│   │   ├── rss.py             # RSS fetchers (Ynet, Walla)
-│   │   ├── mako.py            # Playwright-backed scraper
-│   │   └── maariv.py          # HTML scraper
-│   ├── classifier/
-│   │   └── relevance.py       # LLM classification
-│   ├── dedup/
-│   │   └── similarity.py      # Cross-source deduplication
-│   ├── output/
-│   │   ├── email.py           # SMTP report delivery
-│   │   └── formatter.py       # Console/report formatting
-│   └── store/
-│       └── seen.py            # Seen URL persistence
-├── data/
-│   ├── runs/                  # Per-run outputs (gitignored)
-│   └── seen.json              # Default seen-URL store (gitignored)
-├── agents/                    # Checked-in example configs
-├── tests/
-│   ├── fixtures/              # RSS XML + HTML fixtures
-│   ├── integration/
-│   ├── smoke/
-│   └── unit/
-├── .github/
-│   ├── workflows/
-│   └── skills/                # Repo-local guidance for agents and Copilot
-└── pyproject.toml
+```bash
+python -m playwright install chromium
 ```
 
----
+## Required Validation Commands
 
-## Development Guidelines
-
-### 1) Code Style & Quality
-- Python 3.11+ preferred
-- Full type annotations
-- Lint/format: Ruff
-- Type check: mypy
-- Tests: pytest
+Run the narrowest relevant checks for the files you changed. For cross-cutting changes, run the full set.
 
 ```bash
 ruff format .
 ruff check .
 mypy src/
-pytest
-```
-
-### 2) Legal & Ethical Constraints
-- Only use public, freely accessible sources
-- Prefer RSS over scraping when a stable feed exists
-- Respect robots.txt and anti-abuse boundaries
-- Never store PII beyond what appears in public news articles
-- Comply with Israeli privacy law
-
-### 3) Data Fetching
-- **RSS sources:** fetch the feed, then filter by keyword/date
-- **Mako:** browser-backed with Playwright + headless Chromium; searches and section pages are rendered before parsing
-- **Maariv:** HTML scraping with fixtures and mocked HTTP in tests
-- Keep request pacing conservative and identify the client clearly
-- Normalize Mako article URLs before deduplication or seen tracking so `?Partner=searchResults` does not create duplicate stories
-- Handle source failures per source/search path and continue the rest of the scan
-
-### 4) Classification
-- LLM classifies relevance, category, sub-category, and confidence
-- Prompts should stay short, Hebrew-aware, and grounded in article text
-- Log decisions for review
-- Never fabricate article details
-
-### 5) Deduplication
-- Same story from multiple sources should produce one unified item
-- Keep all source links on the unified item
-- Prefer canonical article URLs before similarity/dedup logic runs
-
-### 6) Output
-- Preferred config uses `output.formats`, not duplicate `format` keys
-- Example:
-
-```yaml
-output:
-  formats:
-    - cli
-    - email
-```
-
-- Legacy `output.format` is still accepted for backward compatibility, but `formats` is the preferred shape for new configs
-
----
-
-## Secrets & Configuration
-
-Never commit secrets. Use env vars:
-
-```text
-ANTHROPIC_API_KEY
-
-DENBUST_TELEGRAM_BOT_TOKEN   # Optional, Telegram mode is not implemented yet
-DENBUST_TELEGRAM_CHAT_ID     # Optional
-
-DENBUST_EMAIL_SMTP_HOST
-DENBUST_EMAIL_SMTP_PORT
-DENBUST_EMAIL_SMTP_USERNAME
-DENBUST_EMAIL_SMTP_PASSWORD
-DENBUST_EMAIL_FROM
-DENBUST_EMAIL_TO             # Comma-separated recipients
-DENBUST_EMAIL_USE_TLS
-DENBUST_EMAIL_SUBJECT
-```
-
-Notes:
-- `DENBUST_EMAIL_TO` accepts comma-separated recipients and is parsed into a list
-- Keep personal/local configs outside the repo when possible, for example under `~/.config/denbust/`
-- Do not rely on ignored files under `agents/local/` for durable personal setup across branch/worktree changes
-- Local runs can use an absolute config path:
-
-```bash
-denbust scan --config ~/.config/denbust/news-email.yaml
-```
-
----
-
-## Testing Guidance
-
-- No live network calls in tests
-- No live browser scraping in CI
-- Unit tests should cover config normalization, classifier parsing, dedup logic, output fanout, and store behavior
-- Integration tests should use mocked HTTP or mocked rendered HTML
-- Mako tests should exercise rendered-HTML helpers and fixtures, not live Mako pages
-
-Useful commands:
-
-```bash
 pytest -q
-pytest -q tests/integration -k Mako
-pytest -q tests/unit
 ```
 
----
+Useful targeted commands:
 
-## CI & Automation Guidance
+```bash
+pytest -q tests/unit
+pytest -q tests/integration -k Mako
+denbust scan --config agents/news/local.yaml
+denbust run --dataset news_items --job discover --config agents/news/local.yaml
+denbust run --dataset news_items --job scrape_candidates --config agents/news/local.yaml
+denbust release --dataset news_items --config agents/release/news_items.yaml
+denbust backup --dataset news_items --config agents/backup/news_items.yaml
+```
 
-Current workflow shape:
-- `pre-commit.ci` handles pre-commit checks
-- `.github/workflows/ci-test.yml` is the main CI workflow
-- `unit-tests` and `integration-tests` produce raw coverage artifacts used by the `coverage` job
-- `coverage` combines coverage data, generates `coverage.xml`, uploads the `coverage-xml` artifact, and uploads to Codecov
-- `pr-agent-context` runs both from the main PR workflow and from `.github/workflows/pr-agent-context-refresh.yml`
-- `pr-agent-context` now consumes the combined `coverage-xml` artifact directly for patch coverage
-- Validation workflows exist for `pyproject.toml` and `codecov.yml`
+## Code Standards
 
-When editing CI:
-- keep workflow responsibilities narrow
-- do not add duplicate coverage producers if the `coverage` job can be reused
-- prefer artifact reuse over reconstructing results in multiple places
+- Full type annotations are required.
+- Ruff is the formatter and linter of record.
+- Mypy runs in strict mode; keep new code strict-clean.
+- Keep public behavior and CLI names backward compatible unless the task explicitly changes them.
+- Prefer small, composable modules over large cross-cutting rewrites.
 
----
+## Architecture Boundaries
 
-## Quick Reference
+- Dataset/job identity is defined through `src/denbust/models/` and `src/denbust/datasets/`; do not hardcode ad hoc dataset/job routing elsewhere.
+- State-path resolution must go through:
+  - `src/denbust/store/state_paths.py`
+  - `src/denbust/discovery/state_paths.py`
+- Discovery/candidacy models live under `src/denbust/discovery/`; ingest/release/backup logic must consume those models instead of redefining candidate state.
+- `news_items` operational/public record schemas live in `src/denbust/news_items/models.py`; reuse them instead of introducing parallel row schemas.
+- Release and backup integrations belong under `src/denbust/publish/` and `src/denbust/news_items/`; avoid embedding publication logic inside unrelated modules.
+- Source adapters belong under `src/denbust/sources/`; source-specific scraping logic should not leak into CLI or config modules.
+- Config normalization lives in `src/denbust/config.py`; prefer env/YAML plumbing there instead of scattered `os.environ` reads.
 
-| Task | Command |
-|------|---------|
-| Install (dev) | `pip install -e ".[dev]"` |
-| Install Mako browser runtime | `python -m playwright install chromium` |
-| Run scan | `denbust scan --config agents/news.yaml` |
-| Run with external config | `denbust scan --config ~/.config/denbust/news-email.yaml` |
-| Tests | `pytest -q` |
-| Lint | `ruff check .` |
-| Format | `ruff format .` |
-| Type check | `mypy src/` |
+## Fetching And Data Handling Rules
 
----
+- Prefer public, stable interfaces; use RSS where a stable feed exists.
+- Keep source failures isolated per source/query path; do not abort the entire run on one source failure.
+- Normalize Mako URLs before deduplication or seen-state writes so query params do not fork duplicate records.
+- Do not fabricate article details or inferred facts beyond what exists in the source text and structured model outputs.
 
-## Local Agent Overrides (Optional, Untracked)
+## Config And Secrets
 
-- If `LOCAL_AGENTS.md` exists at repo root, treat it as additive local instructions
-- `LOCAL_AGENTS.md` must remain untracked
-- On conflicts, repository policy and security constraints take precedence
+- Keep durable personal config outside the repo, for example under `~/.config/denbust/`.
+- Prefer `output.formats` over legacy `output.format` in new config examples.
+- Supported sensitive env vars include:
+  - `ANTHROPIC_API_KEY`
+  - `DENBUST_*`
+- Never add secrets to fixtures, examples, docs, or workflow YAML.
+
+## Testing Constraints
+
+- No live network calls in tests.
+- No live browser scraping in CI tests.
+- Use fixtures/mocked HTTP/rendered HTML for source tests.
+- When changing discovery, ingestion, or persistence behavior, add or update tests in `tests/unit` or `tests/integration`.
+
+## CI Notes
+
+- Main CI workflow: `.github/workflows/ci-test.yml`
+- Reuse the existing coverage flow instead of adding duplicate coverage producers.
+- Prefer artifact reuse over recomputing the same coverage or validation outputs in multiple jobs.

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,9 @@ src/denbust/
     rss.py                     RSS fetchers
     mako.py                    browser-backed scraping
     maariv.py                  HTML scraper
-    walla.py haaretz.py ice.py source adapters
+    walla.py                   source adapter
+    haaretz.py                 source adapter
+    ice.py                     source adapter
   discovery/
     models.py                  candidate/provenance/scrape-attempt schemas
     queries.py                 discovery query building

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,107 @@
+# llms.txt
+
+High-density index for agents working in this repository.
+
+## Core Tree
+
+```text
+src/denbust/
+  cli.py                       Typer entrypoint and job commands
+  config.py                    YAML/env config normalization
+  pipeline.py                  legacy scan pipeline orchestration
+  data_models.py               raw/classified/unified article models
+  models/
+    common.py                  dataset/job identity and shared enums
+    policies.py                review/privacy/publication policy enums
+    runs.py                    run snapshot models
+  datasets/
+    registry.py                dataset/job registry
+    jobs.py                    dataset job wiring
+  sources/
+    base.py                    source protocol
+    rss.py                     RSS fetchers
+    mako.py                    browser-backed scraping
+    maariv.py                  HTML scraper
+    walla.py haaretz.py ice.py source adapters
+  discovery/
+    models.py                  candidate/provenance/scrape-attempt schemas
+    queries.py                 discovery query building
+    persistence.py             candidate persistence orchestration
+    storage.py                 candidate-layer store interface
+    scrape_queue.py            queued scrape flow
+    source_native.py           source-native candidacy
+    state_paths.py             discovery state layout
+  news_items/
+    models.py                  operational/public record schemas
+    ingest.py                  ingest job
+    enrich.py                  enrichment/summaries
+    normalize.py               canonical URLs and IDs
+    publication.py             public release shaping
+    release.py                 release job
+    backup.py                  backup job
+    daily_review.py            suspicious-run review flow
+  ops/
+    storage.py                 operational store interface
+    supabase.py                Supabase backend
+    factory.py                 store backend selection
+  publish/
+    base.py                    publication abstractions
+    release.py                 publisher execution
+    backup.py                  backup execution
+  store/
+    seen.py                    seen URL persistence
+    run_snapshots.py           per-run JSON snapshots
+    state_paths.py             dataset/job state layout
+  validation/
+    models.py                  validation row/result schemas
+    dataset.py                 validation set loading
+    evaluate.py                classifier evaluation
+    import_reviewed.py         reviewed-data import path
+  taxonomy/
+    loader.py                  taxonomy loading
+```
+
+## Schemas And Internal APIs
+
+- Core news/article schemas: `src/denbust/data_models.py`
+- Dataset/job identity and shared run models: `src/denbust/models/common.py`, `src/denbust/models/runs.py`
+- Policy/status enums: `src/denbust/models/policies.py`
+- `news_items` operational/public schemas: `src/denbust/news_items/models.py`
+- Discovery/candidacy schemas: `src/denbust/discovery/models.py`
+- Validation schemas: `src/denbust/validation/models.py`
+- Config API: `src/denbust/config.py`
+- CLI/internal command surface: `src/denbust/cli.py`
+- Dataset registry/internal job routing: `src/denbust/datasets/registry.py`, `src/denbust/datasets/jobs.py`
+- Operational storage interface: `src/denbust/ops/storage.py`
+- Discovery storage interface: `src/denbust/discovery/storage.py`
+- State path resolution: `src/denbust/store/state_paths.py`, `src/denbust/discovery/state_paths.py`
+
+## Config, Workflows, And Migrations
+
+- Package/tooling config: `pyproject.toml`
+- Example/news job configs: `agents/news/local.yaml`, `agents/news/github.yaml`, `agents/news.yaml`
+- Release config: `agents/release/news_items.yaml`
+- Backup config: `agents/backup/news_items.yaml`
+- Validation variants: `agents/validation/classifier_variants.yaml`
+- GitHub Actions: `.github/workflows/`
+- Supabase migrations: `supabase/migrations/`
+
+## Tests And Fixtures
+
+- Unit tests: `tests/unit/`
+- Integration tests: `tests/integration/`
+- Smoke tests: `tests/smoke/`
+- Fixtures: `tests/fixtures/`
+
+## State And Output Locations
+
+- Local dataset/job state root default: `data/`
+- Discovery state paths resolve under dataset/job namespaces via `state_paths.py`
+- Run snapshots: dataset/job `runs/` dirs under the resolved state root
+
+## Planning / Human Context
+
+- Phase C roadmap: `docs/PHASE_C_PLAN.md`
+- Discovery rollout roadmap: `docs/tfht_discovery_layer_implementation_plan.md`
+- Broader implementation backlog: `docs/IMPLEMENTATION_PLAN.md`
+- Current project report: `docs/2026_04_04_tfht_state_of_project_report.md`


### PR DESCRIPTION
## Summary
- condense `AGENTS.md` into a short, scannable set of hard repo constraints and exact commands
- add `llms.txt` as a dense architecture/config/schema index for agents
- add `.agent-plan.md` as a lightweight dynamic state tracker pointing back to preserved planning docs

## Details
- `CLAUDE.md` remains a symlink to `AGENTS.md`
- long-form planning documents under `docs/` were intentionally preserved and not modified
- `.agent-plan.md` only captures the immediate next tranche of work inferred from the existing plans

## Files changed
- modified: `AGENTS.md`
- created: `llms.txt`
- created: `.agent-plan.md`
- left alone intentionally: `docs/PHASE_C_PLAN.md`, `docs/tfht_discovery_layer_implementation_plan.md`, `docs/IMPLEMENTATION_PLAN.md`, `docs/CHATGPT_26_04_PLAN.md`, `docs/2026_04_04_tfht_state_of_project_report.md`

## Validation
- verified `CLAUDE.md` still points to `AGENTS.md`
- checked resulting file set and git status
- did not run code tests because this PR only changes repo context/documentation files