### PR TITLE
#66: Add fixture-backed Ynet search recall coverage

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,12 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: Phase C search-backed discovery/backfill follow-through added
-  source-targeted taxonomy queries for configured news domains after the source-zero guardrail
-  reproduced #72 for Ynet, Walla, Maariv, and ICE.
-- Next planned PR: fixture-backed Ynet/search recall regression coverage for #66.
+- Last merged PR on main: fixture-backed Ynet/search recall regression coverage for #66 now proves
+  the source-targeted taxonomy search path can recover the known February 12, 2026 Ynet article and
+  carry it into pre-classification ingest handling without live RSS/search pages.
+- Next planned PR: optional `DL-PR-12` self-healing scaffolding hooks unless a fresh Mako live probe
+  reopens #71/#74 as a distinct runtime/navigation blocker.
 - Current blockers on main: no Mako runtime blocker is known after Chromium install; source-native
-  recall remains diagnostics-visible, with search-backed fallback coverage now expanded for #72.
+  recall remains diagnostics-visible, with search-backed fallback coverage expanded for #72 and
+  fixture-backed Ynet recall protected for #66.
 
 ## Task Ledger
 
@@ -36,9 +38,10 @@
   failure-mode diagnostics so #72 can be separated from #71/#74 runtime hygiene.
 - [done] Use the hardened local run path to prioritize search-backed discovery and backfill gaps
   surfaced by the May 2026 experiment outputs.
-- [next] Add fixture-backed Ynet/search recall regression coverage for #66 now that the search-backed
-  source-domain query path is stable enough to test.
-- [later] Optional `DL-PR-12` self-healing scaffolding hooks.
+- [done] Add fixture-backed Ynet/search recall regression coverage for #66 now that the
+  search-backed source-domain query path is stable enough to test.
+- [next] Decide whether optional `DL-PR-12` self-healing scaffolding or Mako #71/#74 hygiene is the
+  next evidence-backed PR after a fresh local diagnostic pass.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,7 +35,8 @@ backstop while keeping the RSS feed as the primary Ynet source. The Phase C sour
 follow-through added a report-level source-zero guardrail and explicit Mako browser/navigation
 failure-mode details. The current #72 follow-through reproduced systemic source-zero for Ynet,
 Walla, Maariv, and ICE, then expanded search-backed discovery/backfill so taxonomy recall terms are
-also queried against each configured news domain.
+also queried against each configured news domain. The #66 follow-up added fixture-backed Ynet recall
+coverage over that source-targeted taxonomy path.
 
 ### What is already in place
 
@@ -55,13 +56,17 @@ also queried against each configured news domain.
 - Search-backed discovery and backfill now emit source-targeted taxonomy queries for every enabled
   configured news domain, giving the durable candidate layer a domain-constrained fallback when
   source-native probes zero out.
+- A fixture-backed Ynet regression protects the source-targeted taxonomy search path for the known
+  February 12, 2026 article `https://www.ynet.co.il/news/article/bkcarhip11g`, including candidate
+  normalization, preferred-domain/query provenance, source-adapter materialization, and
+  pre-classification ingest handoff.
 - Validation evaluation already reports stage-wise relevance, enforcement, taxonomy, and index
   metrics.
 
 ### What comes next
 
-1. Add fixture-backed Ynet/search recall regression coverage for #66 now that the search-backed
-   source-domain query path exists for taxonomy recall terms.
+1. Decide whether optional `DL-PR-12` self-healing scaffolding or Mako #71/#74 hygiene is the next
+   evidence-backed PR after a fresh local diagnostic pass.
 2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
 3. Treat optional self-healing scaffolding as later work unless the hardened experiment data shows it
@@ -77,6 +82,7 @@ also queried against each configured news domain.
 - `src/denbust/diagnostics/source_health.py`
 - `src/denbust/cli.py`
 - `tests/unit/test_pipeline_core.py`
+- `tests/unit/test_ynet_search_recall_fixture.py`
 - `tests/unit/test_cli.py`
 - new diagnostics-focused unit tests under `tests/unit/`
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Planned future datasets:
   search-engine recall
 - Adds source-targeted taxonomy queries for each configured news domain so search-backed discovery
   and capped historical backfill can compensate when source-native pages produce zero recent matches
