### PR TITLE
Implement DL-PR-09 backfill foundation

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -2,22 +2,23 @@
 
 ## Current System State
 
-- Active branch: `main`
-- Last action taken: `C-6` monthly-report implementation is now the active tracked PR, covering the new `news_items / monthly_report` job, the `denbust report monthly` CLI wrapper, and the scheduled monthly workflow.
-- Current blockers: no explicit blocker; after `C-6`, the next prioritization choice is whether to do `C-8` keyword expansion/re-scan before or after `DL-PR-09`.
+- Active branch: `codex/dl-pr-09-backfill-foundation`
+- Last action taken: `DL-PR-09` backfill foundation is now in progress, covering the new `news_items / backfill_discover` and `news_items / backfill_scrape` jobs, durable `backfill_batches` persistence, historical query window planning, and batch-aware scrape draining.
+- Current blockers: no explicit blocker; after `DL-PR-09`, the next prioritization choice is whether to do `C-8` keyword expansion/re-scan before or after `DL-PR-10`.
 
 ## Active Task Breakdown
 
 - [x] Wire the monthly report command/workflow from `C-6`
 - [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after the next discovery PR
-- [ ] Start `DL-PR-09` backfill foundation
-- [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after `DL-PR-09`
+- [x] Start `DL-PR-09` backfill foundation
+- [ ] Decide whether `C-8` keyword expansion + 90-day re-scan should happen before or after `DL-PR-10`
 - [ ] Keep `DL-PR-11` workflow rollout scoped to docs/workflows only; do not mix in self-healing or event-table work
 
 ## Planning Workflow
 
 - When a PR is opened against a tracked plan item, the PR should update `.agent-plan.md`, `README.md`, and the relevant human-facing plan document(s) to describe the state as it should look after that PR is merged.
 - When opening a tracked PR, apply appropriate workstream labels and assign a GitHub milestone; create missing labels or milestones if needed.
+- Tracked implementation work is not complete until a non-draft GitHub PR with a detailed description is open and has the expected labels and milestone.
 - Plan-tracked PRs should not leave the repository's planning/docs surfaces one merge behind the code.
 
 ## Context Pointers

--- a/.github/skills/pr-closeout/SKILL.md
+++ b/.github/skills/pr-closeout/SKILL.md
@@ -1,0 +1,39 @@
+# PR Closeout Skill
+
+Use this guidance when finishing a feature branch, tracked plan item, or any task that is expected to end in a GitHub pull request.
+
+## Completion Rule
+
+- Work is not complete until a non-draft PR is open on GitHub.
+- The PR must target `main` unless the task explicitly says otherwise.
+- The PR must have a detailed description that is ready for human review.
+- The PR must have appropriate labels and an assigned GitHub milestone.
+
+## Preferred Tooling
+
+- Use the repo-specific GitHub MCP first for repository reads and GitHub mutations when the needed capability exists.
+- Use the repo-specific Git MCP first for local git actions when available.
+- Fall back to `gh` or local `git` only for capabilities the MCP path does not expose cleanly.
+
+## Required Closeout Steps
+
+1. Confirm the branch contains only the intended scope.
+2. Run the narrowest relevant validation for the touched files.
+3. Stage and commit the intended changes.
+4. Push the branch to `origin`.
+5. Open a non-draft PR against `main`.
+6. Write a detailed PR body covering:
+   - what changed
+   - why it changed
+   - user or operator impact
+   - validation performed
+7. Apply appropriate labels for the workstream or tracked plan item.
+8. Assign the PR to the relevant GitHub milestone.
+9. If the needed label or milestone does not exist, create it before finishing.
+10. Update any checked-in planning or agent-context files that should describe the post-merge state.
+
+## Repo-Specific Expectations
+
+- For tracked plan work, keep `.agent-plan.md`, `README.md`, and relevant human-facing planning docs aligned with the PR's expected post-merge state.
+- Do not treat a local branch, a pushed branch, or a draft PR as the terminal state.
+- If GitHub publication is blocked, report the blocker explicitly; do not claim the task is complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,10 @@
 - Default branch prefix for agent work: `codex/`.
 - Keep branches single-purpose.
 - Open PRs against `main`.
+- Work on a feature, fix, or tracked plan item is not complete until a non-draft GitHub PR is open.
 - Plans should be carried through to an open PR unless the user explicitly says not to open one.
 - Opened PRs should include a detailed description that is ready for human review, not just a placeholder body.
+- The required PR closeout state is: branch pushed, non-draft PR open against `main`, detailed description present, appropriate labels applied, and a GitHub milestone assigned.
 - When opening a PR, apply appropriate GitHub labels for the workstream or tracked plan item and assign the PR to the relevant GitHub milestone.
 - Create missing labels or milestones when needed, preferring the repo-specific GitHub MCP over CLI fallbacks for those actions.
 - When a PR is opened against a tracked plan item, update `.agent-plan.md`, `README.md`, and any relevant human-facing plan document in that same PR so they reflect the expected post-merge state.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ data jobs. Phase A introduced the shared platform spine. Phase B turns the first
 Today, the implemented dataset/jobs are:
 
 - `news_items / discover` (source-native + Brave + Exa + Google CSE candidate persistence)
+- `news_items / backfill_discover`
+- `news_items / backfill_scrape`
 - `news_items / ingest`
 - `news_items / monthly_report`
 - `news_items / release`
@@ -43,6 +45,9 @@ Planned future datasets:
 - Scaffolds a persistent discovery/candidacy layer with dedicated Supabase tables and state-repo
   paths under `news_items/discover/`
 - Runs Brave, Exa, and Google CSE as external discovery engines feeding the durable candidate layer
+- Plans historical backfill windows and persists durable `backfill_batches` metadata for slow-drain
+  discovery/scrape work
+- Drains one historical backfill batch at a time with oldest-window-first scrape prioritization
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
 - Reviews the latest daily ingest artifacts and can open GitHub issues for suspicious runs
@@ -53,6 +58,10 @@ Planned future datasets:
 pip install -e ".[dev]"
 python -m playwright install chromium
 denbust scan --config agents/news/local.yaml
+DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00 \
+DENBUST_BACKFILL_DATE_TO=2026-01-31T23:59:59+00:00 \
+denbust run --dataset news_items --job backfill_discover --config agents/news/local.yaml
+denbust run --dataset news_items --job backfill_scrape --config agents/news/local.yaml
 denbust report monthly --month 2026-03 --config agents/news/local.yaml
 denbust diagnose-discovery --config agents/news/local.yaml
 denbust release --config agents/release/news_items.yaml
@@ -83,6 +92,8 @@ Future-facing commands now exist as real `news_items` jobs:
 
 ```bash
 denbust run --dataset news_items --job discover --config agents/news/local.yaml
+denbust run --dataset news_items --job backfill_discover --config agents/news/local.yaml
+denbust run --dataset news_items --job backfill_scrape --config agents/news/local.yaml
 denbust run --dataset news_items --job scrape_candidates --config agents/news/local.yaml
 denbust run --dataset news_items --job ingest --config agents/news/local.yaml
 denbust run --dataset news_items --job monthly_report --config agents/news/local.yaml
@@ -175,9 +186,13 @@ tfht_enforce_idx_state/
     └── discover/
         ├── runs/
         ├── candidates/
+        │   ├── backfill_queue.jsonl
         │   ├── latest_candidates.jsonl
         │   ├── retry_queue.jsonl
-        │   └── backfill_queue.jsonl
+        │   └── scrape_attempts.jsonl
+        ├── backfill_batches/
+        │   ├── latest_backfill_batches.jsonl
+        │   └── <batch-id>.json
         └── metrics/
             └── engine_overlap_latest.json
 ```
@@ -238,6 +253,7 @@ DL-PR-06 now builds on the earlier discovery milestones:
 - `src/denbust/discovery/` with durable candidate, provenance, scrape-attempt, and discovery-run
   models
 - config sections for `discovery`, `source_discovery`, `candidates`, and `backfill`
+- durable `backfill_batches` metadata mirrored to the state repo and Supabase
 - explicit state-repo path helpers for candidate-layer snapshots and queue files
 - source-native candidate normalization and merge/upsert persistence
 - a real `news_items / discover` job that persists source-native candidates and Brave-discovered
@@ -251,11 +267,17 @@ DL-PR-06 now builds on the earlier discovery milestones:
 - candidate selection / queueing helpers for retryable scrape work
 - scrape-attempt persistence and candidate status transitions underneath the ingest path
 - a real `news_items / scrape_candidates` job that drains queued candidates into article ingest
+- a real `news_items / backfill_discover` job that requires
+  `DENBUST_BACKFILL_DATE_FROM` / `DENBUST_BACKFILL_DATE_TO`, creates a durable batch record,
+  and runs historical search-engine discovery plus capability-based source-native discovery
+- a real `news_items / backfill_scrape` job that drains one historical batch at a time through the
+  existing scrape-to-ingest path
 - `news_items / ingest` now uses the candidate scrape layer for source-native candidates while
   preserving the existing direct-fetch convenience flow as a compatibility fallback
 - Supabase migrations for:
   - `discovery_runs`
   - `persistent_candidates`
+  - `backfill_batches`
   - `candidate_provenance`
   - `scrape_attempts`
 

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -852,6 +852,13 @@ You want:
   - oldest first for historical gap-closure jobs
   - source-specific priority overrides
 
+### Implementation note
+The current implementation persists `backfill_batches` into Supabase and mirrors them into the
+state repo, with `news_items / backfill_discover` reading
+`DENBUST_BACKFILL_DATE_FROM` / `DENBUST_BACKFILL_DATE_TO` to define one requested batch window per
+invocation. Historical source-native discovery is capability-based and records warnings for sources
+that do not implement explicit window fetching.
+
 ---
 
 ## Self-healing support

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -300,6 +300,9 @@ The system can retain useful low-confidence candidates without pretending they a
 ### Goal
 Enable slow, systematic historical gap-closing from the candidate layer.
 
+### Status
+Implemented.
+
 ### Scope
 - Add backfill models/config:
   - `backfill_batches`
@@ -313,6 +316,18 @@ Enable slow, systematic historical gap-closing from the candidate layer.
   - max candidates per run
   - max scrape attempts per run
 - Add docs and tests for backfill scheduling and queue behavior
+
+### Implemented notes
+- `news_items / backfill_discover` now requires
+  `DENBUST_BACKFILL_DATE_FROM` / `DENBUST_BACKFILL_DATE_TO`, creates one durable batch per
+  invocation, and plans contiguous historical windows using `backfill.batch_window_days`
+- backfill batches are mirrored into the state repo and persisted into Supabase via
+  `backfill_batches`
+- historical search-engine discovery is live for Brave, Exa, and Google CSE
+- source-native historical discovery is capability-based: sources that do not implement explicit
+  window fetching are skipped with warnings rather than treated as fatal
+- `news_items / backfill_scrape` drains one historical batch at a time with oldest-window-first
+  ordering and reuses the existing scrape-to-ingest path
 
 ### Out of scope
 - no self-healing yet

--- a/llms.txt
+++ b/llms.txt
@@ -107,4 +107,6 @@ src/denbust/
 - Discovery rollout roadmap: `docs/tfht_discovery_layer_implementation_plan.md`
 - Broader implementation backlog: `docs/IMPLEMENTATION_PLAN.md`
 - Current project report: `docs/2026_04_04_tfht_state_of_project_report.md`
-- PR completion rule: plans should normally end in an open PR with a detailed description, appropriate labels, and a GitHub milestone; create missing labels/milestones when needed via the repo-specific GitHub MCP.
+- PR completion rule: feature or PR work is not complete until a non-draft GitHub PR is open.
+- Required PR closeout state: detailed description present, appropriate labels applied, and a GitHub milestone assigned; create missing labels/milestones when needed via the repo-specific GitHub MCP.
+- Repo-local closeout skill: `.github/skills/pr-closeout/SKILL.md`

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -329,6 +329,7 @@ class CandidatesConfig(BaseModel):
 
     discovery_runs_table: str = "discovery_runs"
     supabase_table: str = "persistent_candidates"
+    backfill_batches_table: str = "backfill_batches"
     provenance_table: str = "candidate_provenance"
     scrape_attempts_table: str = "scrape_attempts"
     keep_search_only_fallbacks: bool = True

--- a/src/denbust/datasets/jobs.py
+++ b/src/denbust/datasets/jobs.py
@@ -13,13 +13,6 @@ from denbust.ops.storage import OperationalStore
 _REGISTERED = False
 
 
-def _scaffolded_job_error(config: Config) -> ValueError:
-    """Build a clear placeholder error for scaffold-only jobs."""
-    return ValueError(
-        f"{config.dataset_name.value}/{config.job_name.value} is scaffolded but not implemented yet"
-    )
-
-
 async def _run_news_items_ingest(
     config: Config,
     config_path: Path | None,
@@ -67,6 +60,38 @@ async def _run_news_items_scrape_candidates(
     from denbust.pipeline import run_news_scrape_candidates_job
 
     return await run_news_scrape_candidates_job(
+        config,
+        config_path=config_path,
+        days_override=days_override,
+        operational_store=operational_store,
+    )
+
+
+async def _run_news_items_backfill_discover(
+    config: Config,
+    config_path: Path | None,
+    days_override: int | None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    from denbust.pipeline import run_news_backfill_discover_job
+
+    return await run_news_backfill_discover_job(
+        config,
+        config_path=config_path,
+        days_override=days_override,
+        operational_store=operational_store,
+    )
+
+
+async def _run_news_items_backfill_scrape(
+    config: Config,
+    config_path: Path | None,
+    days_override: int | None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    from denbust.pipeline import run_news_backfill_scrape_job
+
+    return await run_news_backfill_scrape_job(
         config,
         config_path=config_path,
         days_override=days_override,
@@ -128,17 +153,6 @@ async def _run_scaffolded_backup(
     )
 
 
-async def _run_unimplemented_scaffold_job(
-    config: Config,
-    config_path: Path | None,
-    days_override: int | None,
-    operational_store: OperationalStore | None = None,
-) -> RunSnapshot:
-    """Fail scaffold-only jobs with a purpose-built message."""
-    del config_path, days_override, operational_store
-    raise _scaffolded_job_error(config)
-
-
 def ensure_default_jobs_registered() -> None:
     """Register default dataset jobs exactly once."""
     global _REGISTERED
@@ -160,12 +174,12 @@ def ensure_default_jobs_registered() -> None:
     register_job(
         DatasetName.NEWS_ITEMS,
         JobName.BACKFILL_DISCOVER,
-        _run_unimplemented_scaffold_job,
+        _run_news_items_backfill_discover,
     )
     register_job(
         DatasetName.NEWS_ITEMS,
         JobName.BACKFILL_SCRAPE,
-        _run_unimplemented_scaffold_job,
+        _run_news_items_backfill_scrape,
     )
     register_job(DatasetName.NEWS_ITEMS, JobName.RELEASE, _run_scaffolded_release)
     register_job(DatasetName.NEWS_ITEMS, JobName.BACKUP, _run_scaffolded_backup)

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -1,0 +1,167 @@
+"""Historical backfill planning and window-aware discovery helpers."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pydantic import BaseModel
+
+from denbust.config import Config
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
+
+BACKFILL_BATCH_ID_ENV = "DENBUST_BACKFILL_BATCH_ID"
+BACKFILL_DATE_FROM_ENV = "DENBUST_BACKFILL_DATE_FROM"
+BACKFILL_DATE_TO_ENV = "DENBUST_BACKFILL_DATE_TO"
+
+
+class BackfillWindow(BaseModel):
+    """One contiguous historical slice inside a backfill batch."""
+
+    index: int
+    date_from: datetime
+    date_to: datetime
+
+
+def parse_backfill_datetime(value: str, *, env_name: str) -> datetime:
+    """Parse a required backfill timestamp from an environment variable."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{env_name} must not be empty")
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def resolve_backfill_request_window() -> tuple[datetime, datetime]:
+    """Resolve the requested historical window for a backfill job."""
+    date_from = os.getenv(BACKFILL_DATE_FROM_ENV)
+    date_to = os.getenv(BACKFILL_DATE_TO_ENV)
+    if not date_from or not date_to:
+        missing = [
+            env_name
+            for env_name, value in [
+                (BACKFILL_DATE_FROM_ENV, date_from),
+                (BACKFILL_DATE_TO_ENV, date_to),
+            ]
+            if not value
+        ]
+        raise ValueError(
+            "Missing required backfill window environment variable(s): " + ", ".join(missing)
+        )
+    resolved_from = parse_backfill_datetime(date_from, env_name=BACKFILL_DATE_FROM_ENV)
+    resolved_to = parse_backfill_datetime(date_to, env_name=BACKFILL_DATE_TO_ENV)
+    if resolved_from > resolved_to:
+        raise ValueError(
+            f"{BACKFILL_DATE_FROM_ENV} must be earlier than or equal to {BACKFILL_DATE_TO_ENV}"
+        )
+    return resolved_from, resolved_to
+
+
+def plan_backfill_windows(
+    *,
+    date_from: datetime,
+    date_to: datetime,
+    batch_window_days: int,
+) -> list[BackfillWindow]:
+    """Split a requested historical window into contiguous slices."""
+    windows: list[BackfillWindow] = []
+    current_start = date_from
+    index = 0
+    while current_start <= date_to:
+        current_end = min(
+            date_to,
+            current_start + timedelta(days=batch_window_days) - timedelta(microseconds=1),
+        )
+        windows.append(BackfillWindow(index=index, date_from=current_start, date_to=current_end))
+        index += 1
+        current_start = current_end + timedelta(microseconds=1)
+    return windows
+
+
+def _normalize_keywords(keywords: list[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for keyword in keywords:
+        value = keyword.strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def build_backfill_queries(
+    config: Config,
+    *,
+    window: BackfillWindow,
+) -> list[DiscoveryQuery]:
+    """Build normalized historical discovery queries for one backfill window."""
+    from denbust.discovery.queries import _enabled_source_domains
+
+    keywords = _normalize_keywords(config.keywords)
+    if not keywords:
+        return []
+
+    queries: list[DiscoveryQuery] = []
+    seen_keys: set[tuple[object, ...]] = set()
+    source_domains = _enabled_source_domains(config)
+    for keyword in keywords:
+        if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
+            broad_key = (DiscoveryQueryKind.BROAD, keyword, window.index)
+            if broad_key not in seen_keys:
+                queries.append(
+                    DiscoveryQuery(
+                        query_text=keyword,
+                        language="he",
+                        date_from=window.date_from,
+                        date_to=window.date_to,
+                        query_kind=DiscoveryQueryKind.BROAD,
+                        tags=["backfill", f"window:{window.index}"],
+                    )
+                )
+                seen_keys.add(broad_key)
+
+        if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+            for source_name, domain in source_domains:
+                source_key = (
+                    DiscoveryQueryKind.SOURCE_TARGETED,
+                    keyword,
+                    source_name,
+                    domain,
+                    window.index,
+                )
+                if source_key in seen_keys:
+                    continue
+                queries.append(
+                    DiscoveryQuery(
+                        query_text=keyword,
+                        language="he",
+                        date_from=window.date_from,
+                        date_to=window.date_to,
+                        preferred_domains=[domain],
+                        source_hint=source_name,
+                        query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                        tags=["backfill", source_name, f"window:{window.index}"],
+                    )
+                )
+                seen_keys.add(source_key)
+    return queries
+
+
+def backfill_metadata(
+    *,
+    batch_id: str,
+    window: BackfillWindow,
+) -> dict[str, Any]:
+    """Build stable metadata tags for candidates discovered during backfill."""
+    return {
+        "backfill_batch_id": batch_id,
+        "backfill_window_index": window.index,
+        "backfill_window_start": window.date_from.isoformat(),
+        "backfill_window_end": window.date_to.isoformat(),
+    }

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -101,7 +101,7 @@ def build_backfill_queries(
     window: BackfillWindow,
 ) -> list[DiscoveryQuery]:
     """Build normalized historical discovery queries for one backfill window."""
-    from denbust.discovery.queries import _enabled_source_domains
+    from denbust.discovery.queries import enabled_source_domains
 
     keywords = _normalize_keywords(config.keywords)
     if not keywords:
@@ -109,7 +109,7 @@ def build_backfill_queries(
 
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
-    source_domains = _enabled_source_domains(config)
+    source_domains = enabled_source_domains(config)
     for keyword in keywords:
         if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
             broad_key = (DiscoveryQueryKind.BROAD, keyword, window.index)

--- a/src/denbust/discovery/models.py
+++ b/src/denbust/discovery/models.py
@@ -100,6 +100,18 @@ class DiscoveryRunStatus(StrEnum):
     FAILED = "failed"
 
 
+class BackfillBatchStatus(StrEnum):
+    """Status values for historical backfill batches."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DISCOVERED = "discovered"
+    SCRAPING = "scraping"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    COMPLETED = "completed"
+
+
 class DiscoveryQuery(BaseModel):
     """Normalized search query definition for a discovery engine."""
 
@@ -263,4 +275,43 @@ class DiscoveryRun(BaseModel):
     def _validate_finished_at(self) -> DiscoveryRun:
         if self.finished_at is not None and self.finished_at < self.started_at:
             raise ValueError("finished_at must be later than or equal to started_at")
+        return self
+
+
+class BackfillBatch(BaseModel):
+    """Durable metadata for a historical backfill invocation."""
+
+    batch_id: str = Field(default_factory=_uuid_str)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    dataset_name: DatasetName = DatasetName.NEWS_ITEMS
+    job_name: JobName = JobName.BACKFILL_DISCOVER
+    status: BackfillBatchStatus = BackfillBatchStatus.PENDING
+    requested_date_from: datetime
+    requested_date_to: datetime
+    window_count: int = Field(default=0, ge=0)
+    query_count: int = Field(default=0, ge=0)
+    candidate_count: int = Field(default=0, ge=0)
+    merged_candidate_count: int = Field(default=0, ge=0)
+    queued_for_scrape_count: int = Field(default=0, ge=0)
+    scrape_attempt_count: int = Field(default=0, ge=0)
+    scraped_candidate_count: int = Field(default=0, ge=0)
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_date_window(self) -> BackfillBatch:
+        if self.requested_date_from > self.requested_date_to:
+            raise ValueError(
+                "requested_date_from must be earlier than or equal to requested_date_to"
+            )
+        if self.started_at is not None and self.started_at < self.created_at:
+            raise ValueError("started_at cannot be earlier than created_at")
+        if self.finished_at is not None:
+            anchor = self.started_at or self.created_at
+            if self.finished_at < anchor:
+                raise ValueError("finished_at must be later than or equal to batch start")
         return self

--- a/src/denbust/discovery/persistence.py
+++ b/src/denbust/discovery/persistence.py
@@ -40,9 +40,10 @@ class CandidateStore(ABC):
         self,
         *,
         statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
-        """List durable candidates, optionally filtered by status."""
+        """List durable candidates, optionally filtered by status and batch."""
 
     @abstractmethod
     def find_candidate_by_urls(

--- a/src/denbust/discovery/persistence.py
+++ b/src/denbust/discovery/persistence.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
     CandidateProvenance,
     CandidateStatus,
     DiscoveryRun,
@@ -50,6 +52,27 @@ class CandidateStore(ABC):
         current_url: str,
     ) -> PersistentCandidate | None:
         """Fetch a single durable candidate by canonical or current URL."""
+
+
+class BackfillBatchStore(ABC):
+    """Persistence interface for historical backfill batches."""
+
+    @abstractmethod
+    def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
+        """Insert or update durable backfill-batch rows."""
+
+    @abstractmethod
+    def get_backfill_batch(self, batch_id: str) -> BackfillBatch | None:
+        """Fetch one backfill batch by id."""
+
+    @abstractmethod
+    def list_backfill_batches(
+        self,
+        *,
+        statuses: Sequence[BackfillBatchStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[BackfillBatch]:
+        """List backfill batches, optionally filtered by status."""
 
 
 class ProvenanceStore(ABC):

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -40,7 +40,7 @@ def _source_domain(source: SourceConfig) -> str | None:
     return None
 
 
-def _enabled_source_domains(config: Config) -> list[tuple[str, str]]:
+def enabled_source_domains(config: Config) -> list[tuple[str, str]]:
     source_domains: list[tuple[str, str]] = []
     for source in config.sources:
         if not source.enabled:
@@ -68,7 +68,7 @@ def build_discovery_queries(
     date_to = current_time
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
-    source_domains = _enabled_source_domains(config)
+    source_domains = enabled_source_domains(config)
 
     for keyword in keywords:
         if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -118,11 +118,14 @@ def select_backfill_candidates_for_scrape(
 ) -> list[PersistentCandidate]:
     """Return eligible durable backfill candidates for one historical drain pass."""
     current_time = now or datetime.now(UTC)
+    listed_candidates = persistence.list_candidates(
+        statuses=SCRAPEABLE_CANDIDATE_STATUSES,
+        backfill_batch_id=batch_id,
+    )
     candidates = [
         candidate
-        for candidate in persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+        for candidate in listed_candidates
         if candidate.backfill_batch_id is not None
-        and (batch_id is None or candidate.backfill_batch_id == batch_id)
         and (
             candidate.next_scrape_attempt_at is None
             or candidate.next_scrape_attempt_at <= current_time

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -89,6 +89,77 @@ def select_candidates_for_scrape(
     return ordered[:limit]
 
 
+def _metadata_datetime(candidate: PersistentCandidate, key: str) -> datetime | None:
+    value = candidate.metadata.get(key)
+    if not isinstance(value, str):
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _backfill_publication_datetime(candidate: PersistentCandidate) -> datetime | None:
+    return _metadata_datetime(candidate, "latest_publication_datetime_hint") or _metadata_datetime(
+        candidate, "fallback_publication_datetime"
+    )
+
+
+def select_backfill_candidates_for_scrape(
+    persistence: DiscoveryPersistence,
+    *,
+    limit: int,
+    batch_id: str | None = None,
+    now: datetime | None = None,
+) -> list[PersistentCandidate]:
+    """Return eligible durable backfill candidates for one historical drain pass."""
+    current_time = now or datetime.now(UTC)
+    candidates = [
+        candidate
+        for candidate in persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+        if candidate.backfill_batch_id is not None
+        and (batch_id is None or candidate.backfill_batch_id == batch_id)
+        and (
+            candidate.next_scrape_attempt_at is None
+            or candidate.next_scrape_attempt_at <= current_time
+        )
+    ]
+    if not candidates:
+        return []
+
+    if batch_id is None:
+        selected_batch = min(
+            candidates,
+            key=lambda candidate: (
+                _metadata_datetime(candidate, "backfill_window_start") or candidate.first_seen_at,
+                candidate.first_seen_at,
+                candidate.backfill_batch_id or "",
+            ),
+        ).backfill_batch_id
+        candidates = [
+            candidate for candidate in candidates if candidate.backfill_batch_id == selected_batch
+        ]
+
+    max_datetime = datetime.max.replace(tzinfo=UTC)
+    ordered = sorted(
+        candidates,
+        key=lambda candidate: (
+            _metadata_datetime(candidate, "backfill_window_start") or candidate.first_seen_at,
+            _backfill_publication_datetime(candidate) or candidate.first_seen_at,
+            candidate.first_seen_at,
+            -candidate.retry_priority,
+            0 if candidate.next_scrape_attempt_at is None else 1,
+            candidate.next_scrape_attempt_at or max_datetime,
+            candidate.candidate_id,
+        ),
+    )
+    return ordered[:limit]
+
+
 def queue_candidates_for_scrape(candidates: list[PersistentCandidate]) -> list[PersistentCandidate]:
     """Mark candidates as queued or pending for an immediate scrape pass."""
     queued: list[PersistentCandidate] = []
@@ -286,6 +357,7 @@ async def scrape_candidates(
     candidates: list[PersistentCandidate],
     sources: list[Source],
     preloaded_source_articles: dict[str, list[RawArticle]] | None = None,
+    backfill_mode: bool = False,
 ) -> CandidateScrapeBatch:
     """Attempt to materialize durable candidates into raw articles."""
     if not candidates:
@@ -318,6 +390,13 @@ async def scrape_candidates(
             started_at = datetime.now(UTC)
             article: RawArticle | None = None
             candidate_attempts: list[ScrapeAttempt] = []
+            retry_attempt_kind = (
+                ScrapeAttemptKind.BACKFILL_RETRY
+                if backfill_mode
+                and in_progress.backfill_batch_id is not None
+                and in_progress.scrape_attempt_count > 0
+                else None
+            )
 
             if source_name is not None:
                 source = sources_by_name[source_name]
@@ -342,7 +421,7 @@ async def scrape_candidates(
                                 candidate_id=in_progress.candidate_id,
                                 started_at=started_at,
                                 finished_at=finished_at,
-                                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                                attempt_kind=retry_attempt_kind or ScrapeAttemptKind.SOURCE_ADAPTER,
                                 fetch_status=FetchStatus.SUCCESS,
                                 source_adapter_name=source_name,
                                 article=article,
@@ -361,7 +440,7 @@ async def scrape_candidates(
                             candidate_id=in_progress.candidate_id,
                             started_at=started_at,
                             finished_at=finished_at,
-                            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                            attempt_kind=retry_attempt_kind or ScrapeAttemptKind.SOURCE_ADAPTER,
                             fetch_status=FetchStatus.FAILED,
                             source_adapter_name=source_name,
                             error_code="candidate_not_found",
@@ -376,7 +455,7 @@ async def scrape_candidates(
                             candidate_id=in_progress.candidate_id,
                             started_at=started_at,
                             finished_at=finished_at,
-                            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                            attempt_kind=retry_attempt_kind or ScrapeAttemptKind.SOURCE_ADAPTER,
                             fetch_status=FetchStatus.FAILED,
                             source_adapter_name=source_name,
                             error_code="source_adapter_error",
@@ -393,7 +472,7 @@ async def scrape_candidates(
                     candidate_id=in_progress.candidate_id,
                     started_at=generic_started_at,
                     finished_at=generic_finished_at,
-                    attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                    attempt_kind=retry_attempt_kind or ScrapeAttemptKind.GENERIC_FETCH,
                     fetch_status=fetch_result.fetch_status,
                     error_code=fetch_result.error_code,
                     error_message=fetch_result.error_message,

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -23,7 +23,7 @@ from denbust.discovery.models import (
 )
 from denbust.discovery.storage import DiscoveryPersistence
 from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
-from denbust.sources.base import Source
+from denbust.sources.base import HistoricalSource, Source
 
 
 def build_candidate_id(identity_url: str) -> str:
@@ -78,6 +78,34 @@ class SourceDiscoveryAdapter(SourceCandidateProducer):
             for article in articles
         ]
 
+    @property
+    def supports_historical_window(self) -> bool:
+        """Return whether the wrapped source supports explicit historical windows."""
+        return isinstance(self._source, HistoricalSource)
+
+    async def discover_candidates_for_window(
+        self,
+        context: SourceDiscoveryContext,
+    ) -> list[DiscoveredCandidate]:
+        """Discover candidates for one explicit historical window when supported."""
+        if not self.supports_historical_window:
+            raise ValueError(f"{self.name} does not support historical windows")
+        if context.date_from is None or context.date_to is None:
+            raise ValueError("SourceDiscoveryContext.date_from/date_to are required")
+        historical_source = cast(HistoricalSource, self._source)
+        articles = await historical_source.fetch_window(
+            date_from=context.date_from,
+            date_to=context.date_to,
+            keywords=context.keywords,
+        )
+        return [
+            raw_article_to_discovered_candidate(
+                article,
+                discovered_at=context.metadata.get("discovered_at"),
+            )
+            for article in articles
+        ]
+
 
 def merge_discovered_candidate(
     discovered: DiscoveredCandidate,
@@ -90,6 +118,12 @@ def merge_discovered_candidate(
         existing_metadata["latest_publication_datetime_hint"] = (
             discovered.publication_datetime_hint.isoformat()
         )
+    backfill_batch_id = None
+    if "backfill_batch_id" in discovered.metadata:
+        backfill_batch_id = str(discovered.metadata["backfill_batch_id"])
+    for key in ("backfill_window_index", "backfill_window_start", "backfill_window_end"):
+        if key in discovered.metadata:
+            existing_metadata[key] = discovered.metadata[key]
     if discovered.metadata:
         existing_metadata["latest_discovery_metadata"] = discovered.metadata
 
@@ -144,7 +178,7 @@ def merge_discovered_candidate(
         content_basis=existing.content_basis if existing else ContentBasis.CANDIDATE_ONLY,
         retry_priority=existing.retry_priority if existing else 0,
         needs_review=existing.needs_review if existing else False,
-        backfill_batch_id=existing.backfill_batch_id if existing else None,
+        backfill_batch_id=backfill_batch_id or (existing.backfill_batch_id if existing else None),
         self_heal_eligible=existing.self_heal_eligible if existing else False,
         source_discovery_only=(
             (existing.source_discovery_only if existing else True)
@@ -161,6 +195,7 @@ class PersistedSourceDiscovery:
     run: DiscoveryRun
     candidates: list[PersistentCandidate]
     provenance: list[CandidateProvenance]
+    warnings: list[str] | None = None
 
 
 def persist_discovered_candidates(

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -24,7 +25,9 @@ class DiscoveryStatePaths(BaseModel):
     runs_dir: Path
     candidates_dir: Path
     metrics_dir: Path
+    backfill_batches_dir: Path
     latest_candidates_path: Path
+    latest_backfill_batches_path: Path
     retry_queue_path: Path
     backfill_queue_path: Path
     candidate_provenance_path: Path
@@ -44,6 +47,7 @@ def resolve_discovery_state_paths(
     runs_dir = namespace_dir / "runs"
     candidates_dir = namespace_dir / "candidates"
     metrics_dir = namespace_dir / "metrics"
+    backfill_batches_dir = namespace_dir / "backfill_batches"
     return DiscoveryStatePaths(
         state_root=state_root,
         dataset_name=dataset_name,
@@ -52,7 +56,9 @@ def resolve_discovery_state_paths(
         runs_dir=runs_dir,
         candidates_dir=candidates_dir,
         metrics_dir=metrics_dir,
+        backfill_batches_dir=backfill_batches_dir,
         latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
+        latest_backfill_batches_path=backfill_batches_dir / "latest_backfill_batches.jsonl",
         retry_queue_path=candidates_dir / "retry_queue.jsonl",
         backfill_queue_path=candidates_dir / "backfill_queue.jsonl",
         candidate_provenance_path=candidates_dir / "candidate_provenance.jsonl",
@@ -86,6 +92,25 @@ def write_candidate_jsonl(path: Path, candidates: list[PersistentCandidate]) -> 
         for candidate in candidates:
             handle.write(candidate.model_dump_json())
             handle.write("\n")
+    return path
+
+
+def write_model_jsonl(path: Path, rows: Sequence[BaseModel]) -> Path:
+    """Write generic Pydantic rows to a JSONL file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(row.model_dump_json())
+            handle.write("\n")
+    return path
+
+
+def write_json_snapshot(path: Path, payload: dict[str, Any]) -> Path:
+    """Write one JSON snapshot file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
     return path
 
 

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -10,6 +10,8 @@ import httpx
 
 from denbust.config import Config, OperationalProvider
 from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
     CandidateProvenance,
     CandidateStatus,
     DiscoveryRun,
@@ -17,6 +19,7 @@ from denbust.discovery.models import (
     ScrapeAttempt,
 )
 from denbust.discovery.persistence import (
+    BackfillBatchStore,
     CandidateStore,
     DiscoveryRunStore,
     ProvenanceStore,
@@ -26,12 +29,15 @@ from denbust.discovery.state_paths import (
     DiscoveryStatePaths,
     write_candidate_jsonl,
     write_discovery_run_snapshot,
+    write_json_snapshot,
+    write_model_jsonl,
 )
 
 
 class DiscoveryPersistence(
     DiscoveryRunStore,
     CandidateStore,
+    BackfillBatchStore,
     ProvenanceStore,
     ScrapeAttemptStore,
 ):
@@ -61,6 +67,22 @@ class NullDiscoveryPersistence(DiscoveryPersistence):
         statuses: Sequence[CandidateStatus] | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
+        del statuses, limit
+        return []
+
+    def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
+        del batches
+
+    def get_backfill_batch(self, batch_id: str) -> BackfillBatch | None:
+        del batch_id
+        return None
+
+    def list_backfill_batches(
+        self,
+        *,
+        statuses: Sequence[BackfillBatchStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[BackfillBatch]:
         del statuses, limit
         return []
 
@@ -156,6 +178,42 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
             candidate for candidate in all_candidates if candidate.backfill_batch_id is not None
         ]
         write_candidate_jsonl(self.paths.backfill_queue_path, backfill_candidates)
+
+    def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
+        if not batches:
+            return
+        existing = {batch.batch_id: batch for batch in self.list_backfill_batches()}
+        for batch in batches:
+            existing[batch.batch_id] = batch
+            write_json_snapshot(
+                self.paths.backfill_batches_dir / f"{batch.batch_id}.json",
+                batch.model_dump(mode="json"),
+            )
+        ordered = sorted(
+            existing.values(),
+            key=lambda batch: (batch.requested_date_from, batch.created_at, batch.batch_id),
+        )
+        write_model_jsonl(self.paths.latest_backfill_batches_path, ordered)
+
+    def get_backfill_batch(self, batch_id: str) -> BackfillBatch | None:
+        for batch in self.list_backfill_batches():
+            if batch.batch_id == batch_id:
+                return batch
+        return None
+
+    def list_backfill_batches(
+        self,
+        *,
+        statuses: Sequence[BackfillBatchStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[BackfillBatch]:
+        batches = self._read_jsonl(self.paths.latest_backfill_batches_path, BackfillBatch)
+        if statuses is not None:
+            allowed = set(statuses)
+            batches = [batch for batch in batches if batch.status in allowed]
+        if limit is not None:
+            return batches[:limit]
+        return batches
 
     def get_candidate(self, candidate_id: str) -> PersistentCandidate | None:
         for candidate in self.list_candidates():
@@ -296,6 +354,47 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
             json=payload,
             extra_headers={"Prefer": "resolution=merge-duplicates,return=minimal"},
         )
+
+    def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
+        if not batches:
+            return
+        payload = [batch.model_dump(mode="json") for batch in batches]
+        self._request(
+            "POST",
+            self._table_names["backfill_batches"],
+            params={"on_conflict": "batch_id"},
+            json=payload,
+            extra_headers={"Prefer": "resolution=merge-duplicates,return=minimal"},
+        )
+
+    def get_backfill_batch(self, batch_id: str) -> BackfillBatch | None:
+        response = self._request(
+            "GET",
+            self._table_names["backfill_batches"],
+            params={"select": "*", "batch_id": f"eq.{batch_id}", "limit": "1"},
+        )
+        payload = response.json()
+        if isinstance(payload, list) and payload:
+            return BackfillBatch.model_validate(payload[0])
+        return None
+
+    def list_backfill_batches(
+        self,
+        *,
+        statuses: Sequence[BackfillBatchStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[BackfillBatch]:
+        params: dict[str, str] = {"select": "*", "order": "requested_date_from.asc"}
+        if statuses:
+            joined = ",".join(status.value for status in statuses)
+            params["status"] = f"in.({joined})"
+        if limit is not None:
+            params["limit"] = str(limit)
+        response = self._request("GET", self._table_names["backfill_batches"], params=params)
+        payload = response.json()
+        if isinstance(payload, list):
+            return [BackfillBatch.model_validate(item) for item in payload]
+        return []
 
     def get_candidate(self, candidate_id: str) -> PersistentCandidate | None:
         response = self._request(
@@ -466,8 +565,16 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
         for mirror in self.mirrors:
             mirror.upsert_candidates(candidates)
 
+    def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
+        self.primary.upsert_backfill_batches(batches)
+        for mirror in self.mirrors:
+            mirror.upsert_backfill_batches(batches)
+
     def get_candidate(self, candidate_id: str) -> PersistentCandidate | None:
         return self.primary.get_candidate(candidate_id)
+
+    def get_backfill_batch(self, batch_id: str) -> BackfillBatch | None:
+        return self.primary.get_backfill_batch(batch_id)
 
     def list_candidates(
         self,
@@ -476,6 +583,14 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
         return self.primary.list_candidates(statuses=statuses, limit=limit)
+
+    def list_backfill_batches(
+        self,
+        *,
+        statuses: Sequence[BackfillBatchStatus] | None = None,
+        limit: int | None = None,
+    ) -> list[BackfillBatch]:
+        return self.primary.list_backfill_batches(statuses=statuses, limit=limit)
 
     def find_candidate_by_urls(
         self,
@@ -530,6 +645,7 @@ def create_discovery_persistence(config: Config) -> DiscoveryPersistence:
             table_names={
                 "discovery_runs": config.candidates.discovery_runs_table,
                 "persistent_candidates": config.candidates.supabase_table,
+                "backfill_batches": config.candidates.backfill_batches_table,
                 "candidate_provenance": config.candidates.provenance_table,
                 "scrape_attempts": config.candidates.scrape_attempts_table,
             },

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -65,9 +65,10 @@ class NullDiscoveryPersistence(DiscoveryPersistence):
         self,
         *,
         statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
-        del statuses, limit
+        del statuses, backfill_batch_id, limit
         return []
 
     def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
@@ -225,6 +226,7 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
         self,
         *,
         statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
         candidates = self._read_jsonl(self.paths.latest_candidates_path, PersistentCandidate)
@@ -232,6 +234,12 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
             allowed = set(statuses)
             candidates = [
                 candidate for candidate in candidates if candidate.candidate_status in allowed
+            ]
+        if backfill_batch_id is not None:
+            candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.backfill_batch_id == backfill_batch_id
             ]
         if limit is not None:
             return candidates[:limit]
@@ -411,12 +419,15 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
         self,
         *,
         statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
         params: dict[str, str] = {"select": "*", "order": "last_seen_at.desc"}
         if statuses:
             joined = ",".join(status.value for status in statuses)
             params["candidate_status"] = f"in.({joined})"
+        if backfill_batch_id is not None:
+            params["backfill_batch_id"] = f"eq.{backfill_batch_id}"
         if limit is not None:
             params["limit"] = str(limit)
         response = self._request("GET", self._table_names["persistent_candidates"], params=params)
@@ -580,9 +591,14 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
         self,
         *,
         statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
-        return self.primary.list_candidates(statuses=statuses, limit=limit)
+        return self.primary.list_candidates(
+            statuses=statuses,
+            backfill_batch_id=backfill_batch_id,
+            limit=limit,
+        )
 
     def list_backfill_batches(
         self,

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -479,16 +479,11 @@ def _batch_candidate_counts(
     batch_id: str,
 ) -> tuple[int, int]:
     """Return merged-candidate and queued-for-scrape counts for one backfill batch."""
-    batch_candidates = [
-        candidate
-        for candidate in persistence.list_candidates()
-        if candidate.backfill_batch_id == batch_id
-    ]
-    queued_for_scrape = [
-        candidate
-        for candidate in batch_candidates
-        if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
-    ]
+    batch_candidates = persistence.list_candidates(backfill_batch_id=batch_id)
+    queued_for_scrape = persistence.list_candidates(
+        statuses=SCRAPEABLE_CANDIDATE_STATUSES,
+        backfill_batch_id=batch_id,
+    )
     return len(batch_candidates), len(queued_for_scrape)
 
 
@@ -2111,6 +2106,7 @@ async def run_news_backfill_scrape_job(
     result.seen_count_before = seen_store.count
     store = operational_store
     owns_store = False
+    scrape_batch: CandidateScrapeBatch | None = None
 
     try:
         scrape_batch = await _run_backfill_candidate_scrape_job(
@@ -2168,29 +2164,33 @@ async def run_news_backfill_scrape_job(
             if batch_id is not None:
                 existing_batch = updated_persistence.get_backfill_batch(batch_id)
                 if existing_batch is not None:
-                    remaining_candidates = select_backfill_candidates_for_scrape(
-                        updated_persistence,
+                    remaining_candidates = updated_persistence.list_candidates(
+                        statuses=SCRAPEABLE_CANDIDATE_STATUSES,
+                        backfill_batch_id=batch_id,
                         limit=1,
-                        batch_id=batch_id,
+                    )
+                    scrape_attempts = len(scrape_batch.attempts) if scrape_batch is not None else 0
+                    scraped_candidates = (
+                        len(scrape_batch.selected_candidates) if scrape_batch is not None else 0
                     )
                     final_status = (
-                        BackfillBatchStatus.COMPLETED
-                        if not remaining_candidates
-                        else (
+                        BackfillBatchStatus.PARTIAL
+                        if result.errors
+                        else BackfillBatchStatus.COMPLETED
+                    )
+                    if remaining_candidates:
+                        final_status = (
                             BackfillBatchStatus.PARTIAL
                             if result.errors
                             else BackfillBatchStatus.DISCOVERED
                         )
-                    )
                     _update_backfill_batch_state(
                         updated_persistence,
                         batch=existing_batch,
                         status=final_status,
-                        scrape_attempt_count=existing_batch.scrape_attempt_count
-                        + len(scrape_batch.attempts if "scrape_batch" in locals() else []),
-                        scraped_candidate_count=existing_batch.scraped_candidate_count
-                        + len(
-                            scrape_batch.selected_candidates if "scrape_batch" in locals() else []
+                        scrape_attempt_count=existing_batch.scrape_attempt_count + scrape_attempts,
+                        scraped_candidate_count=(
+                            existing_batch.scraped_candidate_count + scraped_candidates
                         ),
                         warnings=deduplicate_strings([*existing_batch.warnings, *result.warnings]),
                         errors=deduplicate_strings([*existing_batch.errors, *result.errors]),

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -499,13 +499,19 @@ def _update_backfill_batch_state(
     scraped_candidate_count: int | None = None,
     warnings: list[str] | None = None,
     errors: list[str] | None = None,
-    finished: bool = False,
+    finished: bool | None = None,
 ) -> BackfillBatch:
     """Persist one batch state transition with refreshed aggregate counts."""
     merged_candidate_count, queued_for_scrape_count = _batch_candidate_counts(
         persistence,
         batch_id=batch.batch_id,
     )
+    if finished is True:
+        finished_at = datetime.now(UTC)
+    elif finished is False:
+        finished_at = None
+    else:
+        finished_at = batch.finished_at
     updated = batch.model_copy(
         update={
             "updated_at": datetime.now(UTC),
@@ -528,7 +534,7 @@ def _update_backfill_batch_state(
             ),
             "warnings": warnings if warnings is not None else batch.warnings,
             "errors": errors if errors is not None else batch.errors,
-            "finished_at": datetime.now(UTC) if finished else batch.finished_at,
+            "finished_at": finished_at,
         }
     )
     persistence.upsert_backfill_batches([updated])
@@ -2017,12 +2023,12 @@ async def run_news_backfill_discover_job(
             query_count += persisted.run.query_count
             discovered_count += persisted.run.candidate_count
             result.raw_article_count += persisted.run.candidate_count
-            result.unified_item_count += persisted.run.merged_candidate_count
             result.errors.extend(persisted.run.errors)
             batch_errors.extend(persisted.run.errors)
 
+        merged_candidate_count, _ = _batch_candidate_counts(persistence, batch_id=batch.batch_id)
         status = BackfillBatchStatus.DISCOVERED
-        if batch_errors and not result.unified_item_count:
+        if batch_errors and not merged_candidate_count:
             status = BackfillBatchStatus.FAILED
             result.fatal = True
         elif batch_errors:
@@ -2036,11 +2042,12 @@ async def run_news_backfill_discover_job(
             candidate_count=discovered_count,
             warnings=deduplicate_strings(batch_warnings),
             errors=deduplicate_strings(batch_errors),
-            finished=True,
+            finished=status is BackfillBatchStatus.FAILED,
         )
     finally:
         persistence.close()
 
+    result.unified_item_count = batch.merged_candidate_count
     result.warnings.extend(batch.warnings)
     result.set_debug_payload(
         {
@@ -2100,6 +2107,7 @@ async def run_news_backfill_scrape_job(
             status=BackfillBatchStatus.SCRAPING,
             warnings=batch.warnings,
             errors=batch.errors,
+            finished=False,
         )
     finally:
         persistence.close()

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -894,7 +894,8 @@ async def _run_backfill_engine_discovery(
     missing_error: str | None = None
     if engine_name == "brave":
         if not config.brave_search_api_key:
-            missing_error = "brave: missing DENBUST_BRAVE_SEARCH_API_KEY"
+            env_name = config.discovery.engines.brave.api_key_env or "DENBUST_BRAVE_SEARCH_API_KEY"
+            missing_error = f"brave: missing {env_name}"
         else:
             engine = BraveSearchEngine(
                 api_key=config.brave_search_api_key,
@@ -907,7 +908,8 @@ async def _run_backfill_engine_discovery(
             )
     elif engine_name == "exa":
         if not config.exa_api_key:
-            missing_error = "exa: missing DENBUST_EXA_API_KEY"
+            env_name = config.discovery.engines.exa.api_key_env or "DENBUST_EXA_API_KEY"
+            missing_error = f"exa: missing {env_name}"
         else:
             engine = ExaSearchEngine(
                 api_key=config.exa_api_key,
@@ -924,9 +926,13 @@ async def _run_backfill_engine_discovery(
             )
     elif engine_name == "google_cse":
         if not config.google_cse_api_key:
-            missing_error = "google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"
+            env_name = (
+                config.discovery.engines.google_cse.api_key_env or "DENBUST_GOOGLE_CSE_API_KEY"
+            )
+            missing_error = f"google_cse: missing {env_name}"
         elif not config.google_cse_id:
-            missing_error = "google_cse: missing DENBUST_GOOGLE_CSE_ID"
+            env_name = config.discovery.engines.google_cse.cse_id_env or "DENBUST_GOOGLE_CSE_ID"
+            missing_error = f"google_cse: missing {env_name}"
         else:
             engine = GoogleCseSearchEngine(
                 api_key=config.google_cse_api_key,

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -9,6 +9,8 @@ import sys
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
+from uuid import uuid4
 
 from denbust.classifier.relevance import Classifier, create_classifier
 from denbust.config import Config, OutputFormat, SourceType, load_config
@@ -20,19 +22,34 @@ from denbust.diagnostics.discovery import (
     build_discovery_diagnostic_report,
     persist_discovery_diagnostic_artifacts,
 )
+from denbust.discovery.backfill import (
+    BACKFILL_BATCH_ID_ENV,
+    BACKFILL_DATE_FROM_ENV,
+    BACKFILL_DATE_TO_ENV,
+    BackfillWindow,
+    backfill_metadata,
+    build_backfill_queries,
+    plan_backfill_windows,
+    resolve_backfill_request_window,
+)
 from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.engines.exa import ExaSearchEngine
 from denbust.discovery.engines.google_cse import GoogleCseSearchEngine
 from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
+    DiscoveredCandidate,
     DiscoveryRun,
     DiscoveryRunStatus,
     PersistentCandidate,
 )
 from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import (
+    SCRAPEABLE_CANDIDATE_STATUSES,
     CandidateScrapeBatch,
     scrape_candidates,
+    select_backfill_candidates_for_scrape,
     select_candidates_for_scrape,
 )
 from denbust.discovery.source_native import (
@@ -41,7 +58,7 @@ from denbust.discovery.source_native import (
     persist_discovered_candidates,
     raw_article_to_discovered_candidate,
 )
-from denbust.discovery.storage import create_discovery_persistence
+from denbust.discovery.storage import DiscoveryPersistence, create_discovery_persistence
 from denbust.models.common import DatasetName, JobName
 from denbust.models.policies import PublicationStatus, ReviewStatus
 from denbust.models.runs import RunSnapshot
@@ -105,6 +122,7 @@ logger = logging.getLogger(__name__)
 _OPERATIONAL_STORE_JOBS = {
     JobName.INGEST,
     JobName.SCRAPE_CANDIDATES,
+    JobName.BACKFILL_SCRAPE,
     JobName.MONTHLY_REPORT,
     JobName.RELEASE,
     JobName.BACKUP,
@@ -441,6 +459,148 @@ async def _persist_source_native_candidates(
         persistence.close()
 
 
+def _tag_backfill_discovered_candidates(
+    discovered_candidates: list[DiscoveredCandidate],
+    *,
+    batch_id: str,
+    window: BackfillWindow,
+) -> list[DiscoveredCandidate]:
+    """Attach backfill metadata to discovered candidates before persistence."""
+    metadata = backfill_metadata(batch_id=batch_id, window=window)
+    return [
+        candidate.model_copy(update={"metadata": {**candidate.metadata, **metadata}})
+        for candidate in discovered_candidates
+    ]
+
+
+def _batch_candidate_counts(
+    persistence: DiscoveryPersistence,
+    *,
+    batch_id: str,
+) -> tuple[int, int]:
+    """Return merged-candidate and queued-for-scrape counts for one backfill batch."""
+    batch_candidates = [
+        candidate
+        for candidate in persistence.list_candidates()
+        if candidate.backfill_batch_id == batch_id
+    ]
+    queued_for_scrape = [
+        candidate
+        for candidate in batch_candidates
+        if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
+    ]
+    return len(batch_candidates), len(queued_for_scrape)
+
+
+def _update_backfill_batch_state(
+    persistence: DiscoveryPersistence,
+    *,
+    batch: BackfillBatch,
+    status: BackfillBatchStatus,
+    query_count: int | None = None,
+    candidate_count: int | None = None,
+    scrape_attempt_count: int | None = None,
+    scraped_candidate_count: int | None = None,
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+    finished: bool = False,
+) -> BackfillBatch:
+    """Persist one batch state transition with refreshed aggregate counts."""
+    merged_candidate_count, queued_for_scrape_count = _batch_candidate_counts(
+        persistence,
+        batch_id=batch.batch_id,
+    )
+    updated = batch.model_copy(
+        update={
+            "updated_at": datetime.now(UTC),
+            "status": status,
+            "query_count": query_count if query_count is not None else batch.query_count,
+            "candidate_count": (
+                candidate_count if candidate_count is not None else batch.candidate_count
+            ),
+            "merged_candidate_count": merged_candidate_count,
+            "queued_for_scrape_count": queued_for_scrape_count,
+            "scrape_attempt_count": (
+                scrape_attempt_count
+                if scrape_attempt_count is not None
+                else batch.scrape_attempt_count
+            ),
+            "scraped_candidate_count": (
+                scraped_candidate_count
+                if scraped_candidate_count is not None
+                else batch.scraped_candidate_count
+            ),
+            "warnings": warnings if warnings is not None else batch.warnings,
+            "errors": errors if errors is not None else batch.errors,
+            "finished_at": datetime.now(UTC) if finished else batch.finished_at,
+        }
+    )
+    persistence.upsert_backfill_batches([updated])
+    return updated
+
+
+async def _run_source_native_backfill_discovery(
+    *,
+    config: Config,
+    sources: list[Source],
+    run_id: str,
+    window: BackfillWindow,
+    batch_id: str,
+) -> PersistedSourceDiscovery:
+    """Fetch source-native historical candidates when the source supports explicit windows."""
+    enabled_sources = [
+        source for source in sources if _source_discovery_enabled_for_source(config, source.name)
+    ]
+    discovery_run = DiscoveryRun(
+        run_id=run_id,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=DiscoveryRunStatus.RUNNING,
+        query_count=len(enabled_sources),
+    )
+    context = SourceDiscoveryContext(
+        run_id=run_id,
+        source_names=[source.name for source in enabled_sources],
+        keywords=config.keywords,
+        date_from=window.date_from,
+        date_to=window.date_to,
+    )
+    persistence = create_discovery_persistence(config)
+    warnings: list[str] = []
+    try:
+        discovered_candidates = []
+        errors: list[str] = []
+        for source in enabled_sources:
+            adapter = SourceDiscoveryAdapter(source)
+            if not adapter.supports_historical_window:
+                warnings.append(f"{source.name}: historical window discovery is unsupported")
+                continue
+            try:
+                discovered_candidates.extend(
+                    _tag_backfill_discovered_candidates(
+                        await adapter.discover_candidates_for_window(context),
+                        batch_id=batch_id,
+                        window=window,
+                    )
+                )
+            except Exception as exc:
+                logger.exception(
+                    "Error discovering backfill candidates from %s: %s", source.name, exc
+                )
+                errors.append(f"{source.name}: {exc}")
+
+        discovery_run.errors = errors
+        persisted = persist_discovered_candidates(
+            run=discovery_run,
+            discovered_candidates=discovered_candidates,
+            persistence=persistence,
+        )
+        persisted.warnings = warnings
+        return persisted
+    finally:
+        persistence.close()
+
+
 async def _run_source_native_discovery(
     *,
     config: Config,
@@ -699,12 +859,129 @@ async def _run_google_cse_discovery(
         persistence.close()
 
 
+async def _run_backfill_engine_discovery(
+    *,
+    config: Config,
+    run_id: str,
+    batch_id: str,
+    window: BackfillWindow,
+    engine_name: str,
+) -> PersistedSourceDiscovery:
+    """Run one search engine over a historical window and persist tagged candidates."""
+    queries = build_backfill_queries(config, window=window)
+    discovery_run = DiscoveryRun(
+        run_id=run_id,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=DiscoveryRunStatus.RUNNING,
+        query_count=len(queries),
+    )
+    persistence = create_discovery_persistence(config)
+    if not queries:
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    engine: Any | None = None
+    context: DiscoveryContext | None = None
+    missing_error: str | None = None
+    if engine_name == "brave":
+        if not config.brave_search_api_key:
+            missing_error = "brave: missing DENBUST_BRAVE_SEARCH_API_KEY"
+        else:
+            engine = BraveSearchEngine(
+                api_key=config.brave_search_api_key,
+                max_results_per_query=config.discovery.engines.brave.max_results_per_query,
+            )
+            context = DiscoveryContext(
+                run_id=run_id,
+                max_results_per_query=config.discovery.engines.brave.max_results_per_query,
+                metadata={"engine": "brave", **backfill_metadata(batch_id=batch_id, window=window)},
+            )
+    elif engine_name == "exa":
+        if not config.exa_api_key:
+            missing_error = "exa: missing DENBUST_EXA_API_KEY"
+        else:
+            engine = ExaSearchEngine(
+                api_key=config.exa_api_key,
+                max_results_per_query=config.discovery.engines.exa.max_results_per_query,
+            )
+            context = DiscoveryContext(
+                run_id=run_id,
+                max_results_per_query=config.discovery.engines.exa.max_results_per_query,
+                metadata={
+                    "engine": "exa",
+                    "allow_find_similar": config.discovery.engines.exa.allow_find_similar,
+                    **backfill_metadata(batch_id=batch_id, window=window),
+                },
+            )
+    elif engine_name == "google_cse":
+        if not config.google_cse_api_key:
+            missing_error = "google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"
+        elif not config.google_cse_id:
+            missing_error = "google_cse: missing DENBUST_GOOGLE_CSE_ID"
+        else:
+            engine = GoogleCseSearchEngine(
+                api_key=config.google_cse_api_key,
+                cse_id=config.google_cse_id,
+                max_results_per_query=config.discovery.engines.google_cse.max_results_per_query,
+            )
+            context = DiscoveryContext(
+                run_id=run_id,
+                max_results_per_query=config.discovery.engines.google_cse.max_results_per_query,
+                metadata={
+                    "engine": "google_cse",
+                    **backfill_metadata(batch_id=batch_id, window=window),
+                },
+            )
+    else:
+        raise ValueError(f"Unsupported backfill engine: {engine_name}")
+
+    if missing_error is not None:
+        discovery_run.errors.append(missing_error)
+        try:
+            return persist_discovered_candidates(
+                run=discovery_run,
+                discovered_candidates=[],
+                persistence=persistence,
+            )
+        finally:
+            persistence.close()
+
+    assert engine is not None
+    assert context is not None
+    try:
+        try:
+            discovered_candidates = _tag_backfill_discovered_candidates(
+                await engine.discover(queries, context=context),
+                batch_id=batch_id,
+                window=window,
+            )
+        except Exception as exc:
+            discovery_run.errors.append(f"{engine_name}: {type(exc).__name__}: {exc}")
+            discovered_candidates = []
+        return persist_discovered_candidates(
+            run=discovery_run,
+            discovered_candidates=discovered_candidates,
+            persistence=persistence,
+        )
+    finally:
+        await engine.aclose()
+        persistence.close()
+
+
 async def _scrape_candidate_batch(
     *,
     config: Config,
     candidates: list[PersistentCandidate],
     sources: list[Source],
     preloaded_source_articles: dict[str, list[RawArticle]] | None = None,
+    backfill_mode: bool = False,
 ) -> CandidateScrapeBatch:
     """Materialize durable candidates into raw articles and record scrape attempts."""
     persistence = create_discovery_persistence(config)
@@ -715,6 +992,7 @@ async def _scrape_candidate_batch(
             candidates=candidates,
             sources=sources,
             preloaded_source_articles=preloaded_source_articles,
+            backfill_mode=backfill_mode,
         )
     finally:
         persistence.close()
@@ -740,6 +1018,32 @@ async def _run_candidate_scrape_job(
         config=config,
         candidates=selected_candidates,
         sources=sources,
+    )
+
+
+async def _run_backfill_candidate_scrape_job(
+    *,
+    config: Config,
+    sources: list[Source],
+    limit: int,
+    batch_id: str | None = None,
+) -> CandidateScrapeBatch:
+    """Select one historical batch and run the scrape-attempt layer over it."""
+    persistence = create_discovery_persistence(config)
+    try:
+        selected_candidates = select_backfill_candidates_for_scrape(
+            persistence,
+            limit=limit,
+            batch_id=batch_id,
+        )
+    finally:
+        persistence.close()
+
+    return await _scrape_candidate_batch(
+        config=config,
+        candidates=selected_candidates,
+        sources=sources,
+        backfill_mode=True,
     )
 
 
@@ -1587,6 +1891,313 @@ async def run_news_scrape_candidates_job(
         )
         return processed
     finally:
+        if owns_store and store is not None:
+            store.close()
+
+
+async def run_news_backfill_discover_job(
+    config: Config,
+    config_path: Path | None = None,
+    days_override: int | None = None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    """Discover historical candidates over one requested backfill range."""
+    del days_override, operational_store
+    result = _build_run_snapshot(config, config_path=config_path, days=config.days)
+    try:
+        requested_date_from, requested_date_to = resolve_backfill_request_window()
+    except ValueError as exc:
+        result.fatal = True
+        result.errors.append(str(exc))
+        return result.finish("fatal: invalid backfill request window")
+
+    windows = plan_backfill_windows(
+        date_from=requested_date_from,
+        date_to=requested_date_to,
+        batch_window_days=config.backfill.batch_window_days,
+    )
+    sources = create_sources(config)
+    result.source_count = len(sources)
+    source_native_can_run = (
+        config.source_discovery.enabled
+        and config.source_discovery.persist_candidates
+        and bool(sources)
+    )
+    engine_can_run = (
+        config.discovery.enabled
+        and config.discovery.persist_candidates
+        and any(
+            [
+                config.discovery.engines.brave.enabled,
+                config.discovery.engines.exa.enabled,
+                config.discovery.engines.google_cse.enabled,
+            ]
+        )
+    )
+    if not source_native_can_run and not engine_can_run:
+        result.fatal = True
+        result.errors.append("No backfill discovery producers configured")
+        return result.finish("fatal: no backfill discovery producers configured")
+    batch = BackfillBatch(
+        batch_id=os.getenv(BACKFILL_BATCH_ID_ENV) or str(uuid4()),
+        created_at=result.run_timestamp,
+        updated_at=result.run_timestamp,
+        started_at=result.run_timestamp,
+        dataset_name=config.dataset_name,
+        job_name=config.job_name,
+        status=BackfillBatchStatus.RUNNING,
+        requested_date_from=requested_date_from,
+        requested_date_to=requested_date_to,
+        window_count=len(windows),
+        metadata={
+            "requested_date_from_env": BACKFILL_DATE_FROM_ENV,
+            "requested_date_to_env": BACKFILL_DATE_TO_ENV,
+        },
+    )
+    persistence = create_discovery_persistence(config)
+    try:
+        persistence.upsert_backfill_batches([batch])
+        run_base = result.run_timestamp.astimezone(UTC).isoformat()
+        query_count = 0
+        discovered_count = 0
+        batch_warnings: list[str] = []
+        batch_errors: list[str] = []
+        persisted_runs: list[PersistedSourceDiscovery] = []
+
+        for window in windows:
+            if source_native_can_run:
+                persisted = await _run_source_native_backfill_discovery(
+                    config=config,
+                    sources=sources,
+                    run_id=f"{run_base}:source_native:{window.index}",
+                    window=window,
+                    batch_id=batch.batch_id,
+                )
+                persisted_runs.append(persisted)
+                if persisted.warnings:
+                    batch_warnings.extend(persisted.warnings)
+
+            if engine_can_run:
+                if config.discovery.engines.brave.enabled:
+                    persisted_runs.append(
+                        await _run_backfill_engine_discovery(
+                            config=config,
+                            run_id=f"{run_base}:brave:{window.index}",
+                            batch_id=batch.batch_id,
+                            window=window,
+                            engine_name="brave",
+                        )
+                    )
+                if config.discovery.engines.exa.enabled:
+                    persisted_runs.append(
+                        await _run_backfill_engine_discovery(
+                            config=config,
+                            run_id=f"{run_base}:exa:{window.index}",
+                            batch_id=batch.batch_id,
+                            window=window,
+                            engine_name="exa",
+                        )
+                    )
+                if config.discovery.engines.google_cse.enabled:
+                    persisted_runs.append(
+                        await _run_backfill_engine_discovery(
+                            config=config,
+                            run_id=f"{run_base}:google_cse:{window.index}",
+                            batch_id=batch.batch_id,
+                            window=window,
+                            engine_name="google_cse",
+                        )
+                    )
+
+        for persisted in persisted_runs:
+            query_count += persisted.run.query_count
+            discovered_count += persisted.run.candidate_count
+            result.raw_article_count += persisted.run.candidate_count
+            result.unified_item_count += persisted.run.merged_candidate_count
+            result.errors.extend(persisted.run.errors)
+            batch_errors.extend(persisted.run.errors)
+
+        status = BackfillBatchStatus.DISCOVERED
+        if batch_errors and not result.unified_item_count:
+            status = BackfillBatchStatus.FAILED
+            result.fatal = True
+        elif batch_errors:
+            status = BackfillBatchStatus.PARTIAL
+
+        batch = _update_backfill_batch_state(
+            persistence,
+            batch=batch,
+            status=status,
+            query_count=query_count,
+            candidate_count=discovered_count,
+            warnings=deduplicate_strings(batch_warnings),
+            errors=deduplicate_strings(batch_errors),
+            finished=True,
+        )
+    finally:
+        persistence.close()
+
+    result.warnings.extend(batch.warnings)
+    result.set_debug_payload(
+        {
+            "batch_id": batch.batch_id,
+            "requested_date_from": requested_date_from.isoformat(),
+            "requested_date_to": requested_date_to.isoformat(),
+            "window_count": len(windows),
+        }
+    )
+    if result.fatal:
+        return result.finish(f"fatal: backfill discovery failed for batch {batch.batch_id}")
+    return result.finish(
+        f"backfill discovery persisted {batch.merged_candidate_count} candidate(s) for batch {batch.batch_id}"
+    )
+
+
+async def run_news_backfill_scrape_job(
+    config: Config,
+    config_path: Path | None = None,
+    days_override: int | None = None,
+    operational_store: OperationalStore | None = None,
+) -> RunSnapshot:
+    """Drain one historical backfill batch through the candidate scrape pipeline."""
+    days = days_override if days_override is not None else config.days
+    result = _build_run_snapshot(config, config_path=config_path, days=days)
+    if not config.anthropic_api_key:
+        result.fatal = True
+        result.errors.append("ANTHROPIC_API_KEY not set")
+        return result.finish("fatal: missing anthropic api key")
+
+    sources = create_sources(config)
+    result.source_count = len(sources)
+    if not sources:
+        result.fatal = True
+        result.errors.append("No sources configured")
+        return result.finish("fatal: no sources configured")
+
+    batch_id = os.getenv(BACKFILL_BATCH_ID_ENV)
+    persistence = create_discovery_persistence(config)
+    try:
+        scrape_candidates_for_batch = select_backfill_candidates_for_scrape(
+            persistence,
+            limit=config.backfill.max_scrape_attempts_per_run,
+            batch_id=batch_id,
+        )
+        if not scrape_candidates_for_batch:
+            return result.finish("no queued backfill candidates eligible for scrape")
+        batch_id = scrape_candidates_for_batch[0].backfill_batch_id
+        batch = persistence.get_backfill_batch(batch_id) if batch_id is not None else None
+        if batch is None:
+            result.fatal = True
+            result.errors.append("Missing backfill batch metadata")
+            return result.finish("fatal: missing backfill batch metadata")
+        batch = _update_backfill_batch_state(
+            persistence,
+            batch=batch,
+            status=BackfillBatchStatus.SCRAPING,
+            warnings=batch.warnings,
+            errors=batch.errors,
+        )
+    finally:
+        persistence.close()
+
+    classifier = create_classifier(
+        api_key=config.anthropic_api_key,
+        model=config.classifier.model,
+        system_prompt=config.classifier.system_prompt,
+        user_prompt_template=config.classifier.user_prompt_template,
+    )
+    deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
+    seen_store = create_seen_store(config.state_paths.seen_path)
+    result.seen_count_before = seen_store.count
+    store = operational_store
+    owns_store = False
+
+    try:
+        scrape_batch = await _run_backfill_candidate_scrape_job(
+            config=config.model_copy(update={"days": days}),
+            sources=sources,
+            limit=config.backfill.max_scrape_attempts_per_run,
+            batch_id=batch_id,
+        )
+        result.raw_article_count = len(scrape_batch.raw_articles)
+        if scrape_batch.errors:
+            result.errors.extend(scrape_batch.errors)
+            result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
+        if not scrape_batch.selected_candidates:
+            return result.finish("no queued backfill candidates eligible for scrape")
+
+        if store is None and (scrape_batch.raw_articles or scrape_batch.fallback_candidates):
+            store = create_operational_store(config)
+            owns_store = True
+
+        fallback_records = await _build_fallback_operational_records(
+            candidates=scrape_batch.fallback_candidates,
+            classifier=classifier,
+        )
+        if fallback_records and store is not None:
+            store.upsert_records(
+                config.dataset_name.value,
+                [record.model_dump(mode="json") for record in fallback_records],
+            )
+            result.warnings.append(f"fallback_operational_records={len(fallback_records)}")
+
+        if not scrape_batch.raw_articles:
+            result.unified_item_count = len(fallback_records)
+            return result.finish(
+                "fallback retention completed with "
+                f"{len(fallback_records)} provisional row(s) for backfill batch {batch_id}"
+            )
+
+        processed = await _process_ingest_articles(
+            config=config,
+            result=result,
+            source_names=[source.name for source in sources],
+            sources=sources,
+            all_articles=scrape_batch.raw_articles,
+            seen_store=seen_store,
+            classifier=classifier,
+            deduplicator=deduplicator,
+            operational_store=store,
+        )
+        processed.result_summary = f"backfill batch {batch_id}: {processed.result_summary}"
+        processed.set_debug_payload({"batch_id": batch_id})
+        return processed
+    finally:
+        updated_persistence = create_discovery_persistence(config)
+        try:
+            if batch_id is not None:
+                existing_batch = updated_persistence.get_backfill_batch(batch_id)
+                if existing_batch is not None:
+                    remaining_candidates = select_backfill_candidates_for_scrape(
+                        updated_persistence,
+                        limit=1,
+                        batch_id=batch_id,
+                    )
+                    final_status = (
+                        BackfillBatchStatus.COMPLETED
+                        if not remaining_candidates
+                        else (
+                            BackfillBatchStatus.PARTIAL
+                            if result.errors
+                            else BackfillBatchStatus.DISCOVERED
+                        )
+                    )
+                    _update_backfill_batch_state(
+                        updated_persistence,
+                        batch=existing_batch,
+                        status=final_status,
+                        scrape_attempt_count=existing_batch.scrape_attempt_count
+                        + len(scrape_batch.attempts if "scrape_batch" in locals() else []),
+                        scraped_candidate_count=existing_batch.scraped_candidate_count
+                        + len(
+                            scrape_batch.selected_candidates if "scrape_batch" in locals() else []
+                        ),
+                        warnings=deduplicate_strings([*existing_batch.warnings, *result.warnings]),
+                        errors=deduplicate_strings([*existing_batch.errors, *result.errors]),
+                        finished=final_status is BackfillBatchStatus.COMPLETED,
+                    )
+        finally:
+            updated_persistence.close()
         if owns_store and store is not None:
             store.close()
 

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -480,11 +480,12 @@ def _batch_candidate_counts(
 ) -> tuple[int, int]:
     """Return merged-candidate and queued-for-scrape counts for one backfill batch."""
     batch_candidates = persistence.list_candidates(backfill_batch_id=batch_id)
-    queued_for_scrape = persistence.list_candidates(
-        statuses=SCRAPEABLE_CANDIDATE_STATUSES,
-        backfill_batch_id=batch_id,
+    queued_for_scrape_count = sum(
+        1
+        for candidate in batch_candidates
+        if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
     )
-    return len(batch_candidates), len(queued_for_scrape)
+    return len(batch_candidates), queued_for_scrape_count
 
 
 def _update_backfill_batch_state(
@@ -1933,24 +1934,32 @@ async def run_news_backfill_discover_job(
         result.fatal = True
         result.errors.append("No backfill discovery producers configured")
         return result.finish("fatal: no backfill discovery producers configured")
-    batch = BackfillBatch(
-        batch_id=os.getenv(BACKFILL_BATCH_ID_ENV) or str(uuid4()),
-        created_at=result.run_timestamp,
-        updated_at=result.run_timestamp,
-        started_at=result.run_timestamp,
-        dataset_name=config.dataset_name,
-        job_name=config.job_name,
-        status=BackfillBatchStatus.RUNNING,
-        requested_date_from=requested_date_from,
-        requested_date_to=requested_date_to,
-        window_count=len(windows),
-        metadata={
-            "requested_date_from_env": BACKFILL_DATE_FROM_ENV,
-            "requested_date_to_env": BACKFILL_DATE_TO_ENV,
-        },
-    )
+    batch_id = os.getenv(BACKFILL_BATCH_ID_ENV) or str(uuid4())
     persistence = create_discovery_persistence(config)
     try:
+        if (
+            os.getenv(BACKFILL_BATCH_ID_ENV)
+            and persistence.get_backfill_batch(batch_id) is not None
+        ):
+            result.fatal = True
+            result.errors.append(f"Backfill batch {batch_id} already exists")
+            return result.finish(f"fatal: backfill batch {batch_id} already exists")
+        batch = BackfillBatch(
+            batch_id=batch_id,
+            created_at=result.run_timestamp,
+            updated_at=result.run_timestamp,
+            started_at=result.run_timestamp,
+            dataset_name=config.dataset_name,
+            job_name=config.job_name,
+            status=BackfillBatchStatus.RUNNING,
+            requested_date_from=requested_date_from,
+            requested_date_to=requested_date_to,
+            window_count=len(windows),
+            metadata={
+                "requested_date_from_env": BACKFILL_DATE_FROM_ENV,
+                "requested_date_to_env": BACKFILL_DATE_TO_ENV,
+            },
+        )
         persistence.upsert_backfill_batches([batch])
         run_base = result.run_timestamp.astimezone(UTC).isoformat()
         query_count = 0

--- a/src/denbust/sources/base.py
+++ b/src/denbust/sources/base.py
@@ -1,7 +1,8 @@
 """Base protocol for news sources."""
 
 from abc import ABC, abstractmethod
-from typing import Any
+from datetime import datetime
+from typing import Any, Protocol, runtime_checkable
 
 from denbust.data_models import RawArticle
 
@@ -31,3 +32,22 @@ class Source(ABC):
     def get_debug_state(self) -> dict[str, Any] | None:
         """Return optional structured runtime telemetry for debug logs."""
         return None
+
+
+@runtime_checkable
+class HistoricalSource(Protocol):
+    """Optional protocol for sources that can fetch one explicit historical window."""
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        ...
+
+    async def fetch_window(
+        self,
+        *,
+        date_from: datetime,
+        date_to: datetime,
+        keywords: list[str],
+    ) -> list[RawArticle]:
+        """Fetch articles for one explicit historical window."""

--- a/supabase/migrations/20260419_backfill_batches.sql
+++ b/supabase/migrations/20260419_backfill_batches.sql
@@ -1,0 +1,44 @@
+create table if not exists public.backfill_batches (
+    batch_id text primary key,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    started_at timestamptz,
+    finished_at timestamptz,
+    dataset_name text not null,
+    job_name text not null,
+    status text not null,
+    requested_date_from timestamptz not null,
+    requested_date_to timestamptz not null,
+    window_count integer not null default 0,
+    query_count integer not null default 0,
+    candidate_count integer not null default 0,
+    merged_candidate_count integer not null default 0,
+    queued_for_scrape_count integer not null default 0,
+    scrape_attempt_count integer not null default 0,
+    scraped_candidate_count integer not null default 0,
+    warnings jsonb not null default '[]'::jsonb,
+    errors jsonb not null default '[]'::jsonb,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists backfill_batches_status_idx
+    on public.backfill_batches (status, requested_date_from asc);
+
+create index if not exists persistent_candidates_backfill_batch_idx
+    on public.persistent_candidates (backfill_batch_id, candidate_status, next_scrape_attempt_at)
+    where backfill_batch_id is not null;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'persistent_candidates_backfill_batch_fk'
+    ) then
+        alter table public.persistent_candidates
+            add constraint persistent_candidates_backfill_batch_fk
+            foreign key (backfill_batch_id)
+            references public.backfill_batches (batch_id)
+            on delete set null;
+    end if;
+end $$;

--- a/tests/unit/test_backfill_migration.py
+++ b/tests/unit/test_backfill_migration.py
@@ -1,0 +1,21 @@
+"""Unit tests for the backfill-batch Supabase migration."""
+
+from pathlib import Path
+
+MIGRATION_PATH = Path("supabase/migrations/20260419_backfill_batches.sql")
+
+
+def test_backfill_migration_defines_required_table() -> None:
+    """The migration should create the durable backfill-batch table."""
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "create table if not exists public.backfill_batches" in sql
+    assert "create index if not exists backfill_batches_status_idx" in sql
+
+
+def test_backfill_migration_links_candidates_to_batches() -> None:
+    """Persistent candidates should gain indexed batch linkage."""
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "persistent_candidates_backfill_batch_idx" in sql
+    assert "persistent_candidates_backfill_batch_fk" in sql

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -242,6 +242,29 @@ def test_update_backfill_batch_state_refreshes_counts(tmp_path: Path) -> None:
     assert store.get_backfill_batch("batch-1") is not None
 
 
+def test_batch_candidate_counts_uses_batch_filter(tmp_path: Path) -> None:
+    """Batch counting should only consider candidates from the requested backfill batch."""
+    store = build_store(tmp_path)
+    store.upsert_candidates(
+        [
+            build_candidate("batch-1"),
+            build_candidate("batch-1").model_copy(
+                update={
+                    "candidate_id": "future",
+                    "candidate_status": CandidateStatus.SCRAPE_FAILED,
+                    "next_scrape_attempt_at": datetime(2026, 1, 20, tzinfo=UTC),
+                }
+            ),
+            build_candidate("batch-2").model_copy(update={"candidate_id": "other"}),
+        ]
+    )
+
+    merged_count, queued_count = pipeline_module._batch_candidate_counts(store, batch_id="batch-1")
+
+    assert merged_count == 2
+    assert queued_count == 2
+
+
 @pytest.mark.asyncio
 async def test_run_source_native_backfill_discovery_handles_unsupported_and_error(
     monkeypatch: pytest.MonkeyPatch,
@@ -890,6 +913,52 @@ async def test_run_news_backfill_scrape_job_returns_when_selected_batch_drains_t
     )
 
     assert result.result_summary == "no queued backfill candidates eligible for scrape"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_scrape_job_keeps_batch_open_for_future_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Future retry candidates should keep the backfill batch from being marked completed."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    store = build_store(tmp_path)
+    store.upsert_backfill_batches([build_batch(status=BackfillBatchStatus.DISCOVERED)])
+    store.upsert_candidates([build_candidate("batch-1")])
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("ynet")])
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+
+    async def fake_scrape_job(**_kwargs: object) -> CandidateScrapeBatch:
+        store.upsert_candidates(
+            [
+                build_candidate("batch-1").model_copy(
+                    update={
+                        "candidate_id": "candidate-1",
+                        "candidate_status": CandidateStatus.SCRAPE_FAILED,
+                        "next_scrape_attempt_at": datetime(2026, 1, 20, tzinfo=UTC),
+                    }
+                )
+            ]
+        )
+        return build_scrape_batch(raw_articles=[], fallback_candidates=[], errors=["retry later"])
+
+    monkeypatch.setattr("denbust.pipeline._run_backfill_candidate_scrape_job", fake_scrape_job)
+    monkeypatch.setattr(
+        "denbust.pipeline._build_fallback_operational_records",
+        AsyncMock(return_value=[]),
+    )
+
+    result = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path})
+    )
+
+    assert result.result_summary == (
+        "fallback retention completed with 0 provisional row(s) for backfill batch batch-1"
+    )
+    assert store.get_backfill_batch("batch-1").status is BackfillBatchStatus.PARTIAL
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -4,23 +4,30 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import HttpUrl
 
+import denbust.pipeline as pipeline_module
 from denbust.config import Config
 from denbust.data_models import RawArticle
+from denbust.discovery.backfill import BackfillWindow
 from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
     CandidateStatus,
+    DiscoveredCandidate,
     DiscoveryRun,
     DiscoveryRunStatus,
     PersistentCandidate,
 )
+from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
 from denbust.discovery.state_paths import resolve_discovery_state_paths
 from denbust.discovery.storage import StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName, JobName
+from denbust.models.runs import RunSnapshot
 from denbust.pipeline import run_news_backfill_discover_job, run_news_backfill_scrape_job
 
 
@@ -33,6 +40,24 @@ class FakeSource:
     async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
         del days, keywords
         return []
+
+
+class HistoricalFakeSource(FakeSource):
+    """Backfill-capable source stub."""
+
+    def __init__(self, name: str, articles: list[RawArticle] | None = None) -> None:
+        super().__init__(name)
+        self.articles = articles or []
+
+    async def fetch_window(
+        self,
+        *,
+        date_from: datetime,
+        date_to: datetime,
+        keywords: list[str],
+    ) -> list[RawArticle]:
+        del date_from, date_to, keywords
+        return self.articles
 
 
 def build_candidate(batch_id: str) -> PersistentCandidate:
@@ -52,6 +77,434 @@ def build_candidate(batch_id: str) -> PersistentCandidate:
         backfill_batch_id=batch_id,
         metadata={"backfill_window_start": datetime(2026, 1, 1, tzinfo=UTC).isoformat()},
     )
+
+
+def build_window(index: int = 0) -> BackfillWindow:
+    """Create one backfill window fixture."""
+    return BackfillWindow(
+        index=index,
+        date_from=datetime(2026, 1, 1 + index, tzinfo=UTC),
+        date_to=datetime(2026, 1, 2 + index, tzinfo=UTC),
+    )
+
+
+def build_batch(batch_id: str = "batch-1", *, status: BackfillBatchStatus) -> BackfillBatch:
+    """Create one backfill batch fixture."""
+    return BackfillBatch(
+        batch_id=batch_id,
+        created_at=datetime(2026, 1, 10, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 10, tzinfo=UTC),
+        started_at=datetime(2026, 1, 10, tzinfo=UTC),
+        requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        requested_date_to=datetime(2026, 1, 3, tzinfo=UTC),
+        status=status,
+        window_count=2,
+    )
+
+
+def build_discovered_candidate() -> DiscoveredCandidate:
+    """Create one discovered candidate fixture."""
+    return DiscoveredCandidate(
+        producer_name="ynet",
+        producer_kind="source_native",
+        candidate_url=HttpUrl("https://example.com/article"),
+        canonical_url=HttpUrl("https://example.com/article"),
+        title="title",
+        snippet="snippet",
+        discovered_at=datetime(2026, 1, 2, tzinfo=UTC),
+        source_hint="ynet",
+        metadata={"existing": "value"},
+    )
+
+
+def build_persisted_discovery(
+    *,
+    query_count: int = 1,
+    candidate_count: int = 1,
+    merged_candidate_count: int = 1,
+    errors: list[str] | None = None,
+    warnings: list[str] | None = None,
+    batch_id: str = "batch-1",
+) -> PersistedSourceDiscovery:
+    """Create a persisted discovery bundle fixture."""
+    candidate = build_candidate(batch_id)
+    return PersistedSourceDiscovery(
+        run=DiscoveryRun(
+            run_id="run-1",
+            dataset_name=DatasetName.NEWS_ITEMS,
+            job_name=JobName.BACKFILL_DISCOVER,
+            status=DiscoveryRunStatus.SUCCEEDED,
+            query_count=query_count,
+            candidate_count=candidate_count,
+            merged_candidate_count=merged_candidate_count,
+            errors=errors or [],
+        ),
+        candidates=[candidate] if merged_candidate_count else [],
+        provenance=[],
+        warnings=warnings or [],
+    )
+
+
+def build_scrape_batch(
+    *,
+    batch_id: str = "batch-1",
+    raw_articles: list[RawArticle] | None = None,
+    fallback_candidates: list[PersistentCandidate] | None = None,
+    errors: list[str] | None = None,
+) -> CandidateScrapeBatch:
+    """Create a candidate scrape batch fixture."""
+    selected = [build_candidate(batch_id)]
+    return CandidateScrapeBatch(
+        selected_candidates=selected,
+        updated_candidates=selected,
+        fallback_candidates=fallback_candidates or [],
+        attempts=[],
+        raw_articles=raw_articles or [],
+        errors=errors or [],
+    )
+
+
+def build_store(tmp_path: Path) -> StateRepoDiscoveryPersistence:
+    """Create a state-repo discovery store."""
+    return StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+
+
+def build_config(tmp_path: Path, **updates: object) -> Config:
+    """Create a minimal backfill config fixture."""
+    return Config(
+        job_name=JobName.BACKFILL_DISCOVER,
+        store={"state_root": tmp_path},
+        **updates,
+    )
+
+
+def select_stub(
+    persistence: StateRepoDiscoveryPersistence,
+    *,
+    limit: int,
+    batch_id: str | None = None,
+) -> list[PersistentCandidate]:
+    """Return candidates from one store while accepting the full selector signature."""
+    del batch_id
+    return persistence.list_candidates(limit=limit)
+
+
+@pytest.mark.asyncio
+async def test_tag_backfill_discovered_candidates_adds_metadata() -> None:
+    """Backfill tagging should merge existing metadata with batch window metadata."""
+    tagged = pipeline_module._tag_backfill_discovered_candidates(
+        [build_discovered_candidate()],
+        batch_id="batch-1",
+        window=build_window(2),
+    )
+
+    assert tagged[0].metadata["existing"] == "value"
+    assert tagged[0].metadata["backfill_batch_id"] == "batch-1"
+    assert tagged[0].metadata["backfill_window_index"] == 2
+
+
+def test_update_backfill_batch_state_refreshes_counts(tmp_path: Path) -> None:
+    """Batch updates should recompute merged and queued candidate counts before persisting."""
+    store = build_store(tmp_path)
+    store.upsert_candidates(
+        [
+            build_candidate("batch-1"),
+            build_candidate("batch-1").model_copy(
+                update={
+                    "candidate_id": "done",
+                    "candidate_status": CandidateStatus.SCRAPE_SUCCEEDED,
+                }
+            ),
+            build_candidate("other-batch").model_copy(update={"candidate_id": "other"}),
+        ]
+    )
+    batch = build_batch(status=BackfillBatchStatus.RUNNING)
+
+    updated = pipeline_module._update_backfill_batch_state(
+        store,
+        batch=batch,
+        status=BackfillBatchStatus.DISCOVERED,
+        query_count=4,
+        candidate_count=3,
+        warnings=["warning"],
+        errors=["error"],
+        finished=True,
+    )
+
+    assert updated.status is BackfillBatchStatus.DISCOVERED
+    assert updated.query_count == 4
+    assert updated.candidate_count == 3
+    assert updated.merged_candidate_count == 2
+    assert updated.queued_for_scrape_count == 1
+    assert updated.finished_at is not None
+    assert store.get_backfill_batch("batch-1") is not None
+
+
+@pytest.mark.asyncio
+async def test_run_source_native_backfill_discovery_handles_unsupported_and_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unsupported sources should warn and failing historical sources should be recorded as errors."""
+    store = build_store(tmp_path)
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr(
+        "denbust.pipeline.persist_discovered_candidates",
+        lambda **kwargs: PersistedSourceDiscovery(
+            run=kwargs["run"],
+            candidates=[],
+            provenance=[],
+            warnings=[],
+        ),
+    )
+
+    class FailingHistoricalSource(HistoricalFakeSource):
+        async def fetch_window(
+            self,
+            *,
+            date_from: datetime,
+            date_to: datetime,
+            keywords: list[str],
+        ) -> list[RawArticle]:
+            del date_from, date_to, keywords
+            raise RuntimeError("boom")
+
+    result = await pipeline_module._run_source_native_backfill_discovery(
+        config=Config(
+            job_name=JobName.BACKFILL_DISCOVER,
+            store={"state_root": tmp_path},
+            source_discovery={"enabled": True, "persist_candidates": True},
+        ),
+        sources=[FakeSource("walla"), FailingHistoricalSource("ynet")],
+        run_id="run-1",
+        window=build_window(),
+        batch_id="batch-1",
+    )
+
+    assert result.warnings == ["walla: historical window discovery is unsupported"]
+    assert result.run.errors == ["ynet: boom"]
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_engine_discovery_handles_empty_queries_and_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill engine discovery should handle empty queries, missing keys, errors, and bad engines."""
+    store = build_store(tmp_path)
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: [])
+
+    empty = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={"enabled": True, "persist_candidates": True, "engines": {"brave": {}}},
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="brave",
+    )
+    assert empty.run.candidate_count == 0
+
+    monkeypatch.setattr("denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: ["q"])
+    missing_brave = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={"enabled": True, "persist_candidates": True, "engines": {"brave": {}}},
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="brave",
+    )
+    assert missing_brave.run.errors == ["brave: missing DENBUST_BRAVE_SEARCH_API_KEY"]
+
+    missing = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={"enabled": True, "persist_candidates": True, "engines": {"exa": {}}},
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="exa",
+    )
+    assert missing.run.errors == ["exa: missing DENBUST_EXA_API_KEY"]
+
+    discover = AsyncMock(side_effect=RuntimeError("kaput"))
+    fake_engine = MagicMock(discover=discover, aclose=AsyncMock())
+    monkeypatch.setattr("denbust.pipeline.BraveSearchEngine", lambda **_kwargs: fake_engine)
+    monkeypatch.setenv("DENBUST_BRAVE_SEARCH_API_KEY", "key")
+    errored = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {
+                    "brave": {
+                        "api_key_env": "DENBUST_BRAVE_SEARCH_API_KEY",
+                        "max_results_per_query": 5,
+                    }
+                },
+            },
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="brave",
+    )
+    assert errored.run.errors == ["brave: RuntimeError: kaput"]
+    fake_engine.aclose.assert_awaited_once()
+
+    with pytest.raises(ValueError, match="Unsupported backfill engine"):
+        await pipeline_module._run_backfill_engine_discovery(
+            config=build_config(tmp_path),
+            run_id="run-1",
+            batch_id="batch-1",
+            window=build_window(),
+            engine_name="bing",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_engine_discovery_covers_exa_and_google_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill engine discovery should build Exa and Google contexts and handle missing Google config."""
+    store = build_store(tmp_path)
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: ["q"])
+    monkeypatch.setattr(
+        "denbust.pipeline.persist_discovered_candidates",
+        lambda **kwargs: PersistedSourceDiscovery(
+            run=kwargs["run"],
+            candidates=[],
+            provenance=[],
+            warnings=[],
+        ),
+    )
+
+    exa_engine = MagicMock(discover=AsyncMock(return_value=[]), aclose=AsyncMock())
+    monkeypatch.setattr("denbust.pipeline.ExaSearchEngine", lambda **_kwargs: exa_engine)
+    monkeypatch.setenv("DENBUST_EXA_API_KEY", "exa-key")
+    exa_result = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {
+                    "exa": {
+                        "api_key_env": "DENBUST_EXA_API_KEY",
+                        "max_results_per_query": 7,
+                        "allow_find_similar": True,
+                    }
+                },
+            },
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="exa",
+    )
+    exa_context = exa_engine.discover.await_args.kwargs["context"]
+    assert exa_result.run.errors == []
+    assert exa_context.metadata["engine"] == "exa"
+    assert exa_context.metadata["allow_find_similar"] is True
+
+    missing_google_key = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={"enabled": True, "persist_candidates": True, "engines": {"google_cse": {}}},
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="google_cse",
+    )
+    assert missing_google_key.run.errors == ["google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"]
+
+    monkeypatch.setenv("DENBUST_GOOGLE_CSE_API_KEY", "google-key")
+    missing_google_id = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {
+                    "google_cse": {
+                        "api_key_env": "DENBUST_GOOGLE_CSE_API_KEY",
+                        "cse_id_env": "DENBUST_GOOGLE_CSE_ID",
+                    }
+                },
+            },
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="google_cse",
+    )
+    assert missing_google_id.run.errors == ["google_cse: missing DENBUST_GOOGLE_CSE_ID"]
+
+    google_engine = MagicMock(discover=AsyncMock(return_value=[]), aclose=AsyncMock())
+    monkeypatch.setattr("denbust.pipeline.GoogleCseSearchEngine", lambda **_kwargs: google_engine)
+    monkeypatch.setenv("DENBUST_GOOGLE_CSE_ID", "cx-1")
+    google_result = await pipeline_module._run_backfill_engine_discovery(
+        config=build_config(
+            tmp_path,
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {
+                    "google_cse": {
+                        "api_key_env": "DENBUST_GOOGLE_CSE_API_KEY",
+                        "cse_id_env": "DENBUST_GOOGLE_CSE_ID",
+                        "max_results_per_query": 11,
+                    }
+                },
+            },
+        ),
+        run_id="run-1",
+        batch_id="batch-1",
+        window=build_window(),
+        engine_name="google_cse",
+    )
+    google_context = google_engine.discover.await_args.kwargs["context"]
+    assert google_result.run.errors == []
+    assert google_context.metadata["engine"] == "google_cse"
+
+
+@pytest.mark.asyncio
+async def test_run_backfill_candidate_scrape_job_uses_batch_selector(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill scrape selection should use the dedicated selector and backfill mode."""
+    selected = [build_candidate("batch-1")]
+    monkeypatch.setattr(
+        "denbust.pipeline.create_discovery_persistence", lambda _config: build_store(tmp_path)
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline.select_backfill_candidates_for_scrape",
+        lambda *_args, **_kwargs: selected,
+    )
+    scrape = AsyncMock(return_value=build_scrape_batch())
+    monkeypatch.setattr("denbust.pipeline._scrape_candidate_batch", scrape)
+
+    await pipeline_module._run_backfill_candidate_scrape_job(
+        config=Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path}),
+        sources=[FakeSource("ynet")],
+        limit=3,
+        batch_id="batch-1",
+    )
+
+    assert scrape.await_args.kwargs["candidates"] == selected
+    assert scrape.await_args.kwargs["backfill_mode"] is True
 
 
 @pytest.mark.asyncio
@@ -140,3 +593,390 @@ async def test_run_news_backfill_scrape_job_finishes_when_queue_is_empty(
 
     assert result.fatal is False
     assert result.result_summary == "no queued backfill candidates eligible for scrape"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_fails_on_invalid_request_window(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid requested backfill windows should terminate the run as fatal."""
+    monkeypatch.setattr(
+        "denbust.pipeline.resolve_backfill_request_window",
+        lambda: (_ for _ in ()).throw(ValueError("bad window")),
+    )
+
+    result = await run_news_backfill_discover_job(build_config(tmp_path))
+
+    assert result.fatal is True
+    assert result.errors == ["bad window"]
+    assert result.result_summary == "fatal: invalid backfill request window"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_requires_producers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill discovery should fail fast when neither sources nor engines are configured."""
+    monkeypatch.setattr(
+        "denbust.pipeline.resolve_backfill_request_window",
+        lambda: (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)),
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline.plan_backfill_windows", lambda **_kwargs: [build_window()]
+    )
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+
+    result = await run_news_backfill_discover_job(build_config(tmp_path))
+
+    assert result.fatal is True
+    assert result.errors == ["No backfill discovery producers configured"]
+    assert result.result_summary == "fatal: no backfill discovery producers configured"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_marks_partial_and_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill discovery should distinguish partial success from full failure."""
+    monkeypatch.setattr(
+        "denbust.pipeline.resolve_backfill_request_window",
+        lambda: (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)),
+    )
+    monkeypatch.setenv("DENBUST_BACKFILL_BATCH_ID", "batch-1")
+    monkeypatch.setattr(
+        "denbust.pipeline.plan_backfill_windows",
+        lambda **_kwargs: [build_window(0), build_window(1)],
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline.create_sources", lambda _config: [HistoricalFakeSource("ynet")]
+    )
+    store = build_store(tmp_path)
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+
+    source_calls = iter(
+        [
+            build_persisted_discovery(query_count=1, candidate_count=1, merged_candidate_count=1),
+            build_persisted_discovery(
+                query_count=1,
+                candidate_count=0,
+                merged_candidate_count=0,
+                errors=["ynet: boom"],
+                warnings=["ynet: warning"],
+            ),
+        ]
+    )
+    engine_calls = iter(
+        [
+            build_persisted_discovery(
+                query_count=1,
+                candidate_count=1,
+                merged_candidate_count=1,
+                errors=["brave: partial"],
+            ),
+            build_persisted_discovery(
+                query_count=1,
+                candidate_count=0,
+                merged_candidate_count=0,
+                errors=["brave: fatal"],
+            ),
+        ]
+    )
+
+    async def fake_source_native(**_kwargs: object) -> PersistedSourceDiscovery:
+        persisted = next(source_calls)
+        if persisted.candidates:
+            store.upsert_candidates(
+                [
+                    candidate.model_copy(
+                        update={
+                            "candidate_id": f"source-{candidate.candidate_id}-{len(store.list_candidates())}"
+                        }
+                    )
+                    for candidate in persisted.candidates
+                ]
+            )
+        return persisted
+
+    async def fake_engine(**_kwargs: object) -> PersistedSourceDiscovery:
+        persisted = next(engine_calls)
+        if persisted.candidates:
+            store.upsert_candidates(
+                [
+                    candidate.model_copy(
+                        update={
+                            "candidate_id": f"engine-{candidate.candidate_id}-{len(store.list_candidates())}"
+                        }
+                    )
+                    for candidate in persisted.candidates
+                ]
+            )
+        return persisted
+
+    monkeypatch.setattr(
+        "denbust.pipeline._run_source_native_backfill_discovery", fake_source_native
+    )
+    monkeypatch.setattr("denbust.pipeline._run_backfill_engine_discovery", fake_engine)
+
+    partial = await run_news_backfill_discover_job(
+        build_config(
+            tmp_path,
+            source_discovery={"enabled": True, "persist_candidates": True},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"brave": {"enabled": True}},
+            },
+        )
+    )
+
+    batch = store.list_backfill_batches(limit=1)[0]
+    assert partial.fatal is False
+    assert batch.status is BackfillBatchStatus.PARTIAL
+    assert "backfill discovery persisted 2 candidate(s)" in (partial.result_summary or "")
+    assert "ynet: warning" in partial.warnings
+
+    fail_store = build_store(tmp_path / "failed")
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: fail_store)
+    monkeypatch.setattr(
+        "denbust.pipeline._run_source_native_backfill_discovery",
+        AsyncMock(
+            return_value=build_persisted_discovery(
+                merged_candidate_count=0, errors=["source: boom"]
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline._run_backfill_engine_discovery",
+        AsyncMock(
+            return_value=build_persisted_discovery(merged_candidate_count=0, errors=["brave: boom"])
+        ),
+    )
+
+    failed = await run_news_backfill_discover_job(
+        build_config(
+            tmp_path / "failed",
+            source_discovery={"enabled": True, "persist_candidates": True},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"brave": {"enabled": True}},
+            },
+        )
+    )
+
+    assert failed.fatal is True
+    assert failed.result_summary is not None
+    assert failed.result_summary.startswith("fatal: backfill discovery failed for batch ")
+    assert fail_store.list_backfill_batches(limit=1)[0].status is BackfillBatchStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_runs_exa_and_google_engines(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill discovery should invoke each enabled engine family within the window loop."""
+    monkeypatch.setattr(
+        "denbust.pipeline.resolve_backfill_request_window",
+        lambda: (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)),
+    )
+    monkeypatch.setenv("DENBUST_BACKFILL_BATCH_ID", "batch-1")
+    monkeypatch.setattr(
+        "denbust.pipeline.plan_backfill_windows", lambda **_kwargs: [build_window(0)]
+    )
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+    store = build_store(tmp_path)
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    engine_names: list[str] = []
+
+    async def fake_engine(**kwargs: object) -> PersistedSourceDiscovery:
+        engine_names.append(str(kwargs["engine_name"]))
+        return build_persisted_discovery(merged_candidate_count=0)
+
+    monkeypatch.setattr("denbust.pipeline._run_backfill_engine_discovery", fake_engine)
+
+    result = await run_news_backfill_discover_job(
+        build_config(
+            tmp_path,
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {
+                    "exa": {"enabled": True},
+                    "google_cse": {"enabled": True},
+                },
+            },
+        )
+    )
+
+    assert result.fatal is False
+    assert engine_names == ["exa", "google_cse"]
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_scrape_job_handles_missing_requirements_and_batch_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill scrape should fail fast on missing API key, sources, or batch metadata."""
+    missing_key = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path})
+    )
+    assert missing_key.fatal is True
+    assert missing_key.result_summary == "fatal: missing anthropic api key"
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+    no_sources = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path})
+    )
+    assert no_sources.fatal is True
+    assert no_sources.result_summary == "fatal: no sources configured"
+
+    store = build_store(tmp_path / "missing-batch")
+    store.upsert_candidates([build_candidate("batch-missing")])
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("ynet")])
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr(
+        "denbust.pipeline.select_backfill_candidates_for_scrape",
+        select_stub,
+    )
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+
+    missing_batch = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path / "missing-batch"})
+    )
+
+    assert missing_batch.fatal is True
+    assert missing_batch.result_summary == "fatal: missing backfill batch metadata"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_scrape_job_returns_when_selected_batch_drains_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A scrape pass with no selected candidates after dispatch should return the empty-queue summary."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    store = build_store(tmp_path)
+    store.upsert_backfill_batches([build_batch(status=BackfillBatchStatus.DISCOVERED)])
+    store.upsert_candidates([build_candidate("batch-1")])
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("ynet")])
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+    monkeypatch.setattr(
+        "denbust.pipeline._run_backfill_candidate_scrape_job",
+        AsyncMock(
+            return_value=CandidateScrapeBatch(
+                selected_candidates=[],
+                updated_candidates=[],
+                fallback_candidates=[],
+                attempts=[],
+                raw_articles=[],
+                errors=[],
+            )
+        ),
+    )
+
+    result = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path})
+    )
+
+    assert result.result_summary == "no queued backfill candidates eligible for scrape"
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill scrape should support fallback-only and ingest-processing paths with final batch updates."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    sources = [FakeSource("ynet")]
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: sources)
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+
+    fallback_store = build_store(tmp_path / "fallback")
+    fallback_store.upsert_backfill_batches([build_batch(status=BackfillBatchStatus.DISCOVERED)])
+    fallback_store.upsert_candidates([build_candidate("batch-1")])
+    monkeypatch.setattr(
+        "denbust.pipeline.create_discovery_persistence",
+        lambda _config: fallback_store,
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline._run_backfill_candidate_scrape_job",
+        AsyncMock(
+            return_value=build_scrape_batch(
+                fallback_candidates=[build_candidate("batch-1")],
+                raw_articles=[],
+                errors=["candidate failed"],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline._build_fallback_operational_records",
+        AsyncMock(return_value=[MagicMock(model_dump=lambda **_kwargs: {"id": "row-1"})]),
+    )
+    store = MagicMock()
+    monkeypatch.setattr("denbust.pipeline.create_operational_store", lambda _config: store)
+
+    fallback = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path / "fallback"})
+    )
+
+    assert fallback.fatal is False
+    assert fallback.result_summary == (
+        "fallback retention completed with 1 provisional row(s) for backfill batch batch-1"
+    )
+    assert "fallback_operational_records=1" in fallback.warnings
+    assert fallback_store.get_backfill_batch("batch-1") is not None
+
+    processed_store = build_store(tmp_path / "processed")
+    processed_store.upsert_backfill_batches([build_batch(status=BackfillBatchStatus.DISCOVERED)])
+    processed_store.upsert_candidates([build_candidate("batch-1")])
+    monkeypatch.setattr(
+        "denbust.pipeline.create_discovery_persistence",
+        lambda _config: processed_store,
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline._run_backfill_candidate_scrape_job",
+        AsyncMock(
+            return_value=build_scrape_batch(
+                raw_articles=[
+                    RawArticle(
+                        url=HttpUrl("https://example.com/raw"),
+                        title="title",
+                        snippet="snippet",
+                        date=datetime(2026, 1, 2, tzinfo=UTC),
+                        source_name="ynet",
+                    )
+                ]
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline._build_fallback_operational_records",
+        AsyncMock(return_value=[]),
+    )
+    processed_snapshot = RunSnapshot(job_name=JobName.BACKFILL_SCRAPE).finish("processed 1 article")
+    monkeypatch.setattr(
+        "denbust.pipeline._process_ingest_articles",
+        AsyncMock(return_value=processed_snapshot),
+    )
+
+    processed = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path / "processed"})
+    )
+
+    assert processed.result_summary == "backfill batch batch-1: processed 1 article"
+    assert processed.debug_payload == {"batch_id": "batch-1"}
+    assert processed_store.get_backfill_batch("batch-1") is not None

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -659,6 +659,39 @@ async def test_run_news_backfill_discover_job_requires_producers(
 
 
 @pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_rejects_existing_forced_batch_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill discover should fail fast when a forced batch id already exists."""
+    monkeypatch.setattr(
+        "denbust.pipeline.resolve_backfill_request_window",
+        lambda: (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)),
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline.plan_backfill_windows", lambda **_kwargs: [build_window()]
+    )
+    monkeypatch.setattr(
+        "denbust.pipeline.create_sources", lambda _config: [HistoricalFakeSource("ynet")]
+    )
+    monkeypatch.setenv("DENBUST_BACKFILL_BATCH_ID", "batch-1")
+    store = build_store(tmp_path)
+    store.upsert_backfill_batches([build_batch(status=BackfillBatchStatus.DISCOVERED)])
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+
+    result = await run_news_backfill_discover_job(
+        build_config(
+            tmp_path,
+            source_discovery={"enabled": True, "persist_candidates": True},
+        )
+    )
+
+    assert result.fatal is True
+    assert result.result_summary == "fatal: backfill batch batch-1 already exists"
+    assert result.errors == ["Backfill batch batch-1 already exists"]
+
+
+@pytest.mark.asyncio
 async def test_run_news_backfill_discover_job_marks_partial_and_failed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -241,6 +241,15 @@ def test_update_backfill_batch_state_refreshes_counts(tmp_path: Path) -> None:
     assert updated.finished_at is not None
     assert store.get_backfill_batch("batch-1") is not None
 
+    reopened = pipeline_module._update_backfill_batch_state(
+        store,
+        batch=updated,
+        status=BackfillBatchStatus.SCRAPING,
+        finished=False,
+    )
+
+    assert reopened.finished_at is None
+
 
 def test_batch_candidate_counts_uses_batch_filter(tmp_path: Path) -> None:
     """Batch counting should only consider candidates from the requested backfill batch."""
@@ -791,6 +800,8 @@ async def test_run_news_backfill_discover_job_marks_partial_and_failed(
     batch = store.list_backfill_batches(limit=1)[0]
     assert partial.fatal is False
     assert batch.status is BackfillBatchStatus.PARTIAL
+    assert batch.finished_at is None
+    assert partial.unified_item_count == batch.merged_candidate_count
     assert "backfill discovery persisted 2 candidate(s)" in (partial.result_summary or "")
     assert "ynet: warning" in partial.warnings
 
@@ -826,7 +837,9 @@ async def test_run_news_backfill_discover_job_marks_partial_and_failed(
     assert failed.fatal is True
     assert failed.result_summary is not None
     assert failed.result_summary.startswith("fatal: backfill discovery failed for batch ")
-    assert fail_store.list_backfill_batches(limit=1)[0].status is BackfillBatchStatus.FAILED
+    failed_batch = fail_store.list_backfill_batches(limit=1)[0]
+    assert failed_batch.status is BackfillBatchStatus.FAILED
+    assert failed_batch.finished_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -1,0 +1,142 @@
+"""Unit tests for backfill pipeline jobs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import HttpUrl
+
+from denbust.config import Config
+from denbust.data_models import RawArticle
+from denbust.discovery.models import (
+    CandidateStatus,
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    PersistentCandidate,
+)
+from denbust.discovery.source_native import PersistedSourceDiscovery
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName, JobName
+from denbust.pipeline import run_news_backfill_discover_job, run_news_backfill_scrape_job
+
+
+class FakeSource:
+    """Minimal source stub for backfill pipeline tests."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
+        del days, keywords
+        return []
+
+
+def build_candidate(batch_id: str) -> PersistentCandidate:
+    """Create one batch-linked candidate fixture."""
+    return PersistentCandidate(
+        candidate_id="candidate-1",
+        current_url=HttpUrl("https://example.com/article"),
+        canonical_url=HttpUrl("https://example.com/article"),
+        titles=["title"],
+        snippets=["snippet"],
+        discovered_via=["brave"],
+        discovery_queries=["בית בושת"],
+        source_hints=["ynet"],
+        first_seen_at=datetime(2026, 1, 10, tzinfo=UTC),
+        last_seen_at=datetime(2026, 1, 10, tzinfo=UTC),
+        candidate_status=CandidateStatus.NEW,
+        backfill_batch_id=batch_id,
+        metadata={"backfill_window_start": datetime(2026, 1, 1, tzinfo=UTC).isoformat()},
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_succeeds_without_operational_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill discover should succeed with discovery persistence only."""
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_FROM", "2026-01-01T00:00:00+00:00")
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_TO", "2026-01-03T00:00:00+00:00")
+    store = StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+
+    async def fake_engine(
+        *,
+        config: Config,
+        run_id: str,
+        batch_id: str,
+        window,
+        engine_name: str,
+    ) -> PersistedSourceDiscovery:
+        del config, run_id, window, engine_name
+        candidate = build_candidate(batch_id)
+        store.upsert_candidates([candidate])
+        return PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id="run-1",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.BACKFILL_DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                query_count=1,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[candidate],
+            provenance=[],
+            warnings=[],
+        )
+
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+    monkeypatch.setattr("denbust.pipeline._run_backfill_engine_discovery", fake_engine)
+
+    result = await run_news_backfill_discover_job(
+        Config(
+            job_name=JobName.BACKFILL_DISCOVER,
+            store={"state_root": tmp_path},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"brave": {"enabled": True}},
+            },
+        )
+    )
+
+    assert result.fatal is False
+    assert "backfill discovery persisted 1 candidate(s)" in (result.result_summary or "")
+    assert store.list_backfill_batches(limit=1)[0].merged_candidate_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_scrape_job_finishes_when_queue_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Backfill scrape should finish cleanly when no historical candidates are eligible."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [FakeSource("ynet")])
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
+    monkeypatch.setattr(
+        "denbust.pipeline.create_discovery_persistence",
+        lambda _config: StateRepoDiscoveryPersistence(
+            resolve_discovery_state_paths(
+                state_root=tmp_path,
+                dataset_name=DatasetName.NEWS_ITEMS,
+            )
+        ),
+    )
+
+    result = await run_news_backfill_scrape_job(
+        Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path})
+    )
+
+    assert result.fatal is False
+    assert result.result_summary == "no queued backfill candidates eligible for scrape"

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -250,6 +250,15 @@ def test_update_backfill_batch_state_refreshes_counts(tmp_path: Path) -> None:
 
     assert reopened.finished_at is None
 
