### PR TITLE
DL-PR-12: Add self-healing scaffolding hooks

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -9,11 +9,11 @@
 - Last merged PR on main: shared validation row-integrity rules for #97 now keep taxonomy
   pair/version, legacy category compatibility, and `index_relevant` checks aligned between
   `denbust validation-lint` and validation finalize/import.
-- Next planned PR: optional `DL-PR-12` self-healing scaffolding hooks unless a fresh Mako live probe
-  reopens #71/#74 as a distinct runtime/navigation blocker.
+- Next planned PR: run a fresh source-health diagnostic pass to decide whether #71/#74 can be
+  closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
 - Current blockers on main: no Mako runtime blocker is known after Chromium install; source-native
   recall remains diagnostics-visible, with search-backed fallback coverage expanded for #72 and
-  fixture-backed Ynet recall protected for #66.
+  fixture-backed Ynet recall protected for #66; self-healing is scaffolded but not automated.
 
 ## Task Ledger
 
@@ -42,8 +42,11 @@
   search-backed source-domain query path is stable enough to test.
 - [done] Share validation taxonomy/category/index-relevance row-integrity rules between
   validation lint and finalize/import for #97.
-- [next] Decide whether optional `DL-PR-12` self-healing scaffolding or Mako #71/#74 hygiene is the
-  next evidence-backed PR after a fresh local diagnostic pass.
+- [done] Add optional `DL-PR-12` self-healing scaffolding hooks: explicit self-heal eligibility
+  diagnostics, structured scrape-failure grouping, and future self-heal retry selection without AI
+  repair.
+- [next] Run a fresh local source-health diagnostic pass and use it to decide whether #71/#74 can be
+  closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: May 2026 Experiment Follow-Through
+## Current Next Focus: Source-Health Follow-Through After DL-PR-12
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -39,6 +39,10 @@ also queried against each configured news domain. The #66 follow-up added fixtur
 coverage over that source-targeted taxonomy path. The #97 validation follow-up now shares
 taxonomy/category/index-relevance row-integrity checks between validation lint and finalize/import,
 so permanent-set preflight and reviewed-row ingestion enforce the same semantic invariants.
+`DL-PR-12` now adds the smallest self-healing on-ramp: scrape failures are grouped into structured
+diagnostic buckets, the queue reports self-heal-eligible candidates, generic fetch/source-adapter
+attempts carry stable failure-stage diagnostics, and future orchestration can select
+self-heal-eligible failed candidates without running AI repair.
 
 ### What is already in place
 
@@ -50,6 +54,10 @@ so permanent-set preflight and reviewed-row ingestion enforce the same semantic 
   cases.
 - Source-health diagnostics include a `source_zero_summary` that flags the 4+ affected-source
   guardrail used to decide whether a run is systemic rather than source-specific.
+- Discovery diagnostics include structured scrape-failure groups keyed by attempt kind, fetch
+  status, error code, source adapter, and domain, including self-heal-eligible counts.
+- Candidate scrape failures mark durable candidates as `self_heal_eligible`, and the candidate queue
+  exposes a future self-heal selector without changing current ingest/backfill behavior.
 - Mako live diagnostics distinguish missing browser runtime, navigation timeout, context destroyed,
   redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero failure modes where the
   rendered state supports that classification.
@@ -69,12 +77,12 @@ so permanent-set preflight and reviewed-row ingestion enforce the same semantic 
 
 ### What comes next
 
-1. Decide whether optional `DL-PR-12` self-healing scaffolding or Mako #71/#74 hygiene is the next
-   evidence-backed PR after a fresh local diagnostic pass.
+1. Run a fresh local source-health diagnostic pass and use it to decide whether #71/#74 can be
+   closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
 2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-3. Treat optional self-healing scaffolding as later work unless the hardened experiment data shows it
-   is the highest-leverage next step.
+3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
+   self-heal implementation PR has fresh failure evidence.
 
 ### Likely code touchpoints
 
@@ -82,7 +90,9 @@ so permanent-set preflight and reviewed-row ingestion enforce the same semantic 
 - `src/denbust/discovery/state_paths.py`
 - `src/denbust/discovery/storage.py`
 - `src/denbust/discovery/models.py`
+- `src/denbust/discovery/scrape_queue.py`
 - `src/denbust/diagnostics/__init__.py`
+- `src/denbust/diagnostics/discovery.py`
 - `src/denbust/diagnostics/source_health.py`
 - `src/denbust/cli.py`
 - `tests/unit/test_pipeline_core.py`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Planned future datasets:
   + Google CSE discovery experiments
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
+- Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
+  repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains
 - Lints the tracked classifier validation CSV with `denbust validation-lint`
 - Shares validation taxonomy/category/index-relevance row-integrity rules between
@@ -348,6 +350,11 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   4+ affected-source guardrail, plus Mako `failure_mode` details for missing Chromium, navigation
   timeout, context teardown, redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero
   outcomes
+- `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
+  `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
+  attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable
+  failure-stage diagnostics, and code can select eligible failed candidates for a later
+  `self_heal_retry` orchestration pass without implementing AI repair.
 
 ## Config Layout
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -187,6 +187,23 @@ state_repo/news_items/backfill_scrape/
 operationally sensitive. Operators should choose when to spend scrape budget on historical work
 instead of scheduling it blindly.
 