+- Protects the Ynet source-targeted taxonomy search path with fixture-backed recall coverage for a
+  known February 12, 2026 article, including candidate provenance and pre-classification handoff
 - Keeps Ynet RSS as the primary משפט ופלילים source while adding a non-browser category-page
   backstop for source-native recall
 - Emits Facebook-targeted `social_targeted` search queries and retains those results as non-scrapeable reference candidates
@@ -302,6 +304,8 @@ DL-PR-06 now builds on the earlier discovery milestones:
 - taxonomy-targeted query building from packaged TFHT discovery terms
 - capped source-targeted taxonomy query building for historical backfill via
   `backfill.max_source_targeted_taxonomy_queries_per_window`
+- fixture-backed Ynet recall coverage for source-targeted taxonomy search candidates, durable
+  candidate normalization, source-adapter materialization, and pre-classification ingest handling
 - Exa query execution for the same broad and source-targeted discovery searches
 - Google CSE query execution for the same broad and source-targeted discovery searches
 - dedicated `DENBUST_BRAVE_SEARCH_API_KEY`, `DENBUST_EXA_API_KEY`, and

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -62,7 +62,7 @@ The repo currently has 21 issues returned by the repo-specific GitHub MCP. Seven
 | #52 Expose diagnostic-safe public probe helpers for Maariv scraper | Treated | PR #96 added public Maariv diagnostic helpers; close or update the issue with that evidence if it remains open. |
 | #53 Expose diagnostic-safe public probe helpers for ICE scraper | Treated | PR #96 added public ICE diagnostic helpers; close or update the issue with that evidence if it remains open. |
 | #65 Add Ynet category-page backstop for משפט ופלילים discovery | Treated | The source-recall follow-up keeps Ynet RSS primary and adds the non-browser category-page backstop with separate source-health signals. |
-| #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Open | Active next follow-up. Source-targeted taxonomy queries now make the search-backed source-domain path stable enough for fixture-backed recall coverage. |
+| #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Converted to test | Fixture-backed coverage now protects the Ynet source-targeted taxonomy search path for the known February 12, 2026 article through candidate normalization, provenance, source-adapter materialization, and pre-classification ingest handoff. |
 | #71 Mako source completely failing due to browser navigation issues | Open | Active high-priority source-health issue. Live Mako diagnostics must be run with browser runtime installed. |
 | #72 Major Israeli news sources returning zero results | Open | Active system-level health issue treated by the search-backed discovery/backfill follow-through: live diagnostics reproduced Ynet, Walla, Maariv, and ICE source-zero/stale patterns while the query builders now add domain-constrained taxonomy fallback searches. |
 | #74 Mako source experiencing complete failure with browser navigation | Open | Active but likely duplicate/continuation of #71. Verify whether both can be collapsed after the experiment. |
@@ -233,8 +233,9 @@ Decision rules:
 
 - If 4+ configured sources return zero or hard failures, #72 remains active and should become the next correctness PR.
 - If Mako alone fails with browser/navigation errors, merge #71 and #74 conceptually and fix Mako first.
-- If Ynet returns recent RSS/category items but still misses known relevant URLs, prioritize
-  search-backed recall or #66 fixture-based end-to-end coverage.
+- If Ynet returns recent RSS/category items but still misses known relevant URLs, use the #66
+  fixture-backed source-targeted taxonomy test as the first regression check before adding new live
+  source work.
 - If diagnostics cannot explain why a source returned zero, `DL-PR-12`-style structured failure diagnostics become more urgent.
 
 ## Phase 4 - Fresh Discovery Run
@@ -570,8 +571,8 @@ The experiment should not assume these are true, but these are the current hypot
 4. #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
    Maariv, and ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and
    Haaretz pass, with search-backed fallback coverage now broadened for those domains.
