### PR TITLE
Phase C #97: Share validation row integrity rules

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,9 +6,9 @@
 
 ## Mainline Status
 
-- Last merged PR on main: fixture-backed Ynet/search recall regression coverage for #66 now proves
-  the source-targeted taxonomy search path can recover the known February 12, 2026 Ynet article and
-  carry it into pre-classification ingest handling without live RSS/search pages.
+- Last merged PR on main: shared validation row-integrity rules for #97 now keep taxonomy
+  pair/version, legacy category compatibility, and `index_relevant` checks aligned between
+  `denbust validation-lint` and validation finalize/import.
 - Next planned PR: optional `DL-PR-12` self-healing scaffolding hooks unless a fresh Mako live probe
   reopens #71/#74 as a distinct runtime/navigation blocker.
 - Current blockers on main: no Mako runtime blocker is known after Chromium install; source-native
@@ -40,6 +40,8 @@
   surfaced by the May 2026 experiment outputs.
 - [done] Add fixture-backed Ynet/search recall regression coverage for #66 now that the
   search-backed source-domain query path is stable enough to test.
+- [done] Share validation taxonomy/category/index-relevance row-integrity rules between
+  validation lint and finalize/import for #97.
 - [next] Decide whether optional `DL-PR-12` self-healing scaffolding or Mako #71/#74 hygiene is the
   next evidence-backed PR after a fresh local diagnostic pass.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,7 +36,9 @@ follow-through added a report-level source-zero guardrail and explicit Mako brow
 failure-mode details. The current #72 follow-through reproduced systemic source-zero for Ynet,
 Walla, Maariv, and ICE, then expanded search-backed discovery/backfill so taxonomy recall terms are
 also queried against each configured news domain. The #66 follow-up added fixture-backed Ynet recall
-coverage over that source-targeted taxonomy path.
+coverage over that source-targeted taxonomy path. The #97 validation follow-up now shares
+taxonomy/category/index-relevance row-integrity checks between validation lint and finalize/import,
+so permanent-set preflight and reviewed-row ingestion enforce the same semantic invariants.
 
 ### What is already in place
 
@@ -62,6 +64,8 @@ coverage over that source-targeted taxonomy path.
   pre-classification ingest handoff.
 - Validation evaluation already reports stage-wise relevance, enforcement, taxonomy, and index
   metrics.
+- Validation lint and reviewed-row finalize/import now share row-level taxonomy pair/version,
+  legacy category compatibility, and `index_relevant` checks.
 
 ### What comes next
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Planned future datasets:
   `denbust diagnose-discovery`
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains
 - Lints the tracked classifier validation CSV with `denbust validation-lint`
+- Shares validation taxonomy/category/index-relevance row-integrity rules between
+  `denbust validation-lint` and reviewed-row finalize/import
 - Runs tracked classifier/live-source scenarios with `denbust live-check`
 - Runs scheduled GitHub Actions discovery separately from candidate-driven ingest
 - Exposes manual GitHub Actions workflows for historical `backfill_discover` and `backfill_scrape`

