### PR TITLE
Add discovery diagnostics reporting for DL-PR-07

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+# PLAN.md
+
+This repo currently has one main plan and two important sub-plans.
+
+## Main Plan
+
+- [`docs/CHATGPT_26_04_PLAN.md`](docs/CHATGPT_26_04_PLAN.md) is the primary implementation roadmap.
+- It describes the high-level product and data-model evolution of the project across the major milestones.
+- When there is a question about overall sequencing or intended end-state, this is the source of truth.
+
+## Milestone 3 Validation Sub-Plan
+
+- [`docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md`](docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md) is a branch plan under Milestone 3 of the main plan.
+- It exists because Milestone 3 validation work exposed enough complexity and implementation issues to justify splitting that milestone into smaller reviewable PRs.
+- It should be read as a delivery breakdown for Milestone 3, not as a separate product roadmap.
+
+## Discovery/Candidacy Architecture Sub-Plan
+
+- [`docs/tfht_discovery_layer_implementation_plan.md`](docs/tfht_discovery_layer_implementation_plan.md) is a separate sub-plan for the discovery-layer architecture update.
+- Its `DL-PR-*` series covers the separation of discovery and candidacy concerns from scraping/ingest concerns, along with rollout of the new operational model.
+- It is related to the main plan as enabling architecture, but it is not a replacement for the main milestone roadmap.
+
+## Practical Reading Order
+
+1. Read `docs/CHATGPT_26_04_PLAN.md` for the overall roadmap.
+2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
+3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
+
+## Current Next Focus: `DL-PR-07`
+
+`DL-PR-07` is the next planned discovery-layer step. Its purpose is to make the discovery/candidacy layer measurable and debuggable, building on the existing `DL-PR-01` through `DL-PR-06` foundation.
+
+### What already exists
+
+- Candidate persistence, scrape attempts, and queue state already exist under `src/denbust/discovery/`.
+- A lightweight overlap artifact already exists at `state_repo/.../metrics/engine_overlap_latest.json`.
+- The pipeline already aggregates per-engine candidate IDs in `src/denbust/pipeline.py`.
+- The repo already has a diagnostics pattern in `src/denbust/diagnostics/source_health.py` and `src/denbust/cli.py`.
+
+### What `DL-PR-07` still needs
+
+1. Introduce a dedicated discovery diagnostics/reporting module under `src/denbust/diagnostics/` for discovery-layer observability.
+2. Define typed report models for:
+   - engine overlap
+   - source-native vs search-engine recall/coverage
+   - candidate-to-news-item conversion
+   - queue health
+3. Expand discovery metrics outputs beyond `engine_overlap_latest.json` to include a coherent report artifact set under `src/denbust/discovery/state_paths.py`.
+4. Add queue-health calculations from persisted candidates and scrape attempts:
+   - new candidates
+   - stale candidates
+   - failed candidates
+   - retry backlog
+5. Add conversion metrics from candidate state and downstream ingest results:
+   - scrape succeeded
+   - scrape failed
+   - partially scraped
+   - unsupported source
+   - candidate-to-news-item conversion counts/rates
+6. Add source-native vs search-engine coverage reporting using current candidate provenance and discovered-via metadata.
+7. Add a CLI entry point in `src/denbust/cli.py` for discovery diagnostics, following the same text/JSON pattern used by `diagnose-sources`.
+8. Add unit tests for report generation, artifact writing, and CLI behavior.
+
+### Likely code touchpoints
+
+- `src/denbust/pipeline.py`
+- `src/denbust/discovery/state_paths.py`
+- `src/denbust/discovery/storage.py`
+- `src/denbust/discovery/models.py`
+- `src/denbust/diagnostics/__init__.py`
+- `src/denbust/diagnostics/source_health.py` as a structural reference only
+- `src/denbust/cli.py`
+- `tests/unit/test_pipeline_core.py`
+- `tests/unit/test_cli.py`
+- new diagnostics-focused unit tests under `tests/unit/`
+
+### Scope guardrails
+
+- Do not add backfill logic yet; that belongs to `DL-PR-09`.
+- Do not add self-healing or event-table work yet.
+- Keep this PR focused on observability/reporting, not on changing scrape semantics or public-release policy.

--- a/PLAN.md
+++ b/PLAN.md
@@ -34,7 +34,7 @@ This repo currently has one main plan and two important sub-plans.
 
 - Candidate persistence, scrape attempts, and queue state already exist under `src/denbust/discovery/`.
 - A lightweight overlap artifact already exists at `state_repo/.../metrics/engine_overlap_latest.json`.