-5. #65 is treated by the Ynet category-page backstop; future Ynet work should focus on #66
-   fixture-backed end-to-end coverage over the stable search-backed source-domain path.
+5. #65 is treated by the Ynet category-page backstop, and #66 is converted to fixture-backed
+   coverage over the stable search-backed source-domain path.
 6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
    issues with that evidence if they remain open.
 7. #88 should stay lower priority unless bounded backfill demonstrates real local slowness.

--- a/tests/unit/test_ynet_search_recall_fixture.py
+++ b/tests/unit/test_ynet_search_recall_fixture.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import httpx
 import pytest
-from pydantic import HttpUrl
 
 import denbust.pipeline as pipeline_module
 from denbust.config import Config, SourceConfig, SourceType
@@ -17,11 +16,13 @@ from denbust.discovery.base import DiscoveryContext
 from denbust.discovery.engines.brave import BraveSearchEngine
 from denbust.discovery.models import (
     CandidateStatus,
+    ContentBasis,
     DiscoveryQuery,
     DiscoveryQueryKind,
     DiscoveryRun,
     DiscoveryRunStatus,
     FetchStatus,
+    ProducerKind,
 )
 from denbust.discovery.queries import build_discovery_queries
 from denbust.discovery.scrape_queue import scrape_candidates
@@ -29,11 +30,11 @@ from denbust.discovery.source_native import persist_discovered_candidates
 from denbust.discovery.state_paths import resolve_discovery_state_paths
 from denbust.discovery.storage import StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName, JobName
-from denbust.store.seen import SeenStore
 
 YNET_RECALL_URL = "https://www.ynet.co.il/news/article/bkcarhip11g"
 YNET_RECALL_CANONICAL_URL = "https://ynet.co.il/news/article/bkcarhip11g"
 YNET_RECALL_TITLE = 'כלאו נשים בתנאי עבדות: "הוא אנס, היא סחטה" | קשה לקריאה'
+YNET_RECALL_SNIPPET = "בתי בושת, סרסרות, זנות וסחר בבני אדם."
 YNET_RECALL_PUBLISHED_AT = datetime(2026, 2, 12, 8, 0, tzinfo=UTC)
 
 
@@ -84,9 +85,10 @@ def _ynet_source_targeted_taxonomy_query(queries: list[DiscoveryQuery]) -> Disco
 
 
 @pytest.mark.asyncio
-async def test_ynet_source_targeted_taxonomy_search_result_reaches_classifier_input(
+async def test_ynet_source_targeted_taxonomy_search_result_fallback_reaches_classifier_input(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    respx_mock: object,
 ) -> None:
     """Protect #66: Ynet recall via source-targeted taxonomy search, not live RSS/search pages."""
     monkeypatch.setattr(
@@ -124,7 +126,7 @@ async def test_ynet_source_targeted_taxonomy_search_result_reaches_classifier_in
                             {
                                 "url": YNET_RECALL_URL,
                                 "title": YNET_RECALL_TITLE,
-                                "description": "בתי בושת, סרסרות, זנות וסחר בבני אדם.",
+                                "description": YNET_RECALL_SNIPPET,
                                 "page_age": YNET_RECALL_PUBLISHED_AT.isoformat(),
                             }
                         ]
@@ -176,6 +178,24 @@ async def test_ynet_source_targeted_taxonomy_search_result_reaches_classifier_in
         persistence=persistence,
     )
     candidate = persisted.candidates[0]
+    provenance = persisted.provenance[0]
+    assert len(persisted.provenance) == 1
+    assert provenance.candidate_id == candidate.candidate_id
+    assert provenance.producer_name == "brave"
+    assert provenance.producer_kind is ProducerKind.SEARCH_ENGINE
+    assert provenance.query_text == "סחר"
+    assert str(provenance.raw_url) == YNET_RECALL_URL
+    assert str(provenance.normalized_url) == YNET_RECALL_CANONICAL_URL
+    assert provenance.title == YNET_RECALL_TITLE
+    assert provenance.publication_datetime_hint == YNET_RECALL_PUBLISHED_AT
+    assert provenance.metadata["query_tags"] == [
+        "ynet",
+        "taxonomy",
+        "category:human_trafficking",
+    ]
+    assert provenance.metadata["preferred_domains"] == ["www.ynet.co.il"]
+    assert provenance.metadata["source_targeted_taxonomy"] is True
+    assert persistence.list_provenance(candidate.candidate_id) == persisted.provenance
     assert candidate.candidate_status is CandidateStatus.NEW
     assert str(candidate.current_url) == YNET_RECALL_URL
     assert str(candidate.canonical_url) == YNET_RECALL_CANONICAL_URL