+    preserved = pipeline_module._update_backfill_batch_state(
+        store,
+        batch=updated,
+        status=BackfillBatchStatus.PARTIAL,
+        finished=None,
+    )
+
+    assert preserved.finished_at == updated.finished_at
+
 
 def test_batch_candidate_counts_uses_batch_filter(tmp_path: Path) -> None:
     """Batch counting should only consider candidates from the requested backfill batch."""
@@ -357,14 +366,18 @@ async def test_run_backfill_engine_discovery_handles_empty_queries_and_errors(
     missing = await pipeline_module._run_backfill_engine_discovery(
         config=build_config(
             tmp_path,
-            discovery={"enabled": True, "persist_candidates": True, "engines": {"exa": {}}},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"exa": {"api_key_env": "CUSTOM_EXA_KEY"}},
+            },
         ),
         run_id="run-1",
         batch_id="batch-1",
         window=build_window(),
         engine_name="exa",
     )
-    assert missing.run.errors == ["exa: missing DENBUST_EXA_API_KEY"]
+    assert missing.run.errors == ["exa: missing CUSTOM_EXA_KEY"]
 
     discover = AsyncMock(side_effect=RuntimeError("kaput"))
     fake_engine = MagicMock(discover=discover, aclose=AsyncMock())
@@ -452,14 +465,18 @@ async def test_run_backfill_engine_discovery_covers_exa_and_google_variants(
     missing_google_key = await pipeline_module._run_backfill_engine_discovery(
         config=build_config(
             tmp_path,
-            discovery={"enabled": True, "persist_candidates": True, "engines": {"google_cse": {}}},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"google_cse": {"api_key_env": "CUSTOM_GOOGLE_KEY"}},
+            },
         ),
         run_id="run-1",
         batch_id="batch-1",
         window=build_window(),
         engine_name="google_cse",
     )
