### PR TITLE
Update plans after PR #82 merge

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,18 +2,24 @@
 
 ## Current System State
 
-- Active branch: `codex/refactor-agent-context-architecture`
-- Last action taken: agent-context cleanup branch created; `AGENTS.md` condensed; `llms.txt` added.
-- Current blockers: no explicit repo-tracked blocker, but the next implementation slice is split between unfinished Phase C follow-through and post-`DL-PR-06` discovery work. Prioritization should be explicit before larger feature work starts.
+- Active branch: `main`
+- Last action taken: `DL-PR-07` discovery observability and overlap reporting merged via PR `#82`.
+- Current blockers: no explicit repo-tracked blocker, but prioritization is still needed between unfinished Phase C follow-through and the next discovery-layer slice.
 
 ## Active Task Breakdown
 
 - [ ] Finish Phase C test/validation follow-through from `C-7`
 - [ ] Wire the monthly report command/workflow from `C-6`
 - [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
-- [ ] Start `DL-PR-07` discovery observability and overlap reporting
-- [ ] Queue `DL-PR-09` backfill foundation after observability is in place
+- [ ] Decide whether to take `DL-PR-08` or `DL-PR-09` next; the discovery rollout plan's default merge order points to `DL-PR-08`
+- [ ] Start `DL-PR-08` search-result-only fallback rows and partial retention
+- [ ] Queue `DL-PR-09` backfill foundation after the next discovery slice lands
 - [ ] Keep `DL-PR-11` workflow rollout scoped to docs/workflows only; do not mix in self-healing or event-table work
+
+## Planning Workflow
+
+- When a PR is opened against a tracked plan item, the PR should update `.agent-plan.md`, `README.md`, and the relevant human-facing plan document(s) to describe the state as it should look after that PR is merged.
+- Plan-tracked PRs should not leave the repository's planning/docs surfaces one merge behind the code.
 
 ## Context Pointers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Default branch prefix for agent work: `codex/`.
 - Keep branches single-purpose.
 - Open PRs against `main`.
+- When a PR is opened against a tracked plan item, update `.agent-plan.md`, `README.md`, and any relevant human-facing plan document in that same PR so they reflect the expected post-merge state.
 - Preserve `CLAUDE.md -> AGENTS.md` when changing repo guidance.
 
 ## Environment

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,40 +26,29 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: `DL-PR-07`
+## Current Next Focus: Post-`DL-PR-07` Discovery Work
 
-`DL-PR-07` is the next planned discovery-layer step. Its purpose is to make the discovery/candidacy layer measurable and debuggable, building on the existing `DL-PR-01` through `DL-PR-06` foundation.
+`DL-PR-07` is now merged via PR `#82`. The next default discovery-layer step in the rollout plan is `DL-PR-08`, while `DL-PR-09` remains queued immediately after it unless priorities are explicitly reordered.
 
-### What already exists
+### What `DL-PR-07` delivered
 
 - Candidate persistence, scrape attempts, and queue state already exist under `src/denbust/discovery/`.
 - A lightweight overlap artifact already exists at `state_repo/.../metrics/engine_overlap_latest.json`.
 - Discovery overlap/diagnostics generation already flows through `src/denbust/diagnostics/discovery.py`; the pipeline no longer keeps separate per-engine candidate ID sets.
 - The repo already has a diagnostics pattern in `src/denbust/diagnostics/source_health.py` and `src/denbust/cli.py`.
+- Discovery diagnostics now also emit a fuller `discovery_diagnostics_latest.json` artifact and a `denbust diagnose-discovery` CLI entry point.
 
-### What `DL-PR-07` still needs
+### What comes next
 
-1. Introduce a dedicated discovery diagnostics/reporting module under `src/denbust/diagnostics/` for discovery-layer observability.
-2. Define typed report models for:
-   - engine overlap
-   - source-native vs search-engine recall/coverage
-   - candidate-to-news-item conversion
-   - queue health
-3. Expand discovery metrics outputs beyond `engine_overlap_latest.json` to include a coherent report artifact set under `src/denbust/discovery/state_paths.py`.
-4. Add queue-health calculations from persisted candidates and scrape attempts:
-   - new candidates
-   - stale candidates
-   - failed candidates
-   - retry backlog
-5. Add conversion metrics from candidate state and downstream ingest results:
-   - scrape succeeded
-   - scrape failed
-   - partially scraped
-   - unsupported source
-   - candidate-to-news-item conversion counts/rates
-6. Add source-native vs search-engine coverage reporting using current candidate provenance and discovered-via metadata.
-7. Add a CLI entry point in `src/denbust/cli.py` for discovery diagnostics, following the same text/JSON pattern used by `diagnose-sources`.
-8. Add unit tests for report generation, artifact writing, and CLI behavior.
+1. `DL-PR-08` is the default next discovery PR in the rollout plan:
+   - search-result-only fallback rows
+   - partial retention
+   - lower-confidence review/publication handling
+2. `DL-PR-09` remains the next queued follow-up after that:
+   - backfill batches
+   - historical query generation
+   - backfill discover/scrape jobs
+3. Phase C follow-through is still open in parallel, so `.agent-plan.md` should be treated as the operational priority pointer when sequencing work.
 
 ### Likely code touchpoints
 
@@ -76,6 +65,11 @@ This repo currently has one main plan and two important sub-plans.
 
 ### Scope guardrails
 
-- Do not add backfill logic yet; that belongs to `DL-PR-09`.
+- Do not fold `DL-PR-09` backfill work into the next PR unless priorities are explicitly changed.
 - Do not add self-healing or event-table work yet.
-- Keep this PR focused on observability/reporting, not on changing scrape semantics or public-release policy.
+- Keep the next discovery PR focused on its slice rather than mixing in workflow rollout or later-stage architecture work.
+
+## Planning Workflow
+
+- When a PR is opened against a tracked plan item, the PR itself should update `.agent-plan.md`, `README.md`, and any relevant human-facing plan document so the repository reflects the state expected after that PR is merged.
+- Plan-tracked PRs should land with both implementation and planning/docs state aligned in the same merge.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Planned future datasets:
 - Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
   paths under `news_items/discover/`
 - Runs Brave, Exa, and Google CSE as external discovery engines feeding the durable candidate layer
+- Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
+  `denbust diagnose-discovery`
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
 
 ## Quick Start
@@ -49,6 +51,7 @@ Planned future datasets:
 pip install -e ".[dev]"
 python -m playwright install chromium
 denbust scan --config agents/news/local.yaml
+denbust diagnose-discovery --config agents/news/local.yaml
 denbust release --config agents/release/news_items.yaml
 denbust backup --config agents/backup/news_items.yaml
 ```
@@ -542,9 +545,20 @@ For backup specifically:
 
 ## Documentation
 
+- [Agent Plan](.agent-plan.md) - Current operational priority pointer
+- [Repo Plan Summary](PLAN.md) - Human-friendly map of the main plan and active sub-plans
 - [Product Definition](docs/product_def.md) - Full project background (Hebrew)
 - [MVP Spec](docs/MVP_SPEC.md) - Phase 1 technical scope
 - [Implementation Plan](docs/IMPLEMENTATION_PLAN.md) - Task breakdown
+- [Discovery Layer Rollout Plan](docs/tfht_discovery_layer_implementation_plan.md) - `DL-PR-*` sequence
+
+## Planning Workflow
+
+- When a PR is opened against a tracked plan item, the PR should update `.agent-plan.md`,
+  `README.md`, and the relevant human-facing plan document(s) in the same branch.
+- Those documentation updates should describe the state the repo is expected to be in after the PR
+  is merged, not the pre-merge state from before the work landed.
+- Plan-tracked PRs should not leave planning and docs surfaces one merge behind the code.
 
 ## Roadmap
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -238,6 +238,9 @@ The initial three-engine discovery layer is complete:
 ### Goal
 Make the new layer measurable and debuggable.
 
+### Status
+Implemented.
+
 ### Scope
 - Add engine overlap report generation
 - Add source-native vs search-engine recall reporting


### PR DESCRIPTION
## Summary
- update the tracked plan surfaces to reflect that PR #82 / `DL-PR-07` is already merged
- advance the operational planning pointer from `DL-PR-07` to post-merge discovery work
- document the repo workflow that plan-tracked PRs must update planning/docs surfaces to their expected post-merge state

## What changed
- `.agent-plan.md`
  - records `DL-PR-07` as merged via PR #82
  - moves the next discovery pointer to the `DL-PR-08` / `DL-PR-09` decision point, with `DL-PR-08` as the default next slice from the rollout plan
  - adds a short "Planning Workflow" section describing the post-merge-state expectation for plan-tracked PRs
- `PLAN.md`
  - replaces the stale `DL-PR-07`-as-next section with a post-`DL-PR-07` handoff section
  - notes what `DL-PR-07` delivered
  - adds the same planning-workflow rule in the human-facing repo plan
- `docs/tfht_discovery_layer_implementation_plan.md`
  - marks `DL-PR-07` as implemented
- `README.md`
  - updates the capability summary / quick start to include discovery diagnostics
  - adds links to `.agent-plan.md`, `PLAN.md`, and the discovery rollout plan
  - documents the best practice that plan-tracked PRs should ship with the planning/docs state they expect after merge
- `AGENTS.md`
  - adds the same branch/PR rule for future agent work

## Why this workflow note is in this PR
The repository should not require a follow-up cleanup PR just to make the plans catch up with code that already merged. If a PR is opened from a tracked plan item, the PR should land with the planning/docs state already updated to what `main` should look like after merge.

## Validation
- `git diff --check`