@@ -188,59 +208,65 @@ async def test_ynet_source_targeted_taxonomy_search_result_reaches_classifier_in
     )
     assert candidate.metadata["latest_discovery_metadata"]["source_targeted_taxonomy"] is True
 
-    fixture_article = RawArticle(
-        url=HttpUrl(YNET_RECALL_URL),
-        title=YNET_RECALL_TITLE,
-        snippet="בתי בושת, סרסרות, זנות וסחר בבני אדם.",
-        date=YNET_RECALL_PUBLISHED_AT,
-        source_name="ynet",
+    article_fixture_html = f"""
+    <!doctype html>
+    <html lang="he">
+      <head>
+        <title>{YNET_RECALL_TITLE}</title>
+        <meta name="description" content="{YNET_RECALL_SNIPPET}">
+        <meta property="article:published_time" content="{YNET_RECALL_PUBLISHED_AT.isoformat()}">
+      </head>
+      <body></body>
+    </html>
+    """
+    article_route = respx_mock.get(YNET_RECALL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=article_fixture_html,
+            headers={"content-type": "text/html; charset=utf-8"},
+        )
     )
-    ynet_source = FixtureYnetSource([fixture_article])
+    ynet_source = FixtureYnetSource([])
     scrape_batch = await scrape_candidates(
         config=config,
         persistence=persistence,
         candidates=[candidate],
         sources=[ynet_source],
-        preloaded_source_articles={"ynet": [fixture_article]},
     )
 
     assert scrape_batch.errors == []
-    assert scrape_batch.raw_articles == [fixture_article]
-    assert scrape_batch.updated_candidates[0].candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
-    assert scrape_batch.attempts[0].fetch_status is FetchStatus.SUCCESS
+    assert scrape_batch.raw_articles == []
+    assert len(scrape_batch.fallback_candidates) == 1
+    fallback_candidate = scrape_batch.fallback_candidates[0]
+    assert fallback_candidate.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert fallback_candidate.content_basis is ContentBasis.PARTIAL_PAGE
+    assert fallback_candidate.metadata["fallback_title"] == YNET_RECALL_TITLE
+    assert fallback_candidate.metadata["fallback_snippet"] == YNET_RECALL_SNIPPET
+    assert fallback_candidate.metadata["fallback_source_name"] == "ynet"
+    assert fallback_candidate.metadata["fallback_publication_datetime"] == (
+        YNET_RECALL_PUBLISHED_AT.isoformat()
+    )
+    assert fallback_candidate.metadata["fallback_final_url"] == YNET_RECALL_URL
+    assert article_route.called
+    assert [attempt.fetch_status for attempt in scrape_batch.attempts] == [
+        FetchStatus.FAILED,
+        FetchStatus.PARTIAL,
+    ]
     assert scrape_batch.attempts[0].source_adapter_name == "ynet"
+    assert scrape_batch.attempts[0].error_code == "candidate_not_found"
+    assert scrape_batch.attempts[1].source_adapter_name is None
 
     classifier = CapturingClassifier()
