### PR TITLE
Implement DL-PR-08 fallback retention

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -3,7 +3,7 @@
 ## Current System State
 
 - Active branch: `main`
-- Last action taken: `DL-PR-07` discovery observability and overlap reporting merged via PR `#82`.
+- Last action taken: `DL-PR-08` fallback retention and provisional internal rows landed on top of the discovery layer.
 - Current blockers: no explicit repo-tracked blocker, but prioritization is still needed between unfinished Phase C follow-through and the next discovery-layer slice.
 
 ## Active Task Breakdown
@@ -11,9 +11,8 @@
 - [ ] Finish Phase C test/validation follow-through from `C-7`
 - [ ] Wire the monthly report command/workflow from `C-6`
 - [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
-- [ ] Decide whether to take `DL-PR-08` or `DL-PR-09` next; the discovery rollout plan's default merge order points to `DL-PR-08`
-- [ ] Start `DL-PR-08` search-result-only fallback rows and partial retention
-- [ ] Queue `DL-PR-09` backfill foundation after the next discovery slice lands
+- [ ] Start `DL-PR-09` backfill foundation
+- [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after `DL-PR-09`
 - [ ] Keep `DL-PR-11` workflow rollout scoped to docs/workflows only; do not mix in self-healing or event-table work
 
 ## Planning Workflow

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,28 +23,60 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: python -m mypy src/
-        language: system
+        entry: scripts/run_python_with_src.sh
+        language: python
+        additional_dependencies: &python_hook_dependencies
+          - anthropic>=0.40.0
+          - beautifulsoup4>=4.12.0
+          - boto3>=1.36.0
+          - feedparser>=6.0.10
+          - google-api-python-client>=2.154.0
+          - google-auth>=2.36.0
+          - httpx>=0.27.0
+          - huggingface_hub>=0.27.0
+          - kaggle>=1.7.4.5
+          - lxml>=5.0.0
+          - mypy>=1.10.0
+          - openpyxl>=3.1.5
+          - playwright>=1.53.0
+          - pyarrow>=18.0.0
+          - pydantic>=2.5.0
+          - pytest>=8.0.0
+          - pytest-asyncio>=0.24.0
+          - pytest-cov>=5.0.0
+          - pytest-mock>=3.12.0
+          - pyyaml>=6.0.1
+          - respx>=0.21.0
+          - typer>=0.12.0
+          - types-beautifulsoup4>=4.12.0
+          - types-pyyaml>=6.0.0
+        args: ["-m", "mypy", "src/"]
         pass_filenames: false
         stages: [pre-commit]
 
       - id: smoke-tests
         name: smoke tests
-        entry: python -m pytest -q --maxfail=1 tests/smoke
-        language: system
+        entry: scripts/run_python_with_src.sh
+        language: python
+        additional_dependencies: *python_hook_dependencies
+        args: ["-m", "pytest", "-q", "--maxfail=1", "tests/smoke"]
         pass_filenames: false
         stages: [pre-commit]
 
       - id: unit-tests
         name: unit tests
-        entry: python -m pytest -q tests/unit
-        language: system
+        entry: scripts/run_python_with_src.sh
+        language: python
+        additional_dependencies: *python_hook_dependencies
+        args: ["-m", "pytest", "-q", "tests/unit"]
         pass_filenames: false
         stages: [pre-push]
 
       - id: integration-tests
         name: integration tests
-        entry: python -m pytest -q tests/integration
-        language: system
+        entry: scripts/run_python_with_src.sh
+        language: python
+        additional_dependencies: *python_hook_dependencies
+        args: ["-m", "pytest", "-q", "tests/integration"]
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,28 +25,13 @@ repos:
         name: mypy
         entry: scripts/run_python_with_src.sh
         language: python
-        additional_dependencies: &python_hook_dependencies
+        additional_dependencies:
           - anthropic>=0.40.0
           - beautifulsoup4>=4.12.0
-          - boto3>=1.36.0
-          - feedparser>=6.0.10
-          - google-api-python-client>=2.154.0
-          - google-auth>=2.36.0
           - httpx>=0.27.0
-          - huggingface_hub>=0.27.0
-          - kaggle>=1.7.4.5
-          - lxml>=5.0.0
           - mypy>=1.10.0
-          - openpyxl>=3.1.5
-          - playwright>=1.53.0
-          - pyarrow>=18.0.0
           - pydantic>=2.5.0
-          - pytest>=8.0.0
-          - pytest-asyncio>=0.24.0
-          - pytest-cov>=5.0.0
-          - pytest-mock>=3.12.0
           - pyyaml>=6.0.1
-          - respx>=0.21.0
           - typer>=0.12.0
           - types-beautifulsoup4>=4.12.0
           - types-pyyaml>=6.0.0
@@ -58,7 +43,16 @@ repos:
         name: smoke tests
         entry: scripts/run_python_with_src.sh
         language: python
-        additional_dependencies: *python_hook_dependencies
+        additional_dependencies:
+          - anthropic>=0.40.0
+          - beautifulsoup4>=4.12.0
+          - feedparser>=6.0.10
+          - httpx>=0.27.0
+          - pydantic>=2.5.0
+          - pytest>=8.0.0
+          - pytest-asyncio>=0.24.0
+          - pyyaml>=6.0.1
+          - typer>=0.12.0
         args: ["-m", "pytest", "-q", "--maxfail=1", "tests/smoke"]
         pass_filenames: false
         stages: [pre-commit]
@@ -66,8 +60,7 @@ repos:
       - id: unit-tests
         name: unit tests
         entry: scripts/run_python_with_src.sh
-        language: python
-        additional_dependencies: *python_hook_dependencies
+        language: system
         args: ["-m", "pytest", "-q", "tests/unit"]
         pass_filenames: false
         stages: [pre-push]
@@ -75,8 +68,7 @@ repos:
       - id: integration-tests
         name: integration tests
         entry: scripts/run_python_with_src.sh
-        language: python
-        additional_dependencies: *python_hook_dependencies
+        language: system
         args: ["-m", "pytest", "-q", "tests/integration"]
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -14,3 +18,33 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: python -m mypy src/
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: smoke-tests
+        name: smoke tests
+        entry: python -m pytest -q --maxfail=1 tests/smoke
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: unit-tests
+        name: unit tests
+        entry: python -m pytest -q tests/unit
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: integration-tests
+        name: integration tests
+        entry: python -m pytest -q tests/integration
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -252,9 +252,18 @@ DL-PR-06 now builds on the earlier discovery milestones:
   - `candidate_provenance`
   - `scrape_attempts`
 
-The generic fetch/extract fallback remains scaffolded structurally for retry bookkeeping. The
-current daily monitoring flow remains operational, and the durable candidate substrate now accepts
-source-native discovery plus Brave, Exa, and Google CSE search results.
+The current daily monitoring flow remains operational, and the durable candidate substrate now
+accepts source-native discovery plus Brave, Exa, and Google CSE search results.
+
+DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
+
+- source-adapter successes now persist `content_basis = full_article_page`
+- generic fetch fallback can retain `content_basis = partial_page` when page metadata is recoverable
+- failed full scrapes can retain `content_basis = search_result_only` using discovery metadata
+- retained fallback candidates can materialize provisional internal-only `news_items` rows for
+  monitoring and review, while staying excluded from public release by default
+- discovery diagnostics now report candidate-basis counts so operators can distinguish full-page,
+  partial-page, and search-result-only retention
 
 ## Config Layout
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -269,6 +269,9 @@ You can now tell whether the discovery layer is actually helping.
 ### Goal
 Retain value from promising candidates even when full scraping fails.
 
+### Status
+Implemented.
+
 ### Scope
 - Add explicit handling for:
   - `content_basis = search_result_only`
@@ -423,6 +426,7 @@ The recommended order is:
 
 ### After DL-PR-08
 - candidate retention is mature enough for real-world imperfect scraping
+- partial-page and search-result-only fallbacks can be retained without leaking into public release
 
 ### After DL-PR-09
 - historical backfill becomes feasible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,13 @@ warn_unused_configs = true
 show_error_codes = true
 
 [[tool.mypy.overrides]]
-module = ["feedparser.*", "bs4.*"]
+module = [
+    "bs4.*",
+    "feedparser.*",
+    "google.*",
+    "huggingface_hub.*",
+    "playwright.*",
+]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,15 @@ show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = [
+    "anthropic.*",
+    "boto3.*",
     "bs4.*",
     "feedparser.*",
     "google.*",
+    "googleapiclient.*",
     "huggingface_hub.*",
+    "kaggle.*",
+    "pyarrow.*",
     "playwright.*",
 ]
 ignore_missing_imports = true

--- a/scripts/run_python_with_src.sh
+++ b/scripts/run_python_with_src.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="src:${PYTHONPATH}"
+else
+    export PYTHONPATH="src"
+fi
+
+exec python "$@"

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from denbust.config import Config, OperationalProvider, load_config
 from denbust.discovery.models import (
     CandidateStatus,
+    ContentBasis,
     FetchStatus,
     PersistentCandidate,
     ScrapeAttempt,
@@ -84,6 +85,9 @@ class QueueHealthMetrics(BaseModel):
     scrape_failed_candidates: int = 0
     partially_scraped_candidates: int = 0
     unsupported_source_candidates: int = 0
+    search_result_only_candidates: int = 0
+    partial_page_candidates: int = 0
+    full_article_page_candidates: int = 0
     stale_candidates: int = 0
     retry_backlog_candidates: int = 0
 
@@ -111,6 +115,9 @@ class CandidateConversionMetrics(BaseModel):
     scrape_failed_candidates: int = 0
     unsupported_source_candidates: int = 0
     never_scraped_candidates: int = 0
+    search_result_only_candidates: int = 0
+    partial_page_candidates: int = 0
+    full_article_page_candidates: int = 0
     operational_record_matches: int = 0
     scrape_success_rate: float = 0.0
     operational_match_rate: float = 0.0
@@ -300,12 +307,24 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
         "unsupported={unsupported_source_candidates} stale={stale_candidates} "
         "retry_backlog={retry_backlog_candidates}".format(**queue.model_dump(mode="json"))
     )
+    lines.append(
+        "  basis search_result_only={search_result_only_candidates} "
+        "partial_page={partial_page_candidates} full_article_page={full_article_page_candidates}".format(
+            **queue.model_dump(mode="json")
+        )
+    )
     lines.append("")
     lines.append("Conversion")
     lines.append(
         "  scrape_succeeded={scrape_succeeded_candidates} partial={partially_scraped_candidates} "
         "failed={scrape_failed_candidates} unsupported={unsupported_source_candidates} "
         "never_scraped={never_scraped_candidates}".format(**conversion.model_dump(mode="json"))
+    )
+    lines.append(
+        "  basis search_result_only={search_result_only_candidates} "
+        "partial_page={partial_page_candidates} full_article_page={full_article_page_candidates}".format(
+            **conversion.model_dump(mode="json")
+        )
     )
     lines.append(
         f"  scrape_success_rate={conversion.scrape_success_rate:.2%} "
@@ -448,6 +467,7 @@ def _build_queue_health_metrics(
         ):
             stale += 1
     status_counts = Counter(candidate.candidate_status for candidate in candidates)
+    basis_counts = Counter(candidate.content_basis for candidate in candidates)
     return QueueHealthMetrics(
         total_candidates=len(candidates),
         new_candidates=status_counts[CandidateStatus.NEW],
@@ -457,6 +477,9 @@ def _build_queue_health_metrics(
         scrape_failed_candidates=status_counts[CandidateStatus.SCRAPE_FAILED],
         partially_scraped_candidates=status_counts[CandidateStatus.PARTIALLY_SCRAPED],
         unsupported_source_candidates=status_counts[CandidateStatus.UNSUPPORTED_SOURCE],
+        search_result_only_candidates=basis_counts[ContentBasis.SEARCH_RESULT_ONLY],
+        partial_page_candidates=basis_counts[ContentBasis.PARTIAL_PAGE],
+        full_article_page_candidates=basis_counts[ContentBasis.FULL_ARTICLE_PAGE],
         stale_candidates=stale,
         retry_backlog_candidates=retry_backlog,
     )
@@ -503,6 +526,7 @@ def _build_candidate_conversion_metrics(
         if operational_urls and _candidate_identity_urls(candidate) & operational_urls
     }
     status_counts = Counter(candidate.candidate_status for candidate in candidates)
+    basis_counts = Counter(candidate.content_basis for candidate in candidates)
     per_producer: list[ProducerConversionMetrics] = []
     all_producers = sorted(
         {producer_name for candidate in candidates for producer_name in candidate.discovered_via}
@@ -555,6 +579,9 @@ def _build_candidate_conversion_metrics(
             + status_counts[CandidateStatus.SCRAPE_PENDING]
             + status_counts[CandidateStatus.SCRAPE_IN_PROGRESS]
         ),
+        search_result_only_candidates=basis_counts[ContentBasis.SEARCH_RESULT_ONLY],
+        partial_page_candidates=basis_counts[ContentBasis.PARTIAL_PAGE],
+        full_article_page_candidates=basis_counts[ContentBasis.FULL_ARTICLE_PAGE],
         operational_record_matches=len(matched_candidate_ids),
         scrape_success_rate=_safe_ratio(
             status_counts[CandidateStatus.SCRAPE_SUCCEEDED],

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+import httpx
+from bs4 import BeautifulSoup
 
 from denbust.config import Config
 from denbust.data_models import RawArticle
@@ -34,9 +39,24 @@ class CandidateScrapeBatch:
 
     selected_candidates: list[PersistentCandidate]
     updated_candidates: list[PersistentCandidate]
+    fallback_candidates: list[PersistentCandidate]
     attempts: list[ScrapeAttempt]
     raw_articles: list[RawArticle]
     errors: list[str]
+
+
+@dataclass(frozen=True)
+class GenericFetchResult:
+    """Minimal metadata recovered from a candidate page fetch."""
+
+    fetch_status: FetchStatus
+    title: str | None = None
+    snippet: str | None = None
+    publication_datetime: datetime | None = None
+    final_url: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    diagnostics: dict[str, object] | None = None
 
 
 def select_candidates_for_scrape(
@@ -139,7 +159,7 @@ def _mark_attempt_success(
             "next_scrape_attempt_at": None,
             "last_scrape_error_code": None,
             "last_scrape_error_message": None,
-            "content_basis": ContentBasis.PARTIAL_PAGE,
+            "content_basis": ContentBasis.FULL_ARTICLE_PAGE,
             "titles": deduplicate_strings([*candidate.titles, article.title]),
             "snippets": deduplicate_strings([*candidate.snippets, article.snippet]),
             "metadata": {
@@ -159,6 +179,9 @@ def _mark_attempt_failure(
     error_code: str,
     error_message: str,
     config: Config,
+    content_basis: ContentBasis | None = None,
+    needs_review: bool | None = None,
+    metadata_updates: dict[str, object] | None = None,
 ) -> PersistentCandidate:
     final_attempt = attempts[-1]
     finished_at = final_attempt.finished_at or final_attempt.started_at
@@ -176,10 +199,82 @@ def _mark_attempt_failure(
             "next_scrape_attempt_at": retry_at,
             "last_scrape_error_code": error_code,
             "last_scrape_error_message": error_message,
-            "needs_review": candidate.needs_review or status is CandidateStatus.UNSUPPORTED_SOURCE,
+            "content_basis": content_basis or candidate.content_basis,
+            "needs_review": (
+                candidate.needs_review
+                or status is CandidateStatus.UNSUPPORTED_SOURCE
+                or bool(needs_review)
+            ),
             "self_heal_eligible": status is CandidateStatus.SCRAPE_FAILED,
+            "metadata": {
+                **candidate.metadata,
+                **(metadata_updates or {}),
+            },
         }
     )
+
+
+def _mark_partial_recovery(
+    candidate: PersistentCandidate,
+    *,
+    attempt: ScrapeAttempt,
+    fetch_result: GenericFetchResult,
+    source_name: str | None,
+) -> PersistentCandidate:
+    return candidate.model_copy(
+        update={
+            "candidate_status": CandidateStatus.PARTIALLY_SCRAPED,
+            "scrape_attempt_count": candidate.scrape_attempt_count + 1,
+            "last_scrape_attempt_at": attempt.finished_at,
+            "next_scrape_attempt_at": None,
+            "last_scrape_error_code": None,
+            "last_scrape_error_message": None,
+            "content_basis": ContentBasis.PARTIAL_PAGE,
+            "needs_review": True,
+            "self_heal_eligible": False,
+            "titles": deduplicate_strings([*candidate.titles, fetch_result.title or ""]),
+            "snippets": deduplicate_strings([*candidate.snippets, fetch_result.snippet or ""]),
+            "metadata": {
+                **candidate.metadata,
+                **_fallback_metadata(
+                    candidate=candidate,
+                    content_basis=ContentBasis.PARTIAL_PAGE,
+                    title=fetch_result.title,
+                    snippet=fetch_result.snippet,
+                    publication_datetime=fetch_result.publication_datetime,
+                    source_name=source_name,
+                    fetch_result=fetch_result,
+                ),
+            },
+        }
+    )
+
+
+def _fallback_metadata(
+    *,
+    candidate: PersistentCandidate,
+    content_basis: ContentBasis,
+    title: str | None,
+    snippet: str | None,
+    publication_datetime: datetime | None,
+    source_name: str | None,
+    fetch_result: GenericFetchResult,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "fallback_title": title or next(iter(candidate.titles), None),
+        "fallback_snippet": snippet or next(iter(candidate.snippets), None),
+        "fallback_source_name": source_name
+        or next(iter(candidate.source_hints), None)
+        or next(iter(candidate.discovered_via), None),
+        "fallback_content_basis": content_basis.value,
+    }
+    if publication_datetime is not None:
+        payload["fallback_publication_datetime"] = publication_datetime.isoformat()
+    if fetch_result.final_url is not None:
+        payload["fallback_final_url"] = fetch_result.final_url
+    if fetch_result.diagnostics:
+        payload["fallback_diagnostics"] = dict(fetch_result.diagnostics)
+    return payload
 
 
 async def scrape_candidates(
@@ -192,7 +287,7 @@ async def scrape_candidates(
 ) -> CandidateScrapeBatch:
     """Attempt to materialize durable candidates into raw articles."""
     if not candidates:
-        return CandidateScrapeBatch([], [], [], [], [])
+        return CandidateScrapeBatch([], [], [], [], [], [])
 
     queued_candidates = queue_candidates_for_scrape(candidates)
     persistence.upsert_candidates(queued_candidates)
@@ -200,6 +295,7 @@ async def scrape_candidates(
     source_articles_cache = dict(preloaded_source_articles or {})
     sources_by_name = {source.name: source for source in sources}
     updated_candidates: list[PersistentCandidate] = []
+    fallback_candidates: list[PersistentCandidate] = []
     attempts: list[ScrapeAttempt] = []
     raw_articles: list[RawArticle] = []
     errors: list[str] = []
@@ -292,63 +388,190 @@ async def scrape_candidates(
                 attempts.extend(candidate_attempts)
                 errors.append(f"{in_progress.candidate_id}: {error_message}")
                 continue
-        else:
-            finished_at = datetime.now(UTC)
-            candidate_attempts.append(
-                _build_attempt(
-                    candidate_id=in_progress.candidate_id,
-                    started_at=started_at,
-                    finished_at=finished_at,
-                    attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                    fetch_status=FetchStatus.UNSUPPORTED,
-                    error_code="source_adapter_unavailable",
-                    error_message="No source adapter available for candidate source hints",
-                )
-            )
 
         generic_started_at = datetime.now(UTC)
+        fetch_result = await _fetch_partial_page(in_progress)
         generic_finished_at = datetime.now(UTC)
-        generic_error_message = "generic fetch fallback not implemented yet"
         candidate_attempts.append(
             _build_attempt(
                 candidate_id=in_progress.candidate_id,
                 started_at=generic_started_at,
                 finished_at=generic_finished_at,
                 attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
-                fetch_status=FetchStatus.UNSUPPORTED,
-                error_code="generic_fetch_not_implemented",
-                error_message=generic_error_message,
+                fetch_status=fetch_result.fetch_status,
+                error_code=fetch_result.error_code,
+                error_message=fetch_result.error_message,
+                diagnostics=fetch_result.diagnostics,
             )
         )
 
-        if source_name is None:
-            status = CandidateStatus.UNSUPPORTED_SOURCE
-            error_code = "unsupported_source"
-            error_message = "No supported source adapter or generic fetch path is available"
-        else:
-            status = CandidateStatus.SCRAPE_FAILED
-            error_code = "generic_fetch_not_implemented"
-            error_message = generic_error_message
-
-        updated_candidates.append(
-            _mark_attempt_failure(
+        if fetch_result.fetch_status is FetchStatus.PARTIAL and (
+            fetch_result.title or fetch_result.snippet
+        ):
+            partial_candidate = _mark_partial_recovery(
                 in_progress,
-                attempts=candidate_attempts,
-                status=status,
-                error_code=error_code,
-                error_message=error_message,
-                config=config,
+                attempt=candidate_attempts[-1],
+                fetch_result=fetch_result,
+                source_name=source_name,
             )
+            updated_candidates.append(partial_candidate)
+            fallback_candidates.append(partial_candidate)
+            attempts.extend(candidate_attempts)
+            continue
+
+        fallback_candidate = _mark_attempt_failure(
+            in_progress,
+            attempts=candidate_attempts,
+            status=CandidateStatus.SCRAPE_FAILED,
+            error_code=fetch_result.error_code or "generic_fetch_failed",
+            error_message=fetch_result.error_message or "Generic fetch failed",
+            config=config,
+            content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+            needs_review=True,
+            metadata_updates=_fallback_metadata(
+                candidate=in_progress,
+                content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+                title=fetch_result.title,
+                snippet=fetch_result.snippet,
+                publication_datetime=fetch_result.publication_datetime,
+                source_name=source_name,
+                fetch_result=fetch_result,
+            ),
         )
+        updated_candidates.append(fallback_candidate)
+        fallback_candidates.append(fallback_candidate)
         attempts.extend(candidate_attempts)
-        errors.append(f"{in_progress.candidate_id}: {error_message}")
+        errors.append(
+            f"{in_progress.candidate_id}: "
+            f"{fetch_result.error_message or 'Generic fetch failed; retained search-result-only fallback'}"
+        )
 
     persistence.append_attempts(attempts)
     persistence.upsert_candidates(updated_candidates)
     return CandidateScrapeBatch(
         selected_candidates=queued_candidates,
         updated_candidates=updated_candidates,
+        fallback_candidates=fallback_candidates,
         attempts=attempts,
         raw_articles=raw_articles,
         errors=errors,
     )
+
+
+async def _fetch_partial_page(candidate: PersistentCandidate) -> GenericFetchResult:
+    headers = {"User-Agent": "denbust-discovery/1.0"}
+    try:
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, headers=headers) as client:
+            response = await client.get(str(candidate.current_url))
+            response.raise_for_status()
+    except httpx.TimeoutException as exc:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.TIMEOUT,
+            error_code="generic_fetch_timeout",
+            error_message=f"Generic fetch timed out: {exc}",
+        )
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code
+        return GenericFetchResult(
+            fetch_status=FetchStatus.BLOCKED if status_code in {401, 403, 429} else FetchStatus.FAILED,
+            error_code=f"generic_fetch_http_{status_code}",
+            error_message=f"Generic fetch returned HTTP {status_code}",
+        )
+    except httpx.HTTPError as exc:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_error",
+            error_message=f"Generic fetch failed: {type(exc).__name__}: {exc}",
+        )
+
+    parsed = _extract_partial_page_metadata(response.text)
+    if parsed["title"] or parsed["snippet"]:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title=parsed["title"],
+            snippet=parsed["snippet"],
+            publication_datetime=parsed["publication_datetime"],
+            final_url=str(response.url),
+            diagnostics={"content_type": response.headers.get("content-type", "")},
+        )
+    return GenericFetchResult(
+        fetch_status=FetchStatus.FAILED,
+        error_code="generic_fetch_no_metadata",
+        error_message="Generic fetch returned a page without usable metadata",
+        final_url=str(response.url),
+        diagnostics={"content_type": response.headers.get("content-type", "")},
+    )
+
+
+def _extract_partial_page_metadata(html: str) -> dict[str, Any]:
+    soup = BeautifulSoup(html, "html.parser")
+    title = _first_non_empty(
+        soup.title.string if soup.title and soup.title.string else None,
+        _meta_content(soup, property_name="og:title"),
+        _meta_content(soup, name="twitter:title"),
+    )
+    snippet = _first_non_empty(
+        _meta_content(soup, name="description"),
+        _meta_content(soup, property_name="og:description"),
+        _meta_content(soup, name="twitter:description"),
+    )
+    publication_datetime = _parse_publication_datetime(
+        _first_non_empty(
+            _meta_content(soup, property_name="article:published_time"),
+            _meta_content(soup, name="article:published_time"),
+            _meta_content(soup, name="pubdate"),
+            _meta_content(soup, name="publish-date"),
+            _meta_content(soup, name="date"),
+        )
+    )
+    return {
+        "title": title,
+        "snippet": snippet,
+        "publication_datetime": publication_datetime,
+    }
+
+
+def _meta_content(
+    soup: BeautifulSoup,
+    *,
+    name: str | None = None,
+    property_name: str | None = None,
+) -> str | None:
+    attrs: dict[str, str] = {}
+    if name is not None:
+        attrs["name"] = name
+    if property_name is not None:
+        attrs["property"] = property_name
+    tag = soup.find("meta", attrs=attrs)
+    if tag is None:
+        return None
+    value = tag.get("content")
+    if not isinstance(value, str):
+        return None
+    normalized = " ".join(value.split()).strip()
+    return normalized or None
+
+
+def _first_non_empty(*values: str | None) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        normalized = " ".join(value.split()).strip()
+        if normalized:
+            return normalized
+    return None
+
+
+def _parse_publication_datetime(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -461,7 +461,9 @@ async def scrape_candidates(
 async def _fetch_partial_page(candidate: PersistentCandidate) -> GenericFetchResult:
     headers = {"User-Agent": "denbust-discovery/1.0"}
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True, headers=headers) as client:
+        async with httpx.AsyncClient(
+            timeout=15.0, follow_redirects=True, headers=headers
+        ) as client:
             response = await client.get(str(candidate.current_url))
             response.raise_for_status()
     except httpx.TimeoutException as exc:
@@ -473,7 +475,9 @@ async def _fetch_partial_page(candidate: PersistentCandidate) -> GenericFetchRes
     except httpx.HTTPStatusError as exc:
         status_code = exc.response.status_code
         return GenericFetchResult(
-            fetch_status=FetchStatus.BLOCKED if status_code in {401, 403, 429} else FetchStatus.FAILED,
+            fetch_status=FetchStatus.BLOCKED
+            if status_code in {401, 403, 429}
+            else FetchStatus.FAILED,
             error_code=f"generic_fetch_http_{status_code}",
             error_message=f"Generic fetch returned HTTP {status_code}",
         )

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -383,19 +383,7 @@ async def scrape_candidates(
                             error_message=error_message,
                         )
                     )
-                    updated_candidates.append(
-                        _mark_attempt_failure(
-                            in_progress,
-                            attempts=candidate_attempts,
-                            status=CandidateStatus.SCRAPE_FAILED,
-                            error_code="source_adapter_error",
-                            error_message=error_message,
-                            config=config,
-                        )
-                    )
-                    attempts.extend(candidate_attempts)
                     errors.append(f"{in_progress.candidate_id}: {error_message}")
-                    continue
 
             generic_started_at = datetime.now(UTC)
             fetch_result = await _fetch_partial_page(in_progress, client=client)

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -218,6 +218,7 @@ def _mark_attempt_failure(
 def _mark_partial_recovery(
     candidate: PersistentCandidate,
     *,
+    attempts: list[ScrapeAttempt],
     attempt: ScrapeAttempt,
     fetch_result: GenericFetchResult,
     source_name: str | None,
@@ -225,7 +226,7 @@ def _mark_partial_recovery(
     return candidate.model_copy(
         update={
             "candidate_status": CandidateStatus.PARTIALLY_SCRAPED,
-            "scrape_attempt_count": candidate.scrape_attempt_count + 1,
+            "scrape_attempt_count": candidate.scrape_attempt_count + len(attempts),
             "last_scrape_attempt_at": attempt.finished_at,
             "next_scrape_attempt_at": None,
             "last_scrape_error_code": None,
@@ -301,151 +302,158 @@ async def scrape_candidates(
     raw_articles: list[RawArticle] = []
     errors: list[str] = []
 
-    for queued_candidate in queued_candidates:
-        in_progress = queued_candidate.model_copy(
-            update={"candidate_status": CandidateStatus.SCRAPE_IN_PROGRESS}
-        )
-        persistence.upsert_candidates([in_progress])
+    headers = {"User-Agent": "denbust-discovery/1.0"}
+    async with httpx.AsyncClient(
+        timeout=15.0,
+        follow_redirects=True,
+        headers=headers,
+    ) as client:
+        for queued_candidate in queued_candidates:
+            in_progress = queued_candidate.model_copy(
+                update={"candidate_status": CandidateStatus.SCRAPE_IN_PROGRESS}
+            )
+            persistence.upsert_candidates([in_progress])
 
-        source_name = _select_source_name(in_progress, sources_by_name)
-        started_at = datetime.now(UTC)
-        article: RawArticle | None = None
-        candidate_attempts: list[ScrapeAttempt] = []
+            source_name = _select_source_name(in_progress, sources_by_name)
+            started_at = datetime.now(UTC)
+            article: RawArticle | None = None
+            candidate_attempts: list[ScrapeAttempt] = []
 
-        if source_name is not None:
-            source = sources_by_name[source_name]
-            try:
-                articles = source_articles_cache.get(source_name)
-                if articles is None:
-                    articles = await source.fetch(days=config.days, keywords=config.keywords)
-                    source_articles_cache[source_name] = articles
-                candidate_urls = _candidate_urls(in_progress)
-                article = next(
-                    (
-                        candidate_article
-                        for candidate_article in articles
-                        if canonicalize_news_url(str(candidate_article.url)) in candidate_urls
-                    ),
-                    None,
-                )
-                finished_at = datetime.now(UTC)
-                if article is not None:
+            if source_name is not None:
+                source = sources_by_name[source_name]
+                try:
+                    articles = source_articles_cache.get(source_name)
+                    if articles is None:
+                        articles = await source.fetch(days=config.days, keywords=config.keywords)
+                        source_articles_cache[source_name] = articles
+                    candidate_urls = _candidate_urls(in_progress)
+                    article = next(
+                        (
+                            candidate_article
+                            for candidate_article in articles
+                            if canonicalize_news_url(str(candidate_article.url)) in candidate_urls
+                        ),
+                        None,
+                    )
+                    finished_at = datetime.now(UTC)
+                    if article is not None:
+                        candidate_attempts.append(
+                            _build_attempt(
+                                candidate_id=in_progress.candidate_id,
+                                started_at=started_at,
+                                finished_at=finished_at,
+                                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                                fetch_status=FetchStatus.SUCCESS,
+                                source_adapter_name=source_name,
+                                article=article,
+                                diagnostics={"matched_candidate_urls": sorted(candidate_urls)},
+                            )
+                        )
+                        updated_candidates.append(
+                            _mark_attempt_success(in_progress, candidate_attempts[-1], article)
+                        )
+                        raw_articles.append(article)
+                        attempts.extend(candidate_attempts)
+                        continue
+
                     candidate_attempts.append(
                         _build_attempt(
                             candidate_id=in_progress.candidate_id,
                             started_at=started_at,
                             finished_at=finished_at,
                             attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                            fetch_status=FetchStatus.SUCCESS,
+                            fetch_status=FetchStatus.FAILED,
                             source_adapter_name=source_name,
-                            article=article,
-                            diagnostics={"matched_candidate_urls": sorted(candidate_urls)},
+                            error_code="candidate_not_found",
+                            error_message=f"{source_name} adapter did not return the candidate URL",
+                        )
+                    )
+                except Exception as exc:
+                    finished_at = datetime.now(UTC)
+                    error_message = f"{source_name} adapter failed: {type(exc).__name__}: {exc}"
+                    candidate_attempts.append(
+                        _build_attempt(
+                            candidate_id=in_progress.candidate_id,
+                            started_at=started_at,
+                            finished_at=finished_at,
+                            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                            fetch_status=FetchStatus.FAILED,
+                            source_adapter_name=source_name,
+                            error_code="source_adapter_error",
+                            error_message=error_message,
                         )
                     )
                     updated_candidates.append(
-                        _mark_attempt_success(in_progress, candidate_attempts[-1], article)
+                        _mark_attempt_failure(
+                            in_progress,
+                            attempts=candidate_attempts,
+                            status=CandidateStatus.SCRAPE_FAILED,
+                            error_code="source_adapter_error",
+                            error_message=error_message,
+                            config=config,
+                        )
                     )
-                    raw_articles.append(article)
                     attempts.extend(candidate_attempts)
+                    errors.append(f"{in_progress.candidate_id}: {error_message}")
                     continue
 
-                candidate_attempts.append(
-                    _build_attempt(
-                        candidate_id=in_progress.candidate_id,
-                        started_at=started_at,
-                        finished_at=finished_at,
-                        attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                        fetch_status=FetchStatus.FAILED,
-                        source_adapter_name=source_name,
-                        error_code="candidate_not_found",
-                        error_message=f"{source_name} adapter did not return the candidate URL",
-                    )
+            generic_started_at = datetime.now(UTC)
+            fetch_result = await _fetch_partial_page(in_progress, client=client)
+            generic_finished_at = datetime.now(UTC)
+            candidate_attempts.append(
+                _build_attempt(
+                    candidate_id=in_progress.candidate_id,
+                    started_at=generic_started_at,
+                    finished_at=generic_finished_at,
+                    attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                    fetch_status=fetch_result.fetch_status,
+                    error_code=fetch_result.error_code,
+                    error_message=fetch_result.error_message,
+                    diagnostics=fetch_result.diagnostics,
                 )
-            except Exception as exc:
-                finished_at = datetime.now(UTC)
-                error_message = f"{source_name} adapter failed: {type(exc).__name__}: {exc}"
-                candidate_attempts.append(
-                    _build_attempt(
-                        candidate_id=in_progress.candidate_id,
-                        started_at=started_at,
-                        finished_at=finished_at,
-                        attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
-                        fetch_status=FetchStatus.FAILED,
-                        source_adapter_name=source_name,
-                        error_code="source_adapter_error",
-                        error_message=error_message,
-                    )
+            )
+
+            if fetch_result.fetch_status is FetchStatus.PARTIAL and (
+                fetch_result.title or fetch_result.snippet
+            ):
+                partial_candidate = _mark_partial_recovery(
+                    in_progress,
+                    attempts=candidate_attempts,
+                    attempt=candidate_attempts[-1],
+                    fetch_result=fetch_result,
+                    source_name=source_name,
                 )
-                updated_candidates.append(
-                    _mark_attempt_failure(
-                        in_progress,
-                        attempts=candidate_attempts,
-                        status=CandidateStatus.SCRAPE_FAILED,
-                        error_code="source_adapter_error",
-                        error_message=error_message,
-                        config=config,
-                    )
-                )
+                updated_candidates.append(partial_candidate)
+                fallback_candidates.append(partial_candidate)
                 attempts.extend(candidate_attempts)
-                errors.append(f"{in_progress.candidate_id}: {error_message}")
                 continue
 
-        generic_started_at = datetime.now(UTC)
-        fetch_result = await _fetch_partial_page(in_progress)
-        generic_finished_at = datetime.now(UTC)
-        candidate_attempts.append(
-            _build_attempt(
-                candidate_id=in_progress.candidate_id,
-                started_at=generic_started_at,
-                finished_at=generic_finished_at,
-                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
-                fetch_status=fetch_result.fetch_status,
-                error_code=fetch_result.error_code,
-                error_message=fetch_result.error_message,
-                diagnostics=fetch_result.diagnostics,
-            )
-        )
-
-        if fetch_result.fetch_status is FetchStatus.PARTIAL and (
-            fetch_result.title or fetch_result.snippet
-        ):
-            partial_candidate = _mark_partial_recovery(
+            fallback_candidate = _mark_attempt_failure(
                 in_progress,
-                attempt=candidate_attempts[-1],
-                fetch_result=fetch_result,
-                source_name=source_name,
-            )
-            updated_candidates.append(partial_candidate)
-            fallback_candidates.append(partial_candidate)
-            attempts.extend(candidate_attempts)
-            continue
-
-        fallback_candidate = _mark_attempt_failure(
-            in_progress,
-            attempts=candidate_attempts,
-            status=CandidateStatus.SCRAPE_FAILED,
-            error_code=fetch_result.error_code or "generic_fetch_failed",
-            error_message=fetch_result.error_message or "Generic fetch failed",
-            config=config,
-            content_basis=ContentBasis.SEARCH_RESULT_ONLY,
-            needs_review=True,
-            metadata_updates=_fallback_metadata(
-                candidate=in_progress,
+                attempts=candidate_attempts,
+                status=CandidateStatus.SCRAPE_FAILED,
+                error_code=fetch_result.error_code or "generic_fetch_failed",
+                error_message=fetch_result.error_message or "Generic fetch failed",
+                config=config,
                 content_basis=ContentBasis.SEARCH_RESULT_ONLY,
-                title=fetch_result.title,
-                snippet=fetch_result.snippet,
-                publication_datetime=fetch_result.publication_datetime,
-                source_name=source_name,
-                fetch_result=fetch_result,
-            ),
-        )
-        updated_candidates.append(fallback_candidate)
-        fallback_candidates.append(fallback_candidate)
-        attempts.extend(candidate_attempts)
-        errors.append(
-            f"{in_progress.candidate_id}: "
-            f"{fetch_result.error_message or 'Generic fetch failed; retained search-result-only fallback'}"
-        )
+                needs_review=True,
+                metadata_updates=_fallback_metadata(
+                    candidate=in_progress,
+                    content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+                    title=fetch_result.title,
+                    snippet=fetch_result.snippet,
+                    publication_datetime=fetch_result.publication_datetime,
+                    source_name=source_name,
+                    fetch_result=fetch_result,
+                ),
+            )
+            updated_candidates.append(fallback_candidate)
+            fallback_candidates.append(fallback_candidate)
+            attempts.extend(candidate_attempts)
+            errors.append(
+                f"{in_progress.candidate_id}: "
+                f"{fetch_result.error_message or 'Generic fetch failed; retained search-result-only fallback'}"
+            )
 
     persistence.append_attempts(attempts)
     persistence.upsert_candidates(updated_candidates)
@@ -459,14 +467,14 @@ async def scrape_candidates(
     )
 
 
-async def _fetch_partial_page(candidate: PersistentCandidate) -> GenericFetchResult:
-    headers = {"User-Agent": "denbust-discovery/1.0"}
+async def _fetch_partial_page(
+    candidate: PersistentCandidate,
+    *,
+    client: httpx.AsyncClient,
+) -> GenericFetchResult:
     try:
-        async with httpx.AsyncClient(
-            timeout=15.0, follow_redirects=True, headers=headers
-        ) as client:
-            response = await client.get(str(candidate.current_url))
-            response.raise_for_status()
+        response = await client.get(str(candidate.current_url))
+        response.raise_for_status()
     except httpx.TimeoutException as exc:
         return GenericFetchResult(
             fetch_status=FetchStatus.TIMEOUT,

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import httpx
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from denbust.config import Config
 from denbust.data_models import RawArticle
@@ -547,7 +548,7 @@ def _meta_content(
     if property_name is not None:
         attrs["property"] = property_name
     tag = soup.find("meta", attrs=attrs)
-    if tag is None:
+    if not isinstance(tag, Tag):
         return None
     value = tag.get("content")
     if not isinstance(value, str):

--- a/src/denbust/news_items/backup.py
+++ b/src/denbust/news_items/backup.py
@@ -48,10 +48,10 @@ class GoogleDriveLatestBackupUploader:
             raise ValueError("Google Drive backup requires DENBUST_DRIVE_SERVICE_ACCOUNT_JSON.")
 
         from google.oauth2 import service_account
-        from googleapiclient.discovery import build  # type: ignore[import-untyped]
-        from googleapiclient.http import MediaFileUpload  # type: ignore[import-untyped]
+        from googleapiclient.discovery import build  # type: ignore[import-not-found]
+        from googleapiclient.http import MediaFileUpload  # type: ignore[import-not-found]
 
-        credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
+        credentials = service_account.Credentials.from_service_account_file(
             self._service_account_json,
             scopes=["https://www.googleapis.com/auth/drive"],
         )
@@ -104,7 +104,7 @@ class ObjectStorageLatestBackupUploader:
                 "Object storage backup requires DENBUST_OBJECT_STORE_ACCESS_KEY_ID and DENBUST_OBJECT_STORE_SECRET_ACCESS_KEY."
             )
 
-        import boto3  # type: ignore[import-untyped]
+        import boto3  # type: ignore[import-not-found]
 
         client = boto3.client(
             "s3",

--- a/src/denbust/news_items/backup.py
+++ b/src/denbust/news_items/backup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Any, cast
 
 from denbust.config import Config
 from denbust.publish.backup import BackupManifest, BackupTarget
@@ -48,10 +49,11 @@ class GoogleDriveLatestBackupUploader:
             raise ValueError("Google Drive backup requires DENBUST_DRIVE_SERVICE_ACCOUNT_JSON.")
 
         from google.oauth2 import service_account
-        from googleapiclient.discovery import build  # type: ignore[import-not-found]
-        from googleapiclient.http import MediaFileUpload  # type: ignore[import-not-found]
+        from googleapiclient.discovery import build
+        from googleapiclient.http import MediaFileUpload
 
-        credentials = service_account.Credentials.from_service_account_file(
+        credentials_factory = cast(Any, service_account.Credentials)
+        credentials = credentials_factory.from_service_account_file(
             self._service_account_json,
             scopes=["https://www.googleapis.com/auth/drive"],
         )
@@ -104,7 +106,7 @@ class ObjectStorageLatestBackupUploader:
                 "Object storage backup requires DENBUST_OBJECT_STORE_ACCESS_KEY_ID and DENBUST_OBJECT_STORE_SECRET_ACCESS_KEY."
             )
 
-        import boto3  # type: ignore[import-not-found]
+        import boto3
 
         client = boto3.client(
             "s3",

--- a/src/denbust/news_items/models.py
+++ b/src/denbust/news_items/models.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from denbust.data_models import Category, SubCategory, UnifiedItem
+from denbust.discovery.models import ContentBasis
 from denbust.models.policies import (
     PrivacyRisk,
     PublicationStatus,
@@ -81,6 +82,8 @@ class NewsItemOperationalRecord(NewsItemPublicRecord):
     source_urls: list[str] = Field(default_factory=list)
     source_count: int = 1
     classification_confidence: str | None = None
+    record_confidence: str | None = None
+    content_basis: ContentBasis = ContentBasis.FULL_ARTICLE_PAGE
     suppression_reason: str | None = None
     summary_generation_model: str | None = None
     privacy_reason: str | None = None
@@ -97,6 +100,8 @@ class NewsItemOperationalRecord(NewsItemPublicRecord):
             "source_urls",
             "source_count",
             "classification_confidence",
+            "record_confidence",
+            "content_basis",
             "suppression_reason",
             "summary_generation_model",
             "privacy_reason",
@@ -170,6 +175,8 @@ class NewsItemOperationalRecord(NewsItemPublicRecord):
             source_urls=source_urls,
             source_count=len(source_urls),
             classification_confidence=classification_confidence,
+            record_confidence=classification_confidence or "medium",
+            content_basis=ContentBasis.FULL_ARTICLE_PAGE,
             suppression_reason=suppression_reason,
             summary_generation_model=summary_generation_model,
             privacy_reason=privacy_reason or enrichment.privacy_reason,

--- a/src/denbust/news_items/publication.py
+++ b/src/denbust/news_items/publication.py
@@ -26,7 +26,7 @@ class KagglePublisher:
 
         import os
 
-        from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-untyped]
+        from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
 
         metadata_path = release_dir / "dataset-metadata.json"
         metadata = {

--- a/src/denbust/news_items/publication.py
+++ b/src/denbust/news_items/publication.py
@@ -26,7 +26,7 @@ class KagglePublisher:
 
         import os
 
-        from kaggle.api.kaggle_api_extended import KaggleApi  # type: ignore[import-not-found]
+        from kaggle.api.kaggle_api_extended import KaggleApi
 
         metadata_path = release_dir / "dataset-metadata.json"
         metadata = {

--- a/src/denbust/news_items/release.py
+++ b/src/denbust/news_items/release.py
@@ -232,8 +232,8 @@ class NewsItemsReleaseBuilder(ReleaseBuilder):
 
     def _write_parquet(self, rows: Sequence[NewsItemPublicRecord], path: Path) -> None:
         try:
-            import pyarrow as pa  # type: ignore[import-not-found]
-            import pyarrow.parquet as pq  # type: ignore[import-not-found]
+            import pyarrow as pa
+            import pyarrow.parquet as pq
         except ImportError as exc:
             raise RuntimeError(
                 "pyarrow is required to build the news_items Parquet release."

--- a/src/denbust/news_items/release.py
+++ b/src/denbust/news_items/release.py
@@ -232,8 +232,8 @@ class NewsItemsReleaseBuilder(ReleaseBuilder):
 
     def _write_parquet(self, rows: Sequence[NewsItemPublicRecord], path: Path) -> None:
         try:
-            import pyarrow as pa  # type: ignore[import-untyped]
-            import pyarrow.parquet as pq  # type: ignore[import-untyped]
+            import pyarrow as pa  # type: ignore[import-not-found]
+            import pyarrow.parquet as pq  # type: ignore[import-not-found]
         except ImportError as exc:
             raise RuntimeError(
                 "pyarrow is required to build the news_items Parquet release."

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -213,7 +213,7 @@ def _fallback_source_name(candidate: PersistentCandidate) -> str:
         return source_name.strip()
     for value in [*candidate.source_hints, *candidate.discovered_via]:
         if value.strip():
-            return value
+            return value.strip()
     return candidate.domain or "candidate_fallback"
 
 
@@ -309,9 +309,14 @@ async def _build_fallback_operational_records(
         return []
 
     classified = await classifier.classify_batch([article for _, article in fallback_inputs])
+    if len(classified) != len(fallback_inputs):
+        raise ValueError(
+            "classifier.classify_batch() returned "
+            f"{len(classified)} results for {len(fallback_inputs)} fallback inputs"
+        )
     records: list[NewsItemOperationalRecord] = []
     retrieval_datetime = datetime.now(UTC)
-    for (candidate, article), classified_article in zip(fallback_inputs, classified, strict=False):
+    for (candidate, article), classified_article in zip(fallback_inputs, classified, strict=True):
         classification = classified_article.classification
         if not classification.relevant:
             continue

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from denbust.classifier.relevance import Classifier, create_classifier
 from denbust.config import Config, OutputFormat, SourceType, load_config
-from denbust.data_models import ClassifiedArticle, RawArticle, UnifiedItem
+from denbust.data_models import ClassifiedArticle, RawArticle, SourceReference, UnifiedItem
 from denbust.datasets.jobs import ensure_default_jobs_registered
 from denbust.datasets.registry import require_job_handler
 from denbust.dedup.similarity import Deduplicator, create_deduplicator
@@ -24,7 +24,11 @@ from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.engines.exa import ExaSearchEngine
 from denbust.discovery.engines.google_cse import GoogleCseSearchEngine
-from denbust.discovery.models import DiscoveryRun, DiscoveryRunStatus, PersistentCandidate
+from denbust.discovery.models import (
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    PersistentCandidate,
+)
 from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import (
     CandidateScrapeBatch,
@@ -39,6 +43,7 @@ from denbust.discovery.source_native import (
 )
 from denbust.discovery.storage import create_discovery_persistence
 from denbust.models.common import DatasetName, JobName
+from denbust.models.policies import PublicationStatus, ReviewStatus
 from denbust.models.runs import RunSnapshot
 from denbust.news_items.annotations import (
     apply_manual_annotations,
@@ -46,12 +51,15 @@ from denbust.news_items.annotations import (
     parse_news_item_corrections,
 )
 from denbust.news_items.backup import execute_latest_backup
+from denbust.news_items.enrich import fallback_enrichment
 from denbust.news_items.ingest import (
     build_operational_records,
     parse_suppression_rules,
     summarize_privacy_mix,
 )
+from denbust.news_items.models import NewsItemOperationalRecord
 from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
+from denbust.news_items.policy import infer_privacy_risk, merge_privacy_risk
 from denbust.news_items.publication import publish_release_bundle
 from denbust.news_items.release import (
     NewsItemsReleaseBuilder,
@@ -196,6 +204,146 @@ def deduplicate_articles(
     items = deduplicator.deduplicate(articles)
     logger.info("Deduplicated to %s unique stories", len(items))
     return items
+
+
+def _fallback_source_name(candidate: PersistentCandidate) -> str:
+    metadata = candidate.metadata
+    source_name = metadata.get("fallback_source_name")
+    if isinstance(source_name, str) and source_name.strip():
+        return source_name.strip()
+    for value in [*candidate.source_hints, *candidate.discovered_via]:
+        if value.strip():
+            return value
+    return candidate.domain or "candidate_fallback"
+
+
+def _fallback_publication_datetime(candidate: PersistentCandidate) -> datetime:
+    value = candidate.metadata.get("fallback_publication_datetime")
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+        if parsed is not None:
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=UTC)
+            return parsed.astimezone(UTC)
+    return candidate.last_seen_at
+
+
+def _fallback_text(candidate: PersistentCandidate) -> tuple[str | None, str | None]:
+    metadata = candidate.metadata
+    title = metadata.get("fallback_title")
+    if not isinstance(title, str) or not title.strip():
+        title = next((item for item in candidate.titles if item.strip()), None)
+    snippet = metadata.get("fallback_snippet")
+    if not isinstance(snippet, str) or not snippet.strip():
+        snippet = next((item for item in candidate.snippets if item.strip()), None)
+    normalized_title = " ".join(title.split()).strip() if isinstance(title, str) else None
+    normalized_snippet = " ".join(snippet.split()).strip() if isinstance(snippet, str) else None
+    return normalized_title or None, normalized_snippet or None
+
+
+def _fallback_input_article(candidate: PersistentCandidate) -> RawArticle | None:
+    title, snippet = _fallback_text(candidate)
+    if title is None and snippet is None:
+        return None
+    return RawArticle(
+        url=candidate.canonical_url or candidate.current_url,
+        title=title or snippet or str(candidate.current_url),
+        snippet=snippet or title or "",
+        date=_fallback_publication_datetime(candidate),
+        source_name=_fallback_source_name(candidate),
+    )
+
+
+def _fallback_combined_privacy_input(item: UnifiedItem) -> str:
+    return " ".join(
+        segment
+        for segment in (
+            item.headline,
+            item.summary,
+            item.taxonomy_category_id or "",
+            item.taxonomy_subcategory_id or "",
+            item.category.value,
+            item.sub_category.value if item.sub_category else "",
+        )
+        if segment
+    )
+
+
+def _build_fallback_unified_item(
+    candidate: PersistentCandidate,
+    article: RawArticle,
+    classified_article: ClassifiedArticle,
+) -> UnifiedItem:
+    classification = classified_article.classification
+    return UnifiedItem(
+        headline=article.title,
+        summary=article.snippet or article.title,
+        sources=[SourceReference(source_name=article.source_name, url=article.url)],
+        date=article.date,
+        enforcement_related=classification.enforcement_related,
+        index_relevant=classification.index_relevant,
+        taxonomy_version=classification.taxonomy_version,
+        taxonomy_category_id=classification.taxonomy_category_id,
+        taxonomy_subcategory_id=classification.taxonomy_subcategory_id,
+        category=classification.category,
+        sub_category=classification.sub_category,
+        canonical_url=candidate.canonical_url or candidate.current_url,
+        primary_source_name=article.source_name,
+    )
+
+
+async def _build_fallback_operational_records(
+    *,
+    candidates: list[PersistentCandidate],
+    classifier: Classifier,
+) -> list[NewsItemOperationalRecord]:
+    fallback_inputs: list[tuple[PersistentCandidate, RawArticle]] = []
+    for candidate in candidates:
+        article = _fallback_input_article(candidate)
+        if article is not None:
+            fallback_inputs.append((candidate, article))
+    if not fallback_inputs:
+        return []
+
+    classified = await classifier.classify_batch([article for _, article in fallback_inputs])
+    records: list[NewsItemOperationalRecord] = []
+    retrieval_datetime = datetime.now(UTC)
+    for (candidate, article), classified_article in zip(fallback_inputs, classified, strict=False):
+        classification = classified_article.classification
+        if not classification.relevant:
+            continue
+        item = _build_fallback_unified_item(candidate, article, classified_article)
+        enrichment = fallback_enrichment(item)
+        rule_risk, rule_reason = infer_privacy_risk(_fallback_combined_privacy_input(item))
+        privacy_risk = merge_privacy_risk(enrichment.privacy_risk_level, rule_risk)
+        if privacy_risk is not enrichment.privacy_risk_level:
+            enrichment = enrichment.model_copy(
+                update={
+                    "privacy_risk_level": privacy_risk,
+                    "privacy_reason": rule_reason or enrichment.privacy_reason,
+                }
+            )
+        record = NewsItemOperationalRecord.from_unified_item(
+            item,
+            retrieval_datetime=retrieval_datetime,
+            enrichment=enrichment,
+            classification_confidence=classification.confidence,
+            review_status=ReviewStatus.NEEDS_FACT_REVIEW,
+            publication_status=PublicationStatus.INTERNAL_ONLY,
+            privacy_reason=rule_reason or enrichment.privacy_reason,
+        ).model_copy(
+            update={
+                "event_candidate_ids": [candidate.candidate_id],
+                "content_basis": candidate.content_basis,
+                "record_confidence": "low",
+                "annotation_source": "candidate_fallback",
+            }
+        )
+        records.append(record)
+    return records
 
 
 def _source_discovery_enabled_for_source(config: Config, source_name: str) -> bool:
@@ -1365,30 +1513,60 @@ async def run_news_scrape_candidates_job(
     deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
     seen_store = create_seen_store(config.state_paths.seen_path)
     result.seen_count_before = seen_store.count
+    store = operational_store
+    owns_store = False
 
-    scrape_batch = await _run_candidate_scrape_job(
-        config=config.model_copy(update={"days": days}),
-        sources=sources,
-        limit=config.max_articles,
-    )
-    result.raw_article_count = len(scrape_batch.raw_articles)
-    if scrape_batch.errors:
-        result.errors.extend(scrape_batch.errors)
-        result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
-    if not scrape_batch.selected_candidates:
-        return result.finish("no queued candidates eligible for scrape")
+    try:
+        scrape_batch = await _run_candidate_scrape_job(
+            config=config.model_copy(update={"days": days}),
+            sources=sources,
+            limit=config.max_articles,
+        )
+        result.raw_article_count = len(scrape_batch.raw_articles)
+        if scrape_batch.errors:
+            result.errors.extend(scrape_batch.errors)
+            result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
+        if not scrape_batch.selected_candidates:
+            return result.finish("no queued candidates eligible for scrape")
 
-    return await _process_ingest_articles(
-        config=config,
-        result=result,
-        source_names=source_names,
-        sources=sources,
-        all_articles=scrape_batch.raw_articles,
-        seen_store=seen_store,
-        classifier=classifier,
-        deduplicator=deduplicator,
-        operational_store=operational_store,
-    )
+        if store is None and (scrape_batch.raw_articles or scrape_batch.fallback_candidates):
+            store = create_operational_store(config)
+            owns_store = True
+
+        fallback_records = await _build_fallback_operational_records(
+            candidates=scrape_batch.fallback_candidates,
+            classifier=classifier,
+        )
+        if fallback_records and store is not None:
+            store.upsert_records(
+                config.dataset_name.value,
+                [record.model_dump(mode="json") for record in fallback_records],
+            )
+            result.warnings.append(f"fallback_operational_records={len(fallback_records)}")
+
+        if not scrape_batch.raw_articles:
+            result.unified_item_count = len(fallback_records)
+            if fallback_records:
+                return result.finish(
+                    f"fallback retention completed with {len(fallback_records)} provisional row(s)"
+                )
+            return result.finish("candidate scrape completed with no materializable rows")
+
+        processed = await _process_ingest_articles(
+            config=config,
+            result=result,
+            source_names=source_names,
+            sources=sources,
+            all_articles=scrape_batch.raw_articles,
+            seen_store=seen_store,
+            classifier=classifier,
+            deduplicator=deduplicator,
+            operational_store=store,
+        )
+        return processed
+    finally:
+        if owns_store and store is not None:
+            store.close()
 
 
 async def run_pipeline_async(config: Config, days: int) -> RunSnapshot:

--- a/src/denbust/sources/haaretz.py
+++ b/src/denbust/sources/haaretz.py
@@ -7,7 +7,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup, Tag
@@ -265,7 +265,7 @@ class HaaretzScraper(Source):
                 timeout=READY_TIMEOUT_MS,
             )
             await page.wait_for_timeout(POST_READY_DELAY_MS)
-            return cast(str, await page.content())
+            return str(await page.content())
         except PlaywrightTimeoutError as e:
             raise RuntimeError(
                 f"Haaretz search navigation timed out for '{keyword}' on page {page_number}."

--- a/src/denbust/sources/haaretz.py
+++ b/src/denbust/sources/haaretz.py
@@ -7,7 +7,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup, Tag
@@ -265,7 +265,7 @@ class HaaretzScraper(Source):
                 timeout=READY_TIMEOUT_MS,
             )
             await page.wait_for_timeout(POST_READY_DELAY_MS)
-            return await page.content()
+            return cast(str, await page.content())
         except PlaywrightTimeoutError as e:
             raise RuntimeError(
                 f"Haaretz search navigation timed out for '{keyword}' on page {page_number}."

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -8,7 +8,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup, Tag
@@ -412,7 +412,7 @@ class MakoScraper(Source):
                 f"If Chromium is missing, install it with `{PLAYWRIGHT_INSTALL_HINT}`."
             ) from e
 
-        return cast(str, await page.content())
+        return str(await page.content())
 
     async def _fetch_search_results_html(
         self,
@@ -463,7 +463,7 @@ class MakoScraper(Source):
 
             if snapshot.state == "results":
                 await page.wait_for_timeout(POST_READY_DELAY_MS)
-                return cast(str, await page.content())
+                return str(await page.content())
 
             if snapshot.state == "empty":
                 logger.info("Mako browser search returned no results for '%s'", keyword)

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -8,7 +8,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from bs4 import BeautifulSoup, Tag
@@ -412,7 +412,7 @@ class MakoScraper(Source):
                 f"If Chromium is missing, install it with `{PLAYWRIGHT_INSTALL_HINT}`."
             ) from e
 
-        return await page.content()
+        return cast(str, await page.content())
 
     async def _fetch_search_results_html(
         self,
@@ -463,7 +463,7 @@ class MakoScraper(Source):
 
             if snapshot.state == "results":
                 await page.wait_for_timeout(POST_READY_DELAY_MS)
-                return await page.content()
+                return cast(str, await page.content())
 
             if snapshot.state == "empty":
                 logger.info("Mako browser search returned no results for '%s'", keyword)

--- a/supabase/migrations/20260417_news_items_fallback_retention.sql
+++ b/supabase/migrations/20260417_news_items_fallback_retention.sql
@@ -1,0 +1,19 @@
+alter table public.news_items
+    add column if not exists content_basis text;
+
+update public.news_items
+set content_basis = 'full_article_page'
+where content_basis is null;
+
+alter table public.news_items
+    alter column content_basis set default 'full_article_page';
+
+alter table public.news_items
+    alter column content_basis set not null;
+
+alter table public.news_items
+    add column if not exists record_confidence text;
+
+update public.news_items
+set record_confidence = coalesce(classification_confidence, 'medium')
+where record_confidence is null;

--- a/supabase/migrations/20260417_news_items_fallback_retention.sql
+++ b/supabase/migrations/20260417_news_items_fallback_retention.sql
@@ -17,3 +17,6 @@ alter table public.news_items
 update public.news_items
 set record_confidence = coalesce(classification_confidence, 'medium')
 where record_confidence is null;
+
+alter table public.news_items
+    alter column record_confidence set default 'medium';

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -22,6 +22,7 @@ from denbust.diagnostics.discovery import (
 )
 from denbust.discovery.models import (
     CandidateStatus,
+    ContentBasis,
     FetchStatus,
     PersistentCandidate,
     ScrapeAttempt,
@@ -41,6 +42,7 @@ def _candidate(
     first_seen_at: datetime,
     last_seen_at: datetime,
     next_scrape_attempt_at: datetime | None = None,
+    content_basis: ContentBasis = ContentBasis.CANDIDATE_ONLY,
 ) -> PersistentCandidate:
     return PersistentCandidate(
         candidate_id=candidate_id,
@@ -51,6 +53,7 @@ def _candidate(
         titles=[candidate_id],
         snippets=[candidate_id],
         candidate_status=status,
+        content_basis=content_basis,
         first_seen_at=first_seen_at,
         last_seen_at=last_seen_at,
         next_scrape_attempt_at=next_scrape_attempt_at,
@@ -77,6 +80,7 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
                 status=CandidateStatus.SCRAPE_SUCCEEDED,
                 first_seen_at=now - timedelta(days=2),
                 last_seen_at=now - timedelta(hours=2),
+                content_basis=ContentBasis.FULL_ARTICLE_PAGE,
             ),
             _candidate(
                 "candidate-source-only",
@@ -94,6 +98,7 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
                 first_seen_at=now - timedelta(days=3),
                 last_seen_at=now - timedelta(days=2),
                 next_scrape_attempt_at=now - timedelta(hours=1),
+                content_basis=ContentBasis.SEARCH_RESULT_ONLY,
             ),
             _candidate(
                 "candidate-google-partial",
@@ -103,6 +108,7 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
                 first_seen_at=now - timedelta(days=1),
                 last_seen_at=now - timedelta(hours=3),
                 next_scrape_attempt_at=now + timedelta(hours=12),
+                content_basis=ContentBasis.PARTIAL_PAGE,
             ),
         ]
     )
@@ -159,9 +165,13 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
     assert report.queue_health.new_candidates == 1
     assert report.queue_health.scrape_failed_candidates == 1
     assert report.queue_health.partially_scraped_candidates == 1
+    assert report.queue_health.search_result_only_candidates == 1
+    assert report.queue_health.partial_page_candidates == 1
+    assert report.queue_health.full_article_page_candidates == 1
     assert report.queue_health.stale_candidates == 1
     assert report.queue_health.retry_backlog_candidates == 1
     assert report.candidate_conversion.scrape_succeeded_candidates == 1
+    assert report.candidate_conversion.search_result_only_candidates == 1
     assert report.candidate_conversion.operational_record_matches == 1
     assert report.candidate_conversion.per_producer[0].candidate_count >= 1
     assert report.top_failure_sources[0].name == "mako"

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import httpx
 import pytest
+from bs4 import BeautifulSoup
 from pydantic import HttpUrl
 
+import denbust.discovery.scrape_queue as scrape_queue_module
 from denbust.config import Config
 from denbust.data_models import RawArticle
 from denbust.discovery.models import (
@@ -228,7 +231,10 @@ async def test_scrape_candidates_retains_failed_candidate_for_retry(tmp_path: Pa
     source = FakeSource("ynet", [])
     original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
         return GenericFetchResult(
             fetch_status=FetchStatus.FAILED,
             error_code="generic_fetch_failed",
@@ -278,7 +284,10 @@ async def test_scrape_candidates_accumulates_attempt_count_across_retries(tmp_pa
     source = FakeSource("ynet", [])
     original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
         return GenericFetchResult(
             fetch_status=FetchStatus.FAILED,
             error_code="generic_fetch_failed",
@@ -317,7 +326,10 @@ async def test_scrape_candidates_retains_unknown_sources_as_search_results(tmp_p
     )
     original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
         return GenericFetchResult(
             fetch_status=FetchStatus.FAILED,
             error_code="generic_fetch_failed",
@@ -354,7 +366,10 @@ async def test_scrape_candidates_retains_partial_page_metadata(tmp_path: Path) -
     source = FakeSource("ynet", [])
     original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
         return GenericFetchResult(
             fetch_status=FetchStatus.PARTIAL,
             title="כותרת חלקית",
@@ -381,6 +396,8 @@ async def test_scrape_candidates_retains_partial_page_metadata(tmp_path: Path) -
     assert stored.next_scrape_attempt_at is None
     assert stored.needs_review is True
     assert stored.self_heal_eligible is False
+    assert stored.scrape_attempt_count == 2
+    assert stored.metadata["fallback_publication_datetime"] == "2026-04-11T12:00:00+00:00"
     assert [candidate.candidate_id for candidate in batch.fallback_candidates] == ["candidate-5"]
 
 
@@ -412,7 +429,10 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
     ]
     original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
         return GenericFetchResult(
             fetch_status=FetchStatus.FAILED,
             error_code="generic_fetch_failed",
@@ -449,3 +469,182 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
         FetchStatus.FAILED,
         FetchStatus.SUCCESS,
     ]
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_records_fallback_metadata_for_final_url_and_diagnostics(
+    tmp_path: Path,
+) -> None:
+    """Search-result fallbacks should persist generic-fetch provenance for review."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-6", status=CandidateStatus.NEW)
+    store.upsert_candidates([candidate])
+    source = FakeSource("ynet", [])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_no_metadata",
+            error_message="Generic fetch returned a page without usable metadata",
+            title="כותרת מגוגל",
+            snippet="תקציר מגוגל",
+            final_url="https://www.ynet.co.il/news/article/abc?ref=final",
+            diagnostics={"content_type": "text/html"},
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[source],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-6")
+    assert stored is not None
+    assert (
+        stored.metadata["fallback_final_url"] == "https://www.ynet.co.il/news/article/abc?ref=final"
+    )
+    assert stored.metadata["fallback_diagnostics"] == {"content_type": "text/html"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_partial_page_reuses_passed_client_and_extracts_metadata() -> None:
+    """Generic fetch helper should parse title, description, and publication metadata."""
+    html = """
+    <html>
+      <head>
+        <title>  Page Title  </title>
+        <meta property="og:description" content="  Page description  ">
+        <meta name="article:published_time" content="2026-04-11T12:00:00Z">
+      </head>
+    </html>
+    """
+    request = httpx.Request("GET", "https://example.com/article")
+    response = httpx.Response(
+        200,
+        request=request,
+        text=html,
+        headers={"content-type": "text/html; charset=utf-8"},
+    )
+
+    class FakeClient:
+        async def get(self, url: str) -> httpx.Response:
+            assert url == "https://www.ynet.co.il/news/article/abc?utm_source=test"
+            return response
+
+    result = await scrape_queue_module._fetch_partial_page(
+        build_candidate("candidate-7", status=CandidateStatus.NEW),
+        client=FakeClient(),
+    )
+
+    assert result.fetch_status is FetchStatus.PARTIAL
+    assert result.title == "Page Title"
+    assert result.snippet == "Page description"
+    assert result.final_url == "https://example.com/article"
+    assert result.diagnostics == {"content_type": "text/html; charset=utf-8"}
+    assert result.publication_datetime == datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_fetch_partial_page_returns_timeout_blocked_http_error_and_no_metadata() -> None:
+    """Generic fetch helper should classify timeout, blocked, transport, and no-metadata outcomes."""
+    candidate = build_candidate("candidate-8", status=CandidateStatus.NEW)
+    request = httpx.Request("GET", "https://example.com/article")
+
+    class TimeoutClient:
+        async def get(self, url: str) -> httpx.Response:
+            raise httpx.ReadTimeout("boom", request=httpx.Request("GET", url))
+
+    timeout_result = await scrape_queue_module._fetch_partial_page(
+        candidate, client=TimeoutClient()
+    )
+    assert timeout_result.fetch_status is FetchStatus.TIMEOUT
+    assert timeout_result.error_code == "generic_fetch_timeout"
+
+    blocked_response = httpx.Response(403, request=request)
+
+    class BlockedClient:
+        async def get(self, url: str) -> httpx.Response:
+            del url
+            raise httpx.HTTPStatusError("blocked", request=request, response=blocked_response)
+
+    blocked_result = await scrape_queue_module._fetch_partial_page(
+        candidate, client=BlockedClient()
+    )
+    assert blocked_result.fetch_status is FetchStatus.BLOCKED
+    assert blocked_result.error_code == "generic_fetch_http_403"
+
+    class ErrorClient:
+        async def get(self, url: str) -> httpx.Response:
+            raise httpx.RequestError("network", request=httpx.Request("GET", url))
+
+    error_result = await scrape_queue_module._fetch_partial_page(candidate, client=ErrorClient())
+    assert error_result.fetch_status is FetchStatus.FAILED
+    assert error_result.error_code == "generic_fetch_error"
+
+    no_meta_response = httpx.Response(
+        200,
+        request=request,
+        text="<html><head></head><body>hello</body></html>",
+        headers={"content-type": "text/html"},
+    )
+
+    class NoMetadataClient:
+        async def get(self, url: str) -> httpx.Response:
+            del url
+            return no_meta_response
+
+    no_meta_result = await scrape_queue_module._fetch_partial_page(
+        candidate, client=NoMetadataClient()
+    )
+    assert no_meta_result.fetch_status is FetchStatus.FAILED
+    assert no_meta_result.error_code == "generic_fetch_no_metadata"
+    assert no_meta_result.final_url == "https://example.com/article"
+    assert no_meta_result.diagnostics == {"content_type": "text/html"}
+
+
+def test_extract_partial_page_helpers_cover_meta_parsing_edge_cases() -> None:
+    """Metadata helpers should normalize values and accept ISO/RFC-2822 publication dates."""
+    html = """
+    <html>
+      <head>
+        <meta name="twitter:title" content="  Twitter title  ">
+        <meta name="description" content="  Summary text  ">
+        <meta name="pubdate" content="Tue, 11 Apr 2026 10:00:00 +0000">
+      </head>
+    </html>
+    """
+
+    parsed = scrape_queue_module._extract_partial_page_metadata(html)
+
+    assert parsed["title"] == "Twitter title"
+    assert parsed["snippet"] == "Summary text"
+    assert parsed["publication_datetime"] == datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    assert scrape_queue_module._first_non_empty(None, "  ", " value ") == "value"
+    assert scrape_queue_module._first_non_empty(None, "  ") is None
+    assert scrape_queue_module._extract_partial_page_metadata(
+        '<meta name="description" content><meta name="date" content="2026-04-11T10:00:00">'
+    )["publication_datetime"] == datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    assert (
+        scrape_queue_module._extract_partial_page_metadata(
+            '<meta name="description" content><meta name="date" content="2026-04-11T10:00:00">'
+        )["snippet"]
+        is None
+    )
+    assert (
+        scrape_queue_module._meta_content(
+            BeautifulSoup('<meta name="description">', "html.parser"),
+            name="description",
+        )
+        is None
+    )
+    assert scrape_queue_module._parse_publication_datetime("bad date") is None

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -10,9 +10,15 @@ from pydantic import HttpUrl
 
 from denbust.config import Config
 from denbust.data_models import RawArticle
-from denbust.discovery.models import CandidateStatus, FetchStatus, PersistentCandidate
+from denbust.discovery.models import (
+    CandidateStatus,
+    ContentBasis,
+    FetchStatus,
+    PersistentCandidate,
+)
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
+    GenericFetchResult,
     scrape_candidates,
     select_candidates_for_scrape,
 )
@@ -179,6 +185,7 @@ async def test_scrape_candidates_returns_empty_batch_for_no_candidates(tmp_path:
 
     assert batch.selected_candidates == []
     assert batch.updated_candidates == []
+    assert batch.fallback_candidates == []
     assert batch.attempts == []
     assert batch.raw_articles == []
     assert batch.errors == []
@@ -203,7 +210,9 @@ async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path:
     stored = store.get_candidate("candidate-1")
     assert stored is not None
     assert stored.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
+    assert stored.content_basis is ContentBasis.FULL_ARTICLE_PAGE
     assert stored.scrape_attempt_count == 1
+    assert batch.fallback_candidates == []
     assert len(batch.raw_articles) == 1
     assert len(batch.attempts) == 1
     assert batch.attempts[0].fetch_status is FetchStatus.SUCCESS
@@ -217,24 +226,41 @@ async def test_scrape_candidates_retains_failed_candidate_for_retry(tmp_path: Pa
     candidate = build_candidate("candidate-2", status=CandidateStatus.SCRAPE_FAILED)
     store.upsert_candidates([candidate])
     source = FakeSource("ynet", [])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    batch = await scrape_candidates(
-        config=Config(store={"state_root": tmp_path}),
-        persistence=store,
-        candidates=[candidate],
-        sources=[source],
-    )
+    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_failed",
+            error_message="Generic fetch failed",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[source],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
 
     stored = store.get_candidate("candidate-2")
     assert stored is not None
     assert stored.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert stored.content_basis is ContentBasis.SEARCH_RESULT_ONLY
     assert stored.scrape_attempt_count == 2
     assert stored.next_scrape_attempt_at is not None
+    assert stored.needs_review is True
+    assert stored.self_heal_eligible is True
     assert [attempt.fetch_status for attempt in batch.attempts] == [
         FetchStatus.FAILED,
-        FetchStatus.UNSUPPORTED,
+        FetchStatus.FAILED,
     ]
     assert batch.raw_articles == []
+    assert [candidate.candidate_id for candidate in batch.fallback_candidates] == ["candidate-2"]
     assert len(store.list_attempts("candidate-2")) == 2
 
 
@@ -250,13 +276,26 @@ async def test_scrape_candidates_accumulates_attempt_count_across_retries(tmp_pa
     )
     store.upsert_candidates([candidate])
     source = FakeSource("ynet", [])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    batch = await scrape_candidates(
-        config=Config(store={"state_root": tmp_path}),
-        persistence=store,
-        candidates=[candidate],
-        sources=[source],
-    )
+    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_failed",
+            error_message="Generic fetch failed",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[source],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
 
     stored = store.get_candidate("candidate-3")
     assert stored is not None
@@ -266,8 +305,8 @@ async def test_scrape_candidates_accumulates_attempt_count_across_retries(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_scrape_candidates_marks_unknown_sources_as_unsupported(tmp_path: Path) -> None:
-    """Candidates without a matching source adapter should become unsupported."""
+async def test_scrape_candidates_retains_unknown_sources_as_search_results(tmp_path: Path) -> None:
+    """Candidates without a matching source adapter should retain search-result-only metadata."""
     store = build_store(tmp_path)
     candidate = build_candidate(
         "candidate-4",
@@ -276,20 +315,73 @@ async def test_scrape_candidates_marks_unknown_sources_as_unsupported(tmp_path: 
         current_url="https://unknown.example.com/article",
         canonical_url="https://unknown.example.com/article",
     )
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    batch = await scrape_candidates(
-        config=Config(store={"state_root": tmp_path}),
-        persistence=store,
-        candidates=[candidate],
-        sources=[],
-    )
+    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_failed",
+            error_message="Generic fetch failed",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
 
     stored = store.get_candidate("candidate-4")
     assert stored is not None
-    assert stored.candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
+    assert stored.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert stored.content_basis is ContentBasis.SEARCH_RESULT_ONLY
+    assert stored.next_scrape_attempt_at is not None
+    assert len(batch.attempts) == 1
+    assert batch.attempts[0].fetch_status is FetchStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_retains_partial_page_metadata(tmp_path: Path) -> None:
+    """Generic fetches with limited metadata should become partial-page fallback rows."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-5", status=CandidateStatus.NEW)
+    store.upsert_candidates([candidate])
+    source = FakeSource("ynet", [])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת חלקית",
+            snippet="תיאור חלקי",
+            publication_datetime=datetime(2026, 4, 11, 12, 0, tzinfo=UTC),
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[source],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-5")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.content_basis is ContentBasis.PARTIAL_PAGE
     assert stored.next_scrape_attempt_at is None
-    assert len(batch.attempts) == 2
-    assert batch.attempts[0].fetch_status is FetchStatus.UNSUPPORTED
+    assert stored.needs_review is True
+    assert stored.self_heal_eligible is False
+    assert [candidate.candidate_id for candidate in batch.fallback_candidates] == ["candidate-5"]
 
 
 @pytest.mark.asyncio
@@ -313,18 +405,31 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
             "mako",
             [
                 build_raw_article(
-                    "https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako"
+            "https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako"
                 )
             ],
         ),
     ]
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
 
-    batch = await scrape_candidates(
-        config=Config(store={"state_root": tmp_path}),
-        persistence=store,
-        candidates=[failing_candidate, succeeding_candidate],
-        sources=sources,
-    )
+    async def fake_fetch_partial_page(_candidate: PersistentCandidate) -> GenericFetchResult:
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_failed",
+            error_message="Generic fetch failed",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[failing_candidate, succeeding_candidate],
+            sources=sources,
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
 
     failed = store.get_candidate("candidate-fail")
     succeeded = store.get_candidate("candidate-ok")

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -405,7 +405,7 @@ async def test_scrape_candidates_retains_partial_page_metadata(tmp_path: Path) -
 async def test_scrape_candidates_records_adapter_exceptions_and_continues(
     tmp_path: Path,
 ) -> None:
-    """Adapter exceptions should fail only the affected candidate and continue the batch."""
+    """Adapter exceptions should still fall back to generic retention and continue the batch."""
     store = build_store(tmp_path)
     failing_candidate = build_candidate("candidate-fail", status=CandidateStatus.NEW)
     succeeding_candidate = build_candidate(
@@ -455,9 +455,12 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
     succeeded = store.get_candidate("candidate-ok")
     assert failed is not None
     assert failed.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert failed.content_basis is ContentBasis.SEARCH_RESULT_ONLY
     assert failed.next_scrape_attempt_at is not None
-    assert failed.last_scrape_error_code == "source_adapter_error"
-    assert "adapter boom" in (failed.last_scrape_error_message or "")
+    assert failed.last_scrape_error_code == "generic_fetch_failed"
+    assert failed.last_scrape_error_message == "Generic fetch failed"
+    assert failed.needs_review is True
+    assert failed.metadata["fallback_source_name"] == "ynet"
     assert succeeded is not None
     assert succeeded.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
     assert len(batch.raw_articles) == 1
@@ -467,7 +470,52 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
     )
     assert [attempt.fetch_status for attempt in batch.attempts] == [
         FetchStatus.FAILED,
+        FetchStatus.FAILED,
         FetchStatus.SUCCESS,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_retains_partial_fallback_after_adapter_exception(
+    tmp_path: Path,
+) -> None:
+    """Adapter exceptions should still allow partial-page fallback retention."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-partial", status=CandidateStatus.NEW)
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת חלקית",
+            snippet="תיאור חלקי",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[FailingSource("ynet", RuntimeError("adapter boom"))],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-partial")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.content_basis is ContentBasis.PARTIAL_PAGE
+    assert stored.scrape_attempt_count == 2
+    assert stored.metadata["fallback_source_name"] == "ynet"
+    assert [attempt.fetch_status for attempt in batch.attempts] == [
+        FetchStatus.FAILED,
+        FetchStatus.PARTIAL,
     ]
 
 

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -405,7 +405,7 @@ async def test_scrape_candidates_records_adapter_exceptions_and_continues(
             "mako",
             [
                 build_raw_article(
-            "https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako"
+                    "https://www.mako.co.il/news/article/ok?utm_source=test", source_name="mako"
                 )
             ],
         ),

--- a/tests/unit/test_news_items_phase_b.py
+++ b/tests/unit/test_news_items_phase_b.py
@@ -17,6 +17,7 @@ import pytest
 
 from denbust.config import Config
 from denbust.data_models import Category, SourceReference, SubCategory, UnifiedItem
+from denbust.discovery.models import ContentBasis
 from denbust.models.policies import PrivacyRisk, PublicationStatus, ReviewStatus, TakedownStatus
 from denbust.news_items.backup import (
     GoogleDriveLatestBackupUploader,
@@ -141,12 +142,22 @@ def test_select_releasable_records_filters_internal_and_suppressed_rows() -> Non
     approved = build_record()
     internal = build_record(publication_status=PublicationStatus.INTERNAL_ONLY)
     suppressed = build_record(takedown_status=TakedownStatus.SUPPRESSED)
+    fallback = build_record(
+        publication_status=PublicationStatus.INTERNAL_ONLY,
+        review_status=ReviewStatus.NEEDS_FACT_REVIEW,
+    ).model_copy(
+        update={
+            "content_basis": ContentBasis.SEARCH_RESULT_ONLY,
+            "record_confidence": "low",
+        }
+    )
 
     public_rows = select_releasable_records(
         [
             approved.model_dump(mode="json"),
             internal.model_dump(mode="json"),
             suppressed.model_dump(mode="json"),
+            fallback.model_dump(mode="json"),
         ],
         release_version="2026-03-22",
     )
@@ -190,6 +201,24 @@ def test_serialized_row_stringifies_non_string_scalars() -> None:
     assert payload["source_count"] == "3"
     assert payload["index_relevant"] == "True"
     assert payload["taxonomy_version"] == ""
+
+
+def test_operational_record_defaults_to_full_article_content_basis() -> None:
+    record = build_record()
+
+    assert record.content_basis is ContentBasis.FULL_ARTICLE_PAGE
+    assert record.record_confidence == "medium"
+
+
+def test_news_items_fallback_migration_adds_operational_columns() -> None:
+    sql = Path("supabase/migrations/20260417_news_items_fallback_retention.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert "add column if not exists content_basis text" in sql
+    assert "set content_basis = 'full_article_page'" in sql
+    assert "alter column content_basis set not null" in sql
+    assert "add column if not exists record_confidence text" in sql
 
 
 def test_execute_latest_backup_returns_empty_manifest_when_no_targets(tmp_path: Path) -> None:

--- a/tests/unit/test_news_items_phase_b.py
+++ b/tests/unit/test_news_items_phase_b.py
@@ -219,6 +219,7 @@ def test_news_items_fallback_migration_adds_operational_columns() -> None:
     assert "set content_basis = 'full_article_page'" in sql
     assert "alter column content_basis set not null" in sql
     assert "add column if not exists record_confidence text" in sql
+    assert "alter column record_confidence set default 'medium'" in sql
 
 
 def test_execute_latest_backup_returns_empty_manifest_when_no_targets(tmp_path: Path) -> None:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -25,6 +25,7 @@ from denbust.data_models import (
 )
 from denbust.discovery.models import (
     CandidateStatus,
+    ContentBasis,
     DiscoveryRun,
     DiscoveryRunStatus,
     PersistentCandidate,
@@ -33,7 +34,8 @@ from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
 from denbust.discovery.storage import StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName, JobName
-from denbust.models.policies import PrivacyRisk
+from denbust.models.policies import PrivacyRisk, PublicationStatus, ReviewStatus
+from denbust.news_items.models import NewsItemEnrichment, NewsItemOperationalRecord
 from denbust.ops.storage import LocalJsonOperationalStore
 from denbust.pipeline import (
     _build_classifier_summary,
@@ -1421,6 +1423,7 @@ class TestRunPipelineAsync:
         scrape_batch = CandidateScrapeBatch(
             selected_candidates=[],
             updated_candidates=[],
+            fallback_candidates=[],
             attempts=[],
             raw_articles=[source_scraped],
             errors=[],
@@ -1500,6 +1503,7 @@ class TestRunPipelineAsync:
                 return_value=CandidateScrapeBatch(
                     selected_candidates=[MagicMock()],
                     updated_candidates=[],
+                    fallback_candidates=[],
                     attempts=[],
                     raw_articles=[raw_article],
                     errors=["candidate-1: generic fetch fallback not implemented yet"],
@@ -1531,6 +1535,159 @@ class TestRunPipelineAsync:
         mark_seen_mock.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_upserts_fallback_rows_without_marking_seen(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Fallback candidates should become provisional internal rows and remain unseen."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        seen_store = MagicMock(count=0)
+        fallback_candidate = build_persistent_candidate(
+            "candidate-fallback",
+            current_url="https://example.com/fallback",
+        ).model_copy(
+            update={
+                "content_basis": ContentBasis.SEARCH_RESULT_ONLY,
+                "metadata": {
+                    "fallback_title": "כותרת מגוגל",
+                    "fallback_snippet": "תקציר מגוגל",
+                    "fallback_source_name": "brave",
+                },
+            }
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[
+                build_classified_article("https://example.com/fallback", relevant=True),
+            ]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            AsyncMock(
+                return_value=CandidateScrapeBatch(
+                    selected_candidates=[fallback_candidate],
+                    updated_candidates=[fallback_candidate],
+                    fallback_candidates=[fallback_candidate],
+                    attempts=[],
+                    raw_articles=[],
+                    errors=[],
+                )
+            ),
+        )
+        mark_seen_mock = MagicMock()
+        monkeypatch.setattr("denbust.pipeline.mark_seen", mark_seen_mock)
+        operational_store = LocalJsonOperationalStore(tmp_path / "ops")
+
+        result = await run_news_scrape_candidates_job(
+            Config(job_name=JobName.SCRAPE_CANDIDATES),
+            operational_store=operational_store,
+        )
+
+        rows = operational_store.fetch_records("news_items")
+        assert result.result_summary == "fallback retention completed with 1 provisional row(s)"
+        assert result.unified_item_count == 1
+        assert mark_seen_mock.call_count == 0
+        assert len(rows) == 1
+        assert rows[0]["publication_status"] == PublicationStatus.INTERNAL_ONLY.value
+        assert rows[0]["review_status"] == ReviewStatus.NEEDS_FACT_REVIEW.value
+        assert rows[0]["content_basis"] == ContentBasis.SEARCH_RESULT_ONLY.value
+        assert rows[0]["record_confidence"] == "low"
+        assert rows[0]["event_candidate_ids"] == ["candidate-fallback"]
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_upgrades_existing_fallback_row_in_place(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A later full scrape should overwrite the provisional fallback row for the same URL."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        seen_store = MagicMock(count=0)
+        raw_article = build_raw_article("https://example.com/upgraded")
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[build_classified_article("https://example.com/upgraded", relevant=True)]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: seen_store)
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            AsyncMock(
+                return_value=CandidateScrapeBatch(
+                    selected_candidates=[MagicMock()],
+                    updated_candidates=[],
+                    fallback_candidates=[],
+                    attempts=[],
+                    raw_articles=[raw_article],
+                    errors=[],
+                )
+            ),
+        )
+        monkeypatch.setattr("denbust.pipeline.filter_seen", lambda articles, _store: articles)
+        monkeypatch.setattr(
+            "denbust.pipeline.deduplicate_articles",
+            lambda _articles, _deduplicator: [build_unified_item("https://example.com/upgraded")],
+        )
+        full_record = NewsItemOperationalRecord.from_unified_item(
+            build_unified_item("https://example.com/upgraded"),
+            retrieval_datetime=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+            enrichment=NewsItemEnrichment(
+                summary_one_sentence="סיכום מלא",
+                topic_tags=["brothel", "closure"],
+            ),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.build_operational_records",
+            AsyncMock(return_value=[full_record]),
+        )
+        mark_seen_mock = MagicMock()
+        monkeypatch.setattr("denbust.pipeline.mark_seen", mark_seen_mock)
+        operational_store = LocalJsonOperationalStore(tmp_path / "ops")
+        operational_store.upsert_records(
+            "news_items",
+            [
+                NewsItemOperationalRecord.from_unified_item(
+                    build_unified_item("https://example.com/upgraded"),
+                    retrieval_datetime=datetime(2026, 4, 11, 8, 0, tzinfo=UTC),
+                    enrichment=NewsItemEnrichment(
+                        summary_one_sentence="סיכום זמני",
+                        topic_tags=["candidate-fallback"],
+                    ),
+                    review_status=ReviewStatus.NEEDS_FACT_REVIEW,
+                    publication_status=PublicationStatus.INTERNAL_ONLY,
+                )
+                .model_copy(
+                    update={
+                        "content_basis": ContentBasis.SEARCH_RESULT_ONLY,
+                        "record_confidence": "low",
+                        "event_candidate_ids": ["candidate-fallback"],
+                    }
+                )
+                .model_dump(mode="json")
+            ],
+        )
+
+        await run_news_scrape_candidates_job(
+            Config(job_name=JobName.SCRAPE_CANDIDATES),
+            operational_store=operational_store,
+        )
+
+        rows = operational_store.fetch_records("news_items")
+        assert len(rows) == 1
+        assert rows[0]["content_basis"] == ContentBasis.FULL_ARTICLE_PAGE.value
+        assert rows[0]["publication_status"] == PublicationStatus.APPROVED.value
+        assert rows[0]["review_status"] == ReviewStatus.NONE.value
+        assert rows[0]["record_confidence"] == "medium"
+        mark_seen_mock.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_run_candidate_scrape_job_selects_candidates_and_closes_persistence(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1550,6 +1707,7 @@ class TestRunPipelineAsync:
             return_value=CandidateScrapeBatch(
                 selected_candidates=selected_candidates,
                 updated_candidates=[],
+                fallback_candidates=[],
                 attempts=[],
                 raw_articles=[],
                 errors=[],
@@ -1682,6 +1840,7 @@ class TestRunPipelineAsync:
                 return_value=CandidateScrapeBatch(
                     selected_candidates=[],
                     updated_candidates=[],
+                    fallback_candidates=[],
                     attempts=[],
                     raw_articles=[],
                     errors=[],
@@ -1718,6 +1877,7 @@ class TestRunPipelineAsync:
             return CandidateScrapeBatch(
                 selected_candidates=[],
                 updated_candidates=[],
+                fallback_candidates=[],
                 attempts=[],
                 raw_articles=[],
                 errors=[],

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -419,6 +419,144 @@ class TestFetchAndClassifyHelpers:
 
         assert items == expected
 
+    def test_fallback_helpers_cover_metadata_and_field_fallbacks(self) -> None:
+        """Fallback helper functions should normalize metadata and candidate-derived values."""
+        candidate = build_persistent_candidate(
+            "candidate-helper",
+            current_url="https://example.com/helper",
+        ).model_copy(
+            update={
+                "titles": ["  Candidate title  "],
+                "snippets": ["  Candidate snippet  "],
+                "source_hints": ["  hinted-source  "],
+                "discovered_via": ["  discovered-source  "],
+                "last_seen_at": datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+                "metadata": {
+                    "fallback_title": " ",
+                    "fallback_snippet": " ",
+                    "fallback_publication_datetime": "2026-04-11T10:00:00",
+                },
+            }
+        )
+
+        assert pipeline_module._fallback_source_name(candidate) == "  hinted-source  "
+        assert pipeline_module._fallback_publication_datetime(candidate) == datetime(
+            2026, 4, 11, 10, 0, tzinfo=UTC
+        )
+        assert pipeline_module._fallback_text(candidate) == (
+            "Candidate title",
+            "Candidate snippet",
+        )
+
+        fallback_article = pipeline_module._fallback_input_article(candidate)
+        assert fallback_article is not None
+        assert fallback_article.title == "Candidate title"
+        assert fallback_article.snippet == "Candidate snippet"
+        assert fallback_article.source_name == "  hinted-source  "
+
+        no_text_candidate = candidate.model_copy(
+            update={
+                "titles": [" "],
+                "snippets": [" "],
+                "source_hints": [" "],
+                "discovered_via": [" "],
+                "metadata": {},
+                "current_url": HttpUrl("https://sub.example.com/no-text"),
+                "canonical_url": HttpUrl("https://sub.example.com/no-text"),
+            }
+        )
+        assert pipeline_module._fallback_source_name(no_text_candidate) == "example.com"
+        assert pipeline_module._fallback_publication_datetime(no_text_candidate) == datetime(
+            2026, 4, 11, 9, 0, tzinfo=UTC
+        )
+        assert pipeline_module._fallback_input_article(no_text_candidate) is None
+
+        candidate_fallback = no_text_candidate.model_copy(
+            update={
+                "current_url": HttpUrl("https://localhost/no-domain"),
+                "canonical_url": HttpUrl("https://localhost/no-domain"),
+                "domain": None,
+            }
+        )
+        assert pipeline_module._fallback_source_name(candidate_fallback) == "candidate_fallback"
+
+        aware_publication_candidate = candidate.model_copy(
+            update={"metadata": {"fallback_publication_datetime": "2026-04-11T12:00:00+02:00"}}
+        )
+        assert pipeline_module._fallback_publication_datetime(
+            aware_publication_candidate
+        ) == datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+
+        invalid_publication_candidate = candidate.model_copy(
+            update={"metadata": {"fallback_publication_datetime": "not-a-date"}}
+        )
+        assert pipeline_module._fallback_publication_datetime(
+            invalid_publication_candidate
+        ) == datetime(2026, 4, 11, 9, 0, tzinfo=UTC)
+
+    @pytest.mark.asyncio
+    async def test_build_fallback_operational_records_skips_non_relevant_and_merges_rule_risk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fallback operational rows should skip irrelevant candidates and elevate rule-based privacy risk."""
+        relevant_candidate = build_persistent_candidate(
+            "candidate-relevant",
+            current_url="https://example.com/relevant",
+        ).model_copy(
+            update={
+                "content_basis": ContentBasis.PARTIAL_PAGE,
+                "metadata": {
+                    "fallback_title": "Relevant title",
+                    "fallback_snippet": "Relevant summary",
+                    "fallback_source_name": "brave",
+                },
+            }
+        )
+        ignored_candidate = build_persistent_candidate(
+            "candidate-ignored",
+            current_url="https://example.com/ignored",
+        ).model_copy(
+            update={"metadata": {"fallback_title": "Ignored title", "fallback_snippet": "Ignored"}}
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[
+                build_classified_article("https://example.com/relevant", relevant=True),
+                build_classified_article("https://example.com/ignored", relevant=False),
+            ]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.fallback_enrichment",
+            lambda item: NewsItemEnrichment(
+                summary_one_sentence=f"Enriched: {item.headline}",
+                privacy_risk_level=PrivacyRisk.LOW,
+                privacy_reason="fallback default",
+            ),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.infer_privacy_risk",
+            lambda _text: (PrivacyRisk.HIGH, "rule-based high risk"),
+        )
+
+        records = await pipeline_module._build_fallback_operational_records(
+            candidates=[relevant_candidate, ignored_candidate],
+            classifier=classifier,
+        )
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.event_candidate_ids == ["candidate-relevant"]
+        assert record.content_basis is ContentBasis.PARTIAL_PAGE
+        assert record.record_confidence == "low"
+        assert record.review_status is ReviewStatus.NEEDS_FACT_REVIEW
+        assert record.publication_status is PublicationStatus.INTERNAL_ONLY
+        assert record.annotation_source == "candidate_fallback"
+        assert record.privacy_risk_level is PrivacyRisk.HIGH
+        assert record.privacy_reason == "rule-based high risk"
+        assert record.source_name == "brave"
+        assert record.title == "Relevant title"
+        assert record.summary_one_sentence == "Enriched: Relevant title"
+
 
 class TestRunPipelineAsync:
     """Tests for async pipeline control flow."""
@@ -1686,6 +1824,49 @@ class TestRunPipelineAsync:
         assert rows[0]["review_status"] == ReviewStatus.NONE.value
         assert rows[0]["record_confidence"] == "medium"
         mark_seen_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_news_scrape_candidates_job_finishes_without_materializable_rows_and_closes_store(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fallback-only scrape passes with no classifiable rows should still close owned stores."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(return_value=[])
+        monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
+        monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+        monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+        fallback_candidate = build_persistent_candidate(
+            "candidate-empty-fallback",
+            current_url="https://example.com/empty-fallback",
+        ).model_copy(update={"titles": [" "], "snippets": [" "], "metadata": {}})
+        monkeypatch.setattr(
+            "denbust.pipeline._run_candidate_scrape_job",
+            AsyncMock(
+                return_value=CandidateScrapeBatch(
+                    selected_candidates=[fallback_candidate],
+                    updated_candidates=[fallback_candidate],
+                    fallback_candidates=[fallback_candidate],
+                    attempts=[],
+                    raw_articles=[],
+                    errors=[],
+                )
+            ),
+        )
+        created_store = MagicMock()
+        monkeypatch.setattr(
+            "denbust.pipeline.create_operational_store", lambda _config: created_store
+        )
+
+        result = await run_news_scrape_candidates_job(Config(job_name=JobName.SCRAPE_CANDIDATES))
+
+        assert result.result_summary == "candidate scrape completed with no materializable rows"
+        assert result.unified_item_count == 0
+        created_store.upsert_records.assert_not_called()
+        created_store.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_run_candidate_scrape_job_selects_candidates_and_closes_persistence(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -439,7 +439,7 @@ class TestFetchAndClassifyHelpers:
             }
         )
 
-        assert pipeline_module._fallback_source_name(candidate) == "  hinted-source  "
+        assert pipeline_module._fallback_source_name(candidate) == "hinted-source"
         assert pipeline_module._fallback_publication_datetime(candidate) == datetime(
             2026, 4, 11, 10, 0, tzinfo=UTC
         )
@@ -452,7 +452,7 @@ class TestFetchAndClassifyHelpers:
         assert fallback_article is not None
         assert fallback_article.title == "Candidate title"
         assert fallback_article.snippet == "Candidate snippet"
-        assert fallback_article.source_name == "  hinted-source  "
+        assert fallback_article.source_name == "hinted-source"
 
         no_text_candidate = candidate.model_copy(
             update={
@@ -556,6 +556,34 @@ class TestFetchAndClassifyHelpers:
         assert record.source_name == "brave"
         assert record.title == "Relevant title"
         assert record.summary_one_sentence == "Enriched: Relevant title"
+
+    @pytest.mark.asyncio
+    async def test_build_fallback_operational_records_rejects_classifier_length_mismatch(
+        self,
+    ) -> None:
+        """Fallback operational rows should fail loudly if classification cardinality drifts."""
+        candidate = build_persistent_candidate(
+            "candidate-mismatch",
+            current_url="https://example.com/mismatch",
+        ).model_copy(
+            update={
+                "metadata": {
+                    "fallback_title": "Mismatch title",
+                    "fallback_snippet": "Mismatch summary",
+                }
+            }
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(return_value=[])
+
+        with pytest.raises(
+            ValueError,
+            match="classifier.classify_batch\\(\\) returned 0 results for 1 fallback inputs",
+        ):
+            await pipeline_module._build_fallback_operational_records(
+                candidates=[candidate],
+                classifier=classifier,
+            )
 
 
 class TestRunPipelineAsync:


### PR DESCRIPTION
## Summary

This PR implements `DL-PR-08` for the discovery track.

It adds fallback retention for candidates that do not yield a full source-adapter scrape, and it carries those retained fallbacks into provisional internal `news_items` rows while keeping public release behavior unchanged.

## What Changed

### Discovery scrape orchestration

- fixed successful source-adapter scrapes to persist `content_basis=full_article_page` instead of `partial_page`
- extended the candidate scrape batch to track retained fallback candidates separately from fully materialized `RawArticle` results
- implemented a minimal generic fetch fallback that extracts:
  - page title
  - meta / Open Graph description
  - common publication-time meta tags
- added explicit fallback retention paths for:
  - `content_basis=partial_page` when minimal page metadata is recovered
  - `content_basis=search_result_only` when only search/discovery metadata is usable
- updated candidate retention semantics so fallback candidates:
  - set `needs_review=true`
  - preserve retry scheduling for retryable failures
  - mark `self_heal_eligible=true` only for true scrape failures
  - store fallback provenance and extracted metadata in candidate `metadata`

### Provisional operational rows

- added a dedicated fallback-to-operational path in `run_news_scrape_candidates_job`
- classifies retained fallback metadata using the existing classifier when enough title/snippet text exists
- materializes provisional internal `news_items` rows directly from fallback candidates
- keeps the row identity on canonical URL so later full scrapes upgrade the same row in place
- does not mark fallback-only rows as seen in `seen.json`
- defaults fallback rows to:
  - `publication_status=internal_only`
  - `review_status=needs_fact_review`
  - `record_confidence=low`

### Schema, release, and diagnostics

- added `content_basis` and `record_confidence` to `NewsItemOperationalRecord`
- added a Supabase migration to backfill and persist those fields in `public.news_items`
- kept public release behavior unchanged except for proving the fallback exclusion path in tests
- extended discovery diagnostics to report `content_basis` counts for:
  - `search_result_only`
  - `partial_page`
  - `full_article_page`

### Docs and tracked plan surfaces

- updated `.agent-plan.md` to reflect `DL-PR-08` as the last completed discovery slice and `DL-PR-09` as the next one
- updated `README.md` to document fallback retention behavior
- updated `docs/tfht_discovery_layer_implementation_plan.md` to mark `DL-PR-08` implemented

## Files Of Interest

- `src/denbust/discovery/scrape_queue.py`
- `src/denbust/pipeline.py`
- `src/denbust/news_items/models.py`
- `src/denbust/diagnostics/discovery.py`
- `supabase/migrations/20260417_news_items_fallback_retention.sql`

## Verification

Ran:

```bash
ruff check src/denbust/discovery/scrape_queue.py src/denbust/pipeline.py src/denbust/news_items/models.py src/denbust/diagnostics/discovery.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_pipeline_core.py tests/unit/test_news_items_phase_b.py tests/unit/test_discovery_diagnostics.py
pytest -q tests/unit/test_discovery_scrape_queue.py tests/unit/test_pipeline_core.py tests/unit/test_news_items_phase_b.py tests/unit/test_discovery_diagnostics.py
```

Result:

- `ruff check` passed
- `pytest` passed: `151 passed`

## Notes

- generated local test artifacts under `data/news_items/` were intentionally left uncommitted
- this PR does not implement full generic article extraction or self-healing; it stops at minimal fallback retention as planned
