### PR TITLE
Phase C #72: Add search-backed source taxonomy backfill

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,12 @@
 
 ## Mainline Status
 
-- Last merged PR on main: Phase C source-health follow-through added a source-zero guardrail
-  summary and explicit Mako browser/navigation failure modes.
-- Next planned PR: search-backed backfill follow-through from the May 2026 experiment findings.
-- Current blockers on main: the fresh Phase C source-health run still flags systemic source-native
-  recall gaps for #72; Mako itself is healthy when Chromium is installed.
+- Last merged PR on main: Phase C search-backed discovery/backfill follow-through added
+  source-targeted taxonomy queries for configured news domains after the source-zero guardrail
+  reproduced #72 for Ynet, Walla, Maariv, and ICE.
+- Next planned PR: fixture-backed Ynet/search recall regression coverage for #66.
+- Current blockers on main: no Mako runtime blocker is known after Chromium install; source-native
+  recall remains diagnostics-visible, with search-backed fallback coverage now expanded for #72.
 
 ## Task Ledger
 
@@ -33,8 +34,10 @@
   health.
 - [done] Add Phase C source-health guardrail reporting and Mako-specific browser/navigation
   failure-mode diagnostics so #72 can be separated from #71/#74 runtime hygiene.
-- [next] Use the hardened local run path to prioritize search-backed discovery and backfill gaps
+- [done] Use the hardened local run path to prioritize search-backed discovery and backfill gaps
   surfaced by the May 2026 experiment outputs.
+- [next] Add fixture-backed Ynet/search recall regression coverage for #66 now that the search-backed
+  source-domain query path is stable enough to test.
 - [later] Optional `DL-PR-12` self-healing scaffolding hooks.
 
 ## Planning Workflow

--- a/PLAN.md
+++ b/PLAN.md
@@ -32,9 +32,10 @@ PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's
 local validation data problems and Anthropic provider failures fail visibly before operators trust
 the resulting metrics. The first source-recall follow-up adds a Ynet משפט ופלילים category-page
 backstop while keeping the RSS feed as the primary Ynet source. The Phase C source-health
-follow-through now adds a report-level source-zero guardrail and explicit Mako browser/navigation
-failure-mode details, making the current #72 systemic source-zero evidence separable from #71/#74
-Mako runtime hygiene.
+follow-through added a report-level source-zero guardrail and explicit Mako browser/navigation
+failure-mode details. The current #72 follow-through reproduced systemic source-zero for Ynet,
+Walla, Maariv, and ICE, then expanded search-backed discovery/backfill so taxonomy recall terms are
+also queried against each configured news domain.
 
 ### What is already in place
 
@@ -51,13 +52,16 @@ Mako runtime hygiene.
   rendered state supports that classification.
 - Ynet source-health diagnostics now split RSS and category-page checks so RSS low coverage,
   category HTTP failure, category parse-zero, and category keyword-zero outcomes are visible.
+- Search-backed discovery and backfill now emit source-targeted taxonomy queries for every enabled
+  configured news domain, giving the durable candidate layer a domain-constrained fallback when
+  source-native probes zero out.
 - Validation evaluation already reports stage-wise relevance, enforcement, taxonomy, and index
   metrics.
 
 ### What comes next
 
-1. Prioritize search-backed discovery and backfill gaps from the Phase C source-health evidence,
-   especially the #72 systemic source-zero pattern.
+1. Add fixture-backed Ynet/search recall regression coverage for #66 now that the search-backed
+   source-domain query path exists for taxonomy recall terms.
 2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
 3. Treat optional self-healing scaffolding as later work unless the hardened experiment data shows it

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Planned future datasets:
 - Runs Brave, Exa, and Google CSE as external discovery engines feeding the durable candidate layer
 - Adds taxonomy-targeted discovery queries from the packaged TFHT taxonomy for broader
   search-engine recall
+- Adds source-targeted taxonomy queries for each configured news domain so search-backed discovery
+  and historical backfill can compensate when source-native pages produce zero recent matches
 - Keeps Ynet RSS as the primary משפט ופלילים source while adding a non-browser category-page
   backstop for source-native recall
 - Emits Facebook-targeted `social_targeted` search queries and retains those results as non-scrapeable reference candidates

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Planned future datasets:
 - Adds taxonomy-targeted discovery queries from the packaged TFHT taxonomy for broader
   search-engine recall
 - Adds source-targeted taxonomy queries for each configured news domain so search-backed discovery