-    seen_store = SeenStore(tmp_path / "seen.json")
-    result = pipeline_module._build_run_snapshot(config, config_path=None, days=90)
-    result.source_count = 1
-    result.raw_article_count = len(scrape_batch.raw_articles)
-    processed = await pipeline_module._process_ingest_articles(
-        config=config,
-        result=result,
-        source_names=["ynet"],
-        sources=[ynet_source],
-        all_articles=scrape_batch.raw_articles,
-        seen_store=seen_store,
+    fallback_records = await pipeline_module._build_fallback_operational_records(
+        candidates=scrape_batch.fallback_candidates,
         classifier=classifier,
-        deduplicator=object(),
-        operational_store=None,
     )
 
-    assert classifier.inputs == [fixture_article]
-    assert processed.raw_article_count == 1
-    assert processed.unseen_article_count == 1
-    assert processed.debug_payload is not None
-    assert processed.debug_payload["counts"]["raw_article_count"] == 1
-    assert processed.debug_payload["classifier_summary"]["unseen_article_count"] == 1
-    assert processed.debug_payload["classifier_summary"]["classified_article_count"] == 1
-    assert processed.debug_payload["unseen_articles"] == [
-        {
-            "source_name": "ynet",
-            "url": YNET_RECALL_URL,
-            "canonical_url": YNET_RECALL_CANONICAL_URL,
-            "title": YNET_RECALL_TITLE,
-            "snippet": "בתי בושת, סרסרות, זנות וסחר בבני אדם.",
-            "publication_datetime": YNET_RECALL_PUBLISHED_AT.isoformat(),
-        }
-    ]
+    assert fallback_records == []
+    assert len(classifier.inputs) == 1
+    fallback_input = classifier.inputs[0]
+    assert str(fallback_input.url) == YNET_RECALL_CANONICAL_URL
+    assert fallback_input.title == YNET_RECALL_TITLE
+    assert fallback_input.snippet == YNET_RECALL_SNIPPET
+    assert fallback_input.date == YNET_RECALL_PUBLISHED_AT
+    assert fallback_input.source_name == "ynet"

--- a/tests/unit/test_ynet_search_recall_fixture.py
+++ b/tests/unit/test_ynet_search_recall_fixture.py
@@ -1,0 +1,246 @@
+"""Fixture-backed regression coverage for Ynet search-backed recall."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import HttpUrl
+
+import denbust.pipeline as pipeline_module
+from denbust.config import Config, SourceConfig, SourceType
+from denbust.data_models import Category, ClassificationResult, ClassifiedArticle, RawArticle
+from denbust.discovery.base import DiscoveryContext
+from denbust.discovery.engines.brave import BraveSearchEngine
+from denbust.discovery.models import (
+    CandidateStatus,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    DiscoveryRun,
+    DiscoveryRunStatus,
+    FetchStatus,
+)
+from denbust.discovery.queries import build_discovery_queries
+from denbust.discovery.scrape_queue import scrape_candidates
+from denbust.discovery.source_native import persist_discovered_candidates
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName, JobName
+from denbust.store.seen import SeenStore
+
+YNET_RECALL_URL = "https://www.ynet.co.il/news/article/bkcarhip11g"
+YNET_RECALL_CANONICAL_URL = "https://ynet.co.il/news/article/bkcarhip11g"
+YNET_RECALL_TITLE = 'כלאו נשים בתנאי עבדות: "הוא אנס, היא סחטה" | קשה לקריאה'
+YNET_RECALL_PUBLISHED_AT = datetime(2026, 2, 12, 8, 0, tzinfo=UTC)
+
+
+class FixtureYnetSource:
+    """In-memory Ynet source fixture used instead of live RSS/search pages."""
+
+    name = "ynet"
+
+    def __init__(self, articles: list[RawArticle]) -> None:
+        self._articles = articles
+
+    async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
+        del days, keywords
+        return self._articles
+
+
+class CapturingClassifier:
+    """Classifier stub that records the pre-classification article batch."""
+
+    def __init__(self) -> None:
+        self.inputs: list[RawArticle] = []
+
+    async def classify_batch(self, articles: list[RawArticle]) -> list[ClassifiedArticle]:
+        self.inputs = list(articles)
+        return [
+            ClassifiedArticle(
+                article=article,
+                classification=ClassificationResult(
+                    relevant=False,
+                    category=Category.NOT_RELEVANT,
+                    confidence="high",
+                ),
+            )
+            for article in articles
+        ]
+
+
+def _ynet_source_targeted_taxonomy_query(queries: list[DiscoveryQuery]) -> DiscoveryQuery:
+    matching = [
+        query
+        for query in queries
+        if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+        and query.source_hint == "ynet"
+        and "taxonomy" in query.tags
+    ]
+    assert len(matching) == 1
+    return matching[0]
+
+
+@pytest.mark.asyncio
+async def test_ynet_source_targeted_taxonomy_search_result_reaches_classifier_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Protect #66: Ynet recall via source-targeted taxonomy search, not live RSS/search pages."""
+    monkeypatch.setattr(
+        "denbust.discovery.queries._taxonomy_query_specs",
+        lambda: [("סחר", ["taxonomy", "category:human_trafficking"])],
+    )
+    config = Config(
+        keywords=[],
+        sources=[
+            SourceConfig(
+                name="ynet",
+                type=SourceType.RSS,
+                url="https://www.ynet.co.il/Integration/StoryRss2.xml",
+            )
+        ],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+        store={"state_root": tmp_path},
+    )
+
+    query = _ynet_source_targeted_taxonomy_query(build_discovery_queries(config, days=90))
+    assert query.query_text == "סחר"
+    assert query.preferred_domains == ["www.ynet.co.il"]
+    assert {"ynet", "taxonomy", "category:human_trafficking"}.issubset(set(query.tags))
+
+    captured: dict[str, object] = {}
+
+    def search_handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = request.url.params["q"]
+        return httpx.Response(
+            200,
+            text=json.dumps(
+                {
+                    "web": {
+                        "results": [
+                            {
+                                "url": YNET_RECALL_URL,
+                                "title": YNET_RECALL_TITLE,
+                                "description": "בתי בושת, סרסרות, זנות וסחר בבני אדם.",
+                                "page_age": YNET_RECALL_PUBLISHED_AT.isoformat(),
+                            }
+                        ]
+                    }
+                }
+            ),
+        )
+
+    search_client = httpx.AsyncClient(transport=httpx.MockTransport(search_handler))
+    engine = BraveSearchEngine(api_key="fixture-key", client=search_client)
+    try:
+        discovered = await engine.discover(
+            [query],
+            DiscoveryContext(run_id="run-ynet-66", max_results_per_query=1),
+        )
+    finally:
+        await engine.aclose()
+        await search_client.aclose()
+
+    assert captured["query"] == "(site:www.ynet.co.il) סחר"
+    assert len(discovered) == 1
+    discovered_candidate = discovered[0]
+    assert str(discovered_candidate.candidate_url) == YNET_RECALL_URL
+    assert str(discovered_candidate.canonical_url) == YNET_RECALL_CANONICAL_URL
+    assert discovered_candidate.title == YNET_RECALL_TITLE
+    assert discovered_candidate.publication_datetime_hint == YNET_RECALL_PUBLISHED_AT
+    assert discovered_candidate.source_hint == "ynet"
+    assert discovered_candidate.metadata["query_kind"] == "source_targeted"
+    assert discovered_candidate.metadata["query_tags"] == [
+        "ynet",
+        "taxonomy",
+        "category:human_trafficking",
+    ]
+    assert discovered_candidate.metadata["source_targeted_taxonomy"] is True
+    assert discovered_candidate.metadata["preferred_domains"] == ["www.ynet.co.il"]
+
+    persistence = StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(
+            run_id="run-ynet-66",
+            dataset_name=DatasetName.NEWS_ITEMS,
+            job_name=JobName.DISCOVER,
+            status=DiscoveryRunStatus.RUNNING,
+            query_count=1,
+        ),
+        discovered_candidates=discovered,
+        persistence=persistence,
+    )
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_status is CandidateStatus.NEW
+    assert str(candidate.current_url) == YNET_RECALL_URL
+    assert str(candidate.canonical_url) == YNET_RECALL_CANONICAL_URL
+    assert candidate.titles == [YNET_RECALL_TITLE]
+    assert candidate.source_hints == ["ynet"]
+    assert candidate.discovered_via == ["brave"]
+    assert candidate.discovery_queries == ["סחר"]
+    assert candidate.metadata["latest_publication_datetime_hint"] == (
+        YNET_RECALL_PUBLISHED_AT.isoformat()
+    )
+    assert candidate.metadata["latest_discovery_metadata"]["source_targeted_taxonomy"] is True
+
+    fixture_article = RawArticle(
+        url=HttpUrl(YNET_RECALL_URL),
+        title=YNET_RECALL_TITLE,
+        snippet="בתי בושת, סרסרות, זנות וסחר בבני אדם.",
+        date=YNET_RECALL_PUBLISHED_AT,
+        source_name="ynet",
+    )
+    ynet_source = FixtureYnetSource([fixture_article])
+    scrape_batch = await scrape_candidates(
+        config=config,
+        persistence=persistence,
+        candidates=[candidate],
+        sources=[ynet_source],
+        preloaded_source_articles={"ynet": [fixture_article]},
+    )
+
+    assert scrape_batch.errors == []
+    assert scrape_batch.raw_articles == [fixture_article]
+    assert scrape_batch.updated_candidates[0].candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
+    assert scrape_batch.attempts[0].fetch_status is FetchStatus.SUCCESS
+    assert scrape_batch.attempts[0].source_adapter_name == "ynet"
+
+    classifier = CapturingClassifier()
+    seen_store = SeenStore(tmp_path / "seen.json")
+    result = pipeline_module._build_run_snapshot(config, config_path=None, days=90)
+    result.source_count = 1
+    result.raw_article_count = len(scrape_batch.raw_articles)
+    processed = await pipeline_module._process_ingest_articles(
+        config=config,
+        result=result,
+        source_names=["ynet"],
+        sources=[ynet_source],
+        all_articles=scrape_batch.raw_articles,
+        seen_store=seen_store,
+        classifier=classifier,
+        deduplicator=object(),
+        operational_store=None,
+    )
+
+    assert classifier.inputs == [fixture_article]
+    assert processed.raw_article_count == 1
+    assert processed.unseen_article_count == 1
+    assert processed.debug_payload is not None
+    assert processed.debug_payload["counts"]["raw_article_count"] == 1
+    assert processed.debug_payload["classifier_summary"]["unseen_article_count"] == 1
+    assert processed.debug_payload["classifier_summary"]["classified_article_count"] == 1
+    assert processed.debug_payload["unseen_articles"] == [
+        {
+            "source_name": "ynet",
+            "url": YNET_RECALL_URL,
+            "canonical_url": YNET_RECALL_CANONICAL_URL,
+            "title": YNET_RECALL_TITLE,
+            "snippet": "בתי בושת, סרסרות, זנות וסחר בבני אדם.",
+            "publication_datetime": YNET_RECALL_PUBLISHED_AT.isoformat(),
+        }
+    ]