--- a/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
+++ b/docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md
@@ -39,11 +39,13 @@ This note breaks Milestone 3 from [CHATGPT_26_04_PLAN.md](/Users/shaypalachy/clo
   booleans/datetimes/categories, invalid taxonomy pairs, and relevant rows missing taxonomy labels
   fail locally before API calls.
 - Keep `denbust validation-lint --validation-set ...` available for credential-free checks.
+- Share taxonomy/category/index-relevance row-integrity checks between validation lint and
+  reviewed-row finalize/import, while leaving CSV-shape diagnostics in the lint layer.
 - Treat Anthropic provider/API failures as fatal run errors instead of synthetic `not_relevant`
   predictions.
 - Keep local validation and live-check outputs untracked; summarize the results in PRs or operator
   notes.
-- Status: current hardening follow-up.
+- Status: merged hardening follow-up.
 
 ## Sequencing
 

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -67,6 +67,7 @@ The repo currently has 21 issues returned by the repo-specific GitHub MCP. Seven
 | #72 Major Israeli news sources returning zero results | Open | Active system-level health issue treated by the search-backed discovery/backfill follow-through: live diagnostics reproduced Ynet, Walla, Maariv, and ICE source-zero/stale patterns while the query builders now add domain-constrained taxonomy fallback searches. |
 | #74 Mako source experiencing complete failure with browser navigation | Open | Active but likely duplicate/continuation of #71. Verify whether both can be collapsed after the experiment. |
 | #88 Optimize backfill batch aggregate counts in discovery persistence | Open | Active optimization, not a correctness blocker. Measure batch/candidate counts but do not prioritize unless local runs show aggregation is materially slow. |
+| #97 Share validation taxonomy rules between lint and finalize | Treated | The validation follow-up now routes taxonomy pair/version, legacy category compatibility, and `index_relevant` row checks through shared validation code used by both lint and reviewed-row finalize/import. |
 
 ### Initial local-state warning
 

--- a/src/denbust/validation/dataset.py
+++ b/src/denbust/validation/dataset.py
@@ -125,12 +125,13 @@ def validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> Vali
     if integrity.issues:
         raise ValueError(_reviewed_row_error_message(integrity.issues[0].message))
 
+    assert integrity.category is not None
+    assert integrity.enforcement_related is not None
+    assert integrity.index_relevant is not None
     category = integrity.category
-    if category is None:
-        raise ValueError(f"Invalid category value: {category_value!r}")
     sub_category = integrity.sub_category
-    enforcement_related = bool(integrity.enforcement_related)
-    index_relevant = bool(integrity.index_relevant)
+    enforcement_related = integrity.enforcement_related
+    index_relevant = integrity.index_relevant
     taxonomy_version = integrity.taxonomy_version
     taxonomy_category_id = integrity.taxonomy_category_id
     taxonomy_subcategory_id = integrity.taxonomy_subcategory_id

--- a/src/denbust/validation/dataset.py
+++ b/src/denbust/validation/dataset.py
@@ -6,10 +6,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from denbust.data_models import Category, SubCategory
 from denbust.taxonomy import default_taxonomy
 from denbust.validation.common import (
-    ALLOWED_SUBCATEGORIES_BY_CATEGORY,
     DEFAULT_VALIDATION_SET_PATH,
     VALIDATION_SET_COLUMNS,
     canonicalize_csv_url,
@@ -22,6 +20,7 @@ from denbust.validation.common import (
     write_csv_rows,
 )
 from denbust.validation.models import ValidationSetRow
+from denbust.validation.row_integrity import RowIntegrityInput, validate_row_integrity
 
 
 @dataclass(frozen=True)
@@ -107,57 +106,43 @@ def validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> Vali
     relevant = parse_bool(raw_row["relevant"])
     enforcement_related = parse_bool(raw_row.get("enforcement_related", "False") or "False")
     index_relevant = parse_bool(raw_row.get("index_relevant", "False") or "False")
-    taxonomy_version = raw_row.get("taxonomy_version", "").strip()
-    taxonomy_category_id = raw_row.get("taxonomy_category_id", "").strip()
-    taxonomy_subcategory_id = raw_row.get("taxonomy_subcategory_id", "").strip()
     category_value = normalize_category_value(raw_row["category"])
     sub_category_value = normalize_subcategory_value(raw_row["sub_category"])
+    integrity = validate_row_integrity(
+        RowIntegrityInput(
+            relevant=relevant,
+            enforcement_related=enforcement_related,
+            index_relevant=index_relevant,
+            category_value=category_value,
+            sub_category_value=sub_category_value,
+            taxonomy_version=raw_row.get("taxonomy_version", ""),
+            taxonomy_category_id=raw_row.get("taxonomy_category_id", ""),
+            taxonomy_subcategory_id=raw_row.get("taxonomy_subcategory_id", ""),
+            normalize_non_relevant=True,
+        ),
+        taxonomy=taxonomy,
+    )
+    if integrity.issues:
+        raise ValueError(_reviewed_row_error_message(integrity.issues[0].message))
 
-    if relevant:
-        category = Category(category_value)
-        if category == Category.NOT_RELEVANT:
-            raise ValueError("Reviewed relevant rows cannot use category 'not_relevant'")
-        sub_category = None
-        if sub_category_value:
-            sub_category = SubCategory(sub_category_value)
-            allowed = ALLOWED_SUBCATEGORIES_BY_CATEGORY[category]
-            if sub_category not in allowed:
-                raise ValueError(
-                    f"Invalid sub_category '{sub_category.value}' for category '{category.value}'"
-                )
-        elif enforcement_related and not (taxonomy_category_id and taxonomy_subcategory_id):
-            raise ValueError(
-                "Reviewed enforcement-related rows must include a non-empty sub_category"
-            )
-    else:
-        category = Category.NOT_RELEVANT
-        enforcement_related = False
-        index_relevant = False
-        taxonomy_version = ""
-        taxonomy_category_id = ""
-        taxonomy_subcategory_id = ""
-        sub_category = None
+    category = integrity.category
+    if category is None:
+        raise ValueError(f"Invalid category value: {category_value!r}")
+    sub_category = integrity.sub_category
+    enforcement_related = bool(integrity.enforcement_related)
+    index_relevant = bool(integrity.index_relevant)
+    taxonomy_version = integrity.taxonomy_version
+    taxonomy_category_id = integrity.taxonomy_category_id
+    taxonomy_subcategory_id = integrity.taxonomy_subcategory_id
 
-    if taxonomy_category_id or taxonomy_subcategory_id:
-        if not (taxonomy_category_id and taxonomy_subcategory_id):
-            raise ValueError("Taxonomy labels must include both category and subcategory ids")
-        if not taxonomy.has_pair(taxonomy_category_id, taxonomy_subcategory_id):
-            raise ValueError(
-                f"Invalid taxonomy pair: {taxonomy_category_id}/{taxonomy_subcategory_id}"
-            )
-        if taxonomy_version and taxonomy_version != taxonomy.version:
-            raise ValueError(
-                f"Unsupported taxonomy version {taxonomy_version!r}; expected {taxonomy.version!r}"
-            )
+    if relevant and (
+        sub_category is None
+        and enforcement_related
+        and not (taxonomy_category_id and taxonomy_subcategory_id)
+    ):
+        raise ValueError("Reviewed enforcement-related rows must include a non-empty sub_category")
+    if taxonomy_category_id and taxonomy_subcategory_id:
         taxonomy_version = taxonomy.version
-        expected_index_relevant = taxonomy.is_index_relevant(
-            taxonomy_category_id,
-            taxonomy_subcategory_id,
-        )
-        if index_relevant != expected_index_relevant:
-            raise ValueError(
-                "index_relevant does not match the packaged taxonomy for the selected leaf"
-            )
 
     finalized_at = datetime.now(UTC)
     return ValidationSetRow(
@@ -189,6 +174,14 @@ def validate_reviewed_row(raw_row: dict[str, str], *, draft_source: str) -> Vali
         finalized_at=finalized_at,
         draft_source=draft_source,
     )
+
+
+def _reviewed_row_error_message(message: str) -> str:
+    if message == "Relevant rows cannot use category 'not_relevant'":
+        return "Reviewed relevant rows cannot use category 'not_relevant'"
+    if message.startswith("index_relevant does not match the packaged taxonomy"):
+        return "index_relevant does not match the packaged taxonomy for the selected leaf"
+    return message
 
 
 def finalize_validation_set(

--- a/src/denbust/validation/lint.py
+++ b/src/denbust/validation/lint.py
@@ -6,15 +6,14 @@ import csv
 from dataclasses import dataclass
 from pathlib import Path
 
-from denbust.data_models import Category, SubCategory
 from denbust.taxonomy import TaxonomyDefinition, default_taxonomy
 from denbust.validation.common import (
-    ALLOWED_SUBCATEGORIES_BY_CATEGORY,
     DEFAULT_VALIDATION_SET_PATH,
     VALIDATION_SET_COLUMNS,
     parse_bool,
     parse_datetime,
 )
+from denbust.validation.row_integrity import RowIntegrityInput, validate_row_integrity
 
 
 @dataclass(frozen=True)
@@ -78,57 +77,7 @@ def _lint_datetime(
         issues.append(ValidationLintIssue(row_number=row_number, field=field, message=str(exc)))
 
 
-def _lint_category(
-    issues: list[ValidationLintIssue],
-    *,
-    row_number: int,
-    row: dict[str, str],
-) -> tuple[Category | None, SubCategory | None]:
-    category: Category | None = None
-    sub_category: SubCategory | None = None
-    category_value = row.get("category", "").strip()
-    sub_category_value = row.get("sub_category", "").strip()
-    try:
-        category = Category(category_value)
-    except ValueError:
-        issues.append(
-            ValidationLintIssue(
-                row_number=row_number,
-                field="category",
-                message=f"Invalid category value: {category_value!r}",
-            )
-        )
-
-    if sub_category_value:
-        try:
-            sub_category = SubCategory(sub_category_value)
-        except ValueError:
-            issues.append(
-                ValidationLintIssue(
-                    row_number=row_number,
-                    field="sub_category",
-                    message=f"Invalid sub_category value: {sub_category_value!r}",
-                )
-            )
-
-    if category is not None and sub_category is not None:
-        allowed = ALLOWED_SUBCATEGORIES_BY_CATEGORY.get(category, set())
-        if sub_category not in allowed:
-            issues.append(
-                ValidationLintIssue(
-                    row_number=row_number,
-                    field="sub_category",
-                    message=(
-                        f"Invalid sub_category {sub_category.value!r} "
-                        f"for category {category.value!r}"
-                    ),
-                )
-            )
-
-    return category, sub_category
-
-
-def _lint_taxonomy(
+def _lint_row_integrity(
     issues: list[ValidationLintIssue],
     *,
     row_number: int,
@@ -137,68 +86,29 @@ def _lint_taxonomy(
     index_relevant: bool | None,
     taxonomy: TaxonomyDefinition,
 ) -> None:
-    taxonomy_version = row.get("taxonomy_version", "").strip()
-    category_id = row.get("taxonomy_category_id", "").strip()
-    subcategory_id = row.get("taxonomy_subcategory_id", "").strip()
-
-    if relevant and not (taxonomy_version and category_id and subcategory_id):
+    result = validate_row_integrity(
+        RowIntegrityInput(
+            relevant=relevant,
+            enforcement_related=None,
+            index_relevant=index_relevant,
+            category_value=row.get("category", ""),
+            sub_category_value=row.get("sub_category", ""),
+            taxonomy_version=row.get("taxonomy_version", ""),
+            taxonomy_category_id=row.get("taxonomy_category_id", ""),
+            taxonomy_subcategory_id=row.get("taxonomy_subcategory_id", ""),
+            require_taxonomy_for_relevant=True,
+            require_taxonomy_version=True,
+        ),
+        taxonomy=taxonomy,
+    )
+    for issue in result.issues:
         issues.append(
             ValidationLintIssue(
                 row_number=row_number,
-                field="taxonomy_category_id",
-                message="Relevant rows must include taxonomy_version and taxonomy ids",
+                field=issue.field,
+                message=issue.message,
             )
         )
-        return
-
-    if not (taxonomy_version or category_id or subcategory_id):
-        return
-
-    if not (taxonomy_version and category_id and subcategory_id):
-        issues.append(
-            ValidationLintIssue(
-                row_number=row_number,
-                field="taxonomy_category_id",
-                message="Taxonomy labels must include version, category, and subcategory",
-            )
-        )
-        return
-
-    if taxonomy_version != taxonomy.version:
-        issues.append(
-            ValidationLintIssue(
-                row_number=row_number,
-                field="taxonomy_version",
-                message=(
-                    f"Unsupported taxonomy version {taxonomy_version!r}; "
-                    f"expected {taxonomy.version!r}"
-                ),
-            )
-        )
-
-    if not taxonomy.has_pair(category_id, subcategory_id):
-        issues.append(
-            ValidationLintIssue(
-                row_number=row_number,
-                field="taxonomy_subcategory_id",
-                message=f"Invalid taxonomy pair: {category_id}/{subcategory_id}",
-            )
-        )
-        return
-
-    if index_relevant is not None:
-        expected = taxonomy.is_index_relevant(category_id, subcategory_id)
-        if index_relevant != expected:
-            issues.append(
-                ValidationLintIssue(
-                    row_number=row_number,
-                    field="index_relevant",
-                    message=(
-                        "index_relevant does not match the packaged taxonomy "
-                        f"for {category_id}/{subcategory_id}"
-                    ),
-                )
-            )
 
 
 def lint_validation_set(
@@ -256,20 +166,7 @@ def lint_validation_set(
                 row=row,
                 field="index_relevant",
             )
-            category, _sub_category = _lint_category(
-                issues,
-                row_number=row_number,
-                row=row,
-            )
-            if relevant and category == Category.NOT_RELEVANT:
-                issues.append(
-                    ValidationLintIssue(
-                        row_number=row_number,
-                        field="category",
-                        message="Relevant rows cannot use category 'not_relevant'",
-                    )
-                )
-            _lint_taxonomy(
+            _lint_row_integrity(
                 issues,
                 row_number=row_number,
                 row=row,

--- a/src/denbust/validation/row_integrity.py
+++ b/src/denbust/validation/row_integrity.py
@@ -47,11 +47,6 @@ class RowIntegrityResult:
     enforcement_related: bool | None
     index_relevant: bool | None
 
-    @property
-    def passed(self) -> bool:
-        """Return whether the row passed all row-level checks."""
-        return not self.issues
-
 
 def validate_row_integrity(
     row: RowIntegrityInput,

--- a/src/denbust/validation/row_integrity.py
+++ b/src/denbust/validation/row_integrity.py
@@ -1,0 +1,289 @@
+"""Shared row-level validation integrity rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from denbust.data_models import Category, SubCategory
+from denbust.taxonomy import TaxonomyDefinition
+from denbust.validation.common import ALLOWED_SUBCATEGORIES_BY_CATEGORY
+
+
+@dataclass(frozen=True)
+class RowIntegrityInput:
+    """Parsed fields needed for validation row integrity checks."""
+
+    relevant: bool | None
+    enforcement_related: bool | None
+    index_relevant: bool | None
+    category_value: str
+    sub_category_value: str
+    taxonomy_version: str
+    taxonomy_category_id: str
+    taxonomy_subcategory_id: str
+    require_taxonomy_for_relevant: bool = False
+    require_taxonomy_version: bool = False
+    normalize_non_relevant: bool = False
+
+
+@dataclass(frozen=True)
+class RowIntegrityIssue:
+    """One row-level validation integrity issue."""
+
+    field: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RowIntegrityResult:
+    """Result of shared row-level integrity checks."""
+
+    issues: list[RowIntegrityIssue]
+    category: Category | None
+    sub_category: SubCategory | None
+    taxonomy_version: str
+    taxonomy_category_id: str
+    taxonomy_subcategory_id: str
+    enforcement_related: bool | None
+    index_relevant: bool | None
+
+    @property
+    def passed(self) -> bool:
+        """Return whether the row passed all row-level checks."""
+        return not self.issues
+
+
+def validate_row_integrity(
+    row: RowIntegrityInput,
+    *,
+    taxonomy: TaxonomyDefinition,
+) -> RowIntegrityResult:
+    """Validate shared category/taxonomy/index invariants for one row."""
+    issues: list[RowIntegrityIssue] = []
+    relevant = row.relevant
+    enforcement_related = row.enforcement_related
+    index_relevant = row.index_relevant
+    taxonomy_version = row.taxonomy_version.strip()
+    taxonomy_category_id = row.taxonomy_category_id.strip()
+    taxonomy_subcategory_id = row.taxonomy_subcategory_id.strip()
+
+    if relevant is False and row.normalize_non_relevant:
+        enforcement_related = False
+        index_relevant = False
+        taxonomy_version = ""
+        taxonomy_category_id = ""
+        taxonomy_subcategory_id = ""
+        return RowIntegrityResult(
+            issues=issues,
+            category=Category.NOT_RELEVANT,
+            sub_category=None,
+            taxonomy_version=taxonomy_version,
+            taxonomy_category_id=taxonomy_category_id,
+            taxonomy_subcategory_id=taxonomy_subcategory_id,
+            enforcement_related=enforcement_related,
+            index_relevant=index_relevant,
+        )
+
+    category = _parse_category(issues, row.category_value)
+    sub_category = _parse_sub_category(issues, row.sub_category_value)
+
+    _validate_relevant_category(issues, relevant, category)
+    _validate_legacy_category_pair(issues, category, sub_category)
+
+    if (
+        relevant
+        and row.require_taxonomy_for_relevant
+        and not (taxonomy_version and taxonomy_category_id and taxonomy_subcategory_id)
+    ):
+        issues.append(
+            RowIntegrityIssue(
+                field="taxonomy_category_id",
+                message="Relevant rows must include taxonomy_version and taxonomy ids",
+            )
+        )
+        return RowIntegrityResult(
+            issues=issues,
+            category=category,
+            sub_category=sub_category,
+            taxonomy_version=taxonomy_version,
+            taxonomy_category_id=taxonomy_category_id,
+            taxonomy_subcategory_id=taxonomy_subcategory_id,
+            enforcement_related=enforcement_related,
+            index_relevant=index_relevant,
+        )
+
+    _validate_taxonomy(
+        issues,
+        taxonomy=taxonomy,
+        taxonomy_version=taxonomy_version,
+        taxonomy_category_id=taxonomy_category_id,
+        taxonomy_subcategory_id=taxonomy_subcategory_id,
+        require_taxonomy_version=row.require_taxonomy_version,
+        index_relevant=index_relevant,
+        category=category,
+        sub_category=sub_category,
+    )
+
+    return RowIntegrityResult(
+        issues=issues,
+        category=category,
+        sub_category=sub_category,
+        taxonomy_version=taxonomy_version,
+        taxonomy_category_id=taxonomy_category_id,
+        taxonomy_subcategory_id=taxonomy_subcategory_id,
+        enforcement_related=enforcement_related,
+        index_relevant=index_relevant,
+    )
+
+
+def _parse_category(issues: list[RowIntegrityIssue], value: str) -> Category | None:
+    try:
+        return Category(value.strip())
+    except ValueError:
+        issues.append(
+            RowIntegrityIssue(
+                field="category",
+                message=f"Invalid category value: {value.strip()!r}",
+            )
+        )
+        return None
+
+
+def _parse_sub_category(issues: list[RowIntegrityIssue], value: str) -> SubCategory | None:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return SubCategory(stripped)
+    except ValueError:
+        issues.append(
+            RowIntegrityIssue(
+                field="sub_category",
+                message=f"Invalid sub_category value: {stripped!r}",
+            )
+        )
+        return None
+
+
+def _validate_legacy_category_pair(
+    issues: list[RowIntegrityIssue],
+    category: Category | None,
+    sub_category: SubCategory | None,
+) -> None:
+    if category is None or sub_category is None:
+        return
+    allowed = ALLOWED_SUBCATEGORIES_BY_CATEGORY.get(category, set())
+    if sub_category not in allowed:
+        issues.append(
+            RowIntegrityIssue(
+                field="sub_category",
+                message=f"Invalid sub_category {sub_category.value!r} for category {category.value!r}",
+            )
+        )
+
+
+def _validate_relevant_category(
+    issues: list[RowIntegrityIssue],
+    relevant: bool | None,
+    category: Category | None,
+) -> None:
+    if relevant and category == Category.NOT_RELEVANT:
+        issues.append(
+            RowIntegrityIssue(
+                field="category",
+                message="Relevant rows cannot use category 'not_relevant'",
+            )
+        )
+
+
+def _validate_taxonomy(
+    issues: list[RowIntegrityIssue],
+    *,
+    taxonomy: TaxonomyDefinition,
+    taxonomy_version: str,
+    taxonomy_category_id: str,
+    taxonomy_subcategory_id: str,
+    require_taxonomy_version: bool,
+    index_relevant: bool | None,
+    category: Category | None,
+    sub_category: SubCategory | None,
+) -> None:
+    has_version = bool(taxonomy_version)
+    has_category_id = bool(taxonomy_category_id)
+    has_subcategory_id = bool(taxonomy_subcategory_id)
+    if not (has_version or has_category_id or has_subcategory_id):
+        return
+
+    if not (has_category_id and has_subcategory_id):
+        issues.append(
+            RowIntegrityIssue(
+                field="taxonomy_category_id",
+                message="Taxonomy labels must include both category and subcategory ids",
+            )
+        )
+        return
+
+    if require_taxonomy_version and not has_version:
+        issues.append(
+            RowIntegrityIssue(
+                field="taxonomy_category_id",
+                message="Taxonomy labels must include version, category, and subcategory",
+            )
+        )
+        return
+
+    if taxonomy_version and taxonomy_version != taxonomy.version:
+        issues.append(
+            RowIntegrityIssue(
+                field="taxonomy_version",
+                message=(
+                    f"Unsupported taxonomy version {taxonomy_version!r}; "
+                    f"expected {taxonomy.version!r}"
+                ),
+            )
+        )
+
+    if not taxonomy.has_pair(taxonomy_category_id, taxonomy_subcategory_id):
+        issues.append(
+            RowIntegrityIssue(
+                field="taxonomy_subcategory_id",
+                message=f"Invalid taxonomy pair: {taxonomy_category_id}/{taxonomy_subcategory_id}",
+            )
+        )
+        return
+
+    expected_category, expected_sub_category = taxonomy.legacy_mapping(
+        taxonomy_category_id,
+        taxonomy_subcategory_id,
+    )
+    if category is not None and category != expected_category:
+        issues.append(
+            RowIntegrityIssue(
+                field="category",
+                message="category does not match the packaged taxonomy legacy mapping",
+            )
+        )
+    if sub_category is not None and sub_category != expected_sub_category:
+        issues.append(
+            RowIntegrityIssue(
+                field="sub_category",
+                message="sub_category does not match the packaged taxonomy legacy mapping",
+            )
+        )
+
+    if index_relevant is None:
+        return
+    expected_index_relevant = taxonomy.is_index_relevant(
+        taxonomy_category_id,
+        taxonomy_subcategory_id,
+    )
+    if index_relevant != expected_index_relevant:
+        issues.append(
+            RowIntegrityIssue(
+                field="index_relevant",
+                message=(
+                    "index_relevant does not match the packaged taxonomy "
+                    f"for {taxonomy_category_id}/{taxonomy_subcategory_id}"
+                ),
+            )
+        )

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -134,6 +134,48 @@ def build_validation_csv_row(**overrides: str) -> dict[str, str]:
     return row
 
 
+def build_validation_draft_row(**overrides: str) -> dict[str, str]:
+    """Create a valid reviewed validation draft row for tests."""
+    row = {
+        "source_name": "mako",
+        "article_date": "2026-03-03T00:00:00+00:00",
+        "url": "https://example.com/b",
+        "canonical_url": "https://example.com/b",
+        "title": "title b",
+        "snippet": "snippet b",
+        "suggested_relevant": "True",
+        "suggested_enforcement_related": "True",
+        "suggested_index_relevant": "True",
+        "suggested_taxonomy_version": "1",
+        "suggested_taxonomy_category_id": "brothels",
+        "suggested_taxonomy_subcategory_id": "administrative_closure",
+        "suggested_category": "brothel",
+        "suggested_sub_category": "closure",
+        "suggested_confidence": "high",
+        "relevant": "True",
+        "enforcement_related": "True",
+        "index_relevant": "True",
+        "taxonomy_version": "1",
+        "taxonomy_category_id": "brothels",
+        "taxonomy_subcategory_id": "administrative_closure",
+        "category": "brothel",
+        "sub_category": "closure",
+        "review_status": "reviewed",
+        "annotation_source": "tfht_manual_tracking_v1",
+        "expected_month_bucket": "",
+        "expected_city": "",
+        "expected_status": "",
+        "manual_city": "",
+        "manual_address": "",
+        "manual_event_label": "",
+        "manual_status": "",
+        "annotation_notes": "",
+        "collected_at": "2026-03-03T00:00:00+00:00",
+    }
+    row.update(overrides)
+    return row
+
+
 class FakeSource:
     """Simple validation collection source stub."""
 
@@ -932,6 +974,69 @@ class TestValidationFinalize:
         with pytest.raises(ValueError, match=match):
             finalize_validation_set(input_path=draft_path, validation_set_path=tmp_path / "out.csv")
 
+    @pytest.mark.parametrize(
+        ("overrides", "lint_match", "finalize_match"),
+        [
+            (
+                {
+                    "taxonomy_category_id": "brothels",
+                    "taxonomy_subcategory_id": "not_a_leaf",
+                },
+                "Invalid taxonomy pair",
+                "Invalid taxonomy pair",
+            ),
+            (
+                {
+                    "taxonomy_category_id": "brothels",
+                    "taxonomy_subcategory_id": "",
+                },
+                "Relevant rows must include taxonomy_version and taxonomy ids",
+                "Taxonomy labels must include both category and subcategory ids",
+            ),
+            (
+                {
+                    "category": "pimping",
+                    "sub_category": "arrest",
+                },
+                "category does not match the packaged taxonomy legacy mapping",
+                "category does not match the packaged taxonomy legacy mapping",
+            ),
+            (
+                {
+                    "index_relevant": "False",
+                },
+                "index_relevant does not match the packaged taxonomy",
+                "index_relevant does not match the packaged taxonomy",
+            ),
+        ],
+    )
+    def test_lint_and_finalize_share_taxonomy_integrity_rejections(
+        self,
+        tmp_path: Path,
+        overrides: dict[str, str],
+        lint_match: str,
+        finalize_match: str,
+    ) -> None:
+        validation_path = tmp_path / "validation.csv"
+        write_csv_rows(
+            validation_path,
+            VALIDATION_SET_COLUMNS,
+            [build_validation_csv_row(**overrides)],
+        )
+        lint_result = lint_validation_set(validation_path)
+
+        draft_path = tmp_path / "draft.csv"
+        write_csv_rows(
+            draft_path,
+            DRAFT_COLUMNS,
+            [build_validation_draft_row(**overrides)],
+        )
+
+        assert lint_result.passed is False
+        assert lint_match in "\n".join(issue.render() for issue in lint_result.issues)
+        with pytest.raises(ValueError, match=finalize_match):
+            finalize_validation_set(input_path=draft_path, validation_set_path=tmp_path / "out.csv")
+
     def test_finalize_validation_set_normalizes_valid_taxonomy_version(
         self, tmp_path: Path
     ) -> None:
@@ -1396,6 +1501,32 @@ class TestValidationEvaluate:
         assert "Invalid sub_category 'arrest' for category 'brothel'" in rendered
         assert "index_relevant does not match the packaged taxonomy" in rendered
         assert "Relevant rows cannot use category 'not_relevant'" in rendered
+
+    def test_validation_lint_keeps_non_relevant_rows_label_strict(self, tmp_path: Path) -> None:
+        validation_path = tmp_path / "validation.csv"
+        write_csv_rows(
+            validation_path,
+            VALIDATION_SET_COLUMNS,
+            [
+                build_validation_csv_row(
+                    relevant="False",
+                    enforcement_related="False",
+                    index_relevant="False",
+                    taxonomy_version="",
+                    taxonomy_category_id="",
+                    taxonomy_subcategory_id="",
+                    category="definitely_invalid",
+                    sub_category="also_invalid",
+                )
+            ],
+        )
+
+        result = lint_validation_set(validation_path)
+
+        rendered = "\n".join(issue.render() for issue in result.issues)
+        assert result.passed is False
+        assert "Invalid category value: 'definitely_invalid'" in rendered
+        assert "Invalid sub_category value: 'also_invalid'" in rendered
 
     def test_validation_lint_reports_missing_file_empty_file_and_bad_header(
         self, tmp_path: Path

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -18,6 +18,7 @@ from denbust.data_models import (
     RawArticle,
     SubCategory,
 )
+from denbust.taxonomy import default_taxonomy
 from denbust.validation.collect import (
     collect_validation_draft,
     run_validation_collect,
@@ -58,6 +59,7 @@ from denbust.validation.evaluate import (
 )
 from denbust.validation.lint import lint_validation_set, run_validation_lint
 from denbust.validation.models import ClassifierVariantSpec, VariantMetrics
+from denbust.validation.row_integrity import RowIntegrityInput, validate_row_integrity
 
 
 def build_raw_article(
@@ -1527,6 +1529,50 @@ class TestValidationEvaluate:
         assert result.passed is False
         assert "Invalid category value: 'definitely_invalid'" in rendered
         assert "Invalid sub_category value: 'also_invalid'" in rendered
+
+    def test_row_integrity_reports_missing_taxonomy_version_when_required(self) -> None:
+        result = validate_row_integrity(
+            RowIntegrityInput(
+                relevant=True,
+                enforcement_related=True,
+                index_relevant=True,
+                category_value="brothel",
+                sub_category_value="closure",
+                taxonomy_version="",
+                taxonomy_category_id="brothels",
+                taxonomy_subcategory_id="administrative_closure",
+                require_taxonomy_version=True,
+            ),
+            taxonomy=default_taxonomy(),
+        )
+
+        assert [
+            (issue.field, issue.message)
+            for issue in result.issues
+            if issue.field == "taxonomy_category_id"
+        ] == [
+            (
+                "taxonomy_category_id",
+                "Taxonomy labels must include version, category, and subcategory",
+            )
+        ]
+
+    def test_row_integrity_accepts_taxonomy_pair_without_index_relevance_check(self) -> None:
+        result = validate_row_integrity(
+            RowIntegrityInput(
+                relevant=True,
+                enforcement_related=True,
+                index_relevant=None,
+                category_value="brothel",
+                sub_category_value="closure",
+                taxonomy_version="1",
+                taxonomy_category_id="brothels",
+                taxonomy_subcategory_id="administrative_closure",
+            ),
+            taxonomy=default_taxonomy(),
+        )
+
+        assert result.issues == []
 
     def test_validation_lint_reports_missing_file_empty_file_and_bad_header(
         self, tmp_path: Path


### PR DESCRIPTION
## Planning notation

- Notation: Phase C #97
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md`

## What changed

- Added `src/denbust/validation/row_integrity.py` as the shared semantic validation boundary for reviewed validation rows.
- Routed both `denbust validation-lint` and `validate_reviewed_row()` through the shared row-integrity checks.
- Kept CSV-shape diagnostics in the lint layer, including headers, row numbers, missing fields, malformed rows, and extra columns.
- Preserved finalize/import behavior for non-relevant rows and existing error messages that tests rely on.
- Added regression coverage proving lint and finalize/import reject the same invalid taxonomy pair, partial taxonomy ID, legacy category compatibility mismatch, and `index_relevant` mismatch cases.
- Updated planning/docs surfaces to describe the post-merge #97 state.

## Why

Issue #97 identified duplicated taxonomy/category/index-relevance logic between validation lint and finalize/import. This made future taxonomy rule changes risky because permanent-set preflight and reviewed-row ingestion could drift.

## Impact

Validation lint and reviewed-row finalization now share the same semantic invariant implementation while keeping their user-facing responsibilities separate. Lint still owns CSV diagnostics; finalize/import still normalizes accepted reviewed rows and preserves backward-compatible handling.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/unit/test_validation.py tests/unit/test_validation_import_reviewed.py tests/unit/test_validation_taxonomy_metrics.py`
- `pytest -q`

## Follow-up

- No follow-up is required for #97 after merge.

Closes #97
