### PR TITLE
Finish Phase C validation follow-through

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,13 +2,13 @@
 
 ## Current System State
 
-- Active branch: `main`
-- Last action taken: `DL-PR-08` fallback retention and provisional internal rows landed on top of the discovery layer.
-- Current blockers: no explicit repo-tracked blocker, but prioritization is still needed between unfinished Phase C follow-through and the next discovery-layer slice.
+- Active branch: `codex/phase-c-c7-followthrough`
+- Last action taken: started the `C-7` follow-through PR for validation/taxonomy test coverage, validation-eval CI artifacts, and durable PR metadata guidance.
+- Current blockers: none beyond landing the `C-7` follow-through before returning to the discovery-layer queue.
 
 ## Active Task Breakdown
 
-- [ ] Finish Phase C test/validation follow-through from `C-7`
+- [ ] Finish Phase C test/validation follow-through from `C-7`, including two-variant validation matrix coverage, secret-gated CI evaluation artifacts, and checked-in PR metadata guidance
 - [ ] Wire the monthly report command/workflow from `C-6`
 - [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
 - [ ] Start `DL-PR-09` backfill foundation
@@ -18,6 +18,7 @@
 ## Planning Workflow
 
 - When a PR is opened against a tracked plan item, the PR should update `.agent-plan.md`, `README.md`, and the relevant human-facing plan document(s) to describe the state as it should look after that PR is merged.
+- When opening a tracked PR, apply appropriate workstream labels and assign a GitHub milestone; create missing labels or milestones if needed.
 - Plan-tracked PRs should not leave the repository's planning/docs surfaces one merge behind the code.
 
 ## Context Pointers

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,13 +2,12 @@
 
 ## Current System State
 
-- Active branch: `codex/phase-c-c7-followthrough`
-- Last action taken: started the `C-7` follow-through PR for validation/taxonomy test coverage, validation-eval CI artifacts, and durable PR metadata guidance.
-- Current blockers: none beyond landing the `C-7` follow-through before returning to the discovery-layer queue.
+- Active branch: `main`
+- Last action taken: `C-7` follow-through landed for validation/taxonomy test coverage, validation-eval CI artifacts, and durable PR metadata guidance.
+- Current blockers: no explicit blocker; the next prioritization choice is whether to return to `C-6` monthly reporting or switch back to the discovery-layer queue.
 
 ## Active Task Breakdown
 
-- [ ] Finish Phase C test/validation follow-through from `C-7`, including two-variant validation matrix coverage, secret-gated CI evaluation artifacts, and checked-in PR metadata guidance
 - [ ] Wire the monthly report command/workflow from `C-6`
 - [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
 - [ ] Start `DL-PR-09` backfill foundation

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -184,6 +184,49 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+  validation-evaluate:
+    name: Validation evaluate
+    needs: [lint, unit-tests, integration-tests, coverage]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      HAS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Skip when Anthropic secret is unavailable
+        if: ${{ env.HAS_ANTHROPIC_API_KEY != 'true' }}
+        run: echo "Skipping validation evaluation artifact job because ANTHROPIC_API_KEY is unavailable."
+
+      - name: Run validation evaluation
+        if: ${{ env.HAS_ANTHROPIC_API_KEY == 'true' }}
+        run: |
+          denbust validation evaluate \
+            --validation-set validation/news_items/classifier_validation.csv \
+            --variants agents/validation/classifier_variants.yaml \
+            --output validation-eval/classifier_variant_eval.json
+
+      - name: Upload validation evaluation artifacts
+        if: ${{ env.HAS_ANTHROPIC_API_KEY == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: validation-evaluation-artifacts
+          path: validation-eval/
+
   pr-agent-context:
     name: PR agent context
     if: ${{ always() && github.event_name == 'pull_request' }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Run validation evaluation
         if: ${{ env.HAS_ANTHROPIC_API_KEY == 'true' }}
         run: |
-          denbust validation evaluate \
+          denbust validation-evaluate \
             --validation-set validation/news_items/classifier_validation.csv \
             --variants agents/validation/classifier_variants.yaml \
             --output validation-eval/classifier_variant_eval.json

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -186,12 +186,12 @@ jobs:
 
   validation-evaluate:
     name: Validation evaluate
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.ANTHROPIC_API_KEY != '' }}
     needs: [lint, unit-tests, integration-tests, coverage]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      HAS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
 
     steps:
       - name: Checkout
@@ -208,12 +208,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
-      - name: Skip when Anthropic secret is unavailable
-        if: ${{ env.HAS_ANTHROPIC_API_KEY != 'true' }}
-        run: echo "Skipping validation evaluation artifact job because ANTHROPIC_API_KEY is unavailable."
-
       - name: Run validation evaluation
-        if: ${{ env.HAS_ANTHROPIC_API_KEY == 'true' }}
         run: |
           denbust validation-evaluate \
             --validation-set validation/news_items/classifier_validation.csv \
@@ -221,7 +216,6 @@ jobs:
             --output validation-eval/classifier_variant_eval.json
 
       - name: Upload validation evaluation artifacts
-        if: ${{ env.HAS_ANTHROPIC_API_KEY == 'true' }}
         uses: actions/upload-artifact@v6
         with:
           name: validation-evaluation-artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@
 - Default branch prefix for agent work: `codex/`.
 - Keep branches single-purpose.
 - Open PRs against `main`.
+- Plans should be carried through to an open PR unless the user explicitly says not to open one.
+- Opened PRs should include a detailed description that is ready for human review, not just a placeholder body.
+- When opening a PR, apply appropriate GitHub labels for the workstream or tracked plan item and assign the PR to the relevant GitHub milestone.
+- Create missing labels or milestones when needed, preferring the repo-specific GitHub MCP over CLI fallbacks for those actions.
 - When a PR is opened against a tracked plan item, update `.agent-plan.md`, `README.md`, and any relevant human-facing plan document in that same PR so they reflect the expected post-merge state.
 - Preserve `CLAUDE.md -> AGENTS.md` when changing repo guidance.
 

--- a/agents/validation/classifier_variants.yaml
+++ b/agents/validation/classifier_variants.yaml
@@ -4,3 +4,63 @@ defaults:
 variants:
   - name: baseline
     description: Current production classifier settings.
+  - name: v1_taxonomy
+    description: Explicit snapshot of the current taxonomy-aware classifier prompts.
+    system_prompt: >-
+      You are a classifier for Hebrew news articles in Israel. Decide two
+      separate things: whether the article is in scope for the monitored
+      dataset, and whether it describes a concrete enforcement or legal-action
+      event. Relevant articles must be materially about brothels, prostitution,
+      pimping, human trafficking, or closely related Israeli legal/public-safety
+      context. Enforcement-related articles must describe a concrete action such
+      as a raid, arrest, closure order, indictment, sentence, rescue,
+      investigation, or police operation. Treat criminal-operation coverage as
+      enforcement-related when it clearly describes suspects, defendants,
+      charges, police suspicion, criminal investigations, prostitution or
+      trafficking networks being operated, victims being exploited, or coercive
+      sexual exploitation, even if the snippet does not explicitly say 'arrest'
+      or 'raid'. For trafficking stories, if the article is about identified
+      victims, systematic sexual exploitation, or a trafficking case being
+      uncovered, default to enforcement_related=true. Exclude celebrity,
+      lifestyle, profile, entertainment, or generic commentary stories even if
+      they mention sex work, unless they are themselves about a concrete Israeli
+      enforcement or legal/public-safety event. Return only JSON and choose only
+      valid TFHT taxonomy category/subcategory pairs.
+    user_prompt_template: |
+      Decide whether the Hebrew news article below is relevant to the monitored TFHT dataset about brothels / בתי בושת, prostitution / זנות, pimping / סרסורות, and human trafficking / סחר בבני אדם.
+
+      Make two separate decisions:
+      1. relevant: is the article in scope for the monitored dataset and reports?
+      2. enforcement_related: does the article describe a concrete enforcement or legal-action event?
+
+      If the article is relevant, choose exactly one TFHT taxonomy category and one valid TFHT taxonomy subcategory from this table:
+
+      - human_trafficking (סחר בבני אדם) -> trafficking_sexual_exploitation: סחר למטרת ניצול מיני (זנות) [index_relevant=yes], trafficking_forced_marriage: סחר למטרת נישואין בכפייה [index_relevant=yes], trafficking_forced_labor: סחר למטרת עבודת כפייה [index_relevant=no], trafficking_organ_harvesting: סחר למטרת נטילת איברים [index_relevant=no], trafficking_cross_border_prostitution: הבאת אדם למדינה אחרת לשם העיסוק בזנות [index_relevant=yes], trafficking_slavery_conditions: החזקה בתנאי עבדות [index_relevant=yes], sexual_slavery: עבדות מינית [index_relevant=yes], trafficking_women: סחר בנשים [index_relevant=yes]
+      - pimping_prostitution (סרסור וזנות) -> pimping: סרסור [index_relevant=yes], bringing_into_prostitution: הבאת אדם לידי זנות [index_relevant=yes], soliciting_prostitution: שידול לזנות [index_relevant=yes], women_testimonies: עדויות של נשים בזנות [index_relevant=no], phenomenon_coverage: סיקור תופעת הזנות [index_relevant=no], online_prostitution: זנות מקוונת [index_relevant=yes], nordic_model_law: חוק איסור צריכת זנות / המודל הנורדי [index_relevant=no]
+      - brothels (בתי בושת) -> keeping_brothel: החזקת מקום לשם זנות [index_relevant=yes], renting_brothel: השכרת מקום לשם זנות [index_relevant=yes], advertising_prostitution: פרסום זנות [index_relevant=yes], client_fine: קנס בגין צריכת זנות [index_relevant=yes], administrative_closure: סגירה מנהלית / צו מנהלי [index_relevant=yes], closure_appeal: ערעור על צו מנהלי [index_relevant=yes], brothel_indictment: כתב אישום על החזקת/השכרת מקום לשם זנות [index_relevant=yes]
+
+      Legacy coarse mapping reference:
+      - brothel -> closure | opening
+      - prostitution -> arrest | fine
+      - pimping -> arrest | sentence
+      - trafficking -> arrest | rescue | sentence
+      - enforcement -> operation | other
+
+      Rules:
+      - Do not invent taxonomy ids. Use only ids that appear in the table.
+      - If the article is not relevant, use enforcement_related=false, taxonomy_category_id=null, and taxonomy_subcategory_id=null.
+      - If the article is relevant but the best TFHT leaf is unclear, return relevant=true, enforcement_related=false, taxonomy_category_id=null, taxonomy_subcategory_id=null, and include the best legacy coarse category in category.
+      - enforcement_related is independent from index_relevant. Do not guess index_relevant; it is derived downstream.
+      - Celebrity, lifestyle, profile, or entertainment stories about sex work are not relevant unless they are themselves about a concrete Israeli enforcement or legal/public-safety event.
+      - Foreign or generic commentary stories with no Israeli monitored-angle are not relevant.
+      - Prefer the main topic of the article, not a minor passing mention.
+      - confidence: high | medium | low
+
+      Article:
+      כותרת: {title}
+      תקציר: {snippet}
+
+      Respond with JSON only, no explanation.
+      If relevant and taxonomy is known: {"relevant": true, "enforcement_related": true, "taxonomy_category_id": "...", "taxonomy_subcategory_id": "...", "confidence": "..."}
+      If relevant but taxonomy is unclear: {"relevant": true, "enforcement_related": false, "category": "...", "sub_category": null, "taxonomy_category_id": null, "taxonomy_subcategory_id": null, "confidence": "low"}
+      If not relevant: {"relevant": false, "enforcement_related": false, "taxonomy_category_id": null, "taxonomy_subcategory_id": null, "confidence": "high"}

--- a/llms.txt
+++ b/llms.txt
@@ -107,3 +107,4 @@ src/denbust/
 - Discovery rollout roadmap: `docs/tfht_discovery_layer_implementation_plan.md`
 - Broader implementation backlog: `docs/IMPLEMENTATION_PLAN.md`
 - Current project report: `docs/2026_04_04_tfht_state_of_project_report.md`
+- PR completion rule: plans should normally end in an open PR with a detailed description, appropriate labels, and a GitHub milestone; create missing labels/milestones when needed via the repo-specific GitHub MCP.

--- a/src/denbust/validation/dataset.py
+++ b/src/denbust/validation/dataset.py
@@ -125,7 +125,7 @@ def validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> Vali
                 raise ValueError(
                     f"Invalid sub_category '{sub_category.value}' for category '{category.value}'"
                 )
-        elif enforcement_related:
+        elif enforcement_related and not (taxonomy_category_id and taxonomy_subcategory_id):
             raise ValueError(
                 "Reviewed enforcement-related rows must include a non-empty sub_category"
             )

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -166,6 +166,80 @@ class TestClassifierParsing:
         assert result.taxonomy_category_id is None
         assert result.taxonomy_subcategory_id is None
 
+    def test_parse_valid_taxonomy_pair_maps_legacy_fields(self) -> None:
+        """Known taxonomy ids should populate both taxonomy and legacy compatibility fields."""
+        classifier = Classifier(api_key="test-key")
+
+        response = (
+            '{"relevant": true, "enforcement_related": true, '
+            '"taxonomy_category_id": "brothels", '
+            '"taxonomy_subcategory_id": "administrative_closure", '
+            '"confidence": "high"}'
+        )
+        result = classifier._parse_response(response)
+
+        assert result.relevant is True
+        assert result.enforcement_related is True
+        assert result.taxonomy_version == "1"
+        assert result.taxonomy_category_id == "brothels"
+        assert result.taxonomy_subcategory_id == "administrative_closure"
+        assert result.category == Category.BROTHEL
+        assert result.sub_category == SubCategory.CLOSURE
+        assert result.index_relevant is True
+
+    def test_parse_invalid_taxonomy_pair_falls_back_to_not_relevant(self) -> None:
+        """Taxonomy pairs outside the packaged taxonomy should be rejected."""
+        classifier = Classifier(api_key="test-key")
+
+        response = (
+            '{"relevant": true, "enforcement_related": true, '
+            '"taxonomy_category_id": "brothels", '
+            '"taxonomy_subcategory_id": "trafficking_women", '
+            '"confidence": "high"}'
+        )
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.enforcement_related is False
+        assert result.taxonomy_version is None
+        assert result.taxonomy_category_id is None
+        assert result.taxonomy_subcategory_id is None
+        assert result.category == Category.NOT_RELEVANT
+        assert result.sub_category is None
+
+    def test_parse_taxonomy_pair_derives_index_relevant_even_when_payload_disagrees(self) -> None:
+        """index_relevant should be computed from the packaged taxonomy rather than the model payload."""
+        classifier = Classifier(api_key="test-key")
+
+        response = (
+            '{"relevant": true, "enforcement_related": true, '
+            '"index_relevant": false, '
+            '"taxonomy_category_id": "brothels", '
+            '"taxonomy_subcategory_id": "administrative_closure", '
+            '"confidence": "high"}'
+        )
+        result = classifier._parse_response(response)
+
+        assert result.index_relevant is True
+
+    def test_parse_non_index_taxonomy_pair_keeps_index_relevant_false(self) -> None:
+        """Non-index taxonomy leaves should stay false even if the payload claims otherwise."""
+        classifier = Classifier(api_key="test-key")
+
+        response = (
+            '{"relevant": true, "enforcement_related": true, '
+            '"index_relevant": true, '
+            '"taxonomy_category_id": "pimping_prostitution", '
+            '"taxonomy_subcategory_id": "women_testimonies", '
+            '"confidence": "high"}'
+        )
+        result = classifier._parse_response(response)
+
+        assert result.relevant is True
+        assert result.taxonomy_category_id == "pimping_prostitution"
+        assert result.taxonomy_subcategory_id == "women_testimonies"
+        assert result.index_relevant is False
+
     def test_parse_relevant_without_taxonomy_or_legacy_category_downgrades_to_not_relevant(
         self,
     ) -> None:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -24,6 +24,7 @@ from denbust.validation.collect import (
     select_promising_candidates,
 )
 from denbust.validation.common import (
+    DEFAULT_VARIANT_MATRIX_PATH,
     DRAFT_COLUMNS,
     VALIDATION_SET_COLUMNS,
     canonicalize_csv_url,
@@ -548,6 +549,71 @@ class TestValidationFinalize:
         rows = read_csv_rows(validation_set_path)
         assert {row["source_name"] for row in rows} == {"ynet", "mako"}
 
+    def test_finalize_validation_set_is_idempotent_for_same_reviewed_import(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-finalizing the same reviewed draft should add no new rows."""
+        draft_path = tmp_path / "draft.csv"
+        validation_set_path = tmp_path / "classifier_validation.csv"
+        write_csv_rows(
+            draft_path,
+            DRAFT_COLUMNS,
+            [
+                {
+                    "source_name": "maariv",
+                    "article_date": "2026-03-01T00:00:00+00:00",
+                    "url": "https://example.com/a?utm_source=one",
+                    "canonical_url": "https://example.com/a",
+                    "title": "title a",
+                    "snippet": "snippet a",
+                    "suggested_relevant": "True",
+                    "suggested_enforcement_related": "True",
+                    "suggested_index_relevant": "True",
+                    "suggested_taxonomy_version": "1",
+                    "suggested_taxonomy_category_id": "brothels",
+                    "suggested_taxonomy_subcategory_id": "administrative_closure",
+                    "suggested_category": "brothel",
+                    "suggested_sub_category": "closure",
+                    "suggested_confidence": "high",
+                    "relevant": "True",
+                    "enforcement_related": "True",
+                    "index_relevant": "True",
+                    "taxonomy_version": "1",
+                    "taxonomy_category_id": "brothels",
+                    "taxonomy_subcategory_id": "administrative_closure",
+                    "category": "brothel",
+                    "sub_category": "closure",
+                    "review_status": "reviewed",
+                    "annotation_source": "tfht_manual_tracking_v1",
+                    "expected_month_bucket": "",
+                    "expected_city": "",
+                    "expected_status": "",
+                    "manual_city": "",
+                    "manual_address": "",
+                    "manual_event_label": "",
+                    "manual_status": "",
+                    "annotation_notes": "",
+                    "collected_at": "2026-03-01T00:00:00+00:00",
+                }
+            ],
+        )
+
+        first = finalize_validation_set(
+            input_path=draft_path,
+            validation_set_path=validation_set_path,
+        )
+        second = finalize_validation_set(
+            input_path=draft_path,
+            validation_set_path=validation_set_path,
+        )
+
+        assert first.added_rows == 1
+        assert first.skipped_duplicates == 0
+        assert second.added_rows == 0
+        assert second.skipped_duplicates == 1
+        rows = read_csv_rows(validation_set_path)
+        assert len(rows) == 1
+
     def test_finalize_validation_set_rejects_invalid_labels(self, tmp_path: Path) -> None:
         """Invalid category/sub-category pairs should fail finalization."""
         draft_path = tmp_path / "draft.csv"
@@ -671,7 +737,7 @@ class TestValidationFinalize:
         self,
         tmp_path: Path,
     ) -> None:
-        """Reviewed enforcement-related rows must include a sub-category."""
+        """Reviewed enforcement-related rows without taxonomy labels must include a sub-category."""
         draft_path = tmp_path / "draft.csv"
         write_csv_rows(
             draft_path,
@@ -702,6 +768,59 @@ class TestValidationFinalize:
 
         with pytest.raises(ValueError, match="must include a non-empty sub_category"):
             finalize_validation_set(input_path=draft_path, validation_set_path=tmp_path / "out.csv")
+
+    def test_finalize_validation_set_allows_taxonomy_labeled_enforcement_rows_without_legacy_subcategory(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Taxonomy-labeled enforcement rows may omit the legacy sub-category when the leaf is valid."""
+        draft_path = tmp_path / "draft.csv"
+        write_csv_rows(
+            draft_path,
+            DRAFT_COLUMNS,
+            [
+                {
+                    "source_name": "mako",
+                    "article_date": "2026-03-03T00:00:00+00:00",
+                    "url": "https://example.com/b",
+                    "canonical_url": "https://example.com/b",
+                    "title": "title b",
+                    "snippet": "snippet b",
+                    "suggested_relevant": "True",
+                    "suggested_enforcement_related": "True",
+                    "suggested_index_relevant": "True",
+                    "suggested_taxonomy_version": "1",
+                    "suggested_taxonomy_category_id": "brothels",
+                    "suggested_taxonomy_subcategory_id": "keeping_brothel",
+                    "suggested_category": "brothel",
+                    "suggested_sub_category": "",
+                    "suggested_confidence": "high",
+                    "relevant": "True",
+                    "enforcement_related": "True",
+                    "index_relevant": "True",
+                    "taxonomy_version": "1",
+                    "taxonomy_category_id": "brothels",
+                    "taxonomy_subcategory_id": "keeping_brothel",
+                    "category": "brothel",
+                    "sub_category": "",
+                    "review_status": "reviewed",
+                    "annotation_source": "tfht_manual_tracking_v1",
+                    "annotation_notes": "",
+                    "collected_at": "2026-03-03T00:00:00+00:00",
+                }
+            ],
+        )
+
+        result = finalize_validation_set(
+            input_path=draft_path,
+            validation_set_path=tmp_path / "out.csv",
+        )
+        rows = read_csv_rows(result.validation_set_path)
+
+        assert rows[0]["enforcement_related"] == "True"
+        assert rows[0]["taxonomy_category_id"] == "brothels"
+        assert rows[0]["taxonomy_subcategory_id"] == "keeping_brothel"
+        assert rows[0]["sub_category"] == ""
 
     @pytest.mark.parametrize(
         (
@@ -1146,6 +1265,21 @@ class TestValidationEvaluate:
         assert "enf_f1" in table
         assert "baseline" in table
         assert "0.667" in table
+
+    def test_load_tracked_variant_matrix_exposes_baseline_and_v1_taxonomy(self) -> None:
+        """The tracked asset should exercise the two-variant Phase C matrix shape."""
+        matrix = _load_variant_matrix(DEFAULT_VARIANT_MATRIX_PATH)
+
+        assert [variant.name for variant in matrix.variants] == ["baseline", "v1_taxonomy"]
+        assert matrix.defaults.model == "claude-sonnet-4-20250514"
+        assert matrix.variants[0].system_prompt is None
+        assert matrix.variants[0].user_prompt_template is None
+        assert matrix.variants[1].system_prompt is not None
+        assert "Return only JSON" in matrix.variants[1].system_prompt
+        assert matrix.variants[1].user_prompt_template is not None
+        assert "taxonomy_category_id" in matrix.variants[1].user_prompt_template
+        assert "{title}" in matrix.variants[1].user_prompt_template
+        assert "{snippet}" in matrix.variants[1].user_prompt_template
 
     def test_load_validation_examples_defaults_missing_enforcement_flag_false(
         self, tmp_path: Path

--- a/tests/unit/test_validation_import_reviewed.py
+++ b/tests/unit/test_validation_import_reviewed.py
@@ -8,6 +8,7 @@ import pytest
 from openpyxl import Workbook
 
 from denbust.validation.common import read_csv_rows
+from denbust.validation.dataset import finalize_validation_set
 from denbust.validation.import_reviewed import (
     TFHT_MANUAL_TRACKING_V1,
     VALIDATION_REVIEWED_EXAMPLES_V1,
@@ -90,6 +91,32 @@ def test_import_reviewed_table_normalizes_manual_tracking_workbook(tmp_path: Pat
 
     assert second_row["taxonomy_subcategory_id"] == "administrative_closure"
     assert second_row["index_relevant"] == "True"
+
+
+def test_import_reviewed_table_and_finalize_are_idempotent(tmp_path: Path) -> None:
+    workbook_path = tmp_path / "manual_tracking.xlsx"
+    validation_set_path = tmp_path / "classifier_validation.csv"
+    _build_manual_tracking_workbook(workbook_path)
+
+    imported = import_reviewed_table(
+        input_path=workbook_path,
+        format_name=TFHT_MANUAL_TRACKING_V1,
+    )
+
+    first = finalize_validation_set(
+        input_path=imported.output_path,
+        validation_set_path=validation_set_path,
+    )
+    second = finalize_validation_set(
+        input_path=imported.output_path,
+        validation_set_path=validation_set_path,
+    )
+
+    assert first.added_rows == 2
+    assert second.added_rows == 0
+    assert second.skipped_duplicates == 2
+    rows = read_csv_rows(validation_set_path)
+    assert len(rows) == 2
 
 
 def test_import_reviewed_table_rejects_unknown_format(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- finish the remaining Phase C C-7 validation follow-through around the taxonomy-aware classifier and validation workflow
- add a secret-gated CI validation-evaluate job that uploads JSON and Markdown artifacts when ANTHROPIC_API_KEY is available
- strengthen repo agent guidance so plan-tracked work ends in a detailed open PR with labels and a milestone

## What Changed

- expand classifier parsing coverage for valid taxonomy pairs, invalid taxonomy fallback, and taxonomy-derived index relevance
- add validation/finalize idempotency coverage for reviewed imports and the tracked two-variant classifier matrix asset
- allow taxonomy-labeled enforcement rows to finalize even when the legacy coarse sub_category is blank
- add the tracked `v1_taxonomy` prompt snapshot alongside the current `baseline` validation variant
- add a non-required validation-evaluation CI job that skips cleanly when the Anthropic secret is unavailable
- update `AGENTS.md`, `llms.txt`, and `.agent-plan.md` with the stronger PR completion rule and PR metadata guidance

## Validation

- `ruff format .`
- `ruff check .`
- `PYTHONPATH=src .../python3 -m mypy src/`
- `PYTHONPATH=src .../python3 -m pytest -q tests/unit`
- pre-push hooks passed, including unit and integration test hooks

## Notes

- left the untracked `data/news_items/` workspace data untouched
- this PR does not implement the Phase C monthly report work from C-6