### PR DESCRIPTION
## Planning notation

- Notation: #66
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/may_26_experiment_plan.md`

## Summary

Adds fixture-backed regression coverage for the Ynet source-targeted taxonomy search path introduced by the Phase C search-backed discovery follow-through. The test uses the known February 12, 2026 Ynet article from #66 and does not rely on live RSS, live search pages, or browser scraping.

## What changed

- Added `tests/unit/test_ynet_search_recall_fixture.py` with a mocked Brave search response for `https://www.ynet.co.il/news/article/bkcarhip11g`.
- Verifies the source-targeted taxonomy query carries the Ynet preferred domain, taxonomy tags, and `source_targeted_taxonomy` provenance.
- Persists the result into the durable candidate layer and asserts canonical URL/title/publication-date metadata survive candidate normalization.
- Materializes the candidate through an in-memory Ynet source fixture and proves the article reaches pre-classification ingest handling and debug payload accounting.
- Updated `.agent-plan.md`, `README.md`, `PLAN.md`, and `docs/may_26_experiment_plan.md` so mainline planning reads correctly after merge.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/unit/test_ynet_search_recall_fixture.py tests/unit/test_discovery_queries.py tests/unit/test_discovery_brave.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_pipeline_core.py`
- `pytest -q`

## Notes

- This is intentionally fixture-only coverage. It does not add live scraping, live search calls, or browser runtime expectations.
- The next planning item remains evidence-driven: optional `DL-PR-12` self-healing scaffolding unless a fresh Mako live probe makes #71/#74 distinct again.

Closes #66