+## Self-Heal Scaffolding
+
+`DL-PR-12` does not run AI repair. It only makes the future repair backlog explicit:
+
+- failed scrape candidates can be marked `self_heal_eligible`
+- `denbust diagnose-discovery` reports the self-heal-eligible queue count
+- the persisted discovery diagnostics artifact includes structured scrape-failure groups by attempt
+  kind, fetch status, error code, source adapter, and domain
+- source-adapter and generic-fetch attempts include stable `failure_stage` diagnostics where the
+  failure path is known
+- future orchestration can select eligible failed candidates and record a `self_heal_retry` scrape
+  attempt after a repair strategy exists
+
+Do not treat these hooks as permission to rewrite selectors, create sources, or call an AI repair
+loop automatically. Those behaviors need a separate implementation PR with live failure evidence and
+fixture-backed regression tests.
+
 Classifier provider/API failures are fatal for `ingest`, `scrape_candidates`, and
 `backfill_scrape`. A run that cannot reach Anthropic records a sanitized
 `classifier_provider_error=...`, sets `fatal=true`, returns `fatal: classifier provider error`, and

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -25,14 +25,14 @@ next PR.
 
 | Document | Current signal for this experiment |
 |---|---|
-| `.agent-plan.md` | Main operational pointer. It says the next planned PR is optional `DL-PR-12` self-healing scaffolding hooks, with no current blockers. |
+| `.agent-plan.md` | Main operational pointer. After `DL-PR-12`, it points to a fresh source-health diagnostic pass to decide whether #71/#74 can close as duplicate Mako hygiene or whether #72 needs another source-native reliability PR. |
 | `PLAN.md` | Human plan map, but currently stale. It still describes "Post-`DL-PR-07`" and says `DL-PR-08` is next even though later discovery PRs have shipped. Treat as a doc-drift signal, not as source of truth. |
 | `README.md` | Most complete current user-facing description of implemented jobs: discover, backfill discover/scrape, ingest, monthly report, release, backup, diagnostics, daily AI review. |
 | `docs/CHATGPT_26_04_PLAN.md` | Main product/data roadmap. It frames the next major work as taxonomy, validation, product alignment, manual corrections, monthly reporting, and minisite export. Much of this appears partly implemented and needs verification. |
 | `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` | Validation sub-plan. It says PR 3.4 typology-aware evaluation reports is the current next PR, which conflicts with `.agent-plan.md`. Treat as a stale or parallel sub-plan until measured. |
 | `docs/PHASE_C_PLAN.md` | Phase C plan. C-8 is marked implemented and the 90-day catch-up remains an operator-run backfill. Use it to verify taxonomy keyword/backfill assumptions. |
 | `docs/tfht_discovery_layer_design_amended.md` | Discovery architecture design. It defines the durable candidate layer, backfill, diagnostics, self-healing fields, and the key evaluation methodology. |
-| `docs/tfht_discovery_layer_implementation_plan.md` | Discovery rollout plan. It says `DL-PR-12` is optional self-healing scaffolding only, not full self-healing. |
+| `docs/tfht_discovery_layer_implementation_plan.md` | Discovery rollout plan. It now records `DL-PR-12` as self-healing scaffolding only, not full self-healing. |
 | `docs/discovery_operations.md` | Local and GitHub runbook after `DL-PR-11`. Use its commands as the starting point for local experiments. |
 | `docs/2026_04_04_tfht_state_of_project_report.md` | Orientation report. It correctly predicts the next major axis as typology, validation, and product alignment. |
 | `docs/articles_examples.md` | Known source/article watchlist. It should become a machine-readable coverage fixture or feed one. |
@@ -237,7 +237,8 @@ Decision rules:
 - If Ynet returns recent RSS/category items but still misses known relevant URLs, use the #66
   fixture-backed source-targeted taxonomy test as the first regression check before adding new live
   source work.
-- If diagnostics cannot explain why a source returned zero, `DL-PR-12`-style structured failure diagnostics become more urgent.
+- If diagnostics cannot explain why a source returned zero after `DL-PR-12`, add a source-health
+  diagnostics follow-up rather than jumping straight to automatic self-healing.
 
 ## Phase 4 - Fresh Discovery Run
 
@@ -577,7 +578,9 @@ The experiment should not assume these are true, but these are the current hypot
 6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
    issues with that evidence if they remain open.
 7. #88 should stay lower priority unless bounded backfill demonstrates real local slowness.
-8. The repo needs a first-class experiment or live-check CLI if these checks are going to be run more
+8. `DL-PR-12` provides structured scrape-failure diagnostics and self-heal eligibility hooks, but
+   full AI repair remains future work.
+9. The repo needs a first-class experiment or live-check CLI if these checks are going to be run more
    than once.
 
 ## Completion Criteria

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -874,12 +874,23 @@ Self-healing needs a backlog of failures to learn from and re-attempt.
 - repeated blocks/timeouts
 - candidates that are valuable but currently unsupported
 