-  and historical backfill can compensate when source-native pages produce zero recent matches
+  and capped historical backfill can compensate when source-native pages produce zero recent matches
 - Keeps Ynet RSS as the primary משפט ופלילים source while adding a non-browser category-page
   backstop for source-native recall
 - Emits Facebook-targeted `social_targeted` search queries and retains those results as non-scrapeable reference candidates
@@ -300,6 +300,8 @@ DL-PR-06 now builds on the earlier discovery milestones:
   plus Exa-discovered and Google CSE-discovered candidates into the same durable substrate
 - Brave query building for broad and source-targeted discovery searches
 - taxonomy-targeted query building from packaged TFHT discovery terms
+- capped source-targeted taxonomy query building for historical backfill via
+  `backfill.max_source_targeted_taxonomy_queries_per_window`
 - Exa query execution for the same broad and source-targeted discovery searches
 - Google CSE query execution for the same broad and source-targeted discovery searches
 - dedicated `DENBUST_BRAVE_SEARCH_API_KEY`, `DENBUST_EXA_API_KEY`, and

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -35,6 +35,9 @@ denbust run --dataset news_items --job backfill_scrape --config agents/news/loca
 Backfill jobs also read and write the shared `news_items/discover/` candidate-layer state.
 The search-engine side of `discover` and `backfill_discover` now emits `taxonomy_targeted` queries
 from the packaged TFHT taxonomy in addition to the coarse operator keyword list.
+When source-targeted taxonomy expansion is enabled for backfill, each window is capped by
+`backfill.max_source_targeted_taxonomy_queries_per_window` so historical recovery does not
+silently multiply search-engine quota use across every source and taxonomy term.
 
 Use `agents/news/local_search.yaml` only when intentionally exercising source-native discovery
 plus Brave, Exa, and Google CSE locally:

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -62,9 +62,9 @@ The repo currently has 21 issues returned by the repo-specific GitHub MCP. Seven
 | #52 Expose diagnostic-safe public probe helpers for Maariv scraper | Treated | PR #96 added public Maariv diagnostic helpers; close or update the issue with that evidence if it remains open. |
 | #53 Expose diagnostic-safe public probe helpers for ICE scraper | Treated | PR #96 added public ICE diagnostic helpers; close or update the issue with that evidence if it remains open. |
 | #65 Add Ynet category-page backstop for משפט ופלילים discovery | Treated | The source-recall follow-up keeps Ynet RSS primary and adds the non-browser category-page backstop with separate source-health signals. |
-| #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Open | Active but dependent. Decide whether web-search source exists enough now or remains blocked by #65/search path work. |
+| #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Open | Active next follow-up. Source-targeted taxonomy queries now make the search-backed source-domain path stable enough for fixture-backed recall coverage. |
 | #71 Mako source completely failing due to browser navigation issues | Open | Active high-priority source-health issue. Live Mako diagnostics must be run with browser runtime installed. |
-| #72 Major Israeli news sources returning zero results | Open | Active system-level health issue. This is the central local experiment target. |
+| #72 Major Israeli news sources returning zero results | Open | Active system-level health issue treated by the search-backed discovery/backfill follow-through: live diagnostics reproduced Ynet, Walla, Maariv, and ICE source-zero/stale patterns while the query builders now add domain-constrained taxonomy fallback searches. |
 | #74 Mako source experiencing complete failure with browser navigation | Open | Active but likely duplicate/continuation of #71. Verify whether both can be collapsed after the experiment. |
 | #88 Optimize backfill batch aggregate counts in discovery persistence | Open | Active optimization, not a correctness blocker. Measure batch/candidate counts but do not prioritize unless local runs show aggregation is materially slow. |
 
@@ -559,17 +559,19 @@ Create `reports/final_experiment_summary.md` with these sections:
 
 The experiment should not assume these are true, but these are the current hypotheses:
 
