### PR TITLE
Phase C #65: Add Ynet category-page backstop

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,9 +6,9 @@
 
 ## Mainline Status
 
-- Last merged PR on main: PR `#95` May 2026 local experiment plan.
-- Next planned PR: source recall and search-backed backfill follow-through from the May 2026
-  experiment findings.
+- Last merged PR on main: PR `#96` hardened the May 2026 validation, live-check, and source-health
+  paths.
+- Next planned PR: search-backed backfill follow-through from the May 2026 experiment findings.
 - Current blockers on main: none; local validation now fails on malformed validation data and
   classifier provider outages instead of recording misleading negative classifications.
 
@@ -28,8 +28,11 @@
 - [done] Merge PR `#95` with the May 2026 local experiment plan.
 - [done] Harden the May 2026 experiment path with validation linting, fatal classifier-provider
   errors, live-check CLI coverage, source diagnostic helper APIs, and opt-in local search config.
-- [next] Use the hardened local run path to prioritize source recall, search-backed discovery, and
-  backfill gaps surfaced by the May 2026 experiment outputs.
+- [done] Add the Ynet משפט ופלילים category-page backstop so RSS remains primary while source
+  recall has a non-browser secondary discovery path and diagnostics can isolate RSS/category
+  health.
+- [next] Use the hardened local run path to prioritize search-backed discovery and backfill gaps
+  surfaced by the May 2026 experiment outputs.
 - [later] Optional `DL-PR-12` self-healing scaffolding hooks.
 
 ## Planning Workflow

--- a/PLAN.md
+++ b/PLAN.md
@@ -28,9 +28,10 @@ This repo currently has one main plan and two important sub-plans.
 
 ## Current Next Focus: May 2026 Experiment Follow-Through
 
-PR `#95` added the May 2026 local experiment plan. The immediate follow-up hardens that plan's
-execution path so local validation data problems and Anthropic provider failures fail visibly before
-operators trust the resulting metrics.
+PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
+local validation data problems and Anthropic provider failures fail visibly before operators trust
+the resulting metrics. The first source-recall follow-up adds a Ynet משפט ופלילים category-page
+backstop while keeping the RSS feed as the primary Ynet source.
 
 ### What is already in place
 
@@ -40,13 +41,15 @@ operators trust the resulting metrics.
   `denbust diagnose-discovery`.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
   cases.
+- Ynet source-health diagnostics now split RSS and category-page checks so RSS low coverage,
+  category HTTP failure, category parse-zero, and category keyword-zero outcomes are visible.
 - Validation evaluation already reports stage-wise relevance, enforcement, taxonomy, and index
   metrics.
 
 ### What comes next
 
 1. Use the hardened May experiment path to rerun validation and live checks locally.
-2. Prioritize source recall, search-backed discovery, and backfill gaps from those outputs.
+2. Prioritize search-backed discovery and backfill gaps from those outputs.
 3. Treat optional self-healing scaffolding as later work unless the hardened experiment data shows it
    is the highest-leverage next step.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Planned future datasets:
 - Runs Brave, Exa, and Google CSE as external discovery engines feeding the durable candidate layer
 - Adds taxonomy-targeted discovery queries from the packaged TFHT taxonomy for broader
   search-engine recall
+- Keeps Ynet RSS as the primary משפט ופלילים source while adding a non-browser category-page
+  backstop for source-native recall
 - Emits Facebook-targeted `social_targeted` search queries and retains those results as non-scrapeable reference candidates
 - Plans historical backfill windows and persists durable `backfill_batches` metadata for slow-drain
   discovery/scrape work
@@ -330,6 +332,8 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   monitoring and review, while staying excluded from public release by default
 - discovery diagnostics now report candidate-basis counts so operators can distinguish full-page,
   partial-page, and search-result-only retention
+- Ynet source-health diagnostics now report separate RSS and category-page checks, distinguishing
+  RSS low coverage, category HTTP failure, category parse-zero, and category keyword-zero cases
 
 ## Config Layout
 

--- a/docs/PHASE_C_PLAN.md
+++ b/docs/PHASE_C_PLAN.md
@@ -471,6 +471,11 @@ TFHT taxonomy. That wider term set is intentionally limited to search-engine dis
 manual backfill path; source-native ingest and source diagnostics still use the coarse operator
 keyword list.
 
+Ynet source-native ingest now keeps the משפט ופלילים RSS feed as primary and supplements it with a
+non-browser category-page backstop from `https://www.ynet.co.il/news/category/190`. The backstop
+parses category cards conservatively, deduplicates against RSS by canonical URL, and exposes
+separate RSS/category-page source-health signals.
+
 The one-time 90-day catch-up run remains an operator-run manual backfill using the existing
 `backfill_discover` and `backfill_scrape` jobs with the default 7-day backfill slicing.
 

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -59,9 +59,9 @@ The repo currently has 21 issues returned by the repo-specific GitHub MCP. Seven
 | #46 Pre-classifier filter silently dropping relevant articles | Closed | Important acceptance criterion. The experiment must prove skip/drop reasons are visible in debug artifacts. |
 | #47 Source scrapers returning zero articles | Closed | Historical symptom. Re-test source health and zero-result visibility. |
 | #48 LLM classifier miscalibrated | Closed | Main classifier regression cluster. Run validation evaluation and live-check scenario. |
-| #52 Expose diagnostic-safe public probe helpers for Maariv scraper | Open | Active design debt. The experiment should detect whether diagnostics still depend on private Maariv helpers and whether that blocks source-health trust. |
-| #53 Expose diagnostic-safe public probe helpers for ICE scraper | Open | Active design debt. Same treatment as #52 for ICE. |
-| #65 Add Ynet category-page backstop for משפט ופלילים discovery | Open | Active source recall issue. Test whether Ynet RSS alone is still shallow and whether category-page probing is needed now. |
+| #52 Expose diagnostic-safe public probe helpers for Maariv scraper | Treated | PR #96 added public Maariv diagnostic helpers; close or update the issue with that evidence if it remains open. |
+| #53 Expose diagnostic-safe public probe helpers for ICE scraper | Treated | PR #96 added public ICE diagnostic helpers; close or update the issue with that evidence if it remains open. |
+| #65 Add Ynet category-page backstop for משפט ופלילים discovery | Treated | The source-recall follow-up keeps Ynet RSS primary and adds the non-browser category-page backstop with separate source-health signals. |
 | #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Open | Active but dependent. Decide whether web-search source exists enough now or remains blocked by #65/search path work. |
 | #71 Mako source completely failing due to browser navigation issues | Open | Active high-priority source-health issue. Live Mako diagnostics must be run with browser runtime installed. |
 | #72 Major Israeli news sources returning zero results | Open | Active system-level health issue. This is the central local experiment target. |
@@ -222,15 +222,17 @@ Record per source:
 - HTTP/browser success or failure
 - zero raw results vs parse failure vs keyword miss
 - whether debug state includes enough detail to explain the failure
-- whether diagnostics rely on private helper methods, especially for #52 and #53
+- whether diagnostics rely on private helper methods, especially if #52/#53 remain open despite the
+  PR #96 helper work
 - whether Mako failures look like missing Chromium, timeout, anti-bot, selector drift, or navigation instability
-- whether Ynet RSS looks too shallow and needs the category-page backstop from #65
+- whether Ynet RSS plus the category-page backstop still leaves source-recall gaps
 
 Decision rules:
 
 - If 4+ configured sources return zero or hard failures, #72 remains active and should become the next correctness PR.
 - If Mako alone fails with browser/navigation errors, merge #71 and #74 conceptually and fix Mako first.
-- If Ynet returns recent RSS items but not known relevant category items, #65 remains active.
+- If Ynet returns recent RSS/category items but still misses known relevant URLs, prioritize
+  search-backed recall or #66 fixture-based end-to-end coverage.
 - If diagnostics cannot explain why a source returned zero, `DL-PR-12`-style structured failure diagnostics become more urgent.
 
 ## Phase 4 - Fresh Discovery Run
@@ -563,10 +565,10 @@ The experiment should not assume these are true, but these are the current hypot
    a fresh Mako probe.
 4. #72 is the central open reliability question: either the source-zero problem still exists, or the
    open issue can be closed with evidence.
-5. #65 remains likely relevant because Ynet RSS is intentionally shallow even after moving to the
-   better crime feed.
-6. #52 and #53 are not user-facing bugs, but they matter if source diagnostics are going to become
-   the basis for self-healing.
+5. #65 is treated by the Ynet category-page backstop; future Ynet work should focus on fixture-based
+   end-to-end coverage or search-backed recall.
+6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
+   issues with that evidence if they remain open.
 7. #88 should stay lower priority unless bounded backfill demonstrates real local slowness.
 8. The repo needs a first-class experiment or live-check CLI if these checks are going to be run more
    than once.

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -385,111 +385,189 @@ async def _probe_ynet(
 ) -> SourceDiagnosticResult:
     cutoff = datetime.now(UTC) - timedelta(days=days)
     feed_url = source_cfg.url or ""
+    checks: list[ProbeCheck] = []
+    buckets: list[FailureBucket] = []
 
     try:
         fetch_result = await _fetch_text(feed_url, user_agent=rss_source.USER_AGENT)
     except Exception as exc:
-        return _live_result(
-            source_name="ynet",
-            status=DiagnosticStatus.FAIL,
-            bucket=FailureBucket.FEED_FETCH_FAILED,
-            checks=[
-                ProbeCheck(
-                    name="live_probe",
-                    status=DiagnosticStatus.FAIL,
-                    summary=f"RSS fetch failed: {exc}",
-                    details={"url": feed_url},
-                )
-            ],
-        )
-
-    parsed = feedparser.parse(fetch_result.text)
-    parse_warning = None
-    if getattr(parsed, "bozo", 0) and getattr(parsed, "bozo_exception", None) is not None:
-        parse_warning = str(parsed.bozo_exception)
-
-    entries = list(getattr(parsed, "entries", []))
-    parseable_date_count = 0
-    recent_entry_count = 0
-    keyword_match_count = 0
-    for entry in entries:
-        date = _probe_rss_entry_date(entry)
-        if date is not None:
-            parseable_date_count += 1
-            if date >= cutoff:
-                recent_entry_count += 1
-        if _probe_rss_entry_matches(entry, cutoff, sample_keywords, source_name="ynet"):
-            keyword_match_count += 1
-
-    unexpected_redirect = _is_unexpected_redirect(fetch_result.final_url, feed_url)
-    details = {
-        "requested_url": feed_url,
-        "final_url": fetch_result.final_url,
-        "status_code": fetch_result.status_code,
-        "content_type": fetch_result.content_type,
-        "payload_length": len(fetch_result.text),
-        "bozo": bool(getattr(parsed, "bozo", 0)),
-        "bozo_exception": parse_warning,
-        "total_entry_count": len(entries),
-        "parseable_date_count": parseable_date_count,
-        "recent_entry_count": recent_entry_count,
-        "keyword_match_count": keyword_match_count,
-    }
-
-    if unexpected_redirect:
-        return _live_result(
-            source_name="ynet",
-            status=DiagnosticStatus.WARN,
-            bucket=FailureBucket.UNEXPECTED_REDIRECT,
-            checks=[
-                ProbeCheck(
-                    name="live_probe",
-                    status=DiagnosticStatus.WARN,
-                    summary="Feed request redirected to an unexpected URL",
-                    details=details,
-                )
-            ],
-        )
-    if len(entries) == 0 or recent_entry_count == 0:
-        return _live_result(
-            source_name="ynet",
-            status=DiagnosticStatus.FAIL,
-            bucket=FailureBucket.FEED_EMPTY_OR_STALE,
-            checks=[
-                ProbeCheck(
-                    name="live_probe",
-                    status=DiagnosticStatus.FAIL,
-                    summary="Feed is empty or contains no recent entries inside the cutoff window",
-                    details=details,
-                )
-            ],
-        )
-    if keyword_match_count == 0:
-        return _live_result(
-            source_name="ynet",
-            status=DiagnosticStatus.WARN,
-            bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
-            checks=[
-                ProbeCheck(
-                    name="live_probe",
-                    status=DiagnosticStatus.WARN,
-                    summary="Feed has recent items but none match the sampled keywords",
-                    details=details,
-                )
-            ],
-        )
-
-    return _live_result(
-        source_name="ynet",
-        status=DiagnosticStatus.OK,
-        checks=[
+        buckets.append(FailureBucket.FEED_FETCH_FAILED)
+        checks.append(
             ProbeCheck(
-                name="live_probe",
-                status=DiagnosticStatus.OK,
-                summary="Feed returned recent keyword-matching entries",
-                details=details,
+                name="rss_feed",
+                status=DiagnosticStatus.FAIL,
+                summary=f"RSS fetch failed: {exc}",
+                details={
+                    "url": feed_url,
+                    "failure_bucket": FailureBucket.FEED_FETCH_FAILED.value,
+                },
             )
-        ],
+        )
+    else:
+        parsed = feedparser.parse(fetch_result.text)
+        parse_warning = None
+        if getattr(parsed, "bozo", 0) and getattr(parsed, "bozo_exception", None) is not None:
+            parse_warning = str(parsed.bozo_exception)
+
+        entries = list(getattr(parsed, "entries", []))
+        parseable_date_count = 0
+        recent_entry_count = 0
+        keyword_match_count = 0
+        for entry in entries:
+            date = _probe_rss_entry_date(entry)
+            if date is not None:
+                parseable_date_count += 1
+                if date >= cutoff:
+                    recent_entry_count += 1
+            if _probe_rss_entry_matches(entry, cutoff, sample_keywords, source_name="ynet"):
+                keyword_match_count += 1
+
+        details = {
+            "requested_url": feed_url,
+            "final_url": fetch_result.final_url,
+            "status_code": fetch_result.status_code,
+            "content_type": fetch_result.content_type,
+            "payload_length": len(fetch_result.text),
+            "bozo": bool(getattr(parsed, "bozo", 0)),
+            "bozo_exception": parse_warning,
+            "total_entry_count": len(entries),
+            "parseable_date_count": parseable_date_count,
+            "recent_entry_count": recent_entry_count,
+            "keyword_match_count": keyword_match_count,
+        }
+
+        if _is_unexpected_redirect(fetch_result.final_url, feed_url):
+            details["failure_bucket"] = FailureBucket.UNEXPECTED_REDIRECT.value
+            buckets.append(FailureBucket.UNEXPECTED_REDIRECT)
+            checks.append(
+                ProbeCheck(
+                    name="rss_feed",
+                    status=DiagnosticStatus.WARN,
+                    summary="RSS request redirected to an unexpected URL",
+                    details=details,
+                )
+            )
+        elif len(entries) == 0 or recent_entry_count == 0:
+            details["failure_bucket"] = FailureBucket.FEED_EMPTY_OR_STALE.value
+            buckets.append(FailureBucket.FEED_EMPTY_OR_STALE)
+            checks.append(
+                ProbeCheck(
+                    name="rss_feed",
+                    status=DiagnosticStatus.FAIL,
+                    summary="RSS feed is empty or contains no recent entries",
+                    details=details,
+                )
+            )
+        elif keyword_match_count == 0:
+            details["failure_bucket"] = FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS.value
+            buckets.append(FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            checks.append(
+                ProbeCheck(
+                    name="rss_feed",
+                    status=DiagnosticStatus.WARN,
+                    summary="RSS feed is healthy but low coverage for sampled keywords",
+                    details=details,
+                )
+            )
+        else:
+            checks.append(
+                ProbeCheck(
+                    name="rss_feed",
+                    status=DiagnosticStatus.OK,
+                    summary="RSS feed returned recent keyword-matching entries",
+                    details=details,
+                )
+            )
+
+    try:
+        category_fetch = await _fetch_text(
+            rss_source.YNET_CATEGORY_URL,
+            user_agent=rss_source.USER_AGENT,
+        )
+    except Exception as exc:
+        buckets.append(FailureBucket.HTTP_FETCH_FAILED)
+        checks.append(
+            ProbeCheck(
+                name="category_page",
+                status=DiagnosticStatus.FAIL,
+                summary=f"Category page fetch failed: {exc}",
+                details={
+                    "requested_url": rss_source.YNET_CATEGORY_URL,
+                    "failure_bucket": FailureBucket.HTTP_FETCH_FAILED.value,
+                },
+            )
+        )
+    else:
+        parsed_category = rss_source.diagnose_ynet_category_html(
+            category_fetch.text,
+            cutoff=cutoff,
+            keywords=sample_keywords,
+            category_url=rss_source.YNET_CATEGORY_URL,
+        )
+        category_details = {
+            "requested_url": rss_source.YNET_CATEGORY_URL,
+            "final_url": category_fetch.final_url,
+            "status_code": category_fetch.status_code,
+            "content_type": category_fetch.content_type,
+            "payload_length": len(category_fetch.text),
+            "container_count": parsed_category.container_count,
+            "parsed_article_count": parsed_category.parsed_article_count,
+            "keyword_match_count": parsed_category.keyword_match_count,
+            "stale_article_count": parsed_category.stale_article_count,
+            "article_urls": parsed_category.article_urls[:5],
+        }
+        if _is_unexpected_redirect(category_fetch.final_url, rss_source.YNET_CATEGORY_URL):
+            category_details["failure_bucket"] = FailureBucket.UNEXPECTED_REDIRECT.value
+            buckets.append(FailureBucket.UNEXPECTED_REDIRECT)
+            checks.append(
+                ProbeCheck(
+                    name="category_page",
+                    status=DiagnosticStatus.WARN,
+                    summary="Category page request redirected to an unexpected URL",
+                    details=category_details,
+                )
+            )
+        elif parsed_category.container_count == 0 or parsed_category.parsed_article_count == 0:
+            category_details["failure_bucket"] = FailureBucket.PARSE_ZEROED_RESULTS.value
+            buckets.append(FailureBucket.PARSE_ZEROED_RESULTS)
+            checks.append(
+                ProbeCheck(
+                    name="category_page",
+                    status=DiagnosticStatus.FAIL,
+                    summary="Category page fetched but parsing returned zero articles",
+                    details=category_details,
+                )
+            )
+        elif parsed_category.keyword_match_count == 0:
+            category_details["failure_bucket"] = FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS.value
+            buckets.append(FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            checks.append(
+                ProbeCheck(
+                    name="category_page",
+                    status=DiagnosticStatus.WARN,
+                    summary="Category page parsed articles but none matched sampled keywords",
+                    details=category_details,
+                )
+            )
+        else:
+            checks.append(
+                ProbeCheck(
+                    name="category_page",
+                    status=DiagnosticStatus.OK,
+                    summary="Category page returned parsed keyword-matching articles",
+                    details=category_details,
+                )
+            )
+
+    status = _merge_status(*(check.status for check in checks))
+    bucket = buckets[0] if buckets else None
+    return SourceDiagnosticResult(
+        source_name="ynet",
+        status=status,
+        live_status=status,
+        failure_bucket=bucket,
+        probe_mode="live_probe",
+        checks=checks,
     )
 
 

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -386,19 +386,19 @@ async def _probe_ynet(
     cutoff = datetime.now(UTC) - timedelta(days=days)
     feed_url = source_cfg.url or ""
     checks: list[ProbeCheck] = []
-    buckets: list[FailureBucket] = []
+    bucket_candidates: list[tuple[DiagnosticStatus, FailureBucket]] = []
 
     try:
         fetch_result = await _fetch_text(feed_url, user_agent=rss_source.USER_AGENT)
     except Exception as exc:
-        buckets.append(FailureBucket.FEED_FETCH_FAILED)
+        bucket_candidates.append((DiagnosticStatus.FAIL, FailureBucket.FEED_FETCH_FAILED))
         checks.append(
             ProbeCheck(
                 name="rss_feed",
                 status=DiagnosticStatus.FAIL,
                 summary=f"RSS fetch failed: {exc}",
                 details={
-                    "url": feed_url,
+                    "requested_url": feed_url,
                     "failure_bucket": FailureBucket.FEED_FETCH_FAILED.value,
                 },
             )
@@ -438,7 +438,7 @@ async def _probe_ynet(
 
         if _is_unexpected_redirect(fetch_result.final_url, feed_url):
             details["failure_bucket"] = FailureBucket.UNEXPECTED_REDIRECT.value
-            buckets.append(FailureBucket.UNEXPECTED_REDIRECT)
+            bucket_candidates.append((DiagnosticStatus.WARN, FailureBucket.UNEXPECTED_REDIRECT))
             checks.append(
                 ProbeCheck(
                     name="rss_feed",
@@ -449,7 +449,7 @@ async def _probe_ynet(
             )
         elif len(entries) == 0 or recent_entry_count == 0:
             details["failure_bucket"] = FailureBucket.FEED_EMPTY_OR_STALE.value
-            buckets.append(FailureBucket.FEED_EMPTY_OR_STALE)
+            bucket_candidates.append((DiagnosticStatus.FAIL, FailureBucket.FEED_EMPTY_OR_STALE))
             checks.append(
                 ProbeCheck(
                     name="rss_feed",
@@ -460,7 +460,9 @@ async def _probe_ynet(
             )
         elif keyword_match_count == 0:
             details["failure_bucket"] = FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS.value
-            buckets.append(FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            bucket_candidates.append(
+                (DiagnosticStatus.WARN, FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            )
             checks.append(
                 ProbeCheck(
                     name="rss_feed",
@@ -485,7 +487,7 @@ async def _probe_ynet(
             user_agent=rss_source.USER_AGENT,
         )
     except Exception as exc:
-        buckets.append(FailureBucket.HTTP_FETCH_FAILED)
+        bucket_candidates.append((DiagnosticStatus.FAIL, FailureBucket.HTTP_FETCH_FAILED))
         checks.append(
             ProbeCheck(
                 name="category_page",
@@ -518,7 +520,7 @@ async def _probe_ynet(
         }
         if _is_unexpected_redirect(category_fetch.final_url, rss_source.YNET_CATEGORY_URL):
             category_details["failure_bucket"] = FailureBucket.UNEXPECTED_REDIRECT.value
-            buckets.append(FailureBucket.UNEXPECTED_REDIRECT)
+            bucket_candidates.append((DiagnosticStatus.WARN, FailureBucket.UNEXPECTED_REDIRECT))
             checks.append(
                 ProbeCheck(
                     name="category_page",
@@ -527,9 +529,20 @@ async def _probe_ynet(
                     details=category_details,
                 )
             )
+        elif parsed_category.parsed_article_count == 0 and parsed_category.stale_article_count > 0:
+            category_details["failure_bucket"] = FailureBucket.STALE_RESULTS.value
+            bucket_candidates.append((DiagnosticStatus.WARN, FailureBucket.STALE_RESULTS))
+            checks.append(
+                ProbeCheck(
+                    name="category_page",
+                    status=DiagnosticStatus.WARN,
+                    summary="Category page only contained stale articles inside the cutoff window",
+                    details=category_details,
+                )
+            )
         elif parsed_category.container_count == 0 or parsed_category.parsed_article_count == 0:
             category_details["failure_bucket"] = FailureBucket.PARSE_ZEROED_RESULTS.value
-            buckets.append(FailureBucket.PARSE_ZEROED_RESULTS)
+            bucket_candidates.append((DiagnosticStatus.FAIL, FailureBucket.PARSE_ZEROED_RESULTS))
             checks.append(
                 ProbeCheck(
                     name="category_page",
@@ -540,7 +553,9 @@ async def _probe_ynet(
             )
         elif parsed_category.keyword_match_count == 0:
             category_details["failure_bucket"] = FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS.value
-            buckets.append(FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            bucket_candidates.append(
+                (DiagnosticStatus.WARN, FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS)
+            )
             checks.append(
                 ProbeCheck(
                     name="category_page",
@@ -560,7 +575,7 @@ async def _probe_ynet(
             )
 
     status = _merge_status(*(check.status for check in checks))
-    bucket = buckets[0] if buckets else None
+    bucket = _select_bucket_by_status(bucket_candidates)
     return SourceDiagnosticResult(
         source_name="ynet",
         status=status,
@@ -1417,6 +1432,16 @@ def _merge_status(*statuses: DiagnosticStatus) -> DiagnosticStatus:
         if candidate in statuses:
             return candidate
     return DiagnosticStatus.SKIP
+
+
+def _select_bucket_by_status(
+    candidates: list[tuple[DiagnosticStatus, FailureBucket]],
+) -> FailureBucket | None:
+    for status in (DiagnosticStatus.FAIL, DiagnosticStatus.WARN):
+        for candidate_status, bucket in candidates:
+            if candidate_status == status:
+                return bucket
+    return None
 
 
 def _derive_bucket_from_checks(checks: list[ProbeCheck]) -> FailureBucket | None:

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -113,7 +113,7 @@ from denbust.sources.haaretz import create_haaretz_source
 from denbust.sources.ice import create_ice_source
 from denbust.sources.maariv import create_maariv_source
 from denbust.sources.mako import create_mako_source
-from denbust.sources.rss import RSSSource
+from denbust.sources.rss import RSSSource, YnetRSSSource
 from denbust.sources.walla import create_walla_source
 from denbust.store.run_snapshots import (
     write_run_debug_log,
@@ -179,7 +179,10 @@ def create_sources(config: Config) -> list[Source]:
 
         if source_cfg.type == SourceType.RSS:
             if source_cfg.url:
-                sources.append(RSSSource(source_name=source_cfg.name, feed_url=source_cfg.url))
+                if source_cfg.name == "ynet":
+                    sources.append(YnetRSSSource(feed_url=source_cfg.url))
+                else:
+                    sources.append(RSSSource(source_name=source_cfg.name, feed_url=source_cfg.url))
             else:
                 logger.warning("RSS source %s missing URL, skipping", source_cfg.name)
 

--- a/src/denbust/sources/rss.py
+++ b/src/denbust/sources/rss.py
@@ -301,11 +301,7 @@ class YnetRSSSource(RSSSource):
             "rss": {"status": "not_run", "requested_url": self._feed_url},
             "category": {"status": "not_run", "requested_url": self._category_url},
         }
-        rss_articles = await super().fetch(days=days, keywords=keywords)
-        rss_status = self._debug_state.get("rss", {}).get("status")
-        if rss_status == "ok" and not rss_articles:
-            self._debug_state["rss"]["status"] = "low_coverage"
-        self._debug_state["rss"]["article_count"] = len(rss_articles)
+        rss_articles = await self._fetch_rss_articles(days=days, keywords=keywords)
 
         category_articles = await self._fetch_category_articles(days=days, keywords=keywords)
         rss_urls = {canonicalize_news_url(str(article.url)) for article in rss_articles}
@@ -325,6 +321,56 @@ class YnetRSSSource(RSSSource):
             "unique_article_count": len(rss_articles) + len(deduped_category_articles),
         }
         return [*rss_articles, *deduped_category_articles]
+
+    async def _fetch_rss_articles(self, *, days: int, keywords: list[str]) -> list[RawArticle]:
+        content = await self._fetch_feed()
+        if not content:
+            self._debug_state["rss"]["article_count"] = 0
+            return []
+
+        feed = feedparser.parse(content)
+        parse_warning = None
+        if feed.bozo and feed.bozo_exception:
+            parse_warning = str(feed.bozo_exception)
+            logger.warning(f"Feed parsing warning for {self._name}: {feed.bozo_exception}")
+
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        effective_keywords = effective_keywords_for_source(self._name, keywords)
+        entries = list(feed.entries)
+        recent_entry_count = 0
+        articles: list[RawArticle] = []
+
+        for entry in entries:
+            date = self._parse_date(entry)
+            if date is None:
+                date = datetime.now(UTC)
+            if date >= cutoff:
+                recent_entry_count += 1
+
+            article = self._parse_entry(entry, cutoff, effective_keywords)
+            if article is not None:
+                articles.append(article)
+
+        if articles:
+            status = "ok"
+        elif recent_entry_count > 0:
+            status = "low_coverage"
+        else:
+            status = "empty_or_stale"
+
+        self._debug_state["rss"].update(
+            {
+                "status": status,
+                "total_entry_count": len(entries),
+                "recent_entry_count": recent_entry_count,
+                "keyword_match_count": len(articles),
+                "article_count": len(articles),
+                "bozo": bool(getattr(feed, "bozo", 0)),
+                "bozo_exception": parse_warning,
+            }
+        )
+        logger.info(f"Found {len(articles)} matching articles from {self._name}")
+        return articles
 
     async def _fetch_feed(self) -> str | None:
         try:
@@ -378,7 +424,9 @@ class YnetRSSSource(RSSSource):
             keywords=keywords,
             category_url=self._category_url,
         )
-        if parsed.parsed_article_count == 0:
+        if parsed.parsed_article_count == 0 and parsed.stale_article_count > 0:
+            status = "stale"
+        elif parsed.parsed_article_count == 0:
             status = "parse_zero"
         elif parsed.keyword_match_count == 0:
             status = "keyword_zero"

--- a/src/denbust/sources/rss.py
+++ b/src/denbust/sources/rss.py
@@ -2,19 +2,27 @@
 
 import calendar
 import logging
+import re
 from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
+from typing import Any
+from urllib.parse import urljoin
 
 import feedparser
 import httpx
+from bs4 import BeautifulSoup, Tag
+from pydantic import HttpUrl
 
 from denbust.data_models import RawArticle
+from denbust.news_items.normalize import canonicalize_news_url
 from denbust.sources.base import Source
 
 logger = logging.getLogger(__name__)
 
 # User agent for HTTP requests
 USER_AGENT = "denbust/0.1.0 (news monitoring bot; +https://github.com/denbust)"
+YNET_CATEGORY_URL = "https://www.ynet.co.il/news/category/190"
+YNET_ARTICLE_URL_RE = re.compile(r"^https://www\.ynet\.co\.il/news/article/[^/?#]+")
 
 YNET_SUPPLEMENTAL_KEYWORDS = [
     "חשד לבית בושת",
@@ -59,6 +67,27 @@ def _matches_keywords_in_text(title: str, snippet: str, keywords: list[str]) -> 
     """Check whether text contains any keyword from an already-normalized list."""
     text = f"{title} {snippet}".casefold()
     return any(keyword.casefold() in text for keyword in keywords)
+
+
+class YnetCategoryParseResult:
+    """Structured parse telemetry for the Ynet category page."""
+
+    def __init__(
+        self,
+        *,
+        container_count: int,
+        parsed_article_count: int,
+        keyword_match_count: int,
+        stale_article_count: int,
+        article_urls: list[str],
+        articles: list[RawArticle],
+    ) -> None:
+        self.container_count = container_count
+        self.parsed_article_count = parsed_article_count
+        self.keyword_match_count = keyword_match_count
+        self.stale_article_count = stale_article_count
+        self.article_urls = article_urls
+        self.articles = articles
 
 
 class RSSSource(Source):
@@ -254,13 +283,282 @@ class RSSSource(Source):
         return clean.strip()
 
 
-# Pre-configured RSS sources
-def create_ynet_source() -> RSSSource:
-    """Create Ynet RSS source."""
-    return RSSSource(
-        source_name="ynet",
-        feed_url="https://www.ynet.co.il/Integration/StoryRss190.xml",
+class YnetRSSSource(RSSSource):
+    """Ynet RSS source with a non-browser category-page backstop."""
+
+    def __init__(self, feed_url: str, category_url: str = YNET_CATEGORY_URL) -> None:
+        super().__init__(source_name="ynet", feed_url=feed_url)
+        self._category_url = category_url
+        self._debug_state: dict[str, Any] = {}
+
+    def get_debug_state(self) -> dict[str, Any] | None:
+        """Return runtime telemetry for RSS and category-page discovery legs."""
+        return self._debug_state or None
+
+    async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
+        """Fetch Ynet RSS first, then supplement it from the category page."""
+        self._debug_state = {
+            "rss": {"status": "not_run", "requested_url": self._feed_url},
+            "category": {"status": "not_run", "requested_url": self._category_url},
+        }
+        rss_articles = await super().fetch(days=days, keywords=keywords)
+        rss_status = self._debug_state.get("rss", {}).get("status")
+        if rss_status == "ok" and not rss_articles:
+            self._debug_state["rss"]["status"] = "low_coverage"
+        self._debug_state["rss"]["article_count"] = len(rss_articles)
+
+        category_articles = await self._fetch_category_articles(days=days, keywords=keywords)
+        rss_urls = {canonicalize_news_url(str(article.url)) for article in rss_articles}
+        deduped_category_articles: list[RawArticle] = []
+        seen_category_urls: set[str] = set()
+        for article in category_articles:
+            canonical_url = canonicalize_news_url(str(article.url))
+            if canonical_url in rss_urls or canonical_url in seen_category_urls:
+                continue
+            seen_category_urls.add(canonical_url)
+            deduped_category_articles.append(article)
+
+        self._debug_state["result"] = {
+            "rss_article_count": len(rss_articles),
+            "category_article_count": len(category_articles),
+            "deduped_category_article_count": len(deduped_category_articles),
+            "unique_article_count": len(rss_articles) + len(deduped_category_articles),
+        }
+        return [*rss_articles, *deduped_category_articles]
+
+    async def _fetch_feed(self) -> str | None:
+        try:
+            async with httpx.AsyncClient(
+                timeout=30.0,
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(self._feed_url)
+                response.raise_for_status()
+                self._debug_state["rss"] = {
+                    "status": "ok",
+                    "requested_url": self._feed_url,
+                    "final_url": str(response.url),
+                    "status_code": response.status_code,
+                    "content_type": response.headers.get("content-type", ""),
+                    "payload_length": len(response.text),
+                }
+                return response.text
+        except httpx.HTTPError as e:
+            logger.error(f"Error fetching RSS feed from {self._name}: {e}")
+            self._debug_state["rss"] = {
+                "status": "http_failure",
+                "requested_url": self._feed_url,
+                "error": str(e),
+            }
+            return None
+
+    async def _fetch_category_articles(self, *, days: int, keywords: list[str]) -> list[RawArticle]:
+        try:
+            async with httpx.AsyncClient(
+                timeout=20.0,
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(self._category_url)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.warning("Error fetching Ynet category page: %s", exc)
+            self._debug_state["category"] = {
+                "status": "http_failure",
+                "requested_url": self._category_url,
+                "error": str(exc),
+            }
+            return []
+
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        parsed = diagnose_ynet_category_html(
+            response.text,
+            cutoff=cutoff,
+            keywords=keywords,
+            category_url=self._category_url,
+        )
+        if parsed.parsed_article_count == 0:
+            status = "parse_zero"
+        elif parsed.keyword_match_count == 0:
+            status = "keyword_zero"
+        else:
+            status = "ok"
+        self._debug_state["category"] = {
+            "status": status,
+            "requested_url": self._category_url,
+            "final_url": str(response.url),
+            "status_code": response.status_code,
+            "content_type": response.headers.get("content-type", ""),
+            "payload_length": len(response.text),
+            "container_count": parsed.container_count,
+            "parsed_article_count": parsed.parsed_article_count,
+            "keyword_match_count": parsed.keyword_match_count,
+            "stale_article_count": parsed.stale_article_count,
+            "article_urls": parsed.article_urls[:10],
+        }
+        return parsed.articles
+
+
+def diagnose_ynet_category_html(
+    html: str,
+    *,
+    cutoff: datetime,
+    keywords: list[str],
+    category_url: str = YNET_CATEGORY_URL,
+) -> YnetCategoryParseResult:
+    """Parse Ynet law/crime category HTML and return candidate telemetry."""
+    soup = BeautifulSoup(html, "lxml")
+    containers = [item for item in soup.select(".slotView") if isinstance(item, Tag)]
+    if not containers:
+        containers = _fallback_ynet_article_link_containers(soup, category_url=category_url)
+
+    effective_keywords = effective_keywords_for_source("ynet", keywords)
+    articles: list[RawArticle] = []
+    article_urls: list[str] = []
+    parsed_article_count = 0
+    stale_article_count = 0
+    seen_urls: set[str] = set()
+
+    for container in containers:
+        candidate = _parse_ynet_category_container(
+            container, cutoff=cutoff, category_url=category_url
+        )
+        if candidate is None:
+            if _ynet_category_container_is_stale(container, cutoff):
+                stale_article_count += 1
+            continue
+        parsed_article_count += 1
+        if not _matches_keywords_in_text(candidate.title, candidate.snippet, effective_keywords):
+            continue
+        article = RawArticle(
+            url=candidate.url,
+            title=candidate.title,
+            snippet=candidate.snippet,
+            date=candidate.date,
+            source_name="ynet",
+        )
+        canonical_url = canonicalize_news_url(str(article.url))
+        if canonical_url in seen_urls:
+            continue
+        seen_urls.add(canonical_url)
+        articles.append(article)
+        article_urls.append(str(article.url))
+
+    return YnetCategoryParseResult(
+        container_count=len(containers),
+        parsed_article_count=parsed_article_count,
+        keyword_match_count=len(articles),
+        stale_article_count=stale_article_count,
+        article_urls=article_urls,
+        articles=articles,
     )
+
+
+def _fallback_ynet_article_link_containers(soup: BeautifulSoup, *, category_url: str) -> list[Tag]:
+    containers: list[Tag] = []
+    for anchor in soup.find_all("a", href=True):
+        if not isinstance(anchor, Tag):
+            continue
+        url = _normalize_ynet_article_url(str(anchor.get("href", "")), category_url)
+        if url is None:
+            continue
+        parent = anchor.find_parent(["article", "li", "div"])
+        containers.append(parent if isinstance(parent, Tag) else anchor)
+    return containers
+
+
+def _parse_ynet_category_container(
+    container: Tag,
+    *,
+    cutoff: datetime,
+    category_url: str,
+) -> RawArticle | None:
+    url = _extract_ynet_category_url(container, category_url)
+    if url is None:
+        return None
+    title = _extract_ynet_category_text(container, ".slotTitle") or _extract_first_anchor_text(
+        container
+    )
+    if not title:
+        return None
+    snippet = _extract_ynet_category_text(container, ".slotSubTitle")
+    date = _parse_ynet_category_date(_extract_ynet_category_text(container, ".dateView"))
+    if date is None:
+        date = datetime.now(UTC)
+    if date < cutoff:
+        return None
+    return RawArticle(
+        url=HttpUrl(url),
+        title=title,
+        snippet=snippet[:300] if snippet else "",
+        date=date,
+        source_name="ynet",
+    )
+
+
+def _ynet_category_container_is_stale(container: Tag, cutoff: datetime) -> bool:
+    date = _parse_ynet_category_date(_extract_ynet_category_text(container, ".dateView"))
+    return date is not None and date < cutoff
+
+
+def _extract_ynet_category_url(container: Tag, category_url: str) -> str | None:
+    for anchor in container.find_all("a", href=True):
+        if not isinstance(anchor, Tag):
+            continue
+        normalized = _normalize_ynet_article_url(str(anchor.get("href", "")), category_url)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def _normalize_ynet_article_url(raw_url: str, category_url: str) -> str | None:
+    absolute_url = urljoin(category_url, raw_url)
+    match = YNET_ARTICLE_URL_RE.match(absolute_url)
+    if match is None:
+        return None
+    return match.group(0)
+
+
+def _extract_ynet_category_text(container: Tag, selector: str) -> str:
+    node = container.select_one(selector)
+    if node is None:
+        return ""
+    return " ".join(node.get_text(" ", strip=True).split())
+
+
+def _extract_first_anchor_text(container: Tag) -> str:
+    anchor = container.find("a", href=True)
+    if not isinstance(anchor, Tag):
+        return ""
+    return " ".join(anchor.get_text(" ", strip=True).split())
+
+
+def _parse_ynet_category_date(value: str) -> datetime | None:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    match = re.search(r"(?P<day>\d{1,2})\.(?P<month>\d{1,2})\.(?P<year>\d{2,4})", stripped)
+    if match is None:
+        return None
+    year = int(match.group("year"))
+    if year < 100:
+        year += 2000
+    try:
+        return datetime(
+            year,
+            int(match.group("month")),
+            int(match.group("day")),
+            tzinfo=UTC,
+        )
+    except ValueError:
+        return None
+
+
+# Pre-configured RSS sources
+def create_ynet_source() -> YnetRSSSource:
+    """Create Ynet RSS source."""
+    return YnetRSSSource(feed_url="https://www.ynet.co.il/Integration/StoryRss190.xml")
 
 
 def create_walla_source() -> RSSSource:

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -205,6 +205,9 @@ class TestPipelineIntegration:
         # Mock RSS feed
         rss_content = load_fixture("rss/ynet_sample.xml")
         respx.get("https://ynet.co.il/feed.xml").mock(return_value=Response(200, text=rss_content))
+        respx.get("https://www.ynet.co.il/news/category/190").mock(
+            return_value=Response(200, text="<html><body>no category matches</body></html>")
+        )
 
         # Create config
         config = Config(

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -22,7 +22,7 @@ from denbust.sources.haaretz import (
 from denbust.sources.ice import IceScraper, create_ice_source
 from denbust.sources.maariv import MaarivScraper, create_maariv_source
 from denbust.sources.mako import SEARCH_POLL_INTERVAL_MS, MakoScraper, create_mako_source
-from denbust.sources.rss import RSSSource
+from denbust.sources.rss import RSSSource, YnetRSSSource, diagnose_ynet_category_html
 from denbust.sources.walla import WallaArchiveEntry, WallaScraper, create_walla_source
 
 # Load fixture files
@@ -69,6 +69,24 @@ def format_walla_pub_date(value: datetime) -> str:
     return (
         f"עודכן: {value.hour:02d}:{value.minute:02d} {value.day:02d}/{value.month:02d}/{value.year}"
     )
+
+
+def ynet_category_fixture(*, title: str, url: str, snippet: str, date: str = "01.05.26") -> str:
+    """Build a minimal Ynet category card fixture."""
+    return f"""
+    <html>
+      <body>
+        <div class="slotView">
+          <a href="{url}"><img alt="" /></a>
+          <div class="textDiv">
+            <div class="slotTitle"><a href="{url}">{title}</a></div>
+            <div class="slotSubTitle"><a href="{url}">{snippet}</a></div>
+            <div class="moreDetails"><span class="dateView"> {date} </span></div>
+          </div>
+        </div>
+      </body>
+    </html>
+    """
 
 
 def load_recent_walla_archive_fixture() -> str:
@@ -3642,6 +3660,109 @@ class TestRSSSource:
 
         assert len(articles) == 1
         assert articles[0].title.startswith("חשד לבית בושת")
+
+    def test_parse_ynet_category_page_cards(self) -> None:
+        """Ynet category parsing should extract card text, dates, and article URLs."""
+        parsed = diagnose_ynet_category_html(
+            ynet_category_fixture(
+                title="חשד לבית בושת בחיפה",
+                url="https://www.ynet.co.il/news/article/rkpeb8zbwg?utm_source=front",
+                snippet="המשטרה עצרה חשודים לאחר פשיטה על דירה.",
+            ),
+            cutoff=datetime(2026, 1, 1, tzinfo=UTC),
+            keywords=["זנות"],
+        )
+
+        assert parsed.container_count == 1
+        assert parsed.parsed_article_count == 1
+        assert parsed.keyword_match_count == 1
+        assert parsed.article_urls == ["https://www.ynet.co.il/news/article/rkpeb8zbwg"]
+        assert parsed.articles[0].title == "חשד לבית בושת בחיפה"
+        assert parsed.articles[0].date == datetime(2026, 5, 1, tzinfo=UTC)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ynet_category_backstop_deduplicates_rss_urls(self) -> None:
+        """Ynet category articles should supplement RSS without duplicating canonical URLs."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>חשד לבית בושת בחיפה</title>
+              <link>https://www.ynet.co.il/news/article/shared?utm_source=rss</link>
+              <description>המשטרה עצרה חשודים.</description>
+              <pubDate>Fri, 01 May 2026 10:00:00 +0200</pubDate>
+            </item>
+          </channel>
+        </rss>"""
+        category_html = ynet_category_fixture(
+            title="חשד לבית בושת בחיפה",
+            url="https://www.ynet.co.il/news/article/shared",
+            snippet="המשטרה עצרה חשודים.",
+        )
+
+        respx.get("https://ynet.co.il/feed.xml").mock(return_value=Response(200, text=rss_content))
+        respx.get("https://www.ynet.co.il/news/category/190").mock(
+            return_value=Response(200, text=category_html)
+        )
+
+        source = YnetRSSSource("https://ynet.co.il/feed.xml")
+        articles = await source.fetch(days=TEST_LOOKBACK_DAYS, keywords=["זנות"])
+
+        assert len(articles) == 1
+        assert str(articles[0].url) == "https://www.ynet.co.il/news/article/shared?utm_source=rss"
+        debug_state = source.get_debug_state()
+        assert debug_state is not None
+        assert debug_state["rss"]["status"] == "ok"
+        assert debug_state["category"]["status"] == "ok"
+        assert debug_state["result"]["deduped_category_article_count"] == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ynet_category_backstop_handles_http_failure(self) -> None:
+        """A category HTTP failure should not discard RSS results."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>חשד לבית בושת בחיפה</title>
+              <link>https://www.ynet.co.il/news/article/rssonly</link>
+              <description>המשטרה עצרה חשודים.</description>
+              <pubDate>Fri, 01 May 2026 10:00:00 +0200</pubDate>
+            </item>
+          </channel>
+        </rss>"""
+
+        respx.get("https://ynet.co.il/feed.xml").mock(return_value=Response(200, text=rss_content))
+        respx.get("https://www.ynet.co.il/news/category/190").mock(return_value=Response(503))
+
+        source = YnetRSSSource("https://ynet.co.il/feed.xml")
+        articles = await source.fetch(days=TEST_LOOKBACK_DAYS, keywords=["זנות"])
+
+        assert len(articles) == 1
+        debug_state = source.get_debug_state()
+        assert debug_state is not None
+        assert debug_state["category"]["status"] == "http_failure"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ynet_category_backstop_records_parse_zero(self) -> None:
+        """A fetched category page with no parseable cards should be visible in debug state."""
+        respx.get("https://ynet.co.il/feed.xml").mock(
+            return_value=Response(200, text="<rss version='2.0'><channel /></rss>")
+        )
+        respx.get("https://www.ynet.co.il/news/category/190").mock(
+            return_value=Response(200, text="<html><body>no article cards</body></html>")
+        )
+
+        source = YnetRSSSource("https://ynet.co.il/feed.xml")
+        articles = await source.fetch(days=TEST_LOOKBACK_DAYS, keywords=["זנות"])
+
+        assert articles == []
+        debug_state = source.get_debug_state()
+        assert debug_state is not None
+        assert debug_state["rss"]["status"] == "low_coverage"
+        assert debug_state["category"]["status"] == "parse_zero"
 
     def test_effective_keywords_for_generic_rss_source_deduplicates_and_skips_blank_values(
         self,

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -3761,8 +3761,40 @@ class TestRSSSource:
         assert articles == []
         debug_state = source.get_debug_state()
         assert debug_state is not None
-        assert debug_state["rss"]["status"] == "low_coverage"
+        assert debug_state["rss"]["status"] == "empty_or_stale"
         assert debug_state["category"]["status"] == "parse_zero"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ynet_category_backstop_records_rss_low_coverage(self) -> None:
+        """RSS low coverage should mean recent feed entries survived but did not match keywords."""
+        recent = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+        rss_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>חדשות כלליות</title>
+              <link>https://www.ynet.co.il/news/article/nonmatch</link>
+              <description>ללא התאמה</description>
+              <pubDate>{recent}</pubDate>
+            </item>
+          </channel>
+        </rss>"""
+
+        respx.get("https://ynet.co.il/feed.xml").mock(return_value=Response(200, text=rss_content))
+        respx.get("https://www.ynet.co.il/news/category/190").mock(
+            return_value=Response(200, text="<html><body>no article cards</body></html>")
+        )
+
+        source = YnetRSSSource("https://ynet.co.il/feed.xml")
+        articles = await source.fetch(days=21, keywords=["זנות"])
+
+        assert articles == []
+        debug_state = source.get_debug_state()
+        assert debug_state is not None
+        assert debug_state["rss"]["status"] == "low_coverage"
+        assert debug_state["rss"]["recent_entry_count"] == 1
+        assert debug_state["rss"]["keyword_match_count"] == 0
 
     def test_effective_keywords_for_generic_rss_source_deduplicates_and_skips_blank_values(
         self,

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -48,6 +48,28 @@ def _write_summary(logs_dir: Path, stem: str, payload: dict[str, object]) -> Pat
     path = logs_dir / f"{stem}.summary.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
+
+
+def _ynet_category_card(
+    *,
+    title: str = "חשד לבית בושת",
+    snippet: str = "המשטרה עצרה חשודים",
+    date: datetime | None = None,
+) -> str:
+    value = date or datetime.now(UTC)
+    date_text = value.strftime("%d.%m.%y")
+    return f"""
+    <div class="slotView">
+      <a href="https://www.ynet.co.il/news/article/category1"></a>
+      <div class="slotTitle">
+        <a href="https://www.ynet.co.il/news/article/category1">{title}</a>
+      </div>
+      <div class="slotSubTitle">
+        <a href="https://www.ynet.co.il/news/article/category1">{snippet}</a>
+      </div>
+      <span class="dateView">{date_text}</span>
+    </div>
+    """
 
 
 def test_maariv_diagnostic_helper_reports_public_parse_counts() -> None:
@@ -458,18 +480,7 @@ async def test_probe_ynet_distinguishes_keyword_zeroing(
                 final_url=url,
                 status_code=200,
                 content_type="text/html",
-                text="""
-                <div class="slotView">
-                  <a href="https://www.ynet.co.il/news/article/category1"></a>
-                  <div class="slotTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
-                  </div>
-                  <div class="slotSubTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
-                  </div>
-                  <span class="dateView">01.05.26</span>
-                </div>
-                """,
+                text=_ynet_category_card(),
             )
         return _FetchResult(
             requested_url=url,
@@ -525,18 +536,7 @@ async def test_probe_ynet_distinguishes_unexpected_redirect(
                 final_url=url,
                 status_code=200,
                 content_type="text/html",
-                text="""
-                <div class="slotView">
-                  <a href="https://www.ynet.co.il/news/article/category1"></a>
-                  <div class="slotTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
-                  </div>
-                  <div class="slotSubTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
-                  </div>
-                  <span class="dateView">01.05.26</span>
-                </div>
-                """,
+                text=_ynet_category_card(),
             )
         return _FetchResult(
             requested_url=url,
@@ -589,18 +589,7 @@ async def test_probe_ynet_reports_success(monkeypatch: pytest.MonkeyPatch) -> No
                 final_url=url,
                 status_code=200,
                 content_type="text/html",
-                text="""
-                <div class="slotView">
-                  <a href="https://www.ynet.co.il/news/article/category1"></a>
-                  <div class="slotTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
-                  </div>
-                  <div class="slotSubTitle">
-                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
-                  </div>
-                  <span class="dateView">01.05.26</span>
-                </div>
-                """,
+                text=_ynet_category_card(),
             )
         return _FetchResult(
             requested_url=url,
@@ -687,6 +676,108 @@ async def test_probe_ynet_distinguishes_category_http_failure(
     assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
     category_check = next(check for check in result.checks if check.name == "category_page")
     assert category_check.details["failure_bucket"] == FailureBucket.HTTP_FETCH_FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_probe_ynet_top_level_bucket_prefers_failure_over_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recent = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        if url == source_health.rss_source.YNET_CATEGORY_URL:
+            raise httpx.ConnectError("category boom")
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="application/rss+xml",
+            text="<rss />",
+        )
+
+    def fake_parse(text: str) -> object:
+        del text
+        return SimpleNamespace(
+            entries=[
+                {
+                    "link": "https://example.com/1",
+                    "title": "חדשות כלליות",
+                    "summary": "ללא התאמה",
+                    "published": recent,
+                }
+            ],
+            bozo=False,
+            bozo_exception=None,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+    monkeypatch.setattr(source_health.feedparser, "parse", fake_parse)
+
+    result = await source_health._probe_ynet(
+        source_cfg=SimpleNamespace(url="https://example.com/rss"),
+        days=21,
+        sample_keywords=["זנות"],
+    )
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
+
+
+@pytest.mark.asyncio
+async def test_probe_ynet_distinguishes_stale_category_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recent = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    stale_category_date = datetime.now(UTC) - timedelta(days=30)
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html"
+            if url == source_health.rss_source.YNET_CATEGORY_URL
+            else "application/rss+xml",
+            text=_ynet_category_card(date=stale_category_date)
+            if url == source_health.rss_source.YNET_CATEGORY_URL
+            else "<rss />",
+        )
+
+    def fake_parse(text: str) -> object:
+        del text
+        return SimpleNamespace(
+            entries=[
+                {
+                    "link": "https://example.com/1",
+                    "title": "זנות",
+                    "summary": "זנות",
+                    "published": recent,
+                }
+            ],
+            bozo=False,
+            bozo_exception=None,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+    monkeypatch.setattr(source_health.feedparser, "parse", fake_parse)
+
+    result = await source_health._probe_ynet(
+        source_cfg=SimpleNamespace(url="https://example.com/rss"),
+        days=21,
+        sample_keywords=["זנות"],
+    )
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.STALE_RESULTS
+    category_check = next(check for check in result.checks if check.name == "category_page")
+    assert category_check.details["failure_bucket"] == FailureBucket.STALE_RESULTS.value
+    assert category_check.details["stale_article_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -452,6 +452,25 @@ async def test_probe_ynet_distinguishes_keyword_zeroing(
         url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
     ) -> _FetchResult:
         del user_agent, client
+        if url == source_health.rss_source.YNET_CATEGORY_URL:
+            return _FetchResult(
+                requested_url=url,
+                final_url=url,
+                status_code=200,
+                content_type="text/html",
+                text="""
+                <div class="slotView">
+                  <a href="https://www.ynet.co.il/news/article/category1"></a>
+                  <div class="slotTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
+                  </div>
+                  <div class="slotSubTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
+                  </div>
+                  <span class="dateView">01.05.26</span>
+                </div>
+                """,
+            )
         return _FetchResult(
             requested_url=url,
             final_url=url,
@@ -500,6 +519,25 @@ async def test_probe_ynet_distinguishes_unexpected_redirect(
         url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
     ) -> _FetchResult:
         del user_agent, client
+        if url == source_health.rss_source.YNET_CATEGORY_URL:
+            return _FetchResult(
+                requested_url=url,
+                final_url=url,
+                status_code=200,
+                content_type="text/html",
+                text="""
+                <div class="slotView">
+                  <a href="https://www.ynet.co.il/news/article/category1"></a>
+                  <div class="slotTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
+                  </div>
+                  <div class="slotSubTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
+                  </div>
+                  <span class="dateView">01.05.26</span>
+                </div>
+                """,
+            )
         return _FetchResult(
             requested_url=url,
             final_url="https://example.com/redirected",
@@ -545,6 +583,25 @@ async def test_probe_ynet_reports_success(monkeypatch: pytest.MonkeyPatch) -> No
         url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
     ) -> _FetchResult:
         del user_agent, client
+        if url == source_health.rss_source.YNET_CATEGORY_URL:
+            return _FetchResult(
+                requested_url=url,
+                final_url=url,
+                status_code=200,
+                content_type="text/html",
+                text="""
+                <div class="slotView">
+                  <a href="https://www.ynet.co.il/news/article/category1"></a>
+                  <div class="slotTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">חשד לבית בושת</a>
+                  </div>
+                  <div class="slotSubTitle">
+                    <a href="https://www.ynet.co.il/news/article/category1">המשטרה עצרה חשודים</a>
+                  </div>
+                  <span class="dateView">01.05.26</span>
+                </div>
+                """,
+            )
         return _FetchResult(
             requested_url=url,
             final_url=url,
@@ -579,6 +636,109 @@ async def test_probe_ynet_reports_success(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert result.live_status == DiagnosticStatus.OK
     assert result.failure_bucket is None
+    assert [check.name for check in result.checks] == ["rss_feed", "category_page"]
+
+
+@pytest.mark.asyncio
+async def test_probe_ynet_distinguishes_category_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recent = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        if url == source_health.rss_source.YNET_CATEGORY_URL:
+            raise httpx.ConnectError("category boom")
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="application/rss+xml",
+            text="<rss />",
+        )
+
+    def fake_parse(text: str) -> object:
+        del text
+        return SimpleNamespace(
+            entries=[
+                {
+                    "link": "https://example.com/1",
+                    "title": "זנות",
+                    "summary": "זנות",
+                    "published": recent,
+                }
+            ],
+            bozo=False,
+            bozo_exception=None,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+    monkeypatch.setattr(source_health.feedparser, "parse", fake_parse)
+
+    result = await source_health._probe_ynet(
+        source_cfg=SimpleNamespace(url="https://example.com/rss"),
+        days=21,
+        sample_keywords=["זנות"],
+    )
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.HTTP_FETCH_FAILED
+    category_check = next(check for check in result.checks if check.name == "category_page")
+    assert category_check.details["failure_bucket"] == FailureBucket.HTTP_FETCH_FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_probe_ynet_distinguishes_category_parse_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recent = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html"
+            if url == source_health.rss_source.YNET_CATEGORY_URL
+            else "rss",
+            text="<html><body>empty category</body></html>"
+            if url == source_health.rss_source.YNET_CATEGORY_URL
+            else "<rss />",
+        )
+
+    def fake_parse(text: str) -> object:
+        del text
+        return SimpleNamespace(
+            entries=[
+                {
+                    "link": "https://example.com/1",
+                    "title": "זנות",
+                    "summary": "זנות",
+                    "published": recent,
+                }
+            ],
+            bozo=False,
+            bozo_exception=None,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+    monkeypatch.setattr(source_health.feedparser, "parse", fake_parse)
+
+    result = await source_health._probe_ynet(
+        source_cfg=SimpleNamespace(url="https://example.com/rss"),
+        days=21,
+        sample_keywords=["זנות"],
+    )
+
+    assert result.live_status == DiagnosticStatus.FAIL
+    assert result.failure_bucket == FailureBucket.PARSE_ZEROED_RESULTS
+    category_check = next(check for check in result.checks if check.name == "category_page")
+    assert category_check.details["parsed_article_count"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Planning notation

Notation: Phase C #65
Parent milestone: Phase C
Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/may_26_experiment_plan.md`

## Summary

- Keeps Ynet RSS as the primary משפט ופלילים discovery path and adds a non-browser category-page backstop for `https://www.ynet.co.il/news/category/190`.
- Parses conservative Ynet category cards/links into `RawArticle` data, applies the existing Ynet supplemental keyword behavior, and deduplicates category hits against RSS hits by canonical URL.
- Extends source-health diagnostics so Ynet reports separate RSS and category-page checks, including RSS low coverage, category HTTP failure, category parse-zero, and category keyword-zero signals.
- Updates the planning/docs surfaces so the post-merge mainline state reflects PR #96 as merged and this source-recall follow-through as treated.

## Why

The May 2026 experiment follow-through identified issue #65 as the next bounded source-recall fix after PR #96 hardened validation, live-check, and source-health paths. Ynet RSS should remain the stable primary path, but the משפט ופלילים category page carries additional source-native recall without requiring browser automation.

## Impact

- Operators get additional Ynet recall from the category page without changing config files or replacing RSS.
- Debug summaries can distinguish whether Ynet weakness is RSS low coverage, category fetch failure, category selector/parse drift, or keyword filtering.
- Pipeline source construction now instantiates the Ynet-specific RSS/backstop source for configured Ynet RSS entries; other RSS sources remain on the generic implementation.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/integration/test_scrapers.py -k 'Ynet or ynet or rss'`
- `pytest -q tests/unit/test_source_health.py -k 'ynet'`
- `pytest -q tests/unit/test_pipeline_core.py -k 'create_sources or source_summaries'`
- `pytest -q tests/integration/test_pipeline.py`
- `pytest -q tests/unit/test_config.py tests/unit/test_cli.py`
- `pytest -q` (`898 passed`, with the existing CLI runtime warning and Anthropic model deprecation warning)

## Follow-up notes

- Fixes #65.
- #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; this PR notes that in the experiment plan, but does not close them.
- #66 remains the likely Ynet follow-up for fixture-based end-to-end coverage once the search-backed source path is ready.