+### Current scaffolding hooks
+The implemented layer now stops at explicit hooks:
+- `self_heal_eligible` is set on failed scrape candidates and reported in queue-health diagnostics
+- scrape failure diagnostics are grouped by attempt kind, fetch status, error code, source adapter,
+  and domain, including counts of self-heal-eligible candidates
+- source-adapter match/fetch failures and generic fetch/extract failures carry stable
+  `failure_stage` diagnostics
+- future orchestration can select eligible failed candidates and record attempts with
+  `attempt_kind = "self_heal_retry"`
+
 ### Candidate-layer fields that support this
 - `last_scrape_error_code`
 - `last_scrape_error_message`
 - `scrape_attempt_count`
 - `self_heal_eligible`
 - provenance/source adapter metadata
+- scrape-attempt `diagnostics_json`
 
 ### Future self-heal job
 Could:
@@ -888,6 +899,10 @@ Could:
 - suggest source-adapter changes
 - create a revised scrape attempt
 - update candidate status and attempt logs
+
+It should not infer repairs from free-text alone; it should consume the structured failure
+diagnostics and append a `self_heal_retry` scrape attempt only after a concrete repair strategy is
+chosen.
 
 This requires the durable candidate queue/history that this amended design introduces.
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -409,11 +409,26 @@ The feature is operationally usable in CI/GitHub Actions.
 ### Goal
 Add explicit hooks for the future AI-based self-healing phase without implementing it yet.
 
+### Status
+Implemented by the scaffolding PR after the #97 validation-rule follow-up.
+
 ### Scope
 - add `self_heal_eligible` plumbing where still missing
 - add structured scrape-failure diagnostics
 - add explicit self-heal retry attempt kind
 - add docs for future self-heal workflow
+
+### Implemented notes
+- `PersistentCandidate.self_heal_eligible` remains the durable queue flag and is surfaced in
+  discovery queue-health diagnostics.
+- `ScrapeAttemptKind.SELF_HEAL_RETRY` is the explicit attempt kind reserved for a future
+  orchestration pass.
+- Scrape failures now have structured diagnostic groupings by attempt kind, fetch status, error
+  code, source adapter, and domain, with counts for self-heal-eligible candidates.
+- Source-adapter and generic-fetch failures carry stable failure-stage diagnostics so future repair
+  code can reason over failure classes without parsing free-text error messages.
+- The queue exposes selection for self-heal-eligible failed candidates, but no AI repair,
+  selector rewriting, source creation, or live-network-dependent behavior is implemented.
 
 ### Deliverable
 A clean on-ramp for the next large feature, but not the feature itself.
@@ -459,6 +474,12 @@ The recommended order is:
 
 ### After DL-PR-11
 - the feature can be used operationally in CI/jobs
+
+### After DL-PR-12
+- self-heal-eligible failures are visible in diagnostics
+- scrape failure classes are structured enough for later repair triage
+- future self-heal orchestration can select eligible failed candidates and record
+  `self_heal_retry` attempts, but no automatic repair runs yet
 
 ---
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -93,6 +93,7 @@ class QueueHealthMetrics(BaseModel):
     full_article_page_candidates: int = 0
     stale_candidates: int = 0
     retry_backlog_candidates: int = 0
+    self_heal_eligible_candidates: int = 0
 
 
 class ProducerConversionMetrics(BaseModel):
@@ -132,6 +133,19 @@ class FailureSummary(BaseModel):
 
     name: str
     count: int
+
+
+class ScrapeFailureDiagnostic(BaseModel):
+    """Structured scrape-failure group for future self-heal triage."""
+
+    attempt_kind: str
+    fetch_status: str
+    error_code: str
+    source_adapter_name: str
+    domain: str
+    count: int = 0
+    self_heal_eligible_count: int = 0
+    latest_attempt_at: datetime | None = None
 
 
 class SourceSuggestion(BaseModel):
@@ -178,6 +192,7 @@ class DiscoveryDiagnosticReport(BaseModel):
     top_failure_sources: list[FailureSummary] = Field(default_factory=list)
     top_failure_domains: list[FailureSummary] = Field(default_factory=list)
     top_failure_codes: list[FailureSummary] = Field(default_factory=list)
+    scrape_failure_diagnostics: list[ScrapeFailureDiagnostic] = Field(default_factory=list)
     source_suggestions: SourceSuggestionReport = Field(default_factory=SourceSuggestionReport)
 
 
