### PR TITLE
Phase C: add source-zero guardrail diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,11 @@
 
 ## Mainline Status
 
-- Last merged PR on main: PR `#96` hardened the May 2026 validation, live-check, and source-health
-  paths.
+- Last merged PR on main: Phase C source-health follow-through added a source-zero guardrail
+  summary and explicit Mako browser/navigation failure modes.
 - Next planned PR: search-backed backfill follow-through from the May 2026 experiment findings.
-- Current blockers on main: none; local validation now fails on malformed validation data and
-  classifier provider outages instead of recording misleading negative classifications.
+- Current blockers on main: the fresh Phase C source-health run still flags systemic source-native
+  recall gaps for #72; Mako itself is healthy when Chromium is installed.
 
 ## Task Ledger
 
@@ -31,6 +31,8 @@
 - [done] Add the Ynet משפט ופלילים category-page backstop so RSS remains primary while source
   recall has a non-browser secondary discovery path and diagnostics can isolate RSS/category
   health.
+- [done] Add Phase C source-health guardrail reporting and Mako-specific browser/navigation
+  failure-mode diagnostics so #72 can be separated from #71/#74 runtime hygiene.
 - [next] Use the hardened local run path to prioritize search-backed discovery and backfill gaps
   surfaced by the May 2026 experiment outputs.
 - [later] Optional `DL-PR-12` self-healing scaffolding hooks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,7 +31,10 @@ This repo currently has one main plan and two important sub-plans.
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
 the resulting metrics. The first source-recall follow-up adds a Ynet משפט ופלילים category-page
-backstop while keeping the RSS feed as the primary Ynet source.
+backstop while keeping the RSS feed as the primary Ynet source. The Phase C source-health
+follow-through now adds a report-level source-zero guardrail and explicit Mako browser/navigation
+failure-mode details, making the current #72 systemic source-zero evidence separable from #71/#74
+Mako runtime hygiene.
 
 ### What is already in place
 
@@ -41,6 +44,11 @@ backstop while keeping the RSS feed as the primary Ynet source.
   `denbust diagnose-discovery`.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
   cases.
+- Source-health diagnostics include a `source_zero_summary` that flags the 4+ affected-source
+  guardrail used to decide whether a run is systemic rather than source-specific.
+- Mako live diagnostics distinguish missing browser runtime, navigation timeout, context destroyed,
+  redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero failure modes where the
+  rendered state supports that classification.
 - Ynet source-health diagnostics now split RSS and category-page checks so RSS low coverage,
   category HTTP failure, category parse-zero, and category keyword-zero outcomes are visible.
 - Validation evaluation already reports stage-wise relevance, enforcement, taxonomy, and index
@@ -48,8 +56,10 @@ backstop while keeping the RSS feed as the primary Ynet source.
 
 ### What comes next
 
-1. Use the hardened May experiment path to rerun validation and live checks locally.
-2. Prioritize search-backed discovery and backfill gaps from those outputs.
+1. Prioritize search-backed discovery and backfill gaps from the Phase C source-health evidence,
+   especially the #72 systemic source-zero pattern.
+2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
+   future live Mako run fails after Chromium is installed.
 3. Treat optional self-healing scaffolding as later work unless the hardened experiment data shows it
    is the highest-leverage next step.
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   partial-page, and search-result-only retention
 - Ynet source-health diagnostics now report separate RSS and category-page checks, distinguishing
   RSS low coverage, category HTTP failure, category parse-zero, and category keyword-zero cases
+- source-health diagnostics now include a report-level `source_zero_summary` for the Phase C
+  4+ affected-source guardrail, plus Mako `failure_mode` details for missing Chromium, navigation
+  timeout, context teardown, redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero
+  outcomes
 
 ## Config Layout
 

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -226,6 +226,8 @@ Record per source:
   PR #96 helper work
 - whether Mako failures look like missing Chromium, timeout, anti-bot, selector drift, or navigation instability
 - whether Ynet RSS plus the category-page backstop still leaves source-recall gaps
+- whether `source_zero_summary.systemic_source_zero_suspected` is true, which means the 4+ source
+  guardrail has fired and #72 should take priority over a source-specific fix
 
 Decision rules:
 
@@ -557,14 +559,15 @@ Create `reports/final_experiment_summary.md` with these sections:
 
 The experiment should not assume these are true, but these are the current hypotheses:
 
-1. `DL-PR-12` is not the only plausible next step. If source failures are still widespread, a
-   source-health correctness PR should come before optional self-healing scaffolding.
+1. `DL-PR-12` is not the only plausible next step. The fresh Phase C source-health run shows the
+   4+ affected-source guardrail firing, so #72 remains the active systemic source-zero follow-up.
 2. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
    experiment, regardless of what implementation work comes next.
-3. Mako issues #71 and #74 are probably duplicates or near-duplicates and can be consolidated after
-   a fresh Mako probe.
-4. #72 is the central open reliability question: either the source-zero problem still exists, or the
-   open issue can be closed with evidence.
+3. Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
+   after `python -m playwright install chromium`; the current Mako diagnostics are healthy with the
+   browser runtime installed.
+4. #72 is the central open reliability question: the current evidence shows Ynet, Walla, Maariv, and
+   ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and Haaretz pass.
 5. #65 is treated by the Ynet category-page backstop; future Ynet work should focus on fixture-based
    end-to-end coverage or search-backed recall.
 6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -59,6 +59,19 @@ class FailureBucket(StrEnum):
     LIVE_PROBE_EXCEPTION = "live_probe_exception"
 
 
+class MakoFailureMode(StrEnum):
+    """Mako-specific live-probe failure modes."""
+
+    BROWSER_RUNTIME_MISSING = "browser_runtime_missing"
+    NAVIGATION_TIMEOUT = "navigation_timeout"
+    CONTEXT_DESTROYED = "context_destroyed"
+    REDIRECT_OR_ANTI_BOT = "redirect_or_antibot"
+    SELECTOR_DRIFT = "selector_drift"
+    PARSE_ZERO = "parse_zero"
+    STALE_OR_KEYWORD_ZERO = "stale_or_keyword_zero"
+    UNKNOWN_EXCEPTION = "unknown_exception"
+
+
 class ProbeCheck(BaseModel):
     """A single diagnostic check and its structured details."""
 
@@ -80,6 +93,16 @@ class SourceDiagnosticResult(BaseModel):
     checks: list[ProbeCheck] = Field(default_factory=list)
 
 
+class SourceZeroSummary(BaseModel):
+    """Report-level source-zero guardrail summary."""
+
+    threshold: int = 4
+    enabled_source_count: int
+    affected_source_count: int
+    affected_sources: list[str] = Field(default_factory=list)
+    systemic_source_zero_suspected: bool
+
+
 class SourceDiagnosticReport(BaseModel):
     """Full diagnostic report for a source-health run."""
 
@@ -90,6 +113,7 @@ class SourceDiagnosticReport(BaseModel):
     artifact_analysis_enabled: bool
     live_probe_enabled: bool
     latest_artifact_path: str | None = None
+    source_zero_summary: SourceZeroSummary | None = None
     results: list[SourceDiagnosticResult] = Field(default_factory=list)
 
 
@@ -209,6 +233,7 @@ async def run_source_diagnostics_async(
             result.failure_bucket = _derive_bucket_from_checks(checks)
         report.results.append(result)
 
+    report.source_zero_summary = _build_source_zero_summary(report.results)
     return report
 
 
@@ -230,6 +255,18 @@ def render_source_diagnostic_report(report: SourceDiagnosticReport) -> str:
                 findings.append(f"- {result.source_name} [{check.name}]: {check.summary}")
 
     lines.append("")
+    if report.source_zero_summary is not None:
+        summary = report.source_zero_summary
+        sources = ", ".join(summary.affected_sources) if summary.affected_sources else "-"
+        lines.append(
+            "Source-zero guardrail: "
+            f"{summary.affected_source_count}/{summary.enabled_source_count} affected "
+            f"(threshold={summary.threshold}; "
+            f"systemic={str(summary.systemic_source_zero_suspected).lower()}; "
+            f"sources={sources})"
+        )
+        lines.append("")
+
     lines.append("Key findings")
     if findings:
         lines.extend(findings)
@@ -712,9 +749,10 @@ async def _probe_mako(
         session = await scraper._open_browser_session()
     except RuntimeError as exc:
         message = str(exc)
+        session_failure_mode = _classify_mako_exception(exc)
         status = (
             DiagnosticStatus.SKIP
-            if "playwright" in message.lower() or "chromium" in message.lower()
+            if session_failure_mode is MakoFailureMode.BROWSER_RUNTIME_MISSING
             else DiagnosticStatus.FAIL
         )
         return _live_result(
@@ -726,10 +764,12 @@ async def _probe_mako(
                     name="browser_session",
                     status=status,
                     summary=message,
+                    details={"failure_mode": session_failure_mode.value},
                 )
             ],
         )
     except Exception as exc:
+        session_failure_mode = _classify_mako_exception(exc)
         return _live_result(
             source_name="mako",
             status=DiagnosticStatus.FAIL,
@@ -739,6 +779,7 @@ async def _probe_mako(
                     name="browser_session",
                     status=DiagnosticStatus.FAIL,
                     summary=f"Browser session failed unexpectedly: {exc}",
+                    details={"failure_mode": session_failure_mode.value},
                 )
             ],
         )