-- The pipeline already aggregates per-engine candidate IDs in `src/denbust/pipeline.py`.
+- Discovery overlap/diagnostics generation already flows through `src/denbust/diagnostics/discovery.py`; the pipeline no longer keeps separate per-engine candidate ID sets.
 - The repo already has a diagnostics pattern in `src/denbust/diagnostics/source_health.py` and `src/denbust/cli.py`.
 
 ### What `DL-PR-07` still needs

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -138,6 +138,47 @@ def diagnose_sources(
     typer.echo(render_source_diagnostic_report(report))
 
 
+@app.command("diagnose-discovery")
+def diagnose_discovery(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+    stale_days: Annotated[
+        int,
+        typer.Option("--stale-days", help="Age threshold for stale queued candidates"),
+    ] = 7,
+    format: Annotated[
+        DiagnosticOutputFormat,
+        typer.Option("--format", help="Output format"),
+    ] = DiagnosticOutputFormat.TEXT,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Optional JSON output path"),
+    ] = None,
+) -> None:
+    """Summarize discovery-layer overlap, queue health, and conversion diagnostics."""
+    from denbust.diagnostics import (
+        render_discovery_diagnostic_report,
+        run_discovery_diagnostics,
+    )
+
+    config_path = config or Path("agents/news/local.yaml")
+    report = run_discovery_diagnostics(
+        config_path=config_path,
+        stale_after_days=stale_days,
+    )
+
+    if output is not None:
+        output.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+
+    if format == DiagnosticOutputFormat.JSON:
+        typer.echo(report.model_dump_json(indent=2))
+        return
+
+    typer.echo(render_discovery_diagnostic_report(report))
+
+
 @app.command()
 def release(
     dataset: Annotated[

--- a/src/denbust/diagnostics/__init__.py
+++ b/src/denbust/diagnostics/__init__.py
@@ -1,29 +1,55 @@
-"""Diagnostic helpers for source-health investigations."""
+"""Diagnostic helpers for source-health and discovery investigations."""
 
-from denbust.diagnostics.discovery import (
-    DiscoveryDiagnosticReport,
-    build_discovery_diagnostic_report,
-    persist_discovery_diagnostic_artifacts,
-    render_discovery_diagnostic_report,
-    run_discovery_diagnostics,
-)
-from denbust.diagnostics.source_health import (
-    SourceDiagnosticReport,
-    SourceDiagnosticResult,
-    render_source_diagnostic_report,
-    run_source_diagnostics,
-    run_source_diagnostics_async,
-)
+from __future__ import annotations
 
-__all__ = [
-    "DiscoveryDiagnosticReport",
-    "build_discovery_diagnostic_report",
-    "persist_discovery_diagnostic_artifacts",
-    "render_discovery_diagnostic_report",
-    "run_discovery_diagnostics",
-    "SourceDiagnosticReport",
-    "SourceDiagnosticResult",
-    "run_source_diagnostics",
-    "run_source_diagnostics_async",
-    "render_source_diagnostic_report",
-]
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_EXPORTS: dict[str, tuple[str, str | None]] = {
+    "DiscoveryDiagnosticReport": ("denbust.diagnostics.discovery", "DiscoveryDiagnosticReport"),
+    "build_discovery_diagnostic_report": (
+        "denbust.diagnostics.discovery",
+        "build_discovery_diagnostic_report",
+    ),
+    "persist_discovery_diagnostic_artifacts": (
+        "denbust.diagnostics.discovery",
+        "persist_discovery_diagnostic_artifacts",
+    ),
+    "render_discovery_diagnostic_report": (
+        "denbust.diagnostics.discovery",
+        "render_discovery_diagnostic_report",
+    ),
+    "run_discovery_diagnostics": ("denbust.diagnostics.discovery", "run_discovery_diagnostics"),
+    "SourceDiagnosticReport": ("denbust.diagnostics.source_health", "SourceDiagnosticReport"),
+    "SourceDiagnosticResult": ("denbust.diagnostics.source_health", "SourceDiagnosticResult"),
+    "render_source_diagnostic_report": (
+        "denbust.diagnostics.source_health",
+        "render_source_diagnostic_report",
+    ),
+    "run_source_diagnostics": ("denbust.diagnostics.source_health", "run_source_diagnostics"),
+    "run_source_diagnostics_async": (
+        "denbust.diagnostics.source_health",
+        "run_source_diagnostics_async",
+    ),
+    "source_health": ("denbust.diagnostics.source_health", None),
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve diagnostics exports to avoid package import cycles."""
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _EXPORTS[name]
+    module = import_module(module_name)
+    value: ModuleType | Any = module if attr_name is None else getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Report the lazily exported attribute names for interactive use."""
+    return sorted(set(globals()) | set(__all__))

--- a/src/denbust/diagnostics/__init__.py
+++ b/src/denbust/diagnostics/__init__.py
@@ -1,5 +1,12 @@
 """Diagnostic helpers for source-health investigations."""
 
+from denbust.diagnostics.discovery import (
+    DiscoveryDiagnosticReport,
+    build_discovery_diagnostic_report,
+    persist_discovery_diagnostic_artifacts,
+    render_discovery_diagnostic_report,
+    run_discovery_diagnostics,
+)
 from denbust.diagnostics.source_health import (
     SourceDiagnosticReport,
     SourceDiagnosticResult,
@@ -9,6 +16,11 @@ from denbust.diagnostics.source_health import (
 )
 
 __all__ = [
+    "DiscoveryDiagnosticReport",
+    "build_discovery_diagnostic_report",
+    "persist_discovery_diagnostic_artifacts",
+    "render_discovery_diagnostic_report",
+    "run_discovery_diagnostics",
     "SourceDiagnosticReport",
     "SourceDiagnosticResult",
     "run_source_diagnostics",

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -1,0 +1,570 @@
+"""Discovery-layer diagnostics and observability reporting."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from denbust.config import Config, OperationalProvider, load_config
+from denbust.discovery.models import CandidateStatus, PersistentCandidate, ScrapeAttempt
+from denbust.discovery.state_paths import write_metrics_snapshot
+from denbust.news_items.normalize import canonicalize_news_url
+from denbust.ops.factory import create_operational_store
+
+_SEARCH_ENGINE_NAMES: tuple[str, ...] = ("brave", "exa", "google_cse")
+_RETRY_BACKLOG_STATUSES: tuple[CandidateStatus, ...] = (
+    CandidateStatus.QUEUED,
+    CandidateStatus.SCRAPE_PENDING,
+    CandidateStatus.SCRAPE_FAILED,
+    CandidateStatus.PARTIALLY_SCRAPED,
+    CandidateStatus.UNSUPPORTED_SOURCE,
+)
+_STALE_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (
+    CandidateStatus.NEW,
+    CandidateStatus.QUEUED,
+    CandidateStatus.SCRAPE_PENDING,
+    CandidateStatus.SCRAPE_IN_PROGRESS,
+    CandidateStatus.SCRAPE_FAILED,
+    CandidateStatus.PARTIALLY_SCRAPED,
+    CandidateStatus.UNSUPPORTED_SOURCE,
+)
+
+
+class EngineOverlapMetrics(BaseModel):
+    """Overlap counts across source-native and search-engine discovery producers."""
+
+    source_native: int = 0
+    brave: int = 0
+    exa: int = 0
+    google_cse: int = 0
+    source_native_brave_shared: int = 0
+    source_native_exa_shared: int = 0
+    source_native_google_cse_shared: int = 0
+    brave_exa_shared: int = 0
+    brave_google_cse_shared: int = 0
+    exa_google_cse_shared: int = 0
+    shared_all_candidates: int = 0
+
+    def to_legacy_payload(self) -> dict[str, int]:
+        """Return the existing flat overlap artifact payload."""
+        return self.model_dump(mode="json")
+
+
+class SourceSearchCoverageMetrics(BaseModel):
+    """Coverage split between source-native and search-engine discovery."""
+
+    total_candidates: int = 0
+    source_native_candidates: int = 0
+    search_engine_candidates: int = 0
+    source_native_only_candidates: int = 0
+    search_engine_only_candidates: int = 0
+    shared_candidates: int = 0
+    source_native_share: float = 0.0
+    search_engine_share: float = 0.0
+    shared_share: float = 0.0
+
+
+class QueueHealthMetrics(BaseModel):
+    """Current queue state for durable discovery candidates."""
+
+    total_candidates: int = 0
+    new_candidates: int = 0
+    queued_candidates: int = 0
+    scrape_pending_candidates: int = 0
+    scrape_in_progress_candidates: int = 0
+    scrape_failed_candidates: int = 0
+    partially_scraped_candidates: int = 0
+    unsupported_source_candidates: int = 0
+    stale_candidates: int = 0
+    retry_backlog_candidates: int = 0
+
+
+class ProducerConversionMetrics(BaseModel):
+    """Conversion summary for one discovery producer."""
+
+    producer_name: str
+    candidate_count: int = 0
+    scrape_succeeded_candidates: int = 0
+    partially_scraped_candidates: int = 0
+    scrape_failed_candidates: int = 0
+    unsupported_source_candidates: int = 0
+    operational_record_matches: int = 0
+    scrape_success_rate: float = 0.0
+    operational_match_rate: float = 0.0
+
+
+class CandidateConversionMetrics(BaseModel):
+    """Downstream conversion summary for the candidate layer."""
+
+    total_candidates: int = 0
+    scrape_succeeded_candidates: int = 0
+    partially_scraped_candidates: int = 0
+    scrape_failed_candidates: int = 0
+    unsupported_source_candidates: int = 0
+    never_scraped_candidates: int = 0
+    operational_record_matches: int = 0
+    scrape_success_rate: float = 0.0
+    operational_match_rate: float = 0.0
+    per_producer: list[ProducerConversionMetrics] = Field(default_factory=list)
+
+
+class FailureSummary(BaseModel):
+    """Top scrape-failure grouping for diagnostics output."""
+
+    name: str
+    count: int
+
+
+class DiscoveryDiagnosticReport(BaseModel):
+    """Full discovery observability report."""
+
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    config_path: str
+    dataset_name: str
+    stale_after_days: int
+    latest_candidates_path: str
+    scrape_attempts_path: str
+    operational_records_available: bool
+    notes: list[str] = Field(default_factory=list)
+    engine_overlap: EngineOverlapMetrics = Field(default_factory=EngineOverlapMetrics)
+    source_search_coverage: SourceSearchCoverageMetrics = Field(
+        default_factory=SourceSearchCoverageMetrics
+    )
+    queue_health: QueueHealthMetrics = Field(default_factory=QueueHealthMetrics)
+    candidate_conversion: CandidateConversionMetrics = Field(
+        default_factory=CandidateConversionMetrics
+    )
+    top_failure_sources: list[FailureSummary] = Field(default_factory=list)
+    top_failure_domains: list[FailureSummary] = Field(default_factory=list)
+    top_failure_codes: list[FailureSummary] = Field(default_factory=list)
+
+
+def run_discovery_diagnostics(
+    *,
+    config_path: Path,
+    stale_after_days: int = 7,
+) -> DiscoveryDiagnosticReport:
+    """Build a discovery-layer diagnostics report from persisted state."""
+    config = load_config(config_path)
+    return build_discovery_diagnostic_report(
+        config=config,
+        config_path=config_path,
+        stale_after_days=stale_after_days,
+    )
+
+
+def build_discovery_diagnostic_report(
+    *,
+    config: Config,
+    config_path: Path | None = None,
+    stale_after_days: int = 7,
+    candidates_override: list[PersistentCandidate] | None = None,
+    attempts_override: list[ScrapeAttempt] | None = None,
+) -> DiscoveryDiagnosticReport:
+    """Build a discovery observability report for the current persisted state."""
+    paths = config.discovery_state_paths
+    candidates = (
+        candidates_override
+        if candidates_override is not None
+        else _read_jsonl(paths.latest_candidates_path, PersistentCandidate)
+    )
+    attempts = (
+        attempts_override
+        if attempts_override is not None
+        else _read_jsonl(paths.scrape_attempts_path, ScrapeAttempt)
+    )
+    now = datetime.now(UTC)
+    operational_urls, operational_notes = _load_operational_record_urls(config)
+    report = DiscoveryDiagnosticReport(
+        config_path=str(config_path) if config_path is not None else "<in-memory-config>",
+        dataset_name=config.dataset_name.value,
+        stale_after_days=stale_after_days,
+        latest_candidates_path=str(paths.latest_candidates_path),
+        scrape_attempts_path=str(paths.scrape_attempts_path),
+        operational_records_available=bool(operational_urls),
+        notes=operational_notes,
+        engine_overlap=_build_engine_overlap_metrics(candidates),
+        source_search_coverage=_build_source_search_coverage(candidates),
+        queue_health=_build_queue_health_metrics(
+            candidates, now=now, stale_after_days=stale_after_days
+        ),
+        candidate_conversion=_build_candidate_conversion_metrics(
+            candidates,
+            operational_urls=operational_urls,
+        ),
+        top_failure_sources=_build_failure_summaries(candidates, attempts, key="source"),
+        top_failure_domains=_build_failure_summaries(candidates, attempts, key="domain"),
+        top_failure_codes=_build_failure_summaries(candidates, attempts, key="error_code"),
+    )
+    if not candidates:
+        report.notes.append("No persisted discovery candidates were found.")
+    if not attempts:
+        report.notes.append("No persisted scrape attempts were found.")
+    if not operational_urls and config.operational.provider is not OperationalProvider.NONE:
+        report.notes.append(
+            "No operational records were available for candidate-to-news-item matching."
+        )
+    return report
+
+
+def persist_discovery_diagnostic_artifacts(
+    *,
+    config: Config,
+    report: DiscoveryDiagnosticReport,
+) -> None:
+    """Write the combined discovery diagnostics artifact set."""
+    paths = config.discovery_state_paths
+    write_metrics_snapshot(
+        paths.engine_overlap_latest_path,
+        report.engine_overlap.to_legacy_payload(),
+    )
+    write_metrics_snapshot(
+        paths.discovery_diagnostics_latest_path,
+        report.model_dump(mode="json"),
+    )
+
+
+def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str:
+    """Render a compact human-readable discovery diagnostics report."""
+    overlap = report.engine_overlap
+    coverage = report.source_search_coverage
+    queue = report.queue_health
+    conversion = report.candidate_conversion
+
+    lines = ["Discovery diagnostics"]
+    lines.append(f"dataset: {report.dataset_name}")
+    lines.append(f"generated_at: {report.generated_at.isoformat()}")
+    lines.append(f"candidates: {coverage.total_candidates}")
+    lines.append("")
+    lines.append("Overlap")
+    lines.append(
+        "  source_native={source_native} brave={brave} exa={exa} google_cse={google_cse}".format(
+            **overlap.model_dump(mode="json")
+        )
+    )
+    lines.append(
+        "  shared source/brave={source_native_brave_shared} "
+        "source/exa={source_native_exa_shared} "
+        "source/google={source_native_google_cse_shared}".format(**overlap.model_dump(mode="json"))
+    )
+    lines.append(
+        "  shared brave/exa={brave_exa_shared} brave/google={brave_google_cse_shared} "
+        "exa/google={exa_google_cse_shared} all={shared_all_candidates}".format(
+            **overlap.model_dump(mode="json")
+        )
+    )
+    lines.append("")
+    lines.append("Coverage")
+    lines.append(
+        "  source_native={source_native_candidates} search_engine={search_engine_candidates} "
+        "shared={shared_candidates}".format(**coverage.model_dump(mode="json"))
+    )
+    lines.append(
+        "  source_only={source_native_only_candidates} search_only={search_engine_only_candidates}"
+    )
+    lines.append("")
+    lines.append("Queue health")
+    lines.append(
+        "  new={new_candidates} queued={queued_candidates} pending={scrape_pending_candidates} "
+        "in_progress={scrape_in_progress_candidates}".format(**queue.model_dump(mode="json"))
+    )
+    lines.append(
+        "  failed={scrape_failed_candidates} partial={partially_scraped_candidates} "
+        "unsupported={unsupported_source_candidates} stale={stale_candidates} "
+        "retry_backlog={retry_backlog_candidates}".format(**queue.model_dump(mode="json"))
+    )
+    lines.append("")
+    lines.append("Conversion")
+    lines.append(
+        "  scrape_succeeded={scrape_succeeded_candidates} partial={partially_scraped_candidates} "
+        "failed={scrape_failed_candidates} unsupported={unsupported_source_candidates} "
+        "never_scraped={never_scraped_candidates}".format(**conversion.model_dump(mode="json"))
+    )
+    lines.append(
+        f"  scrape_success_rate={conversion.scrape_success_rate:.2%} "
+        f"operational_match_rate={conversion.operational_match_rate:.2%}"
+    )
+    if report.top_failure_sources:
+        lines.append("")
+        lines.append(
+            "Top failure sources: "
+            + ", ".join(f"{item.name}={item.count}" for item in report.top_failure_sources)
+        )
+    if report.top_failure_domains:
+        lines.append(
+            "Top failure domains: "
+            + ", ".join(f"{item.name}={item.count}" for item in report.top_failure_domains)
+        )
+    if report.top_failure_codes:
+        lines.append(
+            "Top failure codes: "
+            + ", ".join(f"{item.name}={item.count}" for item in report.top_failure_codes)
+        )
+    if report.notes:
+        lines.append("")
+        lines.append("Notes")
+        lines.extend(f"  - {note}" for note in report.notes)
+    return "\n".join(lines)
+
+
+def _read_jsonl(path: Path, model: type[PersistentCandidate] | type[ScrapeAttempt]) -> list[Any]:
+    if not path.exists():
+        return []
+    rows: list[Any] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(model.model_validate_json(line))
+    return rows
+
+
+def _is_search_engine_candidate(candidate: PersistentCandidate) -> bool:
+    return any(name in _SEARCH_ENGINE_NAMES for name in candidate.discovered_via)
+
+
+def _is_source_native_candidate(candidate: PersistentCandidate) -> bool:
+    return candidate.source_discovery_only or any(
+        name not in _SEARCH_ENGINE_NAMES for name in candidate.discovered_via
+    )
+
+
+def _build_engine_overlap_metrics(candidates: list[PersistentCandidate]) -> EngineOverlapMetrics:
+    source_native_ids = {
+        candidate.candidate_id for candidate in candidates if _is_source_native_candidate(candidate)
+    }
+    brave_ids = {
+        candidate.candidate_id for candidate in candidates if "brave" in candidate.discovered_via
+    }
+    exa_ids = {
+        candidate.candidate_id for candidate in candidates if "exa" in candidate.discovered_via
+    }
+    google_ids = {
+        candidate.candidate_id
+        for candidate in candidates
+        if "google_cse" in candidate.discovered_via
+    }
+    return EngineOverlapMetrics(
+        source_native=len(source_native_ids),
+        brave=len(brave_ids),
+        exa=len(exa_ids),
+        google_cse=len(google_ids),
+        source_native_brave_shared=len(source_native_ids & brave_ids),
+        source_native_exa_shared=len(source_native_ids & exa_ids),
+        source_native_google_cse_shared=len(source_native_ids & google_ids),
+        brave_exa_shared=len(brave_ids & exa_ids),
+        brave_google_cse_shared=len(brave_ids & google_ids),
+        exa_google_cse_shared=len(exa_ids & google_ids),
+        shared_all_candidates=len(source_native_ids & brave_ids & exa_ids & google_ids),
+    )
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def _build_source_search_coverage(
+    candidates: list[PersistentCandidate],
+) -> SourceSearchCoverageMetrics:
+    source_native = 0
+    search_engine = 0
+    source_only = 0
+    search_only = 0
+    shared = 0
+    for candidate in candidates:
+        has_source_native = _is_source_native_candidate(candidate)
+        has_search_engine = _is_search_engine_candidate(candidate)
+        if has_source_native:
+            source_native += 1
+        if has_search_engine:
+            search_engine += 1
+        if has_source_native and has_search_engine:
+            shared += 1
+        elif has_source_native:
+            source_only += 1
+        elif has_search_engine:
+            search_only += 1
+    total = len(candidates)
+    return SourceSearchCoverageMetrics(
+        total_candidates=total,
+        source_native_candidates=source_native,
+        search_engine_candidates=search_engine,
+        source_native_only_candidates=source_only,
+        search_engine_only_candidates=search_only,
+        shared_candidates=shared,
+        source_native_share=_safe_ratio(source_native, total),
+        search_engine_share=_safe_ratio(search_engine, total),
+        shared_share=_safe_ratio(shared, total),
+    )
+
+
+def _build_queue_health_metrics(
+    candidates: list[PersistentCandidate],
+    *,
+    now: datetime,
+    stale_after_days: int,
+) -> QueueHealthMetrics:
+    stale_cutoff = now - timedelta(days=stale_after_days)
+    retry_backlog = 0
+    stale = 0
+    for candidate in candidates:
+        if (
+            candidate.candidate_status in _RETRY_BACKLOG_STATUSES
+            and candidate.next_scrape_attempt_at is not None
+            and candidate.next_scrape_attempt_at <= now
+        ):
+            retry_backlog += 1
+        if (
+            candidate.candidate_status in _STALE_CANDIDATE_STATUSES
+            and candidate.last_seen_at <= stale_cutoff
+        ):
+            stale += 1
+    status_counts = Counter(candidate.candidate_status for candidate in candidates)
+    return QueueHealthMetrics(
+        total_candidates=len(candidates),
+        new_candidates=status_counts[CandidateStatus.NEW],
+        queued_candidates=status_counts[CandidateStatus.QUEUED],
+        scrape_pending_candidates=status_counts[CandidateStatus.SCRAPE_PENDING],
+        scrape_in_progress_candidates=status_counts[CandidateStatus.SCRAPE_IN_PROGRESS],
+        scrape_failed_candidates=status_counts[CandidateStatus.SCRAPE_FAILED],
+        partially_scraped_candidates=status_counts[CandidateStatus.PARTIALLY_SCRAPED],
+        unsupported_source_candidates=status_counts[CandidateStatus.UNSUPPORTED_SOURCE],
+        stale_candidates=stale,
+        retry_backlog_candidates=retry_backlog,
+    )
+
+
+def _candidate_identity_urls(candidate: PersistentCandidate) -> set[str]:
+    urls: set[str] = set()
+    urls.add(canonicalize_news_url(str(candidate.current_url)))
+    if candidate.canonical_url is not None:
+        urls.add(canonicalize_news_url(str(candidate.canonical_url)))
+    return urls
+
+
+def _load_operational_record_urls(config: Config) -> tuple[set[str], list[str]]:
+    notes: list[str] = []
+    try:
+        store = create_operational_store(config)
+    except Exception as exc:
+        return set(), [f"Operational store unavailable: {type(exc).__name__}: {exc}"]
+
+    try:
+        rows = store.fetch_records(config.dataset_name.value)
+    except Exception as exc:
+        notes.append(f"Operational record fetch failed: {type(exc).__name__}: {exc}")
+        return set(), notes
+    finally:
+        store.close()
+
+    urls = {
+        canonicalize_news_url(str(row["canonical_url"])) for row in rows if row.get("canonical_url")
+    }
+    return urls, notes
+
+
+def _build_candidate_conversion_metrics(
+    candidates: list[PersistentCandidate],
+    *,
+    operational_urls: set[str],
+) -> CandidateConversionMetrics:
+    total = len(candidates)
+    matched_candidate_ids = {
+        candidate.candidate_id
+        for candidate in candidates
+        if operational_urls and _candidate_identity_urls(candidate) & operational_urls
+    }
+    status_counts = Counter(candidate.candidate_status for candidate in candidates)
+    per_producer: list[ProducerConversionMetrics] = []
+    all_producers = sorted(
+        {producer_name for candidate in candidates for producer_name in candidate.discovered_via}
+    )
+    for producer_name in all_producers:
+        producer_candidates = [
+            candidate for candidate in candidates if producer_name in candidate.discovered_via
+        ]
+        producer_total = len(producer_candidates)
+        producer_status_counts = Counter(
+            candidate.candidate_status for candidate in producer_candidates
+        )
+        producer_matches = sum(
+            1
+            for candidate in producer_candidates
+            if candidate.candidate_id in matched_candidate_ids
+        )
+        per_producer.append(
+            ProducerConversionMetrics(
+                producer_name=producer_name,
+                candidate_count=producer_total,
+                scrape_succeeded_candidates=producer_status_counts[
+                    CandidateStatus.SCRAPE_SUCCEEDED
+                ],
+                partially_scraped_candidates=producer_status_counts[
+                    CandidateStatus.PARTIALLY_SCRAPED
+                ],
+                scrape_failed_candidates=producer_status_counts[CandidateStatus.SCRAPE_FAILED],
+                unsupported_source_candidates=producer_status_counts[
+                    CandidateStatus.UNSUPPORTED_SOURCE
+                ],
+                operational_record_matches=producer_matches,
+                scrape_success_rate=_safe_ratio(
+                    producer_status_counts[CandidateStatus.SCRAPE_SUCCEEDED],
+                    producer_total,
+                ),
+                operational_match_rate=_safe_ratio(producer_matches, producer_total),
+            )
+        )
+
+    return CandidateConversionMetrics(
+        total_candidates=total,
+        scrape_succeeded_candidates=status_counts[CandidateStatus.SCRAPE_SUCCEEDED],
+        partially_scraped_candidates=status_counts[CandidateStatus.PARTIALLY_SCRAPED],
+        scrape_failed_candidates=status_counts[CandidateStatus.SCRAPE_FAILED],
+        unsupported_source_candidates=status_counts[CandidateStatus.UNSUPPORTED_SOURCE],
+        never_scraped_candidates=(
+            status_counts[CandidateStatus.NEW]
+            + status_counts[CandidateStatus.QUEUED]
+            + status_counts[CandidateStatus.SCRAPE_PENDING]
+            + status_counts[CandidateStatus.SCRAPE_IN_PROGRESS]
+        ),
+        operational_record_matches=len(matched_candidate_ids),
+        scrape_success_rate=_safe_ratio(
+            status_counts[CandidateStatus.SCRAPE_SUCCEEDED],
+            total,
+        ),
+        operational_match_rate=_safe_ratio(len(matched_candidate_ids), total),
+        per_producer=per_producer,
+    )
+
+
+def _build_failure_summaries(
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+    *,
+    key: str,
+) -> list[FailureSummary]:
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    counts: Counter[str] = Counter()
+    for attempt in attempts:
+        if attempt.fetch_status.value == "success":
+            continue
+        candidate = candidate_by_id.get(attempt.candidate_id)
+        if key == "source":
+            value = attempt.source_adapter_name or "unknown"
+        elif key == "domain":
+            value = (
+                candidate.domain
+                if candidate is not None and candidate.domain is not None
+                else "unknown"
+            )
+        elif key == "error_code":
+            value = attempt.error_code or "unknown"
+        else:
+            raise ValueError(f"Unsupported failure summary key: {key}")
+        counts[value] += 1
+    return [FailureSummary(name=name, count=count) for name, count in counts.most_common(5)]

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -147,6 +147,7 @@ def run_discovery_diagnostics(
     *,
     config_path: Path,
     stale_after_days: int = 7,
+    include_operational_matches: bool = True,
 ) -> DiscoveryDiagnosticReport:
     """Build a discovery-layer diagnostics report from persisted state."""
     config = load_config(config_path)
@@ -154,6 +155,7 @@ def run_discovery_diagnostics(
         config=config,
         config_path=config_path,
         stale_after_days=stale_after_days,
+        include_operational_matches=include_operational_matches,
     )
 
 
@@ -164,6 +166,8 @@ def build_discovery_diagnostic_report(
     stale_after_days: int = 7,
     candidates_override: list[PersistentCandidate] | None = None,
     attempts_override: list[ScrapeAttempt] | None = None,
+    overlap_candidates_override: list[PersistentCandidate] | None = None,
+    include_operational_matches: bool = True,
 ) -> DiscoveryDiagnosticReport:
     """Build a discovery observability report for the current persisted state."""
     paths = config.discovery_state_paths
@@ -177,8 +181,16 @@ def build_discovery_diagnostic_report(
         if attempts_override is not None
         else _read_jsonl(paths.scrape_attempts_path, ScrapeAttempt)
     )
+    overlap_candidates = overlap_candidates_override or candidates
     now = datetime.now(UTC)
-    operational_urls, operational_notes = _load_operational_record_urls(config)
+    operational_urls: set[str] = set()
+    operational_notes: list[str] = []
+    if include_operational_matches:
+        operational_urls, operational_notes = _load_operational_record_urls(config)
+    elif config.operational.provider is not OperationalProvider.NONE:
+        operational_notes.append(
+            "Operational record matching was skipped for this diagnostics artifact."
+        )
     report = DiscoveryDiagnosticReport(
         config_path=str(config_path) if config_path is not None else "<in-memory-config>",
         dataset_name=config.dataset_name.value,
@@ -187,7 +199,7 @@ def build_discovery_diagnostic_report(
         scrape_attempts_path=str(paths.scrape_attempts_path),
         operational_records_available=bool(operational_urls),
         notes=operational_notes,
-        engine_overlap=_build_engine_overlap_metrics(candidates),
+        engine_overlap=_build_engine_overlap_metrics(overlap_candidates),
         source_search_coverage=_build_source_search_coverage(candidates),
         queue_health=_build_queue_health_metrics(
             candidates, now=now, stale_after_days=stale_after_days

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -10,7 +10,12 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from denbust.config import Config, OperationalProvider, load_config
-from denbust.discovery.models import CandidateStatus, PersistentCandidate, ScrapeAttempt
+from denbust.discovery.models import (
+    CandidateStatus,
+    FetchStatus,
+    PersistentCandidate,
+    ScrapeAttempt,
+)
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
@@ -181,7 +186,11 @@ def build_discovery_diagnostic_report(
         if attempts_override is not None
         else _read_jsonl(paths.scrape_attempts_path, ScrapeAttempt)
     )
-    overlap_candidates = overlap_candidates_override or candidates
+    overlap_candidates = (
+        overlap_candidates_override
+        if overlap_candidates_override is not None
+        else candidates
+    )
     now = datetime.now(UTC)
     operational_urls: set[str] = set()
     operational_notes: list[str] = []
@@ -216,7 +225,11 @@ def build_discovery_diagnostic_report(
         report.notes.append("No persisted discovery candidates were found.")
     if not attempts:
         report.notes.append("No persisted scrape attempts were found.")
-    if not operational_urls and config.operational.provider is not OperationalProvider.NONE:
+    if (
+        include_operational_matches
+        and not operational_urls
+        and config.operational.provider is not OperationalProvider.NONE
+    ):
         report.notes.append(
             "No operational records were available for candidate-to-news-item matching."
         )
@@ -563,7 +576,7 @@ def _build_failure_summaries(
     candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
     counts: Counter[str] = Counter()
     for attempt in attempts:
-        if attempt.fetch_status.value == "success":
+        if attempt.fetch_status is FetchStatus.SUCCESS:
             continue
         candidate = candidate_by_id.get(attempt.candidate_id)
         if key == "source":

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -187,9 +187,7 @@ def build_discovery_diagnostic_report(
         else _read_jsonl(paths.scrape_attempts_path, ScrapeAttempt)
     )
     overlap_candidates = (
-        overlap_candidates_override
-        if overlap_candidates_override is not None
-        else candidates
+        overlap_candidates_override if overlap_candidates_override is not None else candidates
     )
     now = datetime.now(UTC)
     operational_urls: set[str] = set()

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -27,7 +27,10 @@ class DiscoveryStatePaths(BaseModel):
     latest_candidates_path: Path
     retry_queue_path: Path
     backfill_queue_path: Path
+    candidate_provenance_path: Path
+    scrape_attempts_path: Path
     engine_overlap_latest_path: Path
+    discovery_diagnostics_latest_path: Path
 
 
 def resolve_discovery_state_paths(
@@ -52,7 +55,10 @@ def resolve_discovery_state_paths(
         latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
         retry_queue_path=candidates_dir / "retry_queue.jsonl",
         backfill_queue_path=candidates_dir / "backfill_queue.jsonl",
+        candidate_provenance_path=candidates_dir / "candidate_provenance.jsonl",
+        scrape_attempts_path=candidates_dir / "scrape_attempts.jsonl",
         engine_overlap_latest_path=metrics_dir / "engine_overlap_latest.json",
+        discovery_diagnostics_latest_path=metrics_dir / "discovery_diagnostics_latest.json",
     )
 
 

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -109,11 +109,11 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
 
     @property
     def provenance_path(self) -> Path:
-        return self.paths.candidates_dir / "candidate_provenance.jsonl"
+        return self.paths.candidate_provenance_path
 
     @property
     def attempts_path(self) -> Path:
-        return self.paths.candidates_dir / "scrape_attempts.jsonl"
+        return self.paths.scrape_attempts_path
 
     def write_run(self, run: DiscoveryRun) -> None:
         write_discovery_run_snapshot(

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -218,14 +218,26 @@ def _write_discovery_diagnostic_artifacts(
     config: Config,
     *,
     config_path: Path | None,
-    candidates: list[PersistentCandidate],
+    overlap_candidates: list[PersistentCandidate],
 ) -> None:
     """Persist the latest discovery diagnostics and overlap artifacts."""
-    report = build_discovery_diagnostic_report(
-        config=config,
-        config_path=config_path,
-        candidates_override=candidates,
-    )
+    persisted_candidates_available = config.discovery_state_paths.latest_candidates_path.exists()
+    persisted_attempts_available = config.discovery_state_paths.scrape_attempts_path.exists()
+    if persisted_candidates_available or persisted_attempts_available:
+        report = build_discovery_diagnostic_report(
+            config=config,
+            config_path=config_path,
+            overlap_candidates_override=overlap_candidates,
+            include_operational_matches=False,
+        )
+    else:
+        report = build_discovery_diagnostic_report(
+            config=config,
+            config_path=config_path,
+            candidates_override=overlap_candidates,
+            overlap_candidates_override=overlap_candidates,
+            include_operational_matches=False,
+        )
     persist_discovery_diagnostic_artifacts(config=config, report=report)
 
 
@@ -1256,6 +1268,7 @@ async def run_news_discover_job(
 
     merged_candidate_ids: set[str] = set()
     merged_candidates_by_id: dict[str, PersistentCandidate] = {}
+    overlap_producers_by_candidate_id: dict[str, list[str]] = {}
     failed_runs = 0
     for producer_name, persisted in persisted_runs:
         result.raw_article_count += persisted.run.candidate_count
@@ -1263,11 +1276,18 @@ async def run_news_discover_job(
         merged_candidate_ids.update(candidate.candidate_id for candidate in persisted.candidates)
         for candidate in persisted.candidates:
             existing_candidate = merged_candidates_by_id.get(candidate.candidate_id)
+            overlap_producers_by_candidate_id[candidate.candidate_id] = deduplicate_strings(
+                [
+                    *overlap_producers_by_candidate_id.get(candidate.candidate_id, []),
+                    producer_name,
+                ]
+            )
             merged_candidates_by_id[candidate.candidate_id] = candidate.model_copy(
                 update={
                     "discovered_via": deduplicate_strings(
                         [
                             *(existing_candidate.discovered_via if existing_candidate else []),
+                            *candidate.discovered_via,
                             producer_name,
                         ]
                     )
@@ -1285,10 +1305,20 @@ async def run_news_discover_job(
         if persisted.run.status is DiscoveryRunStatus.FAILED:
             failed_runs += 1
 
+    overlap_candidates = [
+        candidate.model_copy(
+            update={
+                "discovered_via": overlap_producers_by_candidate_id[candidate_id],
+                "source_discovery_only": overlap_producers_by_candidate_id[candidate_id]
+                == ["source_native"],
+            }
+        )
+        for candidate_id, candidate in merged_candidates_by_id.items()
+    ]
     _write_discovery_diagnostic_artifacts(
         config,
         config_path=config_path,
-        candidates=list(merged_candidates_by_id.values()),
+        overlap_candidates=overlap_candidates,
     )
     result.unified_item_count = len(merged_candidate_ids)
 

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -16,7 +16,7 @@ from denbust.data_models import ClassifiedArticle, RawArticle, UnifiedItem
 from denbust.datasets.jobs import ensure_default_jobs_registered
 from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
-from denbust.diagnostics import (
+from denbust.diagnostics.discovery import (
     build_discovery_diagnostic_report,
     persist_discovery_diagnostic_artifacts,
 )

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -16,6 +16,10 @@ from denbust.data_models import ClassifiedArticle, RawArticle, UnifiedItem
 from denbust.datasets.jobs import ensure_default_jobs_registered
 from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
+from denbust.diagnostics import (
+    build_discovery_diagnostic_report,
+    persist_discovery_diagnostic_artifacts,
+)
 from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.engines.exa import ExaSearchEngine
@@ -33,7 +37,6 @@ from denbust.discovery.source_native import (
     persist_discovered_candidates,
     raw_article_to_discovered_candidate,
 )
-from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.discovery.storage import create_discovery_persistence
 from denbust.models.common import DatasetName, JobName
 from denbust.models.runs import RunSnapshot
@@ -48,7 +51,7 @@ from denbust.news_items.ingest import (
     parse_suppression_rules,
     summarize_privacy_mix,
 )
-from denbust.news_items.normalize import canonicalize_news_url
+from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
 from denbust.news_items.publication import publish_release_bundle
 from denbust.news_items.release import (
     NewsItemsReleaseBuilder,
@@ -211,38 +214,19 @@ def _group_articles_by_source(articles: list[RawArticle]) -> dict[str, list[RawA
     return dict(grouped)
 
 
-def _write_discovery_engine_metrics(
+def _write_discovery_diagnostic_artifacts(
     config: Config,
     *,
-    source_native_candidate_ids: set[str],
-    brave_candidate_ids: set[str],
-    exa_candidate_ids: set[str],
-    google_cse_candidate_ids: set[str],
+    config_path: Path | None,
+    candidates: list[PersistentCandidate],
 ) -> None:
-    """Persist a lightweight engine overlap metrics snapshot."""
-    write_metrics_snapshot(
-        config.discovery_state_paths.engine_overlap_latest_path,
-        {
-            "source_native": len(source_native_candidate_ids),
-            "brave": len(brave_candidate_ids),
-            "exa": len(exa_candidate_ids),
-            "google_cse": len(google_cse_candidate_ids),
-            "source_native_brave_shared": len(source_native_candidate_ids & brave_candidate_ids),
-            "source_native_exa_shared": len(source_native_candidate_ids & exa_candidate_ids),
-            "source_native_google_cse_shared": len(
-                source_native_candidate_ids & google_cse_candidate_ids
-            ),
-            "brave_exa_shared": len(brave_candidate_ids & exa_candidate_ids),
-            "brave_google_cse_shared": len(brave_candidate_ids & google_cse_candidate_ids),
-            "exa_google_cse_shared": len(exa_candidate_ids & google_cse_candidate_ids),
-            "shared_all_candidates": len(
-                source_native_candidate_ids
-                & brave_candidate_ids
-                & exa_candidate_ids
-                & google_cse_candidate_ids
-            ),
-        },
+    """Persist the latest discovery diagnostics and overlap artifacts."""
+    report = build_discovery_diagnostic_report(
+        config=config,
+        config_path=config_path,
+        candidates_override=candidates,
     )
+    persist_discovery_diagnostic_artifacts(config=config, report=report)
 
 
 async def _persist_source_native_candidates(
@@ -1270,50 +1254,41 @@ async def run_news_discover_job(
             )
         )
 
-    source_native_candidate_ids: set[str] = set()
-    brave_candidate_ids: set[str] = set()
-    exa_candidate_ids: set[str] = set()
-    google_cse_candidate_ids: set[str] = set()
     merged_candidate_ids: set[str] = set()
+    merged_candidates_by_id: dict[str, PersistentCandidate] = {}
     failed_runs = 0
     for producer_name, persisted in persisted_runs:
         result.raw_article_count += persisted.run.candidate_count
         result.unseen_article_count += persisted.run.candidate_count
         merged_candidate_ids.update(candidate.candidate_id for candidate in persisted.candidates)
+        for candidate in persisted.candidates:
+            existing_candidate = merged_candidates_by_id.get(candidate.candidate_id)
+            merged_candidates_by_id[candidate.candidate_id] = candidate.model_copy(
+                update={
+                    "discovered_via": deduplicate_strings(
+                        [
+                            *(existing_candidate.discovered_via if existing_candidate else []),
+                            producer_name,
+                        ]
+                    )
+                }
+            )
         result.errors.extend(persisted.run.errors)
-        if producer_name == "source_native":
-            source_native_candidate_ids = {
-                candidate.candidate_id for candidate in persisted.candidates
-            }
-            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
-                result.warnings.append(
-                    "source-native discovery completed with partial source failures"
-                )
-        if producer_name == "brave":
-            brave_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
-            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
-                result.warnings.append("brave discovery completed with partial engine failures")
-        if producer_name == "exa":
-            exa_candidate_ids = {candidate.candidate_id for candidate in persisted.candidates}
-            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
-                result.warnings.append("exa discovery completed with partial engine failures")
-        if producer_name == "google_cse":
-            google_cse_candidate_ids = {
-                candidate.candidate_id for candidate in persisted.candidates
-            }
-            if persisted.run.status is DiscoveryRunStatus.PARTIAL:
-                result.warnings.append(
-                    "google_cse discovery completed with partial engine failures"
-                )
+        if producer_name == "source_native" and persisted.run.status is DiscoveryRunStatus.PARTIAL:
+            result.warnings.append("source-native discovery completed with partial source failures")
+        if producer_name == "brave" and persisted.run.status is DiscoveryRunStatus.PARTIAL:
+            result.warnings.append("brave discovery completed with partial engine failures")
+        if producer_name == "exa" and persisted.run.status is DiscoveryRunStatus.PARTIAL:
+            result.warnings.append("exa discovery completed with partial engine failures")
+        if producer_name == "google_cse" and persisted.run.status is DiscoveryRunStatus.PARTIAL:
+            result.warnings.append("google_cse discovery completed with partial engine failures")
         if persisted.run.status is DiscoveryRunStatus.FAILED:
             failed_runs += 1
 
-    _write_discovery_engine_metrics(
+    _write_discovery_diagnostic_artifacts(
         config,
-        source_native_candidate_ids=source_native_candidate_ids,
-        brave_candidate_ids=brave_candidate_ids,
-        exa_candidate_ids=exa_candidate_ids,
-        google_cse_candidate_ids=google_cse_candidate_ids,
+        config_path=config_path,
+        candidates=list(merged_candidates_by_id.values()),
     )
     result.unified_item_count = len(merged_candidate_ids)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -642,6 +642,38 @@ class TestCli:
         assert payload["dataset_name"] == "news_items"
         assert payload["stale_after_days"] == 7
 
+    def test_diagnose_discovery_writes_output_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """diagnose-discovery should persist JSON output when --output is provided."""
+        report = DiscoveryDiagnosticReport(
+            config_path="agents/news/local.yaml",
+            dataset_name="news_items",
+            stale_after_days=7,
+            latest_candidates_path="candidates.jsonl",
+            scrape_attempts_path="attempts.jsonl",
+            operational_records_available=False,
+        )
+        output_path = tmp_path / "diagnostics.json"
+
+        monkeypatch.setattr(
+            "denbust.diagnostics.run_discovery_diagnostics",
+            lambda **_kwargs: report,
+        )
+        monkeypatch.setattr(
+            "denbust.diagnostics.render_discovery_diagnostic_report",
+            lambda report: f"rendered:{report.dataset_name}",
+        )
+
+        result = runner.invoke(
+            app,
+            ["diagnose-discovery", "--output", str(output_path)],
+        )
+
+        assert result.exit_code == 0
+        assert "rendered:news_items" in result.stdout
+        assert json.loads(output_path.read_text(encoding="utf-8"))["dataset_name"] == "news_items"
+
     def test_validation_evaluate_uses_default_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """validation-evaluate should default to the tracked assets."""
         captured: dict[str, object] = {}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,7 @@ import typer
 from typer.testing import CliRunner
 
 from denbust.cli import app
-from denbust.diagnostics import source_health
+from denbust.diagnostics import DiscoveryDiagnosticReport, source_health
 from denbust.models.common import DatasetName, JobName
 
 runner = CliRunner()
@@ -571,6 +571,76 @@ class TestCli:
 
         assert result.exit_code != 0
         assert "Unknown or disabled sources: ghost" in result.stderr
+
+    def test_diagnose_discovery_forwards_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """diagnose-discovery should forward its config and stale-days flags."""
+        captured: dict[str, object] = {}
+
+        def fake_run_discovery_diagnostics(
+            *,
+            config_path: Path,
+            stale_after_days: int = 7,
+        ) -> DiscoveryDiagnosticReport:
+            captured["config_path"] = config_path
+            captured["stale_after_days"] = stale_after_days
+            return DiscoveryDiagnosticReport(
+                config_path=str(config_path),
+                dataset_name="news_items",
+                stale_after_days=stale_after_days,
+                latest_candidates_path="candidates.jsonl",
+                scrape_attempts_path="attempts.jsonl",
+                operational_records_available=False,
+            )
+
+        monkeypatch.setattr(
+            "denbust.diagnostics.run_discovery_diagnostics",
+            fake_run_discovery_diagnostics,
+        )
+        monkeypatch.setattr(
+            "denbust.diagnostics.render_discovery_diagnostic_report",
+            lambda report: f"rendered:{report.dataset_name}",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "diagnose-discovery",
+                "--config",
+                "agents/custom.yaml",
+                "--stale-days",
+                "11",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured == {
+            "config_path": Path("agents/custom.yaml"),
+            "stale_after_days": 11,
+        }
+        assert "rendered:news_items" in result.stdout
+
+    def test_diagnose_discovery_json_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """diagnose-discovery should emit machine-readable JSON when requested."""
+        report = DiscoveryDiagnosticReport(
+            config_path="agents/news/local.yaml",
+            dataset_name="news_items",
+            stale_after_days=7,
+            latest_candidates_path="candidates.jsonl",
+            scrape_attempts_path="attempts.jsonl",
+            operational_records_available=False,
+        )
+
+        monkeypatch.setattr(
+            "denbust.diagnostics.run_discovery_diagnostics",
+            lambda **_kwargs: report,
+        )
+
+        result = runner.invoke(app, ["diagnose-discovery", "--format", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["dataset_name"] == "news_items"
+        assert payload["stale_after_days"] == 7
 
     def test_validation_evaluate_uses_default_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """validation-evaluate should default to the tracked assets."""

--- a/tests/unit/test_diagnostics_module.py
+++ b/tests/unit/test_diagnostics_module.py
@@ -1,0 +1,21 @@
+"""Tests for lazy diagnostics package exports."""
+
+from __future__ import annotations
+
+import pytest
+
+import denbust.diagnostics as diagnostics
+
+
+def test_diagnostics_module_rejects_unknown_exports() -> None:
+    """Unknown lazy exports should raise AttributeError."""
+    with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+        diagnostics.__getattr__("does_not_exist")
+
+
+def test_diagnostics_module_dir_lists_lazy_exports() -> None:
+    """dir() should expose the lazily available diagnostics names."""
+    names = diagnostics.__dir__()
+
+    assert "run_discovery_diagnostics" in names
+    assert "source_health" in names

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -1,0 +1,181 @@
+"""Unit tests for discovery-layer diagnostics reporting."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pydantic import HttpUrl
+
+from denbust.config import Config, OperationalProvider
+from denbust.diagnostics.discovery import (
+    build_discovery_diagnostic_report,
+    persist_discovery_diagnostic_artifacts,
+    render_discovery_diagnostic_report,
+)
+from denbust.discovery.models import (
+    CandidateStatus,
+    FetchStatus,
+    PersistentCandidate,
+    ScrapeAttempt,
+    ScrapeAttemptKind,
+)
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName
+from denbust.ops.storage import LocalJsonOperationalStore
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    url: str,
+    discovered_via: list[str],
+    status: CandidateStatus,
+    first_seen_at: datetime,
+    last_seen_at: datetime,
+    next_scrape_attempt_at: datetime | None = None,
+) -> PersistentCandidate:
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        current_url=HttpUrl(url),
+        canonical_url=HttpUrl(url),
+        discovered_via=discovered_via,
+        source_hints=discovered_via,
+        titles=[candidate_id],
+        snippets=[candidate_id],
+        candidate_status=status,
+        first_seen_at=first_seen_at,
+        last_seen_at=last_seen_at,
+        next_scrape_attempt_at=next_scrape_attempt_at,
+    )
+
+
+def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> None:
+    """The report should summarize overlap, queue health, failures, and conversion."""
+    now = datetime.now(UTC)
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    persistence.upsert_candidates(
+        [
+            _candidate(
+                "candidate-shared",
+                url="https://www.ynet.co.il/news/article/shared",
+                discovered_via=["ynet", "brave", "exa", "google_cse"],
+                status=CandidateStatus.SCRAPE_SUCCEEDED,
+                first_seen_at=now - timedelta(days=2),
+                last_seen_at=now - timedelta(hours=2),
+            ),
+            _candidate(
+                "candidate-source-only",
+                url="https://www.walla.co.il/news/article/source-only",
+                discovered_via=["walla"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=10),
+                last_seen_at=now - timedelta(days=8),
+            ),
+            _candidate(
+                "candidate-brave-failed",
+                url="https://www.mako.co.il/news/article/brave-failed",
+                discovered_via=["brave"],
+                status=CandidateStatus.SCRAPE_FAILED,
+                first_seen_at=now - timedelta(days=3),
+                last_seen_at=now - timedelta(days=2),
+                next_scrape_attempt_at=now - timedelta(hours=1),
+            ),
+            _candidate(
+                "candidate-google-partial",
+                url="https://www.maariv.co.il/news/article/google-partial",
+                discovered_via=["google_cse"],
+                status=CandidateStatus.PARTIALLY_SCRAPED,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(hours=3),
+                next_scrape_attempt_at=now + timedelta(hours=12),
+            ),
+        ]
+    )
+    persistence.append_attempts(
+        [
+            ScrapeAttempt(
+                candidate_id="candidate-brave-failed",
+                started_at=now - timedelta(hours=2),
+                finished_at=now - timedelta(hours=2),
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.FAILED,
+                source_adapter_name="mako",
+                error_code="candidate_not_found",
+                error_message="mako adapter did not return the candidate URL",
+            ),
+            ScrapeAttempt(
+                candidate_id="candidate-google-partial",
+                started_at=now - timedelta(hours=1),
+                finished_at=now - timedelta(hours=1),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.UNSUPPORTED,
+                error_code="generic_fetch_not_implemented",
+                error_message="generic fetch fallback not implemented yet",
+            ),
+        ]
+    )
+    store = LocalJsonOperationalStore(tmp_path / "operational")
+    store.upsert_records(
+        DatasetName.NEWS_ITEMS.value,
+        [
+            {
+                "id": "news-item-1",
+                "canonical_url": "https://www.ynet.co.il/news/article/shared",
+                "publication_datetime": now.isoformat(),
+            }
+        ],
+    )
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        config_path=Path("agents/news/local.yaml"),
+        stale_after_days=7,
+    )
+
+    assert report.engine_overlap.source_native == 2
+    assert report.engine_overlap.brave == 2
+    assert report.engine_overlap.exa == 1
+    assert report.engine_overlap.google_cse == 2
+    assert report.engine_overlap.source_native_brave_shared == 1
+    assert report.source_search_coverage.total_candidates == 4
+    assert report.source_search_coverage.source_native_only_candidates == 1
+    assert report.source_search_coverage.search_engine_only_candidates == 2
+    assert report.source_search_coverage.shared_candidates == 1
+    assert report.queue_health.new_candidates == 1
+    assert report.queue_health.scrape_failed_candidates == 1
+    assert report.queue_health.partially_scraped_candidates == 1
+    assert report.queue_health.stale_candidates == 1
+    assert report.queue_health.retry_backlog_candidates == 1
+    assert report.candidate_conversion.scrape_succeeded_candidates == 1
+    assert report.candidate_conversion.operational_record_matches == 1
+    assert report.candidate_conversion.per_producer[0].candidate_count >= 1
+    assert report.top_failure_sources[0].name == "mako"
+    assert report.top_failure_domains[0].name in {"www.mako.co.il", "www.maariv.co.il"}
+    assert "Overlap" in render_discovery_diagnostic_report(report)
+
+
+def test_persist_discovery_diagnostic_artifacts_writes_latest_files(tmp_path: Path) -> None:
+    """The diagnostics artifact writer should persist both JSON reports."""
+    config = Config(store={"state_root": tmp_path})
+    report = build_discovery_diagnostic_report(config=config, stale_after_days=7)
+
+    persist_discovery_diagnostic_artifacts(config=config, report=report)
+
+    overlap_payload = json.loads(
+        config.discovery_state_paths.engine_overlap_latest_path.read_text(encoding="utf-8")
+    )
+    combined_payload = json.loads(
+        config.discovery_state_paths.discovery_diagnostics_latest_path.read_text(encoding="utf-8")
+    )
+
+    assert overlap_payload["source_native"] == 0
+    assert combined_payload["dataset_name"] == "news_items"

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -6,13 +6,19 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from pydantic import HttpUrl
 
 from denbust.config import Config, OperationalProvider
 from denbust.diagnostics.discovery import (
+    DiscoveryDiagnosticReport,
+    _build_failure_summaries,
+    _load_operational_record_urls,
+    _read_jsonl,
     build_discovery_diagnostic_report,
     persist_discovery_diagnostic_artifacts,
     render_discovery_diagnostic_report,
+    run_discovery_diagnostics,
 )
 from denbust.discovery.models import (
     CandidateStatus,
@@ -179,3 +185,178 @@ def test_persist_discovery_diagnostic_artifacts_writes_latest_files(tmp_path: Pa
 
     assert overlap_payload["source_native"] == 0
     assert combined_payload["dataset_name"] == "news_items"
+
+
+def test_run_discovery_diagnostics_loads_config_and_forwards_flags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CLI-facing wrapper should load config and forward optional flags."""
+    config = Config(store={"state_root": tmp_path})
+    captured: dict[str, object] = {}
+
+    def fake_build_discovery_diagnostic_report(**kwargs: object) -> DiscoveryDiagnosticReport:
+        captured.update(kwargs)
+        return DiscoveryDiagnosticReport(
+            config_path=str(tmp_path / "agents/news/local.yaml"),
+            dataset_name="news_items",
+            stale_after_days=11,
+            latest_candidates_path="candidates.jsonl",
+            scrape_attempts_path="attempts.jsonl",
+            operational_records_available=False,
+        )
+
+    monkeypatch.setattr("denbust.diagnostics.discovery.load_config", lambda _path: config)
+    monkeypatch.setattr(
+        "denbust.diagnostics.discovery.build_discovery_diagnostic_report",
+        fake_build_discovery_diagnostic_report,
+    )
+
+    report = run_discovery_diagnostics(
+        config_path=tmp_path / "agents/news/local.yaml",
+        stale_after_days=11,
+        include_operational_matches=False,
+    )
+
+    assert report.stale_after_days == 11
+    assert captured["config"] == config
+    assert captured["config_path"] == tmp_path / "agents/news/local.yaml"
+    assert captured["stale_after_days"] == 11
+    assert captured["include_operational_matches"] is False
+
+
+def test_build_discovery_diagnostic_report_notes_when_operational_records_missing(
+    tmp_path: Path,
+) -> None:
+    """Operational providers with no matching records should emit a note."""
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+
+    assert (
+        "No operational records were available for candidate-to-news-item matching."
+        in report.notes
+    )
+
+
+def test_render_discovery_diagnostic_report_includes_notes(tmp_path: Path) -> None:
+    """Rendered reports should include notes when present."""
+    config = Config(store={"state_root": tmp_path})
+    report = build_discovery_diagnostic_report(config=config)
+    report.notes.append("Operational record matching was skipped for this diagnostics artifact.")
+
+    rendered = render_discovery_diagnostic_report(report)
+
+    assert "Notes" in rendered
+    assert "Operational record matching was skipped" in rendered
+
+
+def test_read_jsonl_ignores_blank_lines(tmp_path: Path) -> None:
+    """Blank lines in JSONL files should be skipped."""
+    path = tmp_path / "latest_candidates.jsonl"
+    candidate = _candidate(
+        "candidate-1",
+        url="https://www.ynet.co.il/news/article/1",
+        discovered_via=["ynet"],
+        status=CandidateStatus.NEW,
+        first_seen_at=datetime.now(UTC),
+        last_seen_at=datetime.now(UTC),
+    )
+    path.write_text(f"{candidate.model_dump_json()}\n\n", encoding="utf-8")
+
+    rows = _read_jsonl(path, PersistentCandidate)
+
+    assert [row.candidate_id for row in rows] == ["candidate-1"]
+
+
+def test_load_operational_record_urls_handles_store_creation_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Store-construction failures should become diagnostic notes."""
+    config = Config(store={"state_root": tmp_path})
+    monkeypatch.setattr(
+        "denbust.diagnostics.discovery.create_operational_store",
+        lambda _config: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    urls, notes = _load_operational_record_urls(config)
+
+    assert urls == set()
+    assert notes == ["Operational store unavailable: RuntimeError: boom"]
+
+
+def test_load_operational_record_urls_handles_fetch_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fetch failures should become notes and still close the store."""
+
+    class FakeStore:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def fetch_records(self, dataset_name: str, *, limit: int | None = None) -> list[dict[str, object]]:
+            del dataset_name, limit
+            raise RuntimeError("fetch failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    store = FakeStore()
+    config = Config(store={"state_root": tmp_path})
+    monkeypatch.setattr(
+        "denbust.diagnostics.discovery.create_operational_store",
+        lambda _config: store,
+    )
+
+    urls, notes = _load_operational_record_urls(config)
+
+    assert urls == set()
+    assert notes == ["Operational record fetch failed: RuntimeError: fetch failed"]
+    assert store.closed is True
+
+
+def test_build_failure_summaries_ignores_success_attempts_and_rejects_unknown_keys() -> None:
+    """Only failed attempts should contribute to summaries, and keys must be supported."""
+    now = datetime.now(UTC)
+    candidates = [
+        _candidate(
+            "candidate-1",
+            url="https://www.mako.co.il/news/article/1",
+            discovered_via=["brave"],
+            status=CandidateStatus.SCRAPE_FAILED,
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+    ]
+    attempts = [
+        ScrapeAttempt(
+            candidate_id="candidate-1",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.SUCCESS,
+            source_adapter_name="mako",
+        ),
+        ScrapeAttempt(
+            candidate_id="candidate-1",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.FAILED,
+            source_adapter_name="mako",
+            error_code="candidate_not_found",
+        ),
+    ]
+
+    summaries = _build_failure_summaries(candidates, attempts, key="source")
+
+    assert summaries == [summaries[0]]
+    assert summaries[0].name == "mako"
+    assert summaries[0].count == 1
+    with pytest.raises(ValueError, match="Unsupported failure summary key: nope"):
+        _build_failure_summaries(candidates, attempts, key="nope")

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -239,8 +239,7 @@ def test_build_discovery_diagnostic_report_notes_when_operational_records_missin
     report = build_discovery_diagnostic_report(config=config)
 
     assert (
-        "No operational records were available for candidate-to-news-item matching."
-        in report.notes
+        "No operational records were available for candidate-to-news-item matching." in report.notes
     )
 
 
@@ -299,7 +298,9 @@ def test_load_operational_record_urls_handles_fetch_failure(
         def __init__(self) -> None:
             self.closed = False
 
-        def fetch_records(self, dataset_name: str, *, limit: int | None = None) -> list[dict[str, object]]:
+        def fetch_records(
+            self, dataset_name: str, *, limit: int | None = None
+        ) -> list[dict[str, object]]:
             del dataset_name, limit
             raise RuntimeError("fetch failed")
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -243,6 +243,59 @@ def test_build_discovery_diagnostic_report_notes_when_operational_records_missin
     )
 
 
+def test_build_discovery_diagnostic_report_respects_empty_overlap_override(
+    tmp_path: Path,
+) -> None:
+    """An explicit empty overlap override should not fall back to durable candidates."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    StateRepoDiscoveryPersistence(config.discovery_state_paths).upsert_candidates(
+        [
+            _candidate(
+                "candidate-1",
+                url="https://www.ynet.co.il/news/article/1",
+                discovered_via=["ynet", "brave"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now,
+                last_seen_at=now,
+            )
+        ]
+    )
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        overlap_candidates_override=[],
+    )
+
+    assert report.engine_overlap.source_native == 0
+    assert report.engine_overlap.brave == 0
+    assert report.source_search_coverage.total_candidates == 1
+
+
+def test_build_discovery_diagnostic_report_skipped_operational_matching_omits_missing_note(
+    tmp_path: Path,
+) -> None:
+    """Skip-mode should not also claim that no operational records were available."""
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        include_operational_matches=False,
+    )
+
+    assert "Operational record matching was skipped for this diagnostics artifact." in report.notes
+    assert (
+        "No operational records were available for candidate-to-news-item matching."
+        not in report.notes
+    )
+
+
 def test_render_discovery_diagnostic_report_includes_notes(tmp_path: Path) -> None:
     """Rendered reports should include notes when present."""
     config = Config(store={"state_root": tmp_path})

--- a/tests/unit/test_discovery_state_paths.py
+++ b/tests/unit/test_discovery_state_paths.py
@@ -27,8 +27,14 @@ def test_resolve_discovery_state_paths_uses_discover_namespace() -> None:
     assert paths.latest_candidates_path == Path(
         "state_repo/news_items/discover/candidates/latest_candidates.jsonl"
     )
+    assert paths.scrape_attempts_path == Path(
+        "state_repo/news_items/discover/candidates/scrape_attempts.jsonl"
+    )
     assert paths.engine_overlap_latest_path == Path(
         "state_repo/news_items/discover/metrics/engine_overlap_latest.json"
+    )
+    assert paths.discovery_diagnostics_latest_path == Path(
+        "state_repo/news_items/discover/metrics/discovery_diagnostics_latest.json"
     )
 
 

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2394,7 +2394,8 @@ class TestRunPipelineAsync:
             ).read_text(encoding="utf-8")
         )
         per_producer = {
-            entry["producer_name"]: entry for entry in diagnostics_payload["candidate_conversion"]["per_producer"]
+            entry["producer_name"]: entry
+            for entry in diagnostics_payload["candidate_conversion"]["per_producer"]
         }
 
         assert metrics_payload["exa"] == 0

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -30,6 +31,7 @@ from denbust.discovery.models import (
 )
 from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName, JobName
 from denbust.models.policies import PrivacyRisk
 from denbust.ops.storage import LocalJsonOperationalStore
@@ -2277,6 +2279,133 @@ class TestRunPipelineAsync:
         assert '"exa_google_cse_shared": 1' in metrics_payload
         assert '"shared_all_candidates": 1' in metrics_payload
         assert '"shared_candidates": 1' in diagnostics_payload
+
+    @pytest.mark.asyncio
+    async def test_run_news_discover_job_uses_durable_diagnostics_and_run_overlap_metrics(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Diagnostics should come from durable state while overlap stays scoped to this run."""
+        config = Config(
+            store={"state_root": tmp_path},
+            operational={
+                "provider": "local_json",
+                "root_dir": tmp_path / "operational",
+            },
+            discovery={"enabled": True, "engines": {"brave": {"enabled": True}}},
+        )
+        persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+        persistence.upsert_candidates(
+            [
+                build_persistent_candidate(
+                    "candidate-shared",
+                    current_url="https://www.ynet.co.il/news/article/shared",
+                ).model_copy(update={"discovered_via": ["exa"]}),
+            ]
+        )
+        LocalJsonOperationalStore(tmp_path / "operational").upsert_records(
+            "news_items",
+            [
+                {
+                    "id": "news-item-1",
+                    "canonical_url": "https://www.ynet.co.il/news/article/shared",
+                    "publication_datetime": datetime.now(UTC).isoformat(),
+                }
+            ],
+        )
+
+        async def fake_run_source_native_discovery(
+            *,
+            config: Config,
+            sources: list[object],
+            run_id: str,
+            days: int,
+        ) -> PersistedSourceDiscovery:
+            del config, sources, days
+            candidate = build_persistent_candidate(
+                "candidate-shared",
+                current_url="https://www.ynet.co.il/news/article/shared",
+            ).model_copy(update={"discovered_via": ["exa", "source_native"]})
+            persistence.upsert_candidates([candidate])
+            return PersistedSourceDiscovery(
+                run=DiscoveryRun(
+                    run_id=run_id,
+                    dataset_name=DatasetName.NEWS_ITEMS,
+                    job_name=JobName.DISCOVER,
+                    status=DiscoveryRunStatus.SUCCEEDED,
+                    candidate_count=1,
+                    merged_candidate_count=1,
+                ),
+                candidates=[candidate],
+                provenance=[],
+            )
+
+        async def fake_run_brave_discovery(
+            *,
+            config: Config,
+            run_id: str,
+            days: int,
+        ) -> PersistedSourceDiscovery:
+            del config, days
+            candidate = build_persistent_candidate(
+                "candidate-brave-only",
+                current_url="https://www.mako.co.il/news/article/brave-only",
+            ).model_copy(update={"discovered_via": ["brave"]})
+            persistence.upsert_candidates([candidate])
+            return PersistedSourceDiscovery(
+                run=DiscoveryRun(
+                    run_id=run_id,
+                    dataset_name=DatasetName.NEWS_ITEMS,
+                    job_name=JobName.DISCOVER,
+                    status=DiscoveryRunStatus.SUCCEEDED,
+                    candidate_count=1,
+                    merged_candidate_count=1,
+                ),
+                candidates=[candidate],
+                provenance=[],
+            )
+
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [MagicMock(name="ynet")]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_source_native_discovery",
+            fake_run_source_native_discovery,
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline._run_brave_discovery",
+            fake_run_brave_discovery,
+        )
+
+        result = await run_news_discover_job(config)
+
+        assert result.fatal is False
+        metrics_payload = json.loads(
+            (
+                tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
+            ).read_text(encoding="utf-8")
+        )
+        diagnostics_payload = json.loads(
+            (
+                tmp_path
+                / "news_items"
+                / "discover"
+                / "metrics"
+                / "discovery_diagnostics_latest.json"
+            ).read_text(encoding="utf-8")
+        )
+        per_producer = {
+            entry["producer_name"]: entry for entry in diagnostics_payload["candidate_conversion"]["per_producer"]
+        }
+
+        assert metrics_payload["exa"] == 0
+        assert metrics_payload["source_native"] == 1
+        assert metrics_payload["brave"] == 1
+        assert per_producer["exa"]["candidate_count"] == 1
+        assert diagnostics_payload["operational_records_available"] is False
+        assert any(
+            "Operational record matching was skipped" in note
+            for note in diagnostics_payload["notes"]
+        )
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_marks_brave_failure_fatal_when_it_is_the_only_engine(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1861,9 +1861,13 @@ class TestRunPipelineAsync:
         metrics_payload = (
             tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
         ).read_text(encoding="utf-8")
+        diagnostics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "discovery_diagnostics_latest.json"
+        ).read_text(encoding="utf-8")
         assert '"brave": 2' in metrics_payload
         assert '"source_native": 0' in metrics_payload
         assert '"exa": 0' in metrics_payload
+        assert '"dataset_name": "news_items"' in diagnostics_payload
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_supports_exa_only_and_writes_metrics(
@@ -2264,11 +2268,15 @@ class TestRunPipelineAsync:
         metrics_payload = (
             tmp_path / "news_items" / "discover" / "metrics" / "engine_overlap_latest.json"
         ).read_text(encoding="utf-8")
+        diagnostics_payload = (
+            tmp_path / "news_items" / "discover" / "metrics" / "discovery_diagnostics_latest.json"
+        ).read_text(encoding="utf-8")
         assert '"google_cse": 2' in metrics_payload
         assert '"source_native_google_cse_shared": 1' in metrics_payload
         assert '"brave_google_cse_shared": 1' in metrics_payload
         assert '"exa_google_cse_shared": 1' in metrics_payload
         assert '"shared_all_candidates": 1' in metrics_payload
+        assert '"shared_candidates": 1' in diagnostics_payload
 
     @pytest.mark.asyncio
     async def test_run_news_discover_job_marks_brave_failure_fatal_when_it_is_the_only_engine(


### PR DESCRIPTION
## Summary
This PR implements the `DL-PR-07` observability slice for the discovery/candidacy layer and adds a short top-level `PLAN.md` clarifying how the repo’s planning documents relate to each other.

The core outcome is a new discovery diagnostics/reporting path that can:
- summarize engine overlap
- summarize source-native vs search-engine coverage
- report queue-health metrics
- report candidate conversion metrics
- render the report as text or JSON from the CLI
- persist a combined latest diagnostics artifact alongside the existing overlap artifact

## Planning context
This PR also adds `PLAN.md` at the repo root to make the planning structure explicit:
- `docs/CHATGPT_26_04_PLAN.md` remains the main roadmap
- `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` is the Milestone 3 branch plan under that roadmap
- `docs/tfht_discovery_layer_implementation_plan.md` is the separate `DL-PR-*` architecture plan for the discovery/candidacy split

## What changed
### 1. New discovery diagnostics module
Added `src/denbust/diagnostics/discovery.py` with typed models and helpers for:
- engine overlap metrics
- source-native vs search-engine coverage metrics
- queue health metrics
- candidate conversion metrics
- top scrape-failure summaries by source/domain/error code
- latest artifact persistence
- human-readable report rendering

### 2. New CLI command
Added `denbust diagnose-discovery` in `src/denbust/cli.py`.

Supported behavior:
- defaults to `agents/news/local.yaml`
- supports `--stale-days`
- supports `--format text|json`
- supports `--output` for JSON export

### 3. Discovery artifact wiring in the pipeline
Updated `run_news_discover_job` in `src/denbust/pipeline.py` so the latest discover run now writes:
- `engine_overlap_latest.json`
- `discovery_diagnostics_latest.json`

The current-run artifact generation uses the merged candidates returned by the active producer runs, so the report stays correct even when tests stub the discovery runners directly.

### 4. State-path coverage
Extended `src/denbust/discovery/state_paths.py` so the discovery state model now exposes:
- `candidate_provenance_path`
- `scrape_attempts_path`
- `discovery_diagnostics_latest_path`

This lets the diagnostics layer read the mirrored state-repo JSONL/JSON artifacts directly without depending on backend-specific persistence readers.

### 5. Tests
Added and updated unit coverage for:
- discovery diagnostics report building
- discovery diagnostics artifact persistence
- discovery state paths
- CLI wiring for `diagnose-discovery`
- discover-job artifact generation behavior

## Validation
Ran:
- `ruff check src/denbust/diagnostics/discovery.py src/denbust/diagnostics/__init__.py src/denbust/cli.py src/denbust/pipeline.py src/denbust/discovery/state_paths.py src/denbust/discovery/storage.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_state_paths.py tests/unit/test_cli.py tests/unit/test_pipeline_core.py`
- `mypy src`
- `pytest -q tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_state_paths.py tests/unit/test_cli.py tests/unit/test_pipeline_core.py`

All passed.

## Scope notes
This PR stays inside `DL-PR-07` scope:
- no backfill work
- no self-healing work
- no scrape-semantic changes
- no release-policy changes

It focuses strictly on observability, report generation, and developer/operator access to the new discovery-layer state.