@@ -253,6 +268,7 @@ def build_discovery_diagnostic_report(
         top_failure_sources=_build_failure_summaries(candidates, attempts, key="source"),
         top_failure_domains=_build_failure_summaries(candidates, attempts, key="domain"),
         top_failure_codes=_build_failure_summaries(candidates, attempts, key="error_code"),
+        scrape_failure_diagnostics=_build_scrape_failure_diagnostics(candidates, attempts),
         source_suggestions=_build_source_suggestion_report(
             config=config,
             candidates=candidates,
@@ -343,7 +359,8 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
     lines.append(
         "  failed={scrape_failed_candidates} partial={partially_scraped_candidates} "
         "unsupported={unsupported_source_candidates} stale={stale_candidates} "
-        "retry_backlog={retry_backlog_candidates}".format(**queue.model_dump(mode="json"))
+        "retry_backlog={retry_backlog_candidates} "
+        "self_heal_eligible={self_heal_eligible_candidates}".format(**queue.model_dump(mode="json"))
     )
     lines.append(
         "  basis search_result_only={search_result_only_candidates} "
@@ -384,6 +401,17 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
             "Top failure codes: "
             + ", ".join(f"{item.name}={item.count}" for item in report.top_failure_codes)
         )
+    if report.scrape_failure_diagnostics:
+        lines.append("")
+        lines.append("Structured scrape failures")
+        for failure in report.scrape_failure_diagnostics:
+            lines.append(
+                "  {error_code} source={source_adapter_name} domain={domain} "
+                "kind={attempt_kind} status={fetch_status} count={count} "
+                "self_heal_eligible={self_heal_eligible_count}".format(
+                    **failure.model_dump(mode="json")
+                )
+            )
     if report.source_suggestions.suggestions:
         lines.append("")
         lines.append("Source suggestions")
@@ -532,6 +560,9 @@ def _build_queue_health_metrics(
         full_article_page_candidates=basis_counts[ContentBasis.FULL_ARTICLE_PAGE],
         stale_candidates=stale,
         retry_backlog_candidates=retry_backlog,
+        self_heal_eligible_candidates=sum(
+            1 for candidate in candidates if candidate.self_heal_eligible
+        ),
     )
 
 
@@ -668,6 +699,61 @@ def _build_failure_summaries(
             raise ValueError(f"Unsupported failure summary key: {key}")
         counts[value] += 1
     return [FailureSummary(name=name, count=count) for name, count in counts.most_common(5)]
+
+
+def _build_scrape_failure_diagnostics(
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+) -> list[ScrapeFailureDiagnostic]:
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    grouped: dict[tuple[str, str, str, str, str], ScrapeFailureDiagnostic] = {}
+    for attempt in attempts:
+        if attempt.fetch_status is FetchStatus.SUCCESS:
+            continue
+        candidate = candidate_by_id.get(attempt.candidate_id)
+        domain = (
+            candidate.domain
+            if candidate is not None and candidate.domain is not None
+            else "unknown"
+        )
+        source_adapter_name = attempt.source_adapter_name or "unknown"
+        error_code = attempt.error_code or "unknown"
+        key = (
+            attempt.attempt_kind.value,
+            attempt.fetch_status.value,
+            error_code,
+            source_adapter_name,
+            domain,
+        )
+        diagnostic = grouped.get(key)
+        if diagnostic is None:
+            diagnostic = ScrapeFailureDiagnostic(
+                attempt_kind=attempt.attempt_kind.value,
+                fetch_status=attempt.fetch_status.value,
+                error_code=error_code,
+                source_adapter_name=source_adapter_name,
+                domain=domain,
+            )
+            grouped[key] = diagnostic
+        diagnostic.count += 1
+        if candidate is not None and candidate.self_heal_eligible:
+            diagnostic.self_heal_eligible_count += 1
+        finished_or_started = attempt.finished_at or attempt.started_at
+        if (
+            diagnostic.latest_attempt_at is None
+            or finished_or_started > diagnostic.latest_attempt_at
+        ):
+            diagnostic.latest_attempt_at = finished_or_started
+    return sorted(
+        grouped.values(),
+        key=lambda item: (
+            -item.self_heal_eligible_count,
+            -item.count,
+            item.error_code,
+            item.source_adapter_name,
+            item.domain,
+        ),
+    )[:10]
 
 
 def _build_source_suggestion_report(

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -561,7 +561,10 @@ def _build_queue_health_metrics(
         stale_candidates=stale,
         retry_backlog_candidates=retry_backlog,
         self_heal_eligible_candidates=sum(
-            1 for candidate in candidates if candidate.self_heal_eligible
+            1
+            for candidate in candidates
+            if candidate.candidate_status is CandidateStatus.SCRAPE_FAILED
+            and candidate.self_heal_eligible
         ),
     )
 
@@ -736,7 +739,11 @@ def _build_scrape_failure_diagnostics(
             )
             grouped[key] = diagnostic
         diagnostic.count += 1
-        if candidate is not None and candidate.self_heal_eligible:
+        if (
+            candidate is not None
+            and candidate.candidate_status is CandidateStatus.SCRAPE_FAILED
+            and candidate.self_heal_eligible
+        ):
             diagnostic.self_heal_eligible_count += 1
         finished_or_started = attempt.finished_at or attempt.started_at
         if (

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -114,6 +114,7 @@ def select_candidates_for_self_heal(
         eligible,
         key=lambda candidate: (
             -candidate.retry_priority,
+            0 if candidate.next_scrape_attempt_at is None else 1,
             candidate.next_scrape_attempt_at or max_datetime,
             -candidate.last_scrape_attempt_at.timestamp()
             if candidate.last_scrape_attempt_at is not None
@@ -270,6 +271,7 @@ def _mark_attempt_success(
             "last_scrape_error_code": None,
             "last_scrape_error_message": None,
             "content_basis": ContentBasis.FULL_ARTICLE_PAGE,
+            "self_heal_eligible": False,
             "titles": deduplicate_strings([*candidate.titles, article.title]),
             "snippets": deduplicate_strings([*candidate.snippets, article.snippet]),
             "metadata": {

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -33,6 +33,8 @@ SCRAPEABLE_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (
     CandidateStatus.PARTIALLY_SCRAPED,
 )
 
+SELF_HEAL_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (CandidateStatus.SCRAPE_FAILED,)
+
 
 @dataclass
 class CandidateScrapeBatch:
@@ -83,6 +85,39 @@ def select_candidates_for_scrape(
             0 if candidate.next_scrape_attempt_at is None else 1,
             candidate.next_scrape_attempt_at or max_datetime,
             -candidate.last_seen_at.timestamp(),
+            candidate.candidate_id,
+        ),
+    )
+    return ordered[:limit]
+
+
+def select_candidates_for_self_heal(
+    persistence: DiscoveryPersistence,
+    *,
+    limit: int,
+    now: datetime | None = None,
+) -> list[PersistentCandidate]:
+    """Return failed candidates eligible for a future self-healing workflow."""
+    current_time = now or datetime.now(UTC)
+    candidates = persistence.list_candidates(statuses=SELF_HEAL_CANDIDATE_STATUSES)
+    eligible = [
+        candidate
+        for candidate in candidates
+        if candidate.self_heal_eligible
+        and (
+            candidate.next_scrape_attempt_at is None
+            or candidate.next_scrape_attempt_at <= current_time
+        )
+    ]
+    max_datetime = datetime.max.replace(tzinfo=UTC)
+    ordered = sorted(
+        eligible,
+        key=lambda candidate: (
+            -candidate.retry_priority,
+            candidate.next_scrape_attempt_at or max_datetime,
+            -candidate.last_scrape_attempt_at.timestamp()
+            if candidate.last_scrape_attempt_at is not None
+            else 0,
             candidate.candidate_id,
         ),
     )
@@ -448,6 +483,10 @@ async def scrape_candidates(
                             source_adapter_name=source_name,
                             error_code="candidate_not_found",
                             error_message=f"{source_name} adapter did not return the candidate URL",
+                            diagnostics={
+                                "failure_stage": "source_adapter_match",
+                                "candidate_urls": sorted(candidate_urls),
+                            },
                         )
                     )
                 except Exception as exc:
@@ -463,6 +502,10 @@ async def scrape_candidates(
                             source_adapter_name=source_name,
                             error_code="source_adapter_error",
                             error_message=error_message,
+                            diagnostics={
+                                "failure_stage": "source_adapter_fetch",
+                                "exception_type": type(exc).__name__,
+                            },
                         )
                     )
                     errors.append(f"{in_progress.candidate_id}: {error_message}")
@@ -550,6 +593,7 @@ async def _fetch_partial_page(
             fetch_status=FetchStatus.TIMEOUT,
             error_code="generic_fetch_timeout",
             error_message=f"Generic fetch timed out: {exc}",
+            diagnostics={"failure_stage": "generic_fetch", "exception_type": type(exc).__name__},
         )
     except httpx.HTTPStatusError as exc:
         status_code = exc.response.status_code
@@ -559,12 +603,14 @@ async def _fetch_partial_page(
             else FetchStatus.FAILED,
             error_code=f"generic_fetch_http_{status_code}",
             error_message=f"Generic fetch returned HTTP {status_code}",
+            diagnostics={"failure_stage": "generic_fetch", "http_status": status_code},
         )
     except httpx.HTTPError as exc:
         return GenericFetchResult(
             fetch_status=FetchStatus.FAILED,
             error_code="generic_fetch_error",
             error_message=f"Generic fetch failed: {type(exc).__name__}: {exc}",
+            diagnostics={"failure_stage": "generic_fetch", "exception_type": type(exc).__name__},
         )
 
     parsed = _extract_partial_page_metadata(response.text)
@@ -582,7 +628,10 @@ async def _fetch_partial_page(
         error_code="generic_fetch_no_metadata",
         error_message="Generic fetch returned a page without usable metadata",
         final_url=str(response.url),
-        diagnostics={"content_type": response.headers.get("content-type", "")},
+        diagnostics={
+            "content_type": response.headers.get("content-type", ""),
+            "failure_stage": "generic_extract_metadata",
+        },
     )
 
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -87,6 +87,7 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
                 first_seen_at=now - timedelta(days=2),
                 last_seen_at=now - timedelta(hours=2),
                 content_basis=ContentBasis.FULL_ARTICLE_PAGE,
+                self_heal_eligible=True,
             ),
             _candidate(
                 "candidate-source-only",
@@ -730,6 +731,15 @@ def test_build_scrape_failure_diagnostics_groups_failures_for_self_heal_triage()
             first_seen_at=now,
             last_seen_at=now,
         ),
+        _candidate(
+            "candidate-3",
+            url="https://www.mako.co.il/news/article/3",
+            discovered_via=["exa"],
+            status=CandidateStatus.SCRAPE_SUCCEEDED,
+            first_seen_at=now,
+            last_seen_at=now,
+            self_heal_eligible=True,
+        ),
     ]
     attempts = [
         ScrapeAttempt(
@@ -757,6 +767,15 @@ def test_build_scrape_failure_diagnostics_groups_failures_for_self_heal_triage()
             attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
             fetch_status=FetchStatus.SUCCESS,
         ),
+        ScrapeAttempt(
+            candidate_id="candidate-3",
+            started_at=now - timedelta(seconds=30),
+            finished_at=now - timedelta(seconds=30),
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.FAILED,
+            source_adapter_name="mako",
+            error_code="candidate_not_found",
+        ),
     ]
 
     diagnostics = _build_scrape_failure_diagnostics(candidates, attempts)
@@ -768,6 +787,6 @@ def test_build_scrape_failure_diagnostics_groups_failures_for_self_heal_triage()
     assert diagnostic.error_code == "candidate_not_found"
     assert diagnostic.source_adapter_name == "mako"
     assert diagnostic.domain == "www.mako.co.il"
-    assert diagnostic.count == 2
+    assert diagnostic.count == 3
     assert diagnostic.self_heal_eligible_count == 1
-    assert diagnostic.latest_attempt_at == now - timedelta(minutes=1)
+    assert diagnostic.latest_attempt_at == now - timedelta(seconds=30)

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -13,6 +13,7 @@ from denbust.config import Config, OperationalProvider
 from denbust.diagnostics.discovery import (
     DiscoveryDiagnosticReport,
     _build_failure_summaries,
+    _build_scrape_failure_diagnostics,
     _load_operational_record_urls,
     _normalize_domain,
     _read_jsonl,
@@ -46,6 +47,7 @@ def _candidate(
     last_seen_at: datetime,
     next_scrape_attempt_at: datetime | None = None,
     content_basis: ContentBasis = ContentBasis.CANDIDATE_ONLY,
+    self_heal_eligible: bool = False,
 ) -> PersistentCandidate:
     return PersistentCandidate(
         candidate_id=candidate_id,
@@ -60,6 +62,7 @@ def _candidate(
         first_seen_at=first_seen_at,
         last_seen_at=last_seen_at,
         next_scrape_attempt_at=next_scrape_attempt_at,
+        self_heal_eligible=self_heal_eligible,
     )
 
 
@@ -102,6 +105,7 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
                 last_seen_at=now - timedelta(days=2),
                 next_scrape_attempt_at=now - timedelta(hours=1),
                 content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+                self_heal_eligible=True,
             ),
             _candidate(
                 "candidate-google-partial",
@@ -173,13 +177,17 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
     assert report.queue_health.full_article_page_candidates == 1
     assert report.queue_health.stale_candidates == 1
     assert report.queue_health.retry_backlog_candidates == 1
+    assert report.queue_health.self_heal_eligible_candidates == 1
     assert report.candidate_conversion.scrape_succeeded_candidates == 1
     assert report.candidate_conversion.search_result_only_candidates == 1
     assert report.candidate_conversion.operational_record_matches == 1
     assert report.candidate_conversion.per_producer[0].candidate_count >= 1
     assert report.top_failure_sources[0].name == "mako"
     assert report.top_failure_domains[0].name in {"www.mako.co.il", "www.maariv.co.il"}
+    assert report.scrape_failure_diagnostics[0].error_code == "candidate_not_found"
+    assert report.scrape_failure_diagnostics[0].self_heal_eligible_count == 1
     assert "Overlap" in render_discovery_diagnostic_report(report)
+    assert "Structured scrape failures" in render_discovery_diagnostic_report(report)
 
 
 def test_persist_discovery_diagnostic_artifacts_writes_latest_files(tmp_path: Path) -> None:
@@ -699,3 +707,67 @@ def test_build_failure_summaries_ignores_success_attempts_and_rejects_unknown_ke
     assert summaries[0].count == 1
     with pytest.raises(ValueError, match="Unsupported failure summary key: nope"):
         _build_failure_summaries(candidates, attempts, key="nope")
+
+
+def test_build_scrape_failure_diagnostics_groups_failures_for_self_heal_triage() -> None:
+    """Failure diagnostics should retain source, status, kind, domain, and self-heal counts."""
+    now = datetime.now(UTC)
+    candidates = [
+        _candidate(
+            "candidate-1",
+            url="https://www.mako.co.il/news/article/1",
+            discovered_via=["brave"],
+            status=CandidateStatus.SCRAPE_FAILED,
+            first_seen_at=now,
+            last_seen_at=now,
+            self_heal_eligible=True,
+        ),
+        _candidate(
+            "candidate-2",
+            url="https://www.mako.co.il/news/article/2",
+            discovered_via=["google_cse"],
+            status=CandidateStatus.SCRAPE_FAILED,
+            first_seen_at=now,
+            last_seen_at=now,
+        ),
+    ]
+    attempts = [
+        ScrapeAttempt(
+            candidate_id="candidate-1",
+            started_at=now - timedelta(minutes=2),
+            finished_at=now - timedelta(minutes=2),
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.FAILED,
+            source_adapter_name="mako",
+            error_code="candidate_not_found",
+        ),
+        ScrapeAttempt(
+            candidate_id="candidate-2",
+            started_at=now - timedelta(minutes=1),
+            finished_at=now - timedelta(minutes=1),
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.FAILED,
+            source_adapter_name="mako",
+            error_code="candidate_not_found",
+        ),
+        ScrapeAttempt(
+            candidate_id="candidate-1",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+            fetch_status=FetchStatus.SUCCESS,
+        ),
+    ]
+
+    diagnostics = _build_scrape_failure_diagnostics(candidates, attempts)
+
+    assert len(diagnostics) == 1
+    diagnostic = diagnostics[0]
+    assert diagnostic.attempt_kind == "source_adapter"
+    assert diagnostic.fetch_status == "failed"
+    assert diagnostic.error_code == "candidate_not_found"
+    assert diagnostic.source_adapter_name == "mako"
+    assert diagnostic.domain == "www.mako.co.il"
+    assert diagnostic.count == 2
+    assert diagnostic.self_heal_eligible_count == 1
+    assert diagnostic.latest_attempt_at == now - timedelta(minutes=1)

--- a/tests/unit/test_discovery_models.py
+++ b/tests/unit/test_discovery_models.py
@@ -137,6 +137,7 @@ def test_scrape_attempt_validates_finished_at() -> None:
     )
 
     assert attempt.fetch_status == FetchStatus.SUCCESS
+    assert ScrapeAttemptKind.SELF_HEAL_RETRY.value == "self_heal_retry"
 
     with pytest.raises(ValueError):
         ScrapeAttempt(

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -26,6 +26,7 @@ from denbust.discovery.scrape_queue import (
     scrape_candidates,
     select_backfill_candidates_for_scrape,
     select_candidates_for_scrape,
+    select_candidates_for_self_heal,
 )
 from denbust.discovery.state_paths import resolve_discovery_state_paths
 from denbust.discovery.storage import StateRepoDiscoveryPersistence
@@ -193,6 +194,43 @@ def test_select_candidates_for_scrape_prioritizes_none_and_earlier_retry_times(
         "earlier_due",
         "later_due",
     ]
+
+
+def test_select_candidates_for_self_heal_filters_failed_eligible_due_candidates(
+    tmp_path: Path,
+) -> None:
+    """Future self-heal workflows should only see eligible failed candidates whose retry is due."""
+    store = build_store(tmp_path)
+    due_time = datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    eligible = build_candidate(
+        "eligible",
+        status=CandidateStatus.SCRAPE_FAILED,
+        next_scrape_attempt_at=due_time - timedelta(minutes=5),
+    ).model_copy(
+        update={
+            "self_heal_eligible": True,
+            "retry_priority": 2,
+            "last_scrape_attempt_at": due_time - timedelta(hours=2),
+        }
+    )
+    future = build_candidate(
+        "future",
+        status=CandidateStatus.SCRAPE_FAILED,
+        next_scrape_attempt_at=due_time + timedelta(minutes=5),
+    ).model_copy(update={"self_heal_eligible": True})
+    not_eligible = build_candidate(
+        "not-eligible",
+        status=CandidateStatus.SCRAPE_FAILED,
+        next_scrape_attempt_at=due_time - timedelta(minutes=10),
+    )
+    partial = build_candidate("partial", status=CandidateStatus.PARTIALLY_SCRAPED).model_copy(
+        update={"self_heal_eligible": True}
+    )
+    store.upsert_candidates([future, not_eligible, eligible, partial])
+
+    selected = select_candidates_for_self_heal(store, limit=10, now=due_time)
+
+    assert [candidate.candidate_id for candidate in selected] == ["eligible"]
 
 
 def test_metadata_datetime_handles_invalid_and_naive_values() -> None:
@@ -693,6 +731,10 @@ async def test_fetch_partial_page_returns_timeout_blocked_http_error_and_no_meta
     )
     assert timeout_result.fetch_status is FetchStatus.TIMEOUT
     assert timeout_result.error_code == "generic_fetch_timeout"
+    assert timeout_result.diagnostics == {
+        "failure_stage": "generic_fetch",
+        "exception_type": "ReadTimeout",
+    }
 
     blocked_response = httpx.Response(403, request=request)
 
@@ -706,6 +748,7 @@ async def test_fetch_partial_page_returns_timeout_blocked_http_error_and_no_meta
     )
     assert blocked_result.fetch_status is FetchStatus.BLOCKED
     assert blocked_result.error_code == "generic_fetch_http_403"
+    assert blocked_result.diagnostics == {"failure_stage": "generic_fetch", "http_status": 403}
 
     class ErrorClient:
         async def get(self, url: str) -> httpx.Response:
@@ -714,6 +757,10 @@ async def test_fetch_partial_page_returns_timeout_blocked_http_error_and_no_meta
     error_result = await scrape_queue_module._fetch_partial_page(candidate, client=ErrorClient())
     assert error_result.fetch_status is FetchStatus.FAILED
     assert error_result.error_code == "generic_fetch_error"
+    assert error_result.diagnostics == {
+        "failure_stage": "generic_fetch",
+        "exception_type": "RequestError",
+    }
 
     no_meta_response = httpx.Response(
         200,
@@ -733,7 +780,10 @@ async def test_fetch_partial_page_returns_timeout_blocked_http_error_and_no_meta
     assert no_meta_result.fetch_status is FetchStatus.FAILED
     assert no_meta_result.error_code == "generic_fetch_no_metadata"
     assert no_meta_result.final_url == "https://example.com/article"
-    assert no_meta_result.diagnostics == {"content_type": "text/html"}
+    assert no_meta_result.diagnostics == {
+        "content_type": "text/html",
+        "failure_stage": "generic_extract_metadata",
+    }
 
 
 def test_extract_partial_page_helpers_cover_meta_parsing_edge_cases() -> None:

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -233,6 +233,30 @@ def test_select_candidates_for_self_heal_filters_failed_eligible_due_candidates(
     assert [candidate.candidate_id for candidate in selected] == ["eligible"]
 
 
+def test_select_candidates_for_self_heal_prioritizes_immediate_candidates(
+    tmp_path: Path,
+) -> None:
+    """Self-heal selection should treat missing retry timestamps as immediately due."""
+    store = build_store(tmp_path)
+    due_time = datetime(2026, 4, 11, 10, 0, tzinfo=UTC)
+    immediate = build_candidate("immediate", status=CandidateStatus.SCRAPE_FAILED).model_copy(
+        update={
+            "self_heal_eligible": True,
+            "next_scrape_attempt_at": None,
+        }
+    )
+    dated_retry = build_candidate(
+        "dated-retry",
+        status=CandidateStatus.SCRAPE_FAILED,
+        next_scrape_attempt_at=due_time - timedelta(hours=1),
+    ).model_copy(update={"self_heal_eligible": True})
+    store.upsert_candidates([dated_retry, immediate])
+
+    selected = select_candidates_for_self_heal(store, limit=1, now=due_time)
+
+    assert [candidate.candidate_id for candidate in selected] == ["immediate"]
+
+
 def test_metadata_datetime_handles_invalid_and_naive_values() -> None:
     """Backfill metadata parsing should reject invalid strings and normalize naive ones to UTC."""
     invalid_candidate = build_candidate("invalid", status=CandidateStatus.NEW).model_copy(
@@ -312,7 +336,9 @@ async def test_scrape_candidates_returns_empty_batch_for_no_candidates(tmp_path:
 async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path: Path) -> None:
     """Successful source-adapter scrapes should yield raw articles and succeeded candidates."""
     store = build_store(tmp_path)
-    candidate = build_candidate("candidate-1", status=CandidateStatus.NEW)
+    candidate = build_candidate("candidate-1", status=CandidateStatus.SCRAPE_FAILED).model_copy(
+        update={"self_heal_eligible": True}
+    )
     store.upsert_candidates([candidate])
     source = FakeSource("ynet", [build_raw_article()])
 
@@ -329,6 +355,7 @@ async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path:
     assert stored.candidate_status is CandidateStatus.SCRAPE_SUCCEEDED
     assert stored.content_basis is ContentBasis.FULL_ARTICLE_PAGE
     assert stored.scrape_attempt_count == 1
+    assert stored.self_heal_eligible is False
     assert batch.fallback_candidates == []
     assert len(batch.raw_articles) == 1
     assert len(batch.attempts) == 1


### PR DESCRIPTION
## Planning notation

- Notation: `DL-PR-12`
- Parent milestone: Phase C / discovery-layer follow-through
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/tfht_discovery_layer_implementation_plan.md`

## Summary

This PR adds the smallest self-healing scaffolding hooks for the discovery layer without implementing automatic AI repair, selector rewriting, source creation, or live-network-dependent behavior.

It makes future repair orchestration possible by exposing self-heal-eligible failed candidates, preserving structured failure-stage diagnostics on scrape attempts, and reporting grouped scrape-failure diagnostics for triage.

## Changes

- Adds `self_heal_eligible_candidates` to discovery queue-health diagnostics.
- Adds structured scrape-failure diagnostics grouped by attempt kind, fetch status, error code, source adapter, and domain, including self-heal-eligible counts.
- Adds a future-facing `select_candidates_for_self_heal()` helper that returns due, failed, self-heal-eligible candidates without changing current scrape, ingest, or backfill execution.
- Adds stable `failure_stage` diagnostics for source-adapter candidate misses, source-adapter exceptions, generic fetch failures, and generic metadata-extraction failures.
- Confirms the existing `self_heal_retry` scrape-attempt kind as the explicit future attempt kind.
- Updates `.agent-plan.md`, `README.md`, `PLAN.md`, and discovery operations/design/implementation docs to describe the post-merge mainline state.

## Behavior and compatibility

- No public CLI behavior changes.
- No automatic AI repair is run.
- No selectors, source adapters, or source definitions are rewritten.
- Current discovery, ingest, backfill, fallback retention, and diagnostics behavior is preserved apart from additive diagnostic fields.

## Validation

- `python scripts/validate_agent_plan.py`
- `ruff format .`
- `ruff check .`
- `mypy src/`
- `pytest -q tests/unit/test_discovery_models.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_scrape_queue.py`
- `pytest -q`

Full test suite result: 926 passed, 2 warnings.

## Follow-up

After merge, the next mainline step is a fresh local source-health diagnostic pass to decide whether #71/#74 can close as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.