@@ -758,12 +799,13 @@ async def _probe_mako(
             try:
                 html = await scraper._fetch_search_html(session, keyword)
             except Exception as exc:
+                fetch_failure_details = _mako_failure_details(exc, requested_url=search_url)
                 checks.append(
                     ProbeCheck(
                         name=f"search:{keyword}",
                         status=DiagnosticStatus.FAIL,
                         summary=f"Search fetch failed: {exc}",
-                        details={"requested_url": search_url},
+                        details=fetch_failure_details,
                     )
                 )
                 continue
@@ -779,44 +821,55 @@ async def _probe_mako(
             )
             saw_search_keyword_match = saw_search_keyword_match or keyword_hit
 
+            search_failure_mode: MakoFailureMode | None
             if html is None:
                 status = DiagnosticStatus.WARN
                 summary = "Search reached Mako's not-found terminal state"
+                search_failure_mode = MakoFailureMode.STALE_OR_KEYWORD_ZERO
             elif len(parsed_articles) == 0:
                 status = DiagnosticStatus.WARN
                 summary = "Search page rendered but parsing returned zero articles"
+                search_failure_mode = MakoFailureMode.PARSE_ZERO
             elif keyword_hit:
                 status = DiagnosticStatus.OK
                 summary = "Search page returned parsed keyword-matching articles"
+                search_failure_mode = None
             else:
                 status = DiagnosticStatus.OK
                 summary = "Search page returned parsed articles"
+                search_failure_mode = None
 
+            search_details: dict[str, Any] = {
+                "requested_url": search_url,
+                "final_url": session.page.url,
+                "terminal_state": "not_found" if html is None else "results",
+                "payload_length": len(html) if html is not None else 0,
+                "article_count": len(parsed_articles),
+                "article_urls": [str(article.url) for article in parsed_articles[:5]],
+            }
+            if search_failure_mode is not None:
+                search_details["failure_mode"] = search_failure_mode.value
             checks.append(
                 ProbeCheck(
                     name=f"search:{keyword}",
                     status=status,
                     summary=summary,
-                    details={
-                        "requested_url": search_url,
-                        "final_url": session.page.url,
-                        "terminal_state": "not_found" if html is None else "results",
-                        "payload_length": len(html) if html is not None else 0,
-                        "article_count": len(parsed_articles),
-                        "article_urls": [str(article.url) for article in parsed_articles[:5]],
-                    },
+                    details=search_details,
                 )
             )
 
         try:
             section_html = await scraper._fetch_section_html(session, mako_source.MAKO_MEN_NEWS_URL)
         except Exception as exc:
+            fetch_failure_details = _mako_failure_details(
+                exc, requested_url=mako_source.MAKO_MEN_NEWS_URL
+            )
             checks.append(
                 ProbeCheck(
                     name="section:men-men_news",
                     status=DiagnosticStatus.FAIL,
                     summary=f"Section fetch failed: {exc}",
-                    details={"requested_url": mako_source.MAKO_MEN_NEWS_URL},
+                    details=fetch_failure_details,
                 )
             )
         else:
@@ -839,35 +892,43 @@ async def _probe_mako(
             saw_section_parseable_results = bool(parsed_articles)
             saw_section_keyword_match = bool(keyword_matches)
 
+            section_failure_mode: MakoFailureMode | None
             if len(containers) == 0:
                 status = DiagnosticStatus.FAIL
                 summary = "Section page rendered but no candidate containers were found"
+                section_failure_mode = MakoFailureMode.SELECTOR_DRIFT
             elif len(parsed_articles) == 0:
                 status = DiagnosticStatus.WARN
                 summary = "Section page contains candidates but parsing returned zero articles"
+                section_failure_mode = MakoFailureMode.PARSE_ZERO
             elif len(keyword_matches) == 0:
                 status = DiagnosticStatus.WARN
                 summary = (
                     "Section page returned parsed articles but none match the sampled keywords"
                 )
+                section_failure_mode = MakoFailureMode.STALE_OR_KEYWORD_ZERO
             else:
                 status = DiagnosticStatus.OK
                 summary = "Section page returned parsed keyword-matching articles"
+                section_failure_mode = None
 
+            section_details: dict[str, Any] = {
+                "requested_url": mako_source.MAKO_MEN_NEWS_URL,
+                "final_url": session.page.url,
+                "payload_length": len(section_html),
+                "container_count": len(containers),
+                "parsed_article_count": len(parsed_articles),
+                "keyword_match_count": len(keyword_matches),
+                "article_urls": [str(article.url) for article in keyword_matches[:5]],
+            }
+            if section_failure_mode is not None:
+                section_details["failure_mode"] = section_failure_mode.value
             checks.append(
                 ProbeCheck(
                     name="section:men-men_news",
                     status=status,
                     summary=summary,
-                    details={
-                        "requested_url": mako_source.MAKO_MEN_NEWS_URL,
-                        "final_url": session.page.url,
-                        "payload_length": len(section_html),
-                        "container_count": len(containers),
-                        "parsed_article_count": len(parsed_articles),
-                        "keyword_match_count": len(keyword_matches),
-                        "article_urls": [str(article.url) for article in keyword_matches[:5]],
-                    },
+                    details=section_details,
                 )
             )
     finally:
@@ -875,6 +936,9 @@ async def _probe_mako(
             await scraper._close_browser_session(session)
 
     if unexpected_redirect:
+        for check in checks:
+            if _mako_check_redirected(check):
+                check.details.setdefault("failure_mode", MakoFailureMode.REDIRECT_OR_ANTI_BOT.value)
         return _live_result(
             source_name="mako",
             status=DiagnosticStatus.WARN,
@@ -1444,12 +1508,73 @@ def _select_bucket_by_status(
     return None
 
 
+def _build_source_zero_summary(
+    results: list[SourceDiagnosticResult],
+    *,
+    threshold: int = 4,
+) -> SourceZeroSummary:
+    affected_statuses = {DiagnosticStatus.FAIL, DiagnosticStatus.WARN, DiagnosticStatus.SKIP}
+    affected_sources = [
+        result.source_name
+        for result in results
+        if result.live_status in affected_statuses or result.status in affected_statuses
+    ]
+    return SourceZeroSummary(
+        threshold=threshold,
+        enabled_source_count=len(results),
+        affected_source_count=len(affected_sources),
+        affected_sources=affected_sources,
+        systemic_source_zero_suspected=len(affected_sources) >= threshold,
+    )
+
+
 def _derive_bucket_from_checks(checks: list[ProbeCheck]) -> FailureBucket | None:
     for check in checks:
         bucket_value = check.details.get("failure_bucket")
         if isinstance(bucket_value, str):
             return FailureBucket(bucket_value)
     return None
+
+
+def _classify_mako_exception(exc: Exception) -> MakoFailureMode:
+    message = str(exc).lower()
+    if "playwright" in message or "chromium" in message or "install chromium" in message:
+        return MakoFailureMode.BROWSER_RUNTIME_MISSING
+    if "context destroyed" in message or "target closed" in message or "page closed" in message:
+        return MakoFailureMode.CONTEXT_DESTROYED
+    if (
+        "validate.perfdrive.com" in message
+        or "anti-bot" in message
+        or "antibot" in message
+        or "captcha" in message
+        or "challenge" in message
+        or "access denied" in message
+        or "forbidden" in message
+    ):
+        return MakoFailureMode.REDIRECT_OR_ANTI_BOT
+    if "selector" in message or "no candidate containers" in message:
+        return MakoFailureMode.SELECTOR_DRIFT
+    if "timed out" in message or "timeout" in message or "terminal state" in message:
+        return MakoFailureMode.NAVIGATION_TIMEOUT
+    return MakoFailureMode.UNKNOWN_EXCEPTION
+
+
+def _mako_failure_details(exc: Exception, *, requested_url: str) -> dict[str, str]:
+    failure_mode = _classify_mako_exception(exc)
+    return {
+        "requested_url": requested_url,
+        "failure_mode": failure_mode.value,
+    }
+
+
+def _mako_check_redirected(check: ProbeCheck) -> bool:
+    requested_url = check.details.get("requested_url")
+    final_url = check.details.get("final_url")
+    return (
+        isinstance(requested_url, str)
+        and isinstance(final_url, str)
+        and _is_unexpected_redirect(final_url, requested_url)
+    )
 
 
 def _live_result(

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -955,7 +955,7 @@ async def _probe_mako(
     if unexpected_redirect:
         for check in checks:
             if _mako_check_redirected(check):
-                check.details.setdefault("failure_mode", MakoFailureMode.REDIRECT_OR_ANTI_BOT.value)
+                check.details["failure_mode"] = MakoFailureMode.REDIRECT_OR_ANTI_BOT.value
         return _live_result(
             source_name="mako",
             status=DiagnosticStatus.WARN,

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -59,6 +59,18 @@ class FailureBucket(StrEnum):
     LIVE_PROBE_EXCEPTION = "live_probe_exception"
 
 
+SOURCE_ZERO_GUARDRAIL_BUCKETS = {
+    FailureBucket.FEED_FETCH_FAILED,
+    FailureBucket.FEED_EMPTY_OR_STALE,
+    FailureBucket.STALE_RESULTS,
+    FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+    FailureBucket.HTTP_FETCH_FAILED,
+    FailureBucket.UNEXPECTED_REDIRECT,
+    FailureBucket.SELECTOR_DRIFT_SUSPECTED,
+    FailureBucket.PARSE_ZEROED_RESULTS,
+}
+
+
 class MakoFailureMode(StrEnum):
     """Mako-specific live-probe failure modes."""
 
@@ -1519,17 +1531,20 @@ def _build_source_zero_summary(
     enabled_source_count: int,
     threshold: int = 4,
 ) -> SourceZeroSummary:
-    affected_statuses = {DiagnosticStatus.FAIL, DiagnosticStatus.WARN}
     affected_sources = [
-        result.source_name for result in results if result.status in affected_statuses
+        result.source_name
+        for result in results
+        if result.failure_bucket in SOURCE_ZERO_GUARDRAIL_BUCKETS
     ]
+    selected_source_count = len(results)
+    full_coverage = selected_source_count == enabled_source_count
     return SourceZeroSummary(
         threshold=threshold,
         enabled_source_count=enabled_source_count,
-        selected_source_count=len(results),
+        selected_source_count=selected_source_count,
         affected_source_count=len(affected_sources),
         affected_sources=affected_sources,
-        systemic_source_zero_suspected=len(affected_sources) >= threshold,
+        systemic_source_zero_suspected=full_coverage and len(affected_sources) >= threshold,
     )
 
 
@@ -1543,8 +1558,6 @@ def _derive_bucket_from_checks(checks: list[ProbeCheck]) -> FailureBucket | None
 
 def _classify_mako_exception(exc: Exception) -> MakoFailureMode:
     message = str(exc).lower()
-    if "playwright" in message or "chromium" in message or "install chromium" in message:
-        return MakoFailureMode.BROWSER_RUNTIME_MISSING
     if (
         "context destroyed" in message
         or "execution context was destroyed" in message
@@ -1566,6 +1579,13 @@ def _classify_mako_exception(exc: Exception) -> MakoFailureMode:
         return MakoFailureMode.SELECTOR_DRIFT
     if "timed out" in message or "timeout" in message or "terminal state" in message:
         return MakoFailureMode.NAVIGATION_TIMEOUT
+    if (
+        "playwright is not installed" in message
+        or "chromium could not be launched" in message
+        or "executable doesn't exist" in message
+        or "browser executable not found" in message
+    ):
+        return MakoFailureMode.BROWSER_RUNTIME_MISSING
     return MakoFailureMode.UNKNOWN_EXCEPTION
 
 

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -98,6 +98,7 @@ class SourceZeroSummary(BaseModel):
 
     threshold: int = 4
     enabled_source_count: int
+    selected_source_count: int
     affected_source_count: int
     affected_sources: list[str] = Field(default_factory=list)
     systemic_source_zero_suspected: bool
@@ -233,7 +234,10 @@ async def run_source_diagnostics_async(
             result.failure_bucket = _derive_bucket_from_checks(checks)
         report.results.append(result)
 
-    report.source_zero_summary = _build_source_zero_summary(report.results)
+    report.source_zero_summary = _build_source_zero_summary(
+        report.results,
+        enabled_source_count=len(enabled_source_configs),
+    )
     return report
 
 
@@ -260,8 +264,9 @@ def render_source_diagnostic_report(report: SourceDiagnosticReport) -> str:
         sources = ", ".join(summary.affected_sources) if summary.affected_sources else "-"
         lines.append(
             "Source-zero guardrail: "
-            f"{summary.affected_source_count}/{summary.enabled_source_count} affected "
+            f"{summary.affected_source_count}/{summary.enabled_source_count} enabled affected "
             f"(threshold={summary.threshold}; "
+            f"selected={summary.selected_source_count}; "
             f"systemic={str(summary.systemic_source_zero_suspected).lower()}; "
             f"sources={sources})"
         )
@@ -1511,17 +1516,17 @@ def _select_bucket_by_status(
 def _build_source_zero_summary(
     results: list[SourceDiagnosticResult],
     *,
+    enabled_source_count: int,
     threshold: int = 4,
 ) -> SourceZeroSummary:
-    affected_statuses = {DiagnosticStatus.FAIL, DiagnosticStatus.WARN, DiagnosticStatus.SKIP}
+    affected_statuses = {DiagnosticStatus.FAIL, DiagnosticStatus.WARN}
     affected_sources = [
-        result.source_name
-        for result in results
-        if result.live_status in affected_statuses or result.status in affected_statuses
+        result.source_name for result in results if result.status in affected_statuses
     ]
     return SourceZeroSummary(
         threshold=threshold,
-        enabled_source_count=len(results),
+        enabled_source_count=enabled_source_count,
+        selected_source_count=len(results),
         affected_source_count=len(affected_sources),
         affected_sources=affected_sources,
         systemic_source_zero_suspected=len(affected_sources) >= threshold,
@@ -1540,7 +1545,12 @@ def _classify_mako_exception(exc: Exception) -> MakoFailureMode:
     message = str(exc).lower()
     if "playwright" in message or "chromium" in message or "install chromium" in message:
         return MakoFailureMode.BROWSER_RUNTIME_MISSING
-    if "context destroyed" in message or "target closed" in message or "page closed" in message:
+    if (
+        "context destroyed" in message
+        or "execution context was destroyed" in message
+        or "target closed" in message
+        or "page closed" in message
+    ):
         return MakoFailureMode.CONTEXT_DESTROYED
     if (
         "validate.perfdrive.com" in message

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -308,6 +308,12 @@ def test_render_source_diagnostic_report_includes_findings_and_empty_case() -> N
         sample_keywords=["זנות"],
         artifact_analysis_enabled=True,
         live_probe_enabled=True,
+        source_zero_summary=source_health.SourceZeroSummary(
+            enabled_source_count=2,
+            affected_source_count=1,
+            affected_sources=["ynet"],
+            systemic_source_zero_suspected=False,
+        ),
         results=[
             SourceDiagnosticResult(
                 source_name="ynet",
@@ -336,6 +342,7 @@ def test_render_source_diagnostic_report_includes_findings_and_empty_case() -> N
     rendered = source_health.render_source_diagnostic_report(report)
 
     assert "Source diagnostics" in rendered
+    assert "Source-zero guardrail:" in rendered
     assert "ynet: warn artifact=ok live=warn bucket=keyword_filter_zeroed_results" in rendered
     assert "warning branch" in rendered
 
@@ -389,6 +396,42 @@ def test_merge_status_and_derive_bucket_and_live_result() -> None:
     )
     assert result.probe_mode == "live_probe"
     assert result.checks[0].details["failure_bucket"] == FailureBucket.UNEXPECTED_REDIRECT.value
+
+
+def test_build_source_zero_summary_flags_systemic_source_zero() -> None:
+    summary = source_health._build_source_zero_summary(
+        [
+            SourceDiagnosticResult(
+                source_name="ynet",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+            ),
+            SourceDiagnosticResult(
+                source_name="walla",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+            ),
+            SourceDiagnosticResult(
+                source_name="mako",
+                status=DiagnosticStatus.SKIP,
+                live_status=DiagnosticStatus.SKIP,
+            ),
+            SourceDiagnosticResult(
+                source_name="maariv",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+            ),
+            SourceDiagnosticResult(
+                source_name="haaretz",
+                status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.OK,
+            ),
+        ]
+    )
+
+    assert summary.systemic_source_zero_suspected is True
+    assert summary.affected_source_count == 4
+    assert summary.affected_sources == ["ynet", "walla", "mako", "maariv"]
 
 
 def test_is_unexpected_redirect() -> None:
@@ -2028,6 +2071,12 @@ async def test_probe_mako_reports_parse_zeroed_results(
         "search:בית בושת",
         "section:men-men_news",
     }
+    assert {
+        check.details["failure_mode"] for check in result.checks if "failure_mode" in check.details
+    } == {
+        source_health.MakoFailureMode.PARSE_ZERO.value,
+        source_health.MakoFailureMode.SELECTOR_DRIFT.value,
+    }
 
 
 @pytest.mark.asyncio
@@ -2127,6 +2176,10 @@ async def test_probe_mako_reports_not_found_search_terminal_state(
     search_check = next(check for check in result.checks if check.name == "search:בית בושת")
     assert search_check.summary == "Search reached Mako's not-found terminal state"
     assert search_check.details["terminal_state"] == "not_found"
+    assert (
+        search_check.details["failure_mode"]
+        == source_health.MakoFailureMode.STALE_OR_KEYWORD_ZERO.value
+    )
 
 
 @pytest.mark.asyncio
@@ -2147,6 +2200,10 @@ async def test_probe_mako_skips_when_browser_runtime_is_missing(
     assert result.live_status == DiagnosticStatus.SKIP
     assert result.failure_bucket is None
     assert result.checks[0].name == "browser_session"
+    assert (
+        result.checks[0].details["failure_mode"]
+        == source_health.MakoFailureMode.BROWSER_RUNTIME_MISSING.value
+    )
 
 
 @pytest.mark.asyncio
@@ -2204,6 +2261,10 @@ async def test_probe_mako_reports_http_fetch_failed_when_search_and_section_fail
         "search:בית בושת",
         "section:men-men_news",
     }
+    assert all(
+        check.details["failure_mode"] == source_health.MakoFailureMode.UNKNOWN_EXCEPTION.value
+        for check in result.checks
+    )
 
 
 @pytest.mark.asyncio
@@ -2261,6 +2322,11 @@ async def test_probe_mako_reports_unexpected_redirect_after_keyword_hit(
     assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
     assert any(
         check.summary == "Search page returned parsed keyword-matching articles"
+        for check in result.checks
+    )
+    assert any(
+        check.details.get("failure_mode")
+        == source_health.MakoFailureMode.REDIRECT_OR_ANTI_BOT.value
         for check in result.checks
     )
 
@@ -2322,6 +2388,11 @@ async def test_probe_mako_reports_keyword_zeroing_with_search_hits_and_section_p
     assert summaries["section:men-men_news"] == (
         "Section page contains candidates but parsing returned zero articles"
     )
+    details = {check.name: check.details for check in result.checks}
+    assert (
+        details["section:men-men_news"]["failure_mode"]
+        == source_health.MakoFailureMode.PARSE_ZERO.value
+    )
 
 
 @pytest.mark.asyncio
@@ -2379,6 +2450,11 @@ async def test_probe_mako_reports_section_keyword_zeroing(
     summaries = {check.name: check.summary for check in result.checks}
     assert summaries["section:men-men_news"] == (
         "Section page returned parsed articles but none match the sampled keywords"
+    )
+    details = {check.name: check.details for check in result.checks}
+    assert (
+        details["section:men-men_news"]["failure_mode"]
+        == source_health.MakoFailureMode.STALE_OR_KEYWORD_ZERO.value
     )
 
 

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -310,6 +310,7 @@ def test_render_source_diagnostic_report_includes_findings_and_empty_case() -> N
         live_probe_enabled=True,
         source_zero_summary=source_health.SourceZeroSummary(
             enabled_source_count=2,
+            selected_source_count=2,
             affected_source_count=1,
             affected_sources=["ynet"],
             systemic_source_zero_suspected=False,
@@ -398,7 +399,7 @@ def test_merge_status_and_derive_bucket_and_live_result() -> None:
     assert result.checks[0].details["failure_bucket"] == FailureBucket.UNEXPECTED_REDIRECT.value
 
 
-def test_build_source_zero_summary_flags_systemic_source_zero() -> None:
+def test_build_source_zero_summary_flags_systemic_source_zero_for_warns_and_fails() -> None:
     summary = source_health._build_source_zero_summary(
         [
             SourceDiagnosticResult(
@@ -413,8 +414,8 @@ def test_build_source_zero_summary_flags_systemic_source_zero() -> None:
             ),
             SourceDiagnosticResult(
                 source_name="mako",
-                status=DiagnosticStatus.SKIP,
-                live_status=DiagnosticStatus.SKIP,
+                status=DiagnosticStatus.FAIL,
+                live_status=DiagnosticStatus.FAIL,
             ),
             SourceDiagnosticResult(
                 source_name="maariv",
@@ -426,12 +427,97 @@ def test_build_source_zero_summary_flags_systemic_source_zero() -> None:
                 status=DiagnosticStatus.OK,
                 live_status=DiagnosticStatus.OK,
             ),
-        ]
+        ],
+        enabled_source_count=6,
     )
 
     assert summary.systemic_source_zero_suspected is True
     assert summary.affected_source_count == 4
+    assert summary.enabled_source_count == 6
+    assert summary.selected_source_count == 5
     assert summary.affected_sources == ["ynet", "walla", "mako", "maariv"]
+
+
+def test_build_source_zero_summary_preserves_enabled_count_for_scoped_runs() -> None:
+    summary = source_health._build_source_zero_summary(
+        [
+            SourceDiagnosticResult(
+                source_name="mako",
+                status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.OK,
+            ),
+        ],
+        enabled_source_count=6,
+    )
+
+    assert summary.enabled_source_count == 6
+    assert summary.selected_source_count == 1
+    assert summary.affected_source_count == 0
+    assert summary.systemic_source_zero_suspected is False
+
+
+def test_build_source_zero_summary_ignores_skipped_probe_modes_when_merged_status_is_ok() -> None:
+    summary = source_health._build_source_zero_summary(
+        [
+            SourceDiagnosticResult(
+                source_name="ynet",
+                status=DiagnosticStatus.OK,
+                artifact_status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.SKIP,
+            ),
+            SourceDiagnosticResult(
+                source_name="walla",
+                status=DiagnosticStatus.OK,
+                artifact_status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.SKIP,
+            ),
+            SourceDiagnosticResult(
+                source_name="mako",
+                status=DiagnosticStatus.OK,
+                artifact_status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.SKIP,
+            ),
+            SourceDiagnosticResult(
+                source_name="maariv",
+                status=DiagnosticStatus.OK,
+                artifact_status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.SKIP,
+            ),
+        ],
+        enabled_source_count=6,
+    )
+
+    assert summary.affected_sources == []
+    assert summary.affected_source_count == 0
+    assert summary.systemic_source_zero_suspected is False
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "Execution context was destroyed, most likely because of a navigation",
+            source_health.MakoFailureMode.CONTEXT_DESTROYED,
+        ),
+        (
+            "redirected to validate.perfdrive.com challenge",
+            source_health.MakoFailureMode.REDIRECT_OR_ANTI_BOT,
+        ),
+        (
+            "selector .article did not match any candidate containers",
+            source_health.MakoFailureMode.SELECTOR_DRIFT,
+        ),
+        (
+            "Mako search did not reach a terminal state before timeout",
+            source_health.MakoFailureMode.NAVIGATION_TIMEOUT,
+        ),
+    ],
+)
+def test_classify_mako_exception_distinguishes_navigation_failure_modes(
+    message: str,
+    expected: source_health.MakoFailureMode,
+) -> None:
+    assert source_health._classify_mako_exception(RuntimeError(message)) is expected
 
 
 def test_is_unexpected_redirect() -> None:
@@ -1737,6 +1823,9 @@ store:
     )
 
     assert [result.source_name for result in report.results] == ["ice"]
+    assert report.source_zero_summary is not None
+    assert report.source_zero_summary.enabled_source_count == 3
+    assert report.source_zero_summary.selected_source_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -2478,6 +2478,58 @@ async def test_probe_mako_reports_unexpected_redirect_after_keyword_hit(
 
 
 @pytest.mark.asyncio
+async def test_probe_mako_redirect_failure_mode_overrides_parse_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    article = SimpleNamespace(url="https://www.mako.co.il/men-men_news/Article-123.htm")
+
+    class FakeScraper:
+        def __init__(self, *, rate_limit_delay_seconds: float = 0.0) -> None:
+            del rate_limit_delay_seconds
+
+        async def _open_browser_session(self) -> SimpleNamespace:
+            return SimpleNamespace(page=SimpleNamespace(url="https://www.mako.co.il/Search"))
+
+        async def _close_browser_session(self, _session: object) -> None:
+            return None
+
+        def _build_search_url(self, keyword: str) -> str:
+            return f"https://www.mako.co.il/Search?searchstring_input={keyword}"
+
+        async def _fetch_search_html(self, session: SimpleNamespace, keyword: str) -> str:
+            del keyword
+            session.page.url = "https://example.com/redirected-search"
+            return "<html><body>redirect body</body></html>"
+
+        async def _fetch_section_html(self, session: SimpleNamespace, _url: str) -> str:
+            session.page.url = "https://www.mako.co.il/men-men_news"
+            return "<html><body><article>candidate</article></body></html>"
+
+        def _parse_search_results(self, html: str | None, cutoff: datetime) -> list[object]:
+            del html, cutoff
+            return []
+
+        def _parse_article_item(self, item: object, cutoff: datetime) -> object:
+            del item, cutoff
+            return article
+
+        def _matches_keywords(self, candidate: object, keywords: list[str]) -> bool:
+            del keywords
+            return candidate is article
+
+    monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
+
+    result = await source_health._probe_mako(days=21, sample_keywords=["בית בושת"])
+
+    search_check = next(check for check in result.checks if check.name == "search:בית בושת")
+    assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
+    assert (
+        search_check.details["failure_mode"]
+        == source_health.MakoFailureMode.REDIRECT_OR_ANTI_BOT.value
+    )
+
+
+@pytest.mark.asyncio
 async def test_probe_mako_reports_keyword_zeroing_with_search_hits_and_section_parse_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -399,31 +399,40 @@ def test_merge_status_and_derive_bucket_and_live_result() -> None:
     assert result.checks[0].details["failure_bucket"] == FailureBucket.UNEXPECTED_REDIRECT.value
 
 
-def test_build_source_zero_summary_flags_systemic_source_zero_for_warns_and_fails() -> None:
+def test_build_source_zero_summary_flags_systemic_source_zero_for_relevant_buckets() -> None:
     summary = source_health._build_source_zero_summary(
         [
             SourceDiagnosticResult(
                 source_name="ynet",
                 status=DiagnosticStatus.WARN,
                 live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
             ),
             SourceDiagnosticResult(
                 source_name="walla",
                 status=DiagnosticStatus.WARN,
                 live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.HTTP_FETCH_FAILED,
             ),
             SourceDiagnosticResult(
                 source_name="mako",
                 status=DiagnosticStatus.FAIL,
                 live_status=DiagnosticStatus.FAIL,
+                failure_bucket=FailureBucket.PARSE_ZEROED_RESULTS,
             ),
             SourceDiagnosticResult(
                 source_name="maariv",
                 status=DiagnosticStatus.WARN,
                 live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.SELECTOR_DRIFT_SUSPECTED,
             ),
             SourceDiagnosticResult(
                 source_name="haaretz",
+                status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.OK,
+            ),
+            SourceDiagnosticResult(
+                source_name="ice",
                 status=DiagnosticStatus.OK,
                 live_status=DiagnosticStatus.OK,
             ),
@@ -434,8 +443,34 @@ def test_build_source_zero_summary_flags_systemic_source_zero_for_warns_and_fail
     assert summary.systemic_source_zero_suspected is True
     assert summary.affected_source_count == 4
     assert summary.enabled_source_count == 6
-    assert summary.selected_source_count == 5
+    assert summary.selected_source_count == 6
     assert summary.affected_sources == ["ynet", "walla", "mako", "maariv"]
+
+
+def test_build_source_zero_summary_ignores_generic_warns_without_source_zero_bucket() -> None:
+    summary = source_health._build_source_zero_summary(
+        [
+            SourceDiagnosticResult(
+                source_name="ynet",
+                status=DiagnosticStatus.WARN,
+                artifact_status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.SKIP,
+                failure_bucket=None,
+            ),
+            SourceDiagnosticResult(
+                source_name="walla",
+                status=DiagnosticStatus.FAIL,
+                artifact_status=DiagnosticStatus.SKIP,
+                live_status=DiagnosticStatus.FAIL,
+                failure_bucket=FailureBucket.LIVE_PROBE_EXCEPTION,
+            ),
+        ],
+        enabled_source_count=2,
+    )
+
+    assert summary.affected_sources == []
+    assert summary.affected_source_count == 0
+    assert summary.systemic_source_zero_suspected is False
 
 
 def test_build_source_zero_summary_preserves_enabled_count_for_scoped_runs() -> None:
@@ -443,8 +478,9 @@ def test_build_source_zero_summary_preserves_enabled_count_for_scoped_runs() -> 
         [
             SourceDiagnosticResult(
                 source_name="mako",
-                status=DiagnosticStatus.OK,
-                live_status=DiagnosticStatus.OK,
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
             ),
         ],
         enabled_source_count=6,
@@ -452,7 +488,7 @@ def test_build_source_zero_summary_preserves_enabled_count_for_scoped_runs() -> 
 
     assert summary.enabled_source_count == 6
     assert summary.selected_source_count == 1
-    assert summary.affected_source_count == 0
+    assert summary.affected_source_count == 1
     assert summary.systemic_source_zero_suspected is False
 
 
@@ -511,6 +547,10 @@ def test_build_source_zero_summary_ignores_skipped_probe_modes_when_merged_statu
             "Mako search did not reach a terminal state before timeout",
             source_health.MakoFailureMode.NAVIGATION_TIMEOUT,
         ),
+        (
+            "Mako page never became parseable before timeout; install chromium",
+            source_health.MakoFailureMode.NAVIGATION_TIMEOUT,
+        ),
     ],
 )
 def test_classify_mako_exception_distinguishes_navigation_failure_modes(
@@ -518,6 +558,23 @@ def test_classify_mako_exception_distinguishes_navigation_failure_modes(
     expected: source_health.MakoFailureMode,
 ) -> None:
     assert source_health._classify_mako_exception(RuntimeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Playwright is not installed. Install it and Chromium.",
+        "Chromium could not be launched for Mako scraping.",
+        "browser executable not found",
+    ],
+)
+def test_classify_mako_exception_reports_explicit_missing_browser_runtime(
+    message: str,
+) -> None:
+    assert (
+        source_health._classify_mako_exception(RuntimeError(message))
+        is source_health.MakoFailureMode.BROWSER_RUNTIME_MISSING
+    )
 
 
 def test_is_unexpected_redirect() -> None:
@@ -2280,7 +2337,7 @@ async def test_probe_mako_skips_when_browser_runtime_is_missing(
             del rate_limit_delay_seconds
 
         async def _open_browser_session(self) -> SimpleNamespace:
-            raise RuntimeError("Chromium is not installed")
+            raise RuntimeError("Chromium could not be launched for Mako scraping.")
 
     monkeypatch.setattr(source_health.mako_source, "MakoScraper", FakeScraper)
 


### PR DESCRIPTION
## Summary

This PR follows the Phase C Mako/source-health path from the May 2026 experiment plan. Fresh diagnostics first showed Mako skipped because Chromium was missing locally; after installing Chromium, Mako live probes passed. The same full source-health run still triggered the 4+ configured-source guardrail for #72, so this PR scopes the code change to diagnostics that make the Mako-vs-systemic decision explicit.

Changes:

- Add `source_zero_summary` to source-health JSON reports, including enabled source count, affected source count, affected sources, threshold, and `systemic_source_zero_suspected`.
- Render the source-zero guardrail in text output so operators can see when the #72 systemic path should take priority.
- Add Mako-specific `failure_mode` details for missing browser runtime, navigation timeout, context destroyed, redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero outcomes where the probe has enough rendered-state evidence.
- Update `.agent-plan.md`, `PLAN.md`, `README.md`, and `docs/may_26_experiment_plan.md` so mainline planning reflects the #72 pivot and treats #71/#74 as duplicate or near-duplicate Mako runtime/navigation hygiene unless Mako fails after Chromium is installed.

## Planning notation

No separate `DL-PR-*` notation is defined for this follow-through. This is a Phase C source-health correctness PR under the `Phase C` milestone, driven by issues #71, #72, and #74 plus the May 2026 experiment plan.

## Fresh diagnostic evidence

Commands run locally on May 1, 2026:

- Before browser install: `denbust diagnose-sources --config agents/news/local.yaml --live-only --format json --output /tmp/phase-c-source-health.json`
  - Mako: `skip`, browser session summary: Chromium could not be launched; install with `python -m playwright install chromium`.
  - Other affected configured sources: Ynet, Walla, Maariv, ICE.
- Browser runtime install: `python -m playwright install chromium`.
- Mako-only rerun: `denbust diagnose-sources --config agents/news/local.yaml --live-only --source mako --format json --output /tmp/phase-c-mako-source-health-after-browser.json`
  - Mako: `ok`; search probes returned parsed keyword-matching articles, section probe parsed articles with no sampled-keyword match.
- Patched full rerun: `denbust diagnose-sources --config agents/news/local.yaml --live-only --format json --output /tmp/phase-c-source-health-patched.json`
  - `source_zero_summary.systemic_source_zero_suspected`: `true`
  - affected sources: `ynet`, `walla`, `maariv`, `ice`
  - Mako: `ok`
  - Haaretz: `ok`

## Issue impact

- #72 remains the active systemic source-zero issue: the patched run reports 4 of 6 configured sources affected.
- #71 and #74 look duplicate or near-duplicate after the fresh probe: Mako is healthy once Chromium is installed, and this PR now gives future Mako failures explicit browser/navigation failure modes.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/unit/test_source_health.py tests/unit/test_cli.py`
- `pytest -q`

Full pytest result: 899 passed, 2 warnings. The warnings are the existing `denbust.cli` runpy warning and the Anthropic model deprecation warning in pipeline-core tests.

## Follow-up

The next implementation PR should use this source-zero guardrail evidence to address #72 with search-backed discovery/backfill follow-through rather than making another Mako-only scraper change.