-1. `DL-PR-12` is not the only plausible next step. The fresh Phase C source-health run shows the
-   4+ affected-source guardrail firing, so #72 remains the active systemic source-zero follow-up.
+1. `DL-PR-12` is not the only plausible next step. The fresh Phase C source-health run showed the
+   4+ affected-source guardrail firing, so the #72 follow-through expanded search-backed discovery
+   and backfill with source-targeted taxonomy searches.
 2. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
    experiment, regardless of what implementation work comes next.
 3. Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
    after `python -m playwright install chromium`; the current Mako diagnostics are healthy with the
    browser runtime installed.
-4. #72 is the central open reliability question: the current evidence shows Ynet, Walla, Maariv, and
-   ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and Haaretz pass.
-5. #65 is treated by the Ynet category-page backstop; future Ynet work should focus on fixture-based
-   end-to-end coverage or search-backed recall.
+4. #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
+   Maariv, and ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and
+   Haaretz pass, with search-backed fallback coverage now broadened for those domains.
+5. #65 is treated by the Ynet category-page backstop; future Ynet work should focus on #66
+   fixture-backed end-to-end coverage over the stable search-backed source-domain path.
 6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
    issues with that evidence if they remain open.
 7. #88 should stay lower priority unless bounded backfill demonstrates real local slowness.

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -348,6 +348,7 @@ class BackfillConfig(BaseModel):
     batch_window_days: int = Field(default=7, ge=1)
     max_candidates_per_run: int = Field(default=500, ge=1)
     max_scrape_attempts_per_run: int = Field(default=100, ge=1)
+    max_source_targeted_taxonomy_queries_per_window: int = Field(default=50, ge=0)
 
 
 # Default keywords for searching news articles (Hebrew)

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -184,6 +184,30 @@ def build_backfill_queries(
                 )
             )
             seen_keys.add(taxonomy_key)