-    assert missing_google_key.run.errors == ["google_cse: missing DENBUST_GOOGLE_CSE_API_KEY"]
+    assert missing_google_key.run.errors == ["google_cse: missing CUSTOM_GOOGLE_KEY"]
 
     monkeypatch.setenv("DENBUST_GOOGLE_CSE_API_KEY", "google-key")
     missing_google_id = await pipeline_module._run_backfill_engine_discovery(
@@ -471,7 +488,7 @@ async def test_run_backfill_engine_discovery_covers_exa_and_google_variants(
                 "engines": {
                     "google_cse": {
                         "api_key_env": "DENBUST_GOOGLE_CSE_API_KEY",
-                        "cse_id_env": "DENBUST_GOOGLE_CSE_ID",
+                        "cse_id_env": "CUSTOM_GOOGLE_CSE_ID",
                     }
                 },
             },
@@ -481,7 +498,7 @@ async def test_run_backfill_engine_discovery_covers_exa_and_google_variants(
         window=build_window(),
         engine_name="google_cse",
     )
-    assert missing_google_id.run.errors == ["google_cse: missing DENBUST_GOOGLE_CSE_ID"]
+    assert missing_google_id.run.errors == ["google_cse: missing CUSTOM_GOOGLE_CSE_ID"]
 
     google_engine = MagicMock(discover=AsyncMock(return_value=[]), aclose=AsyncMock())
     monkeypatch.setattr("denbust.pipeline.GoogleCseSearchEngine", lambda **_kwargs: google_engine)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -293,6 +293,7 @@ class TestConfig:
 
         assert config.discovery_runs_table == "discovery_runs"
         assert config.supabase_table == "persistent_candidates"
+        assert config.backfill_batches_table == "backfill_batches"
         assert config.provenance_table == "candidate_provenance"
         assert config.scrape_attempts_table == "scrape_attempts"
         assert config.default_retry_backoff_hours == 24

--- a/tests/unit/test_dataset_jobs.py
+++ b/tests/unit/test_dataset_jobs.py
@@ -9,6 +9,8 @@ import pytest
 
 from denbust.config import Config
 from denbust.datasets.jobs import (
+    _run_news_items_backfill_discover,
+    _run_news_items_backfill_scrape,
     _run_news_items_ingest,
     _run_news_items_monthly_report,
     _run_news_items_scrape_candidates,
@@ -143,6 +145,56 @@ async def test_run_news_items_monthly_report_wrapper_without_store_calls_pipelin
     mock.assert_awaited_once_with(
         config,
         config_path=Path("agents/news/local.yaml"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_news_items_backfill_discover_wrapper_calls_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The backfill-discover wrapper should delegate to the pipeline handler."""
+    expected = build_snapshot()
+    mock = AsyncMock(return_value=expected)
+    monkeypatch.setattr("denbust.pipeline.run_news_backfill_discover_job", mock)
+
+    config = Config(job_name="backfill_discover")
+    result = await _run_news_items_backfill_discover(
+        config,
+        Path("agents/news/local.yaml"),
+        None,
+    )
+
+    assert result is expected
+    mock.assert_awaited_once_with(
+        config,
+        config_path=Path("agents/news/local.yaml"),
+        days_override=None,
+        operational_store=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_news_items_backfill_scrape_wrapper_calls_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The backfill-scrape wrapper should delegate to the pipeline handler."""
+    expected = build_snapshot()
+    mock = AsyncMock(return_value=expected)
+    monkeypatch.setattr("denbust.pipeline.run_news_backfill_scrape_job", mock)
+
+    config = Config(job_name="backfill_scrape")
+    result = await _run_news_items_backfill_scrape(
+        config,
+        Path("agents/news/local.yaml"),
+        9,
+    )
+
+    assert result is expected
+    mock.assert_awaited_once_with(
+        config,
+        config_path=Path("agents/news/local.yaml"),
+        days_override=9,
+        operational_store=None,
     )
 
 

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -1,0 +1,161 @@
+"""Unit tests for historical backfill planning helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import HttpUrl
+
+from denbust.config import Config
+from denbust.discovery.backfill import (
+    BACKFILL_DATE_FROM_ENV,
+    BACKFILL_DATE_TO_ENV,
+    build_backfill_queries,
+    plan_backfill_windows,
+    resolve_backfill_request_window,
+)
+from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
+    CandidateStatus,
+    PersistentCandidate,
+)
+from denbust.discovery.scrape_queue import select_backfill_candidates_for_scrape
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName, JobName
+
+
+def build_candidate(
+    candidate_id: str,
+    *,
+    batch_id: str,
+    window_start: datetime,
+    first_seen_at: datetime,
+    publication_hint: datetime | None = None,
+) -> PersistentCandidate:
+    metadata: dict[str, object] = {
+        "backfill_window_start": window_start.isoformat(),
+    }
+    if publication_hint is not None:
+        metadata["latest_publication_datetime_hint"] = publication_hint.isoformat()
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        current_url=HttpUrl(f"https://example.com/{candidate_id}"),
+        canonical_url=HttpUrl(f"https://example.com/{candidate_id}"),
+        titles=["title"],
+        snippets=["snippet"],
+        discovered_via=["brave"],
+        discovery_queries=["בית בושת"],
+        source_hints=["ynet"],
+        first_seen_at=first_seen_at,
+        last_seen_at=first_seen_at,
+        candidate_status=CandidateStatus.NEW,
+        backfill_batch_id=batch_id,
+        metadata=metadata,
+    )
+
+
+def test_backfill_batch_validates_date_window() -> None:
+    """Backfill batches should reject inverted requested windows."""
+    batch = BackfillBatch(
+        batch_id="batch-1",
+        dataset_name=DatasetName.NEWS_ITEMS,
+        job_name=JobName.BACKFILL_DISCOVER,
+        status=BackfillBatchStatus.RUNNING,
+        requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        requested_date_to=datetime(2026, 1, 31, tzinfo=UTC),
+    )
+
+    assert batch.status == BackfillBatchStatus.RUNNING
+
+    with pytest.raises(ValueError):
+        BackfillBatch(
+            batch_id="batch-2",
+            requested_date_from=datetime(2026, 2, 1, tzinfo=UTC),
+            requested_date_to=datetime(2026, 1, 31, tzinfo=UTC),
+        )
+
+
+def test_plan_backfill_windows_splits_range() -> None:
+    """A historical range should be partitioned into contiguous windows."""
+    windows = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 15, tzinfo=UTC),
+        batch_window_days=7,
+    )
+
+    assert len(windows) == 3
+    assert windows[0].date_from == datetime(2026, 1, 1, tzinfo=UTC)
+    assert windows[-1].date_to == datetime(2026, 1, 15, tzinfo=UTC)
+
+
+def test_build_backfill_queries_uses_explicit_window() -> None:
+    """Historical backfill queries should use the requested date range."""
+    config = Config(
+        discovery={"default_query_kinds": ["broad"]},
+        keywords=["בית בושת"],
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 3, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    assert len(queries) == 1
+    assert queries[0].date_from == window.date_from
+    assert queries[0].date_to == window.date_to
+    assert "backfill" in queries[0].tags
+
+
+def test_resolve_backfill_request_window_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backfill runs should read the requested window from environment variables."""
+    monkeypatch.setenv(BACKFILL_DATE_FROM_ENV, "2026-01-01T00:00:00+00:00")
+    monkeypatch.setenv(BACKFILL_DATE_TO_ENV, "2026-01-15T00:00:00+00:00")
+
+    date_from, date_to = resolve_backfill_request_window()
+
+    assert date_from == datetime(2026, 1, 1, tzinfo=UTC)
+    assert date_to == datetime(2026, 1, 15, tzinfo=UTC)
+
+
+def test_select_backfill_candidates_prefers_oldest_window_then_oldest_publication(
+    tmp_path,
+) -> None:
+    """Backfill scraping should choose the oldest active window first."""
+    store = StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+    store.upsert_candidates(
+        [
+            build_candidate(
+                "older-window",
+                batch_id="batch-a",
+                window_start=datetime(2026, 1, 1, tzinfo=UTC),
+                first_seen_at=datetime(2026, 4, 1, tzinfo=UTC),
+            ),
+            build_candidate(
+                "older-publication",
+                batch_id="batch-a",
+                window_start=datetime(2026, 1, 1, tzinfo=UTC),
+                first_seen_at=datetime(2026, 4, 3, tzinfo=UTC),
+                publication_hint=datetime(2026, 1, 2, tzinfo=UTC),
+            ),
+            build_candidate(
+                "newer-window",
+                batch_id="batch-b",
+                window_start=datetime(2026, 2, 1, tzinfo=UTC),
+                first_seen_at=datetime(2026, 4, 2, tzinfo=UTC),
+            ),
+        ]
+    )
+
+    selected = select_backfill_candidates_for_scrape(store, limit=2)
+
+    assert [candidate.candidate_id for candidate in selected] == [
+        "older-publication",
+        "older-window",
+    ]

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -12,6 +12,7 @@ from denbust.discovery.backfill import (
     BACKFILL_DATE_FROM_ENV,
     BACKFILL_DATE_TO_ENV,
     build_backfill_queries,
+    parse_backfill_datetime,
     plan_backfill_windows,
     resolve_backfill_request_window,
 )
@@ -19,6 +20,7 @@ from denbust.discovery.models import (
     BackfillBatch,
     BackfillBatchStatus,
     CandidateStatus,
+    DiscoveryQueryKind,
     PersistentCandidate,
 )
 from denbust.discovery.scrape_queue import select_backfill_candidates_for_scrape
@@ -120,6 +122,86 @@ def test_resolve_backfill_request_window_reads_env(monkeypatch: pytest.MonkeyPat
 
     assert date_from == datetime(2026, 1, 1, tzinfo=UTC)
     assert date_to == datetime(2026, 1, 15, tzinfo=UTC)
+
+
+def test_parse_backfill_datetime_rejects_empty_and_normalizes_values() -> None:
+    """Backfill datetime parsing should reject blanks and normalize Z/naive timestamps to UTC."""
+    with pytest.raises(ValueError, match="TEST_ENV must not be empty"):
+        parse_backfill_datetime("   ", env_name="TEST_ENV")
+
+    assert parse_backfill_datetime("2026-01-01T00:00:00Z", env_name="TEST_ENV") == datetime(
+        2026, 1, 1, tzinfo=UTC
+    )
+    assert parse_backfill_datetime("2026-01-01T12:00:00", env_name="TEST_ENV") == datetime(
+        2026, 1, 1, 12, 0, tzinfo=UTC
+    )
+
+
+def test_resolve_backfill_request_window_rejects_missing_or_inverted_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backfill request window resolution should reject missing and inverted ranges."""
+    monkeypatch.delenv(BACKFILL_DATE_FROM_ENV, raising=False)
+    monkeypatch.delenv(BACKFILL_DATE_TO_ENV, raising=False)
+    with pytest.raises(ValueError, match="Missing required backfill window environment variable"):
+        resolve_backfill_request_window()
+
+    monkeypatch.setenv(BACKFILL_DATE_FROM_ENV, "2026-01-02T00:00:00+00:00")
+    monkeypatch.setenv(BACKFILL_DATE_TO_ENV, "2026-01-01T00:00:00+00:00")
+    with pytest.raises(ValueError, match="must be earlier than or equal to"):
+        resolve_backfill_request_window()
+
+
+def test_build_backfill_queries_normalizes_keywords_and_emits_source_targeted() -> None:
+    """Backfill queries should ignore blank/duplicate keywords and dedupe source-targeted queries."""
+    config = Config(
+        keywords=["", "בית בושת", "בית בושת", "  סחר  "],
+        sources=[
+            {"name": "ynet", "type": "rss", "enabled": True, "url": "https://example.com/feed.xml"},
+            {"name": "ynet", "type": "rss", "enabled": True, "url": "https://example.com/feed.xml"},
+            {
+                "name": "walla",
+                "type": "rss",
+                "enabled": True,
+                "url": "https://news.walla.co.il/feed",
+            },
+        ],
+        discovery={"default_query_kinds": ["broad", "source_targeted"]},
+    )
+    window = BackfillBatch(
+        requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        requested_date_to=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    queries = build_backfill_queries(
+        config,
+        window=plan_backfill_windows(
+            date_from=window.requested_date_from,
+            date_to=window.requested_date_to,
+            batch_window_days=7,
+        )[0],
+    )
+
+    broad_queries = [query for query in queries if query.query_kind is DiscoveryQueryKind.BROAD]
+    source_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    ]
+
+    assert [query.query_text for query in broad_queries] == ["בית בושת", "סחר"]
+    assert len(source_queries) == 4
+    assert {query.source_hint for query in source_queries} == {"ynet", "walla"}
+    assert all(query.preferred_domains for query in source_queries)
+
+
+def test_build_backfill_queries_returns_empty_when_keywords_normalize_away() -> None:
+    """Backfill query generation should short-circuit when no usable keywords remain."""
+    config = Config(keywords=["", "   "], discovery={"default_query_kinds": ["source_targeted"]})
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 1, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    assert build_backfill_queries(config, window=window) == []
 
 
 def test_select_backfill_candidates_prefers_oldest_window_then_oldest_publication(

--- a/tests/unit/test_discovery_models.py
+++ b/tests/unit/test_discovery_models.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from denbust.discovery.models import (
+    BackfillBatch,
+    BackfillBatchStatus,
     CandidateProvenance,
     CandidateStatus,
     ContentBasis,
@@ -162,4 +164,27 @@ def test_discovery_run_rejects_finished_at_before_started_at() -> None:
         DiscoveryRun(
             started_at=started_at,
             finished_at=started_at - timedelta(minutes=1),
+        )
+
+
+def test_backfill_batch_rejects_invalid_started_and_finished_timestamps() -> None:
+    """Backfill batches should reject invalid started/finished timestamps."""
+    created_at = datetime(2026, 4, 10, 10, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError):
+        BackfillBatch(
+            created_at=created_at,
+            started_at=created_at - timedelta(minutes=1),
+            requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+            requested_date_to=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+
+    with pytest.raises(ValueError):
+        BackfillBatch(
+            created_at=created_at,
+            started_at=created_at + timedelta(minutes=1),
+            finished_at=created_at,
+            status=BackfillBatchStatus.COMPLETED,
+            requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+            requested_date_to=datetime(2026, 1, 2, tzinfo=UTC),
         )

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 
 from denbust.config import Config, SourceConfig, SourceType
 from denbust.discovery.models import DiscoveryQueryKind
-from denbust.discovery.queries import build_discovery_queries
+from denbust.discovery.queries import build_discovery_queries, enabled_source_domains
 
 
 def test_build_discovery_queries_creates_broad_and_source_targeted_queries() -> None:
@@ -123,3 +123,20 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
 
     assert len(targeted_queries) == 1
     assert targeted_queries[0].preferred_domains == ["www.ynet.co.il"]
+
+
+def test_enabled_source_domains_returns_only_enabled_resolved_domains() -> None:
+    """Public source-domain resolution should expose reusable enabled discovery domains."""
+    config = Config(
+        sources=[
+            SourceConfig(name="disabled", type=SourceType.SCRAPER, enabled=False),
+            SourceConfig(name="rss-no-url", type=SourceType.RSS),
+            SourceConfig(name="ynet", type=SourceType.RSS, url="https://www.ynet.co.il/feed.xml"),
+            SourceConfig(name="mako", type=SourceType.SCRAPER),
+        ]
+    )
+
+    assert enabled_source_domains(config) == [
+        ("ynet", "www.ynet.co.il"),
+        ("mako", "www.mako.co.il"),
+    ]

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -213,6 +213,24 @@ def test_select_backfill_candidates_for_scrape_respects_explicit_batch_id(tmp_pa
     assert [candidate.candidate_id for candidate in selected] == ["first"]
 
 
+def test_select_backfill_candidates_for_scrape_uses_batch_filter_when_provided(
+    tmp_path: Path,
+) -> None:
+    """Explicit batch selection should push the batch filter into persistence reads."""
+    store = build_store(tmp_path)
+    batch_candidate = build_candidate("first", status=CandidateStatus.NEW).model_copy(
+        update={"backfill_batch_id": "batch-1"}
+    )
+    other_candidate = build_candidate("second", status=CandidateStatus.NEW).model_copy(
+        update={"backfill_batch_id": "batch-2"}
+    )
+    store.upsert_candidates([batch_candidate, other_candidate])
+
+    selected = select_backfill_candidates_for_scrape(store, limit=10, batch_id="batch-1")
+
+    assert [candidate.candidate_id for candidate in selected] == ["first"]
+
+
 @pytest.mark.asyncio
 async def test_scrape_candidates_returns_empty_batch_for_no_candidates(tmp_path: Path) -> None:
     """An empty scrape pass should return an empty batch without persistence writes."""

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -22,7 +22,9 @@ from denbust.discovery.models import (
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     GenericFetchResult,
+    _metadata_datetime,
     scrape_candidates,
+    select_backfill_candidates_for_scrape,
     select_candidates_for_scrape,
 )
 from denbust.discovery.state_paths import resolve_discovery_state_paths
@@ -172,6 +174,43 @@ def test_select_candidates_for_scrape_prioritizes_none_and_earlier_retry_times(
         "earlier_due",
         "later_due",
     ]
+
+
+def test_metadata_datetime_handles_invalid_and_naive_values() -> None:
+    """Backfill metadata parsing should reject invalid strings and normalize naive ones to UTC."""
+    invalid_candidate = build_candidate("invalid", status=CandidateStatus.NEW).model_copy(
+        update={"metadata": {"backfill_window_start": "not-a-date"}}
+    )
+    naive_candidate = build_candidate("naive", status=CandidateStatus.NEW).model_copy(
+        update={"metadata": {"backfill_window_start": "2026-01-01T12:00:00"}}
+    )
+
+    assert _metadata_datetime(invalid_candidate, "backfill_window_start") is None
+    assert _metadata_datetime(naive_candidate, "backfill_window_start") == datetime(
+        2026, 1, 1, 12, 0, tzinfo=UTC
+    )
+
+
+def test_select_backfill_candidates_for_scrape_respects_explicit_batch_id(tmp_path: Path) -> None:
+    """Explicit backfill batch selection should only return candidates from that batch."""
+    store = build_store(tmp_path)
+    first = build_candidate("first", status=CandidateStatus.NEW).model_copy(
+        update={
+            "backfill_batch_id": "batch-1",
+            "metadata": {"backfill_window_start": "2026-01-01T00:00:00+00:00"},
+        }
+    )
+    second = build_candidate("second", status=CandidateStatus.NEW).model_copy(
+        update={
+            "backfill_batch_id": "batch-2",
+            "metadata": {"backfill_window_start": "2025-12-01T00:00:00+00:00"},
+        }
+    )
+    store.upsert_candidates([first, second])
+
+    selected = select_backfill_candidates_for_scrape(store, limit=10, batch_id="batch-1")
+
+    assert [candidate.candidate_id for candidate in selected] == ["first"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discovery_state_paths.py
+++ b/tests/unit/test_discovery_state_paths.py
@@ -4,13 +4,15 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-from denbust.discovery.models import PersistentCandidate
+from denbust.discovery.models import BackfillBatch, PersistentCandidate
 from denbust.discovery.state_paths import (
     discovery_snapshot_filename,
     resolve_discovery_state_paths,
     write_candidate_jsonl,
     write_discovery_run_snapshot,
+    write_json_snapshot,
     write_metrics_snapshot,
+    write_model_jsonl,
 )
 from denbust.models.common import DatasetName
 
@@ -26,6 +28,9 @@ def test_resolve_discovery_state_paths_uses_discover_namespace() -> None:
     assert paths.runs_dir == Path("state_repo/news_items/discover/runs")
     assert paths.latest_candidates_path == Path(
         "state_repo/news_items/discover/candidates/latest_candidates.jsonl"
+    )
+    assert paths.latest_backfill_batches_path == Path(
+        "state_repo/news_items/discover/backfill_batches/latest_backfill_batches.jsonl"
     )
     assert paths.scrape_attempts_path == Path(
         "state_repo/news_items/discover/candidates/scrape_attempts.jsonl"
@@ -60,11 +65,27 @@ def test_write_discovery_layer_artifacts(tmp_path: Path) -> None:
         run_timestamp=datetime(2026, 4, 10, 12, 0, 1, tzinfo=UTC),
     )
     candidates_path = write_candidate_jsonl(paths.latest_candidates_path, [candidate])
+    batches_path = write_model_jsonl(
+        paths.latest_backfill_batches_path,
+        [
+            BackfillBatch(
+                batch_id="batch-1",
+                requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+                requested_date_to=datetime(2026, 1, 7, tzinfo=UTC),
+            )
+        ],
+    )
     metrics_path = write_metrics_snapshot(paths.engine_overlap_latest_path, {"brave": 3})
+    snapshot_path = write_json_snapshot(
+        paths.backfill_batches_dir / "batch-1.json",
+        {"batch_id": "batch-1"},
+    )
 
     assert run_path.exists()
     assert candidates_path.exists()
+    assert batches_path.exists()
     assert metrics_path.exists()
+    assert snapshot_path.exists()
     assert json.loads(metrics_path.read_text(encoding="utf-8")) == {"brave": 3}
     candidate_lines = candidates_path.read_text(encoding="utf-8").splitlines()
     assert len(candidate_lines) == 1

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -12,8 +12,10 @@ from denbust.config import Config
 from denbust.data_models import RawArticle
 from denbust.discovery.models import (
     BackfillBatch,
+    BackfillBatchStatus,
     CandidateProvenance,
     CandidateStatus,
+    DiscoveredCandidate,
     DiscoveryRun,
     FetchStatus,
     PersistentCandidate,
@@ -130,6 +132,24 @@ class FakeSource:
         return self._articles
 
 
+class HistoricalFakeSource(FakeSource):
+    """Source stub that also supports explicit historical windows."""
+
+    def __init__(self, name: str, articles: list[RawArticle]) -> None:
+        super().__init__(name, articles)
+        self.window_calls: list[tuple[datetime, datetime, list[str]]] = []
+
+    async def fetch_window(
+        self,
+        *,
+        date_from: datetime,
+        date_to: datetime,
+        keywords: list[str],
+    ) -> list[RawArticle]:
+        self.window_calls.append((date_from, date_to, keywords))
+        return self._articles
+
+
 class RecordingPersistence(NullDiscoveryPersistence):
     """Persistence stub that records write calls."""
 
@@ -212,6 +232,113 @@ def test_source_discovery_adapter_requires_days() -> None:
     asyncio.run(run_test())
 
 
+def test_source_discovery_adapter_historical_window_support_and_validation() -> None:
+    """Historical adapters should expose capability, validate windows, and fetch tagged articles."""
+
+    async def run_test() -> None:
+        from denbust.discovery.base import SourceDiscoveryContext
+
+        article = build_raw_article()
+        supported = HistoricalFakeSource("ynet", [article])
+        supported_adapter = SourceDiscoveryAdapter(supported)
+        unsupported_adapter = SourceDiscoveryAdapter(FakeSource("walla", []))
+
+        assert supported_adapter.supports_historical_window is True
+        assert unsupported_adapter.supports_historical_window is False
+
+        try:
+            await unsupported_adapter.discover_candidates_for_window(
+                SourceDiscoveryContext(
+                    run_id="run-1",
+                    source_names=["walla"],
+                    keywords=["בית בושת"],
+                    date_from=datetime(2026, 1, 1, tzinfo=UTC),
+                    date_to=datetime(2026, 1, 2, tzinfo=UTC),
+                )
+            )
+        except ValueError as exc:
+            assert "does not support historical windows" in str(exc)
+        else:
+            raise AssertionError("expected ValueError for unsupported source")
+
+        try:
+            await supported_adapter.discover_candidates_for_window(
+                SourceDiscoveryContext(
+                    run_id="run-1",
+                    source_names=["ynet"],
+                    keywords=["בית בושת"],
+                    date_from=None,
+                    date_to=datetime(2026, 1, 2, tzinfo=UTC),
+                )
+            )
+        except ValueError as exc:
+            assert "date_from/date_to are required" in str(exc)
+        else:
+            raise AssertionError("expected ValueError for missing date_from")
+
+        discovered_at = datetime(2026, 1, 3, 12, 0, tzinfo=UTC)
+        discovered = await supported_adapter.discover_candidates_for_window(
+            SourceDiscoveryContext(
+                run_id="run-1",
+                source_names=["ynet"],
+                keywords=["בית בושת"],
+                date_from=datetime(2026, 1, 1, tzinfo=UTC),
+                date_to=datetime(2026, 1, 2, tzinfo=UTC),
+                metadata={"discovered_at": discovered_at},
+            )
+        )
+
+        assert supported.window_calls == [
+            (
+                datetime(2026, 1, 1, tzinfo=UTC),
+                datetime(2026, 1, 2, tzinfo=UTC),
+                ["בית בושת"],
+            )
+        ]
+        assert discovered[0].discovered_at == discovered_at
+
+    import asyncio
+
+    asyncio.run(run_test())
+
+
+def test_merge_discovered_candidate_preserves_backfill_metadata() -> None:
+    """Backfill candidate merges should propagate batch and window metadata."""
+    from denbust.discovery.models import ProducerKind
+    from denbust.discovery.source_native import merge_discovered_candidate
+
+    discovered = DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        candidate_url=HttpUrl("https://example.com/article"),
+        canonical_url=HttpUrl("https://example.com/article"),
+        title="title",
+        snippet="snippet",
+        discovered_at=datetime(2026, 1, 2, tzinfo=UTC),
+        publication_datetime_hint=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        source_hint="ynet",
+        metadata={
+            "backfill_batch_id": "batch-1",
+            "backfill_window_index": 3,
+            "backfill_window_start": "2026-01-01T00:00:00+00:00",
+            "backfill_window_end": "2026-01-02T00:00:00+00:00",
+        },
+    )
+    existing = build_candidate("candidate-1", backfill_batch_id="older-batch").model_copy(
+        update={"metadata": {"existing": True}}
+    )
+
+    merged = merge_discovered_candidate(discovered, existing)
+
+    assert merged.backfill_batch_id == "batch-1"
+    assert merged.metadata["backfill_window_index"] == 3
+    assert merged.metadata["backfill_window_start"] == "2026-01-01T00:00:00+00:00"
+    assert merged.metadata["backfill_window_end"] == "2026-01-02T00:00:00+00:00"
+    assert merged.metadata["latest_publication_datetime_hint"] == "2026-01-01T09:00:00+00:00"
+    assert merged.metadata["latest_discovery_metadata"]["backfill_batch_id"] == "batch-1"
+    assert merged.source_discovery_only is False
+
+
 def test_persist_discovered_candidates_reuses_identity_map_and_sets_failed_status() -> None:
     """In-memory dedupe within one persistence pass should avoid repeated lookups."""
     first = raw_article_to_discovered_candidate(build_raw_article(title="title-1"))
@@ -249,11 +376,14 @@ def test_null_discovery_persistence_is_noop() -> None:
 
     store.write_run(DiscoveryRun(run_id="run-1"))
     store.upsert_candidates([build_candidate()])
+    store.upsert_backfill_batches([build_backfill_batch()])
     store.append_provenance([build_provenance()])
     store.append_attempts([build_attempt()])
 
     assert store.get_candidate("missing") is None
     assert store.list_candidates() == []
+    assert store.get_backfill_batch("missing") is None
+    assert store.list_backfill_batches() == []
     assert (
         store.find_candidate_by_urls(canonical_url=None, current_url="https://example.com") is None
     )
@@ -325,12 +455,17 @@ def test_state_repo_discovery_persistence_handles_missing_and_blank_jsonl(tmp_pa
     assert store.list_candidates() == []
 
     paths.latest_candidates_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.latest_backfill_batches_path.parent.mkdir(parents=True, exist_ok=True)
     paths.latest_candidates_path.write_text("\n\n", encoding="utf-8")
+    paths.latest_backfill_batches_path.write_text("\n\n", encoding="utf-8")
     store.append_provenance([])
     store.append_attempts([])
     store.upsert_candidates([])
+    store.upsert_backfill_batches([])
 
     assert store.list_candidates() == []
+    assert store.get_backfill_batch("missing") is None
+    assert store.list_backfill_batches(statuses=[BackfillBatchStatus.RUNNING]) == []
 
 
 class FakeHttpClient:
@@ -377,6 +512,7 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_backfill_batch().model_dump(mode="json")]),
+            httpx.Response(200, json=[build_backfill_batch().model_dump(mode="json")]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[]),
             httpx.Response(200, json=[]),
@@ -405,6 +541,7 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
     assert store.get_candidate("candidate-1") is not None
     assert len(store.list_candidates(statuses=[CandidateStatus.NEW], limit=2)) == 1
     assert store.get_backfill_batch("batch-1") is not None
+    assert len(store.list_backfill_batches(statuses=[BackfillBatchStatus.PENDING], limit=1)) == 1
     assert (
         store.find_candidate_by_urls(
             canonical_url="https://www.ynet.co.il/news/article/abc",
@@ -442,6 +579,8 @@ def test_supabase_discovery_persistence_handles_empty_payload_shapes() -> None:
             httpx.Response(200, json={"unexpected": True}),
             httpx.Response(200, json={"unexpected": True}),
             httpx.Response(200, json={"unexpected": True}),
+            httpx.Response(200, json={"unexpected": True}),
+            httpx.Response(200, json={"unexpected": True}),
         ]
     )
     store = SupabaseDiscoveryPersistence(
@@ -460,9 +599,12 @@ def test_supabase_discovery_persistence_handles_empty_payload_shapes() -> None:
 
     assert store.get_candidate("missing") is None
     assert store.list_candidates() == []
+    assert store.get_backfill_batch("missing") is None
+    assert store.list_backfill_batches(statuses=[BackfillBatchStatus.RUNNING], limit=5) == []
     assert store.list_provenance("missing") == []
     assert store.list_attempts("missing") == []
     store.upsert_candidates([])
+    store.upsert_backfill_batches([])
     store.append_provenance([])
     store.append_attempts([])
 
@@ -519,6 +661,7 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
     assert composite.get_candidate(candidate.candidate_id) is not None
     assert composite.get_backfill_batch(batch.batch_id) is not None
     assert composite.list_candidates(limit=1)[0].candidate_id == candidate.candidate_id
+    assert composite.list_backfill_batches(limit=1)[0].batch_id == batch.batch_id
     assert (
         composite.find_candidate_by_urls(
             canonical_url="https://www.ynet.co.il/news/article/abc",

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -11,6 +11,7 @@ from pydantic import HttpUrl
 from denbust.config import Config
 from denbust.data_models import RawArticle
 from denbust.discovery.models import (
+    BackfillBatch,
     CandidateProvenance,
     CandidateStatus,
     DiscoveryRun,
@@ -104,6 +105,15 @@ def build_attempt(candidate_id: str = "candidate-1") -> ScrapeAttempt:
         attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
         fetch_status=FetchStatus.SUCCESS,
         diagnostics={"status": "ok"},
+    )
+
+
+def build_backfill_batch(batch_id: str = "batch-1") -> BackfillBatch:
+    """Build a backfill-batch fixture."""
+    return BackfillBatch(
+        batch_id=batch_id,
+        requested_date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        requested_date_to=datetime(2026, 1, 7, tzinfo=UTC),
     )
 
 
@@ -269,6 +279,7 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
         DiscoveryRun(run_id="run-1", started_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC))
     )
     store.upsert_candidates([queued, backfill])
+    store.upsert_backfill_batches([build_backfill_batch()])
     store.append_provenance([build_provenance("queued"), build_provenance("backfill")])
     store.append_attempts([build_attempt("queued"), build_attempt("backfill")])
 
@@ -277,6 +288,8 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
     assert store.get_candidate("queued") is not None
     assert store.get_candidate("missing") is None
     assert len(store.list_candidates()) == 2
+    assert store.get_backfill_batch("batch-1") is not None
+    assert len(store.list_backfill_batches(limit=1)) == 1
     assert (
         store.list_candidates(statuses=[CandidateStatus.QUEUED], limit=1)[0].candidate_id
         == "queued"
@@ -300,6 +313,7 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
     assert len(store.list_attempts("backfill")) == 1
     assert paths.retry_queue_path.exists()
     assert paths.backfill_queue_path.exists()
+    assert paths.latest_backfill_batches_path.exists()
     assert store.close() is None
 
 
@@ -362,6 +376,8 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
+            httpx.Response(200, json=[build_backfill_batch().model_dump(mode="json")]),
+            httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[]),
             httpx.Response(200, json=[]),
             httpx.Response(200, json=[build_provenance().model_dump(mode="json")]),
@@ -376,6 +392,7 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
         table_names={
             "discovery_runs": "discovery_runs",
             "persistent_candidates": "persistent_candidates",
+            "backfill_batches": "backfill_batches",
             "candidate_provenance": "candidate_provenance",
             "scrape_attempts": "scrape_attempts",
         },
@@ -384,8 +401,10 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
 
     store.write_run(DiscoveryRun(run_id="run-1", errors=["boom"]))
     store.upsert_candidates([build_candidate()])
+    store.upsert_backfill_batches([build_backfill_batch()])
     assert store.get_candidate("candidate-1") is not None
     assert len(store.list_candidates(statuses=[CandidateStatus.NEW], limit=2)) == 1
+    assert store.get_backfill_batch("batch-1") is not None
     assert (
         store.find_candidate_by_urls(
             canonical_url="https://www.ynet.co.il/news/article/abc",
@@ -432,6 +451,7 @@ def test_supabase_discovery_persistence_handles_empty_payload_shapes() -> None:
         table_names={
             "discovery_runs": "discovery_runs",
             "persistent_candidates": "persistent_candidates",
+            "backfill_batches": "backfill_batches",
             "candidate_provenance": "candidate_provenance",
             "scrape_attempts": "scrape_attempts",
         },
@@ -457,6 +477,7 @@ def test_supabase_discovery_persistence_finds_candidate_by_current_url() -> None
         table_names={
             "discovery_runs": "discovery_runs",
             "persistent_candidates": "persistent_candidates",
+            "backfill_batches": "backfill_batches",
             "candidate_provenance": "candidate_provenance",
             "scrape_attempts": "scrape_attempts",
         },
@@ -486,14 +507,17 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
     candidate = build_candidate()
     provenance = build_provenance()
     attempt = build_attempt()
+    batch = build_backfill_batch()
     composite = CompositeDiscoveryPersistence(primary, [mirror])
 
     composite.write_run(DiscoveryRun(run_id="run-1"))
     composite.upsert_candidates([candidate])
+    composite.upsert_backfill_batches([batch])
     composite.append_provenance([provenance])
     composite.append_attempts([attempt])
 
     assert composite.get_candidate(candidate.candidate_id) is not None
+    assert composite.get_backfill_batch(batch.batch_id) is not None
     assert composite.list_candidates(limit=1)[0].candidate_id == candidate.candidate_id
     assert (
         composite.find_candidate_by_urls(

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -424,6 +424,7 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
         store.list_candidates(statuses=[CandidateStatus.QUEUED], limit=1)[0].candidate_id
         == "queued"
     )
+    assert store.list_candidates(backfill_batch_id="batch-1", limit=1)[0].candidate_id == "backfill"
     assert (
         store.find_candidate_by_urls(
             canonical_url="https://www.walla.co.il/item",
@@ -510,6 +511,9 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
             httpx.Response(200, json=[]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
+            httpx.Response(
+                200, json=[build_candidate(backfill_batch_id="batch-1").model_dump(mode="json")]
+            ),
             httpx.Response(200, json=[build_candidate().model_dump(mode="json")]),
             httpx.Response(200, json=[build_backfill_batch().model_dump(mode="json")]),
             httpx.Response(200, json=[build_backfill_batch().model_dump(mode="json")]),
@@ -540,6 +544,7 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
     store.upsert_backfill_batches([build_backfill_batch()])
     assert store.get_candidate("candidate-1") is not None
     assert len(store.list_candidates(statuses=[CandidateStatus.NEW], limit=2)) == 1
+    assert len(store.list_candidates(backfill_batch_id="batch-1", limit=2)) == 1
     assert store.get_backfill_batch("batch-1") is not None
     assert len(store.list_backfill_batches(statuses=[BackfillBatchStatus.PENDING], limit=1)) == 1
     assert (
@@ -565,6 +570,7 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
     assert client.closed is True
     assert client.calls[0]["url"] == "https://supabase.example.com/rest/v1/discovery_runs"
     assert client.calls[0]["json"]["errors"] == ["boom"]  # type: ignore[index]
+    assert client.calls[5]["params"]["backfill_batch_id"] == "eq.batch-1"  # type: ignore[index]
     headers = client.calls[0]["headers"]
     assert isinstance(headers, dict)
     assert headers["Accept-Profile"] == "custom"
@@ -646,10 +652,10 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
         )
     )
     mirror = RecordingPersistence()
-    candidate = build_candidate()
+    batch = build_backfill_batch()
+    candidate = build_candidate(backfill_batch_id=batch.batch_id)
     provenance = build_provenance()
     attempt = build_attempt()
-    batch = build_backfill_batch()
     composite = CompositeDiscoveryPersistence(primary, [mirror])
 
     composite.write_run(DiscoveryRun(run_id="run-1"))
@@ -661,6 +667,9 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
     assert composite.get_candidate(candidate.candidate_id) is not None
     assert composite.get_backfill_batch(batch.batch_id) is not None
     assert composite.list_candidates(limit=1)[0].candidate_id == candidate.candidate_id
+    assert composite.list_candidates(backfill_batch_id=batch.batch_id, limit=1)[0].candidate_id == (
+        candidate.candidate_id
+    )
     assert composite.list_backfill_batches(limit=1)[0].batch_id == batch.batch_id
     assert (
         composite.find_candidate_by_urls(


### PR DESCRIPTION
## Summary

This PR implements `DL-PR-09` and makes historical backfill operational on top of the durable discovery/candidacy layer.

The main result is that `news_items / backfill_discover` and `news_items / backfill_scrape` now exist as real jobs instead of scaffolds. Historical discovery can now be planned in contiguous windows, persisted into durable backfill batches, and drained gradually through the existing scrape-to-ingest path without disturbing the freshness-oriented queue.

## What Changed

### Backfill batches and persistence

- added a first-class `BackfillBatch` model and status enum in `src/denbust/discovery/models.py`
- extended discovery persistence so backfill batch metadata is mirrored into the state repo and persisted to Supabase
- added `supabase/migrations/20260419_backfill_batches.sql` to create `public.backfill_batches` and index/foreign-key support for `persistent_candidates.backfill_batch_id`
- extended discovery state paths with a dedicated `backfill_batches/` area and `latest_backfill_batches.jsonl`

### Historical query planning and batch creation

- added `src/denbust/discovery/backfill.py` with:
  - explicit backfill window resolution from `DENBUST_BACKFILL_DATE_FROM` / `DENBUST_BACKFILL_DATE_TO`
  - contiguous window planning via `backfill.batch_window_days`
  - backfill-specific query generation that reuses the discovery query model while preserving explicit historical ranges
- implemented `run_news_backfill_discover_job` in `src/denbust/pipeline.py`
- each backfill discover invocation now creates one durable batch, tracks counts/status/warnings/errors, and records per-window metadata on discovered candidates

### Historical source-native discovery

- added an optional `HistoricalSource` protocol in `src/denbust/sources/base.py`
- extended `SourceDiscoveryAdapter` with capability-based historical-window support instead of changing the existing `Source.fetch(days, keywords)` contract
- backfill discovery now includes source-native producers when they explicitly support historical windows
- unsupported source-native producers are skipped with warnings recorded on the batch rather than treated as fatal errors

### Backfill scraping and queue behavior

- added a dedicated `select_backfill_candidates_for_scrape` path in `src/denbust/discovery/scrape_queue.py`
- preserved the existing freshness-oriented `select_candidates_for_scrape` behavior for the normal queue
- backfill scraping now:
  - drains one historical batch at a time
  - prioritizes the oldest active window first
  - then prioritizes the oldest publication hint / oldest first-seen candidates within that window
  - respects `backfill.max_scrape_attempts_per_run`
- backfill-origin retries now record `ScrapeAttemptKind.BACKFILL_RETRY` when retrying already-known batch candidates
- implemented `run_news_backfill_scrape_job` and reused the existing scrape-to-ingest pipeline so successful backfill scrapes still flow through classification, deduplication, fallback retention, and operational persistence

### Dataset/job wiring and docs

- replaced scaffolded dataset job handlers for `backfill_discover` and `backfill_scrape`
- updated `.agent-plan.md`, `README.md`, and the discovery design/implementation docs to describe the post-merge backfill state
- updated `AGENTS.md`, `llms.txt`, and added `.github/skills/pr-closeout/SKILL.md` so repo-local agent guidance now explicitly treats work as incomplete until a non-draft PR with a detailed description, labels, and a milestone is open on GitHub
- updated local untracked `LOCAL_AGENTS.md` as additive local memory to mirror the same closeout rule

## Why

Before this change, the discovery layer could persist candidates and scrape retries, but historical gap-closing was still scaffold-only. There was no durable batch model, no historical window planner, and no separate batch-aware drain path that would let the project run slow, resumable historical discovery without overwhelming the normal freshness queue.

This PR closes that gap and makes the discovery layer usable for incremental backfill work while preserving the current ingest and daily discovery behavior.

## Validation

I ran the following validations locally in the repo venv:

- `./.venv-codex/bin/ruff format src/denbust/config.py src/denbust/datasets/jobs.py src/denbust/discovery/backfill.py src/denbust/discovery/models.py src/denbust/discovery/persistence.py src/denbust/discovery/scrape_queue.py src/denbust/discovery/source_native.py src/denbust/discovery/state_paths.py src/denbust/discovery/storage.py src/denbust/pipeline.py src/denbust/sources/base.py tests/unit/test_backfill_migration.py tests/unit/test_backfill_pipeline.py tests/unit/test_config.py tests/unit/test_dataset_jobs.py tests/unit/test_discovery_backfill.py tests/unit/test_discovery_state_paths.py tests/unit/test_discovery_storage.py`
- `./.venv-codex/bin/ruff check src/denbust/config.py src/denbust/datasets/jobs.py src/denbust/discovery/backfill.py src/denbust/discovery/models.py src/denbust/discovery/persistence.py src/denbust/discovery/scrape_queue.py src/denbust/discovery/source_native.py src/denbust/discovery/state_paths.py src/denbust/discovery/storage.py src/denbust/pipeline.py src/denbust/sources/base.py tests/unit/test_backfill_migration.py tests/unit/test_backfill_pipeline.py tests/unit/test_config.py tests/unit/test_dataset_jobs.py tests/unit/test_discovery_backfill.py tests/unit/test_discovery_state_paths.py tests/unit/test_discovery_storage.py`
- `./.venv-codex/bin/mypy src/denbust/discovery src/denbust/pipeline.py src/denbust/datasets/jobs.py src/denbust/sources/base.py`
- `./.venv-codex/bin/python -m pytest -q tests/unit/test_discovery_backfill.py tests/unit/test_backfill_migration.py tests/unit/test_backfill_pipeline.py tests/unit/test_dataset_jobs.py tests/unit/test_discovery_state_paths.py tests/unit/test_discovery_storage.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_pipeline_core.py`

That targeted pytest run passed with `133 passed`.

## Impact / Follow-up

- operators can now run historical backfill in bounded windows using `DENBUST_BACKFILL_DATE_FROM` and `DENBUST_BACKFILL_DATE_TO`
- future rollout work in `DL-PR-11` can wire these backfill jobs into GitHub Actions without adding the underlying batch semantics again
- source-native historical discovery remains capability-based, so adding explicit historical-window support to individual sources can happen incrementally in later PRs without changing the batch model or queue behavior