+            if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+                for source_name, domain in source_domains:
+                    source_key = (
+                        DiscoveryQueryKind.SOURCE_TARGETED,
+                        term,
+                        source_name,
+                        domain,
+                        window.index,
+                    )
+                    if source_key in seen_keys:
+                        continue
+                    queries.append(
+                        DiscoveryQuery(
+                            query_text=term,
+                            language="he",
+                            date_from=window.date_from,
+                            date_to=window.date_to,
+                            preferred_domains=[domain],
+                            source_hint=source_name,
+                            query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                            tags=["backfill", source_name, *tags, f"window:{window.index}"],
+                        )
+                    )
+                    seen_keys.add(source_key)
     return queries
 
 

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -169,6 +169,10 @@ def build_backfill_queries(
 
     if taxonomy_enabled:
         taxonomy_specs = _taxonomy_query_specs()
+        source_targeted_taxonomy_query_count = 0
+        source_targeted_taxonomy_query_limit = (
+            config.backfill.max_source_targeted_taxonomy_queries_per_window
+        )
         for term, tags in taxonomy_specs:
             taxonomy_key = (DiscoveryQueryKind.TAXONOMY_TARGETED, term, window.index)
             if taxonomy_key in seen_keys:
@@ -186,14 +190,17 @@ def build_backfill_queries(
             seen_keys.add(taxonomy_key)
             if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
                 for source_name, domain in source_domains:
-                    source_key = (
+                    if source_targeted_taxonomy_query_count >= source_targeted_taxonomy_query_limit:
+                        break
+                    taxonomy_source_key = (
                         DiscoveryQueryKind.SOURCE_TARGETED,
+                        "taxonomy",
                         term,
                         source_name,
                         domain,
                         window.index,
                     )
-                    if source_key in seen_keys:
+                    if taxonomy_source_key in seen_keys:
                         continue
                     queries.append(
                         DiscoveryQuery(
@@ -207,7 +214,8 @@ def build_backfill_queries(
                             tags=["backfill", source_name, *tags, f"window:{window.index}"],
                         )
                     )
-                    seen_keys.add(source_key)
+                    seen_keys.add(taxonomy_source_key)
+                    source_targeted_taxonomy_query_count += 1
     return queries
 
 

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -119,6 +119,10 @@ class BraveSearchEngine:
                 metadata={
                     "engine": self.name,
                     "query_kind": query.query_kind.value,
+                    "query_tags": query.tags,
+                    "source_targeted_taxonomy": (
+                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                    ),
                     "preferred_domains": query.preferred_domains,
                     "result_url": url,
                     "result_title": result.get("title"),

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -9,7 +9,12 @@ import httpx
 from pydantic import HttpUrl
 
 from denbust.discovery.base import DiscoveryContext
-from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.discovery.models import (
+    DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    ProducerKind,
+)
 from denbust.news_items.normalize import canonicalize_news_url
 
 
@@ -121,7 +126,8 @@ class BraveSearchEngine:
                     "query_kind": query.query_kind.value,
                     "query_tags": query.tags,
                     "source_targeted_taxonomy": (
-                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                        query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+                        and "taxonomy" in query.tags
                     ),
                     "preferred_domains": query.preferred_domains,
                     "result_url": url,

--- a/src/denbust/discovery/engines/exa.py
+++ b/src/denbust/discovery/engines/exa.py
@@ -9,7 +9,12 @@ import httpx
 from pydantic import HttpUrl
 
 from denbust.discovery.base import DiscoveryContext
-from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.discovery.models import (
+    DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    ProducerKind,
+)
 from denbust.news_items.normalize import canonicalize_news_url
 
 
@@ -143,7 +148,8 @@ class ExaSearchEngine:
                     "query_kind": query.query_kind.value,
                     "query_tags": query.tags,
                     "source_targeted_taxonomy": (
-                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                        query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+                        and "taxonomy" in query.tags
                     ),
                     "preferred_domains": query.preferred_domains,
                     "request_id": request_id,

--- a/src/denbust/discovery/engines/exa.py
+++ b/src/denbust/discovery/engines/exa.py
@@ -141,6 +141,10 @@ class ExaSearchEngine:
                 metadata={
                     "engine": self.name,
                     "query_kind": query.query_kind.value,
+                    "query_tags": query.tags,
+                    "source_targeted_taxonomy": (
+                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                    ),
                     "preferred_domains": query.preferred_domains,
                     "request_id": request_id,
                     "result_id": result.get("id"),

--- a/src/denbust/discovery/engines/google_cse.py
+++ b/src/denbust/discovery/engines/google_cse.py
@@ -10,7 +10,12 @@ import httpx
 from pydantic import HttpUrl
 
 from denbust.discovery.base import DiscoveryContext
-from denbust.discovery.models import DiscoveredCandidate, DiscoveryQuery, ProducerKind
+from denbust.discovery.models import (
+    DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    ProducerKind,
+)
 from denbust.news_items.normalize import canonicalize_news_url
 
 
@@ -135,7 +140,8 @@ class GoogleCseSearchEngine:
                     "query_kind": query.query_kind.value,
                     "query_tags": query.tags,
                     "source_targeted_taxonomy": (
-                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                        query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+                        and "taxonomy" in query.tags
                     ),
                     "preferred_domains": query.preferred_domains,
                     "result_url": url,

--- a/src/denbust/discovery/engines/google_cse.py
+++ b/src/denbust/discovery/engines/google_cse.py
@@ -133,6 +133,10 @@ class GoogleCseSearchEngine:
                 metadata={
                     "engine": self.name,
                     "query_kind": query.query_kind.value,
+                    "query_tags": query.tags,
+                    "source_targeted_taxonomy": (
+                        query.query_kind.value == "source_targeted" and "taxonomy" in query.tags
+                    ),
                     "preferred_domains": query.preferred_domains,
                     "result_url": url,
                     "result_title": title if isinstance(title, str) else None,

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -150,5 +150,23 @@ def build_discovery_queries(
                 )
             )
             seen_keys.add(taxonomy_key)
+            if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+                for source_name, domain in source_domains:
+                    source_key = (DiscoveryQueryKind.SOURCE_TARGETED, term, source_name, domain)
+                    if source_key in seen_keys:
+                        continue
+                    queries.append(
+                        DiscoveryQuery(
+                            query_text=term,
+                            language="he",
+                            date_from=date_from,
+                            date_to=date_to,
+                            preferred_domains=[domain],
+                            source_hint=source_name,
+                            query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                            tags=[source_name, *tags],
+                        )
+                    )
+                    seen_keys.add(source_key)
 
     return queries

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -152,8 +152,14 @@ def build_discovery_queries(
             seen_keys.add(taxonomy_key)
             if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
                 for source_name, domain in source_domains:
-                    source_key = (DiscoveryQueryKind.SOURCE_TARGETED, term, source_name, domain)
-                    if source_key in seen_keys:
+                    taxonomy_source_key = (
+                        DiscoveryQueryKind.SOURCE_TARGETED,
+                        "taxonomy",
+                        term,
+                        source_name,
+                        domain,
+                    )
+                    if taxonomy_source_key in seen_keys:
                         continue
                     queries.append(
                         DiscoveryQuery(
@@ -167,6 +173,6 @@ def build_discovery_queries(
                             tags=[source_name, *tags],
                         )
                     )
-                    seen_keys.add(source_key)
+                    seen_keys.add(taxonomy_source_key)
 
     return queries

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -308,9 +308,13 @@ class TestConfig:
         assert config.batch_window_days == 7
         assert config.max_candidates_per_run == 500
         assert config.max_scrape_attempts_per_run == 100
+        assert config.max_source_targeted_taxonomy_queries_per_window == 50
 
         with pytest.raises(ValueError):
             BackfillConfig(batch_window_days=0)
+
+        with pytest.raises(ValueError):
+            BackfillConfig(max_source_targeted_taxonomy_queries_per_window=-1)
 
     def test_store_normalizer_passthrough_for_non_mapping(self) -> None:
         """The pre-validator should pass through non-mapping values unchanged."""

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -201,12 +201,17 @@ def test_build_backfill_queries_normalizes_keywords_and_emits_source_targeted() 
     ]
 
     assert [query.query_text for query in broad_queries] == ["בית בושת", "סחר"]
-    assert len(source_queries) == 4
+    keyword_source_queries = [query for query in source_queries if "taxonomy" not in query.tags]
+    taxonomy_source_queries = [query for query in source_queries if "taxonomy" in query.tags]
+    assert len(keyword_source_queries) == 4
+    assert len(taxonomy_source_queries) == len(taxonomy_queries) * 2
     assert taxonomy_queries
     assert len(social_queries) == 2
-    assert {query.source_hint for query in source_queries} == {"ynet", "walla"}
-    assert all(query.preferred_domains for query in source_queries)
+    assert {query.source_hint for query in keyword_source_queries} == {"ynet", "walla"}
+    assert all(query.preferred_domains for query in keyword_source_queries)
     assert all(not query.preferred_domains for query in taxonomy_queries)
+    assert {query.source_hint for query in taxonomy_source_queries} == {"ynet", "walla"}
+    assert all("backfill" in query.tags and "window:0" in query.tags for query in source_queries)
     assert any(
         query.query_text == "צו הגבלת שימוש"
         and {
@@ -248,6 +253,43 @@ def test_build_backfill_queries_allows_taxonomy_only_generation() -> None:
 
     assert queries
     assert all(query.query_kind is DiscoveryQueryKind.TAXONOMY_TARGETED for query in queries)
+
+
+def test_build_backfill_queries_emits_source_targeted_taxonomy_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backfill taxonomy terms should also be constrained to configured source domains."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [("דירה דיסקרטית", ["taxonomy", "category:brothels"])],
+    )
+    config = Config(
+        keywords=["זנות"],
+        sources=[{"name": "mako", "type": "scraper", "enabled": True}],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 1, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    taxonomy_source_queries = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+        and query.query_text == "דירה דיסקרטית"
+    ]
+    assert len(taxonomy_source_queries) == 1
+    assert taxonomy_source_queries[0].preferred_domains == ["www.mako.co.il"]
+    assert taxonomy_source_queries[0].source_hint == "mako"
+    assert taxonomy_source_queries[0].date_from == window.date_from
+    assert taxonomy_source_queries[0].date_to == window.date_to
+    assert {"backfill", "mako", "taxonomy", "category:brothels", "window:0"}.issubset(
+        set(taxonomy_source_queries[0].tags)
+    )
 
 
 def test_build_backfill_queries_does_not_load_taxonomy_when_disabled(

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -292,6 +292,77 @@ def test_build_backfill_queries_emits_source_targeted_taxonomy_terms(
     )
 
 
+def test_build_backfill_queries_caps_source_targeted_taxonomy_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backfill should cap the taxonomy-derived source-targeted query fanout per window."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [
+            ("דירה דיסקרטית", ["taxonomy", "category:brothels"]),
+            ("צו הגבלת שימוש", ["taxonomy", "category:brothels"]),
+        ],
+    )
+    config = Config(
+        keywords=["זנות"],
+        sources=[
+            {"name": "mako", "type": "scraper", "enabled": True},
+            {"name": "maariv", "type": "scraper", "enabled": True},
+        ],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+        backfill={"max_source_targeted_taxonomy_queries_per_window": 2},
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 1, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    taxonomy_source_queries = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and "taxonomy" in query.tags
+    ]
+    assert len(taxonomy_source_queries) == 2
+    assert [query.query_text for query in taxonomy_source_queries] == [
+        "דירה דיסקרטית",
+        "דירה דיסקרטית",
+    ]
+    assert [query.source_hint for query in taxonomy_source_queries] == ["mako", "maariv"]
+
+
+def test_build_backfill_queries_keeps_taxonomy_source_provenance_for_keyword_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overlapping keyword/taxonomy terms should keep distinct source query provenance."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [("זנות", ["taxonomy", "category:brothels"])],
+    )
+    config = Config(
+        keywords=["זנות"],
+        sources=[{"name": "mako", "type": "scraper", "enabled": True}],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 1, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    source_queries = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and query.query_text == "זנות"
+    ]
+    assert len(source_queries) == 2
+    assert sorted("taxonomy" in query.tags for query in source_queries) == [False, True]
+
+
 def test_build_backfill_queries_does_not_load_taxonomy_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -54,6 +54,7 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
                 preferred_domains=["www.ynet.co.il"],
                 source_hint="ynet",
                 language="he",
+                tags=["ynet", "taxonomy", "category:brothels"],
             )
         ],
         DiscoveryContext(run_id="run-1", max_results_per_query=5),
@@ -74,6 +75,8 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
     assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
     assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
     assert candidates[0].metadata["query_kind"] == "source_targeted"
+    assert candidates[0].metadata["query_tags"] == ["ynet", "taxonomy", "category:brothels"]
+    assert candidates[0].metadata["source_targeted_taxonomy"] is True
     assert candidates[0].metadata["result_url"] == "https://www.ynet.co.il/news/article/abc"
     assert candidates[0].metadata["result_title"] == "פשיטה על בית בושת"
     assert candidates[0].metadata["result_description"] == "המשטרה פשטה על המקום."

--- a/tests/unit/test_discovery_exa.py
+++ b/tests/unit/test_discovery_exa.py
@@ -55,6 +55,7 @@ async def test_exa_search_engine_normalizes_results_and_renders_payload() -> Non
                 language="he",
                 date_from=datetime(2026, 4, 10, tzinfo=UTC),
                 date_to=datetime(2026, 4, 16, tzinfo=UTC),
+                tags=["ynet", "taxonomy", "category:brothels"],
             )
         ],
         DiscoveryContext(run_id="run-1", max_results_per_query=5),
@@ -85,6 +86,8 @@ async def test_exa_search_engine_normalizes_results_and_renders_payload() -> Non
     assert candidates[0].metadata == {
         "engine": "exa",
         "query_kind": "source_targeted",
+        "query_tags": ["ynet", "taxonomy", "category:brothels"],
+        "source_targeted_taxonomy": True,
         "preferred_domains": ["www.ynet.co.il"],
         "request_id": "request-123",
         "result_id": "result-1",

--- a/tests/unit/test_discovery_google_cse.py
+++ b/tests/unit/test_discovery_google_cse.py
@@ -57,6 +57,7 @@ async def test_google_cse_search_engine_normalizes_results_and_renders_params() 
                 preferred_domains=["www.ynet.co.il"],
                 source_hint="ynet",
                 language="he",
+                tags=["ynet", "taxonomy", "category:brothels"],
             )
         ],
         DiscoveryContext(run_id="run-1", max_results_per_query=5),
@@ -83,6 +84,8 @@ async def test_google_cse_search_engine_normalizes_results_and_renders_params() 
     assert candidates[0].metadata == {
         "engine": "google_cse",
         "query_kind": "source_targeted",
+        "query_tags": ["ynet", "taxonomy", "category:brothels"],
+        "source_targeted_taxonomy": True,
         "preferred_domains": ["www.ynet.co.il"],
         "result_url": "https://www.ynet.co.il/news/article/abc?utm_source=google",
         "result_title": "פשיטה על בית בושת",

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -134,6 +134,31 @@ def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
     assert {"mako", "taxonomy", "category:brothels"}.issubset(set(taxonomy_source_queries[0].tags))
 
 
+def test_build_discovery_queries_keeps_taxonomy_source_provenance_for_keyword_overlap(
+    monkeypatch,
+) -> None:
+    """Keyword and taxonomy source queries with the same term should both be retained."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [("זנות", ["taxonomy", "category:brothels"])],
+    )
+    config = Config(
+        keywords=["זנות"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    source_queries = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and query.query_text == "זנות"
+    ]
+    assert len(source_queries) == 2
+    assert sorted("taxonomy" in query.tags for query in source_queries) == [False, True]
+
+
 def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() -> None:
     """Blank/duplicate keywords and unusable sources should be skipped cleanly."""
     config = Config(

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -43,17 +43,25 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     ]
 
     assert len(broad_queries) == 2
-    assert len(targeted_queries) == 4
+    keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
+    taxonomy_targeted_source_queries = [
+        query for query in targeted_queries if "taxonomy" in query.tags
+    ]
+    assert len(keyword_targeted_queries) == 4
+    assert len(taxonomy_targeted_source_queries) == len(taxonomy_queries) * 2
     assert len(taxonomy_queries) == len(
         {term for _, _, term in default_taxonomy().discovery_terms()}
     )
     assert len(social_queries) == 2
     assert {query.query_text for query in broad_queries} == {"בית בושת", "זנות"}
-    assert {(query.source_hint, tuple(query.preferred_domains)) for query in targeted_queries} == {
-        ("ynet", ("www.ynet.co.il",)),
-        ("mako", ("www.mako.co.il",)),
-    }
+    assert {
+        (query.source_hint, tuple(query.preferred_domains)) for query in keyword_targeted_queries
+    } == {("ynet", ("www.ynet.co.il",)), ("mako", ("www.mako.co.il",))}
     assert all(not query.preferred_domains for query in taxonomy_queries)
+    assert {
+        (query.source_hint, tuple(query.preferred_domains))
+        for query in taxonomy_targeted_source_queries
+    } == {("ynet", ("www.ynet.co.il",)), ("mako", ("www.mako.co.il",))}
     assert any(
         query.query_text == "נישואין בכפייה"
         and {
@@ -92,6 +100,40 @@ def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
     assert queries[0].source_hint == "mako"
 
 
+def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
+    monkeypatch,
+) -> None:
+    """Taxonomy recall terms should also be constrained to configured source domains."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [("דירה דיסקרטית", ["taxonomy", "category:brothels"])],
+    )
+    config = Config(
+        keywords=["זנות"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+
+    queries = build_discovery_queries(
+        config,
+        days=5,
+        now=datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+    )
+
+    taxonomy_source_queries = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+        and query.query_text == "דירה דיסקרטית"
+    ]
+    assert len(taxonomy_source_queries) == 1
+    assert taxonomy_source_queries[0].preferred_domains == ["www.mako.co.il"]
+    assert taxonomy_source_queries[0].source_hint == "mako"
+    assert taxonomy_source_queries[0].date_from == datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    assert taxonomy_source_queries[0].date_to == datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+    assert {"mako", "taxonomy", "category:brothels"}.issubset(set(taxonomy_source_queries[0].tags))
+
+
 def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() -> None:
     """Blank/duplicate keywords and unusable sources should be skipped cleanly."""
     config = Config(
@@ -111,15 +153,16 @@ def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() 
     targeted_queries = [
         query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
     ]
+    keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
 
     assert len(broad_queries) == 1
-    assert len(targeted_queries) == 1
+    assert len(keyword_targeted_queries) == 1
     assert broad_queries[0].query_text == "זנות"
-    assert targeted_queries[0].source_hint == "mako"
+    assert keyword_targeted_queries[0].source_hint == "mako"
 
 
-def test_build_discovery_queries_returns_empty_for_empty_keyword_set() -> None:
-    """If all keywords collapse away, only taxonomy-targeted queries should remain."""
+def test_build_discovery_queries_returns_taxonomy_queries_for_empty_keyword_set() -> None:
+    """If keywords collapse away, taxonomy terms should still drive broad and source queries."""
     config = Config(
         keywords=["", "   "],
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
@@ -129,7 +172,11 @@ def test_build_discovery_queries_returns_empty_for_empty_keyword_set() -> None:
     queries = build_discovery_queries(config, days=3)
 
     assert queries
-    assert all(query.query_kind is DiscoveryQueryKind.TAXONOMY_TARGETED for query in queries)
+    assert {query.query_kind for query in queries} == {
+        DiscoveryQueryKind.TAXONOMY_TARGETED,
+        DiscoveryQueryKind.SOURCE_TARGETED,
+    }
+    assert all("taxonomy" in query.tags for query in queries)
 
 
 def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> None:
@@ -151,9 +198,10 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
     targeted_queries = [
         query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
     ]
+    keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
 
-    assert len(targeted_queries) == 1
-    assert targeted_queries[0].preferred_domains == ["www.ynet.co.il"]
+    assert len(keyword_targeted_queries) == 1
+    assert keyword_targeted_queries[0].preferred_domains == ["www.ynet.co.il"]
 
 
 def test_build_discovery_queries_can_disable_social_targeted_generation() -> None:


### PR DESCRIPTION
## Planning notation

- Notation: Phase C #72
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/may_26_experiment_plan.md`

## Summary

This PR implements the smallest search-backed follow-through from the hardened May 2026 experiment path. The fresh live source-health run on May 1, 2026 reproduced the systemic source-zero guardrail with four affected configured sources: Ynet, Walla, Maariv, and ICE. Mako passed with Chromium installed, and Haaretz passed, so this stays focused on #72 rather than #71/#74 runtime hygiene.

The code change expands the existing search-backed discovery/backfill query builders so taxonomy recall terms are not only broad search queries. When `taxonomy_targeted` and `source_targeted` query kinds are enabled, each taxonomy term is also emitted as a source-targeted query for every enabled configured news domain. This gives Brave, Exa, and Google CSE a domain-constrained fallback path for source-zero sources without changing source-native scraping behavior or CI network assumptions.

## Changes

- Add source-targeted taxonomy query generation to current discovery queries.
- Add matching source-targeted taxonomy query generation to historical backfill queries.
- Preserve existing broad taxonomy queries, keyword source-targeted queries, social-targeted queries, and deduplication guards.
- Add unit coverage for the new source-domain taxonomy query behavior in discovery and backfill.
- Update `.agent-plan.md`, `README.md`, `PLAN.md`, and `docs/may_26_experiment_plan.md` to describe the post-merge state and point the next planned work at #66 fixture-backed recall coverage.

## Live diagnostic evidence

Fresh isolated-state source-health command:

```bash
DENBUST_STATE_ROOT=data/may_26_experiment/20260501T204222Z-phase-c-72/state \
  denbust diagnose-sources \
  --config agents/news/local.yaml \
  --live-only \
  --sample-keyword "זנות" \
  --sample-keyword "בית בושת" \
  --sample-keyword "סחר בבני אדם" \
  --format json \
  --output data/may_26_experiment/20260501T204222Z-phase-c-72/artifacts/diagnose_sources_live_all.json
```

Result summary:

- `source_zero_summary.systemic_source_zero_suspected`: `true`
- affected sources: `ynet`, `walla`, `maariv`, `ice`
- passed sources: `mako`, `haaretz`

Generated query check against `agents/news/local_search.yaml` now produces 90 source-targeted taxonomy queries across the six configured domains for both current discovery and backfill, while retaining 25 broad taxonomy queries.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/unit/test_discovery_queries.py tests/unit/test_discovery_backfill.py tests/unit/test_pipeline_core.py tests/unit/test_backfill_pipeline.py tests/unit/test_source_health.py tests/unit/test_discovery_diagnostics.py`
- `pytest -q`
- commit hooks: merge-conflict check, EOF/whitespace checks, Ruff, mypy, smoke tests
- pre-push hooks: merge-conflict check, EOF/whitespace checks, Ruff, unit tests, integration tests

## Follow-up

- #66 should now be the next focused PR: fixture-backed Ynet/search recall regression coverage over the stable search-backed source-domain query path.
- #71/#74 remain Mako hygiene only if a future live Mako probe fails after Chromium is installed.

Addresses #72.