### PR TITLE
Phase C: Document source-health triage decisions

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: shared validation row-integrity rules for #97 now keep taxonomy
-  pair/version, legacy category compatibility, and `index_relevant` checks aligned between
-  `denbust validation-lint` and validation finalize/import.
-- Next planned PR: run a fresh source-health diagnostic pass to decide whether #71/#74 can be
-  closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
-- Current blockers on main: no Mako runtime blocker is known after Chromium install; source-native
-  recall remains diagnostics-visible, with search-backed fallback coverage expanded for #72 and
-  fixture-backed Ynet recall protected for #66; self-healing is scaffolded but not automated.
+- Last merged PR on main: Phase C source-health triage records a fresh Chromium-backed local
+  diagnostic pass: Mako passes, Haaretz passes, and the 4-source zero/stale guardrail still fires
+  for Ynet, Walla, Maariv, and ICE.
+- Next planned PR: implement the narrow #72 source-native reliability follow-up for the affected
+  zero/stale sources while treating #71/#74 as duplicate or stale Mako runtime hygiene.
+- Current blockers on main: source-native recall remains diagnostics-visible for Ynet, Walla,
+  Maariv, and ICE; no Mako runtime blocker is known after Chromium install; search-backed fallback
+  coverage and fixture-backed Ynet recall remain in place; self-healing is scaffolded but not
+  automated.
 
 ## Task Ledger
 
@@ -45,8 +46,12 @@
 - [done] Add optional `DL-PR-12` self-healing scaffolding hooks: explicit self-heal eligibility
   diagnostics, structured scrape-failure grouping, and future self-heal retry selection without AI
   repair.
-- [next] Run a fresh local source-health diagnostic pass and use it to decide whether #71/#74 can be
-  closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
+- [done] Run a fresh Chromium-backed local source-health diagnostic pass: Mako is healthy, Haaretz
+  is healthy, and the systemic 4-source zero/stale guardrail still fires for Ynet, Walla, Maariv,
+  and ICE.
+- [next] Implement the narrow #72 source-native reliability follow-up for the affected zero/stale
+  sources, using the Phase C diagnostic evidence while keeping AI repair, selector rewriting,
+  automatic source creation, and live-network-dependent CI tests out of scope.
 
 ## Planning Workflow
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -69,6 +69,7 @@
 ## Context Pointers
 
 - Phase C plan: [docs/PHASE_C_PLAN.md](docs/PHASE_C_PLAN.md)
+- Phase C source-health triage evidence: [docs/phase_c_source_health_triage_2026_05_03.md](docs/phase_c_source_health_triage_2026_05_03.md)
 - Discovery rollout plan: [docs/tfht_discovery_layer_implementation_plan.md](docs/tfht_discovery_layer_implementation_plan.md)
 - Discovery operations: [docs/discovery_operations.md](docs/discovery_operations.md)
 - Broader implementation backlog: [docs/IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -52,7 +52,8 @@ ICE still produced source-zero, stale-result, or keyword-zero diagnostics, so
 per-source Mako run also passed, which makes #71/#74 duplicate or stale Mako runtime hygiene rather
 than the next correctness fix. #72 remains active as the narrow source-native reliability follow-up.
 #88 remains a later persistence optimization because this diagnostic pass did not exercise or expose
-backfill aggregate-count slowness.
+backfill aggregate-count slowness. The auditable evidence summary is checked in at
+[`docs/phase_c_source_health_triage_2026_05_03.md`](docs/phase_c_source_health_triage_2026_05_03.md).
 
 ### What is already in place
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: Source-Health Follow-Through After DL-PR-12
+## Current Next Focus: #72 Source-Native Reliability Follow-Through
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -43,6 +43,16 @@ so permanent-set preflight and reviewed-row ingestion enforce the same semantic 
 diagnostic buckets, the queue reports self-heal-eligible candidates, generic fetch/source-adapter
 attempts carry stable failure-stage diagnostics, and future orchestration can select
 self-heal-eligible failed candidates without running AI repair.
+
+A fresh Phase C source-health triage pass on 2026-05-03 used an isolated
+`data/may_26_followup/20260503T074131Z/state` root and Chromium installed through Playwright before
+live Mako probing. The all-source run showed Mako `ok` and Haaretz `ok`; Ynet, Walla, Maariv, and
+ICE still produced source-zero, stale-result, or keyword-zero diagnostics, so
+`source_zero_summary.systemic_source_zero_suspected` remains true at the 4-source threshold. The
+per-source Mako run also passed, which makes #71/#74 duplicate or stale Mako runtime hygiene rather
+than the next correctness fix. #72 remains active as the narrow source-native reliability follow-up.
+#88 remains a later persistence optimization because this diagnostic pass did not exercise or expose
+backfill aggregate-count slowness.
 
 ### What is already in place
 
@@ -77,11 +87,13 @@ self-heal-eligible failed candidates without running AI repair.
 
 ### What comes next
 
-1. Run a fresh local source-health diagnostic pass and use it to decide whether #71/#74 can be
-   closed as duplicate Mako hygiene or whether #72 needs another source-native reliability PR.
+1. Implement a narrow #72 source-native reliability PR for Ynet, Walla, Maariv, and ICE using the
+   fresh Phase C diagnostic evidence.
 2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
+3. Keep #88 lower priority unless bounded backfill evidence shows aggregate-count updates are a real
+   local bottleneck.
+4. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 
 ### Likely code touchpoints

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   4+ affected-source guardrail, plus Mako `failure_mode` details for missing Chromium, navigation
   timeout, context teardown, redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero
   outcomes
+- the 2026-05-03 Phase C source-health triage pass, run with an isolated
+  `DENBUST_STATE_ROOT` and Chromium installed before Mako probing, showed Mako and Haaretz healthy
+  while the systemic 4-source guardrail still fired for Ynet, Walla, Maariv, and ICE; this keeps
+  #72 active and makes #71/#74 duplicate or stale Mako runtime hygiene unless Mako regresses again
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -89,9 +89,9 @@ export FOLLOWUP_ROOT="data/may_26_followup/${FOLLOWUP_ID}"
 export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
 mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts}
 
-python -m playwright install chromium
+.venv/bin/python -m playwright install chromium
 
-denbust diagnose-sources \
+.venv/bin/denbust diagnose-sources \
   --config agents/news/local.yaml \
   --live-only \
   --sample-keyword "זנות" \
@@ -101,7 +101,7 @@ denbust diagnose-sources \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_live_all.json"
 
 for source in ynet walla mako maariv haaretz ice; do
-  denbust diagnose-sources \
+  .venv/bin/denbust diagnose-sources \
     --config agents/news/local.yaml \
     --live-only \
     --source "${source}" \
@@ -119,7 +119,8 @@ Haaretz passed, and `source_zero_summary.systemic_source_zero_suspected` stayed 
 Walla, Maariv, and ICE were affected. Operators should treat #71/#74 as duplicate or stale Mako
 runtime hygiene unless a Chromium-backed Mako probe regresses, keep #72 active for source-native
 reliability work, and leave #88 as a later optimization unless backfill aggregation is observed as a
-real bottleneck.
+real bottleneck. The durable evidence summary is checked in at
+[phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
 ## GitHub Actions Run Path
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -80,6 +80,47 @@ denbust live-check \
 Generated `data/may_26_followup/` bundles are local experiment artifacts and should remain
 untracked.
 
+For Phase C source-health triage, install Chromium before probing Mako and isolate state under a
+fresh ignored follow-up root:
+
+```bash
+export FOLLOWUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+export FOLLOWUP_ROOT="data/may_26_followup/${FOLLOWUP_ID}"
+export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
+mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts}
+
+python -m playwright install chromium
+
+denbust diagnose-sources \
+  --config agents/news/local.yaml \
+  --live-only \
+  --sample-keyword "זנות" \
+  --sample-keyword "בית בושת" \
+  --sample-keyword "סחר בבני אדם" \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_live_all.json"
+
+for source in ynet walla mako maariv haaretz ice; do
+  denbust diagnose-sources \
+    --config agents/news/local.yaml \
+    --live-only \
+    --source "${source}" \
+    --sample-keyword "זנות" \
+    --sample-keyword "בית בושת" \
+    --sample-keyword "סחר בבני אדם" \
+    --format json \
+    --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_live_${source}.json"
+done
+```
+
+The 2026-05-03 triage run used this shape under
+`data/may_26_followup/20260503T074131Z/`. Mako passed in both all-source and source-specific runs,
+Haaretz passed, and `source_zero_summary.systemic_source_zero_suspected` stayed true because Ynet,
+Walla, Maariv, and ICE were affected. Operators should treat #71/#74 as duplicate or stale Mako
+runtime hygiene unless a Chromium-backed Mako probe regresses, keep #72 active for source-native
+reliability work, and leave #88 as a later optimization unless backfill aggregation is observed as a
+real bottleneck.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -80,8 +80,8 @@ denbust live-check \
 Generated `data/may_26_followup/` bundles are local experiment artifacts and should remain
 untracked.
 
-For Phase C source-health triage, install Chromium before probing Mako and isolate state under a
-fresh ignored follow-up root:
+For Phase C source-health triage, activate the project environment, install Chromium before probing
+Mako, and isolate state under a fresh ignored follow-up root:
 
 ```bash
 export FOLLOWUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -89,9 +89,9 @@ export FOLLOWUP_ROOT="data/may_26_followup/${FOLLOWUP_ID}"
 export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
 mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts}
 
-.venv/bin/python -m playwright install chromium
+python -m playwright install chromium
 
-.venv/bin/denbust diagnose-sources \
+denbust diagnose-sources \
   --config agents/news/local.yaml \
   --live-only \
   --sample-keyword "זנות" \
@@ -101,7 +101,7 @@ mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts}
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_live_all.json"
 
 for source in ynet walla mako maariv haaretz ice; do
-  .venv/bin/denbust diagnose-sources \
+  denbust diagnose-sources \
     --config agents/news/local.yaml \
     --live-only \
     --source "${source}" \
@@ -112,6 +112,9 @@ for source in ynet walla mako maariv haaretz ice; do
     --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_live_${source}.json"
 done
 ```
+
+If the project environment is not activated but the repo-local `.venv` exists, prefix the commands
+with `.venv/bin/`.
 
 The 2026-05-03 triage run used this shape under
 `data/may_26_followup/20260503T074131Z/`. Mako passed in both all-source and source-specific runs,

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -63,10 +63,10 @@ The repo currently has 21 issues returned by the repo-specific GitHub MCP. Seven
 | #53 Expose diagnostic-safe public probe helpers for ICE scraper | Treated | PR #96 added public ICE diagnostic helpers; close or update the issue with that evidence if it remains open. |
 | #65 Add Ynet category-page backstop for משפט ופלילים discovery | Treated | The source-recall follow-up keeps Ynet RSS primary and adds the non-browser category-page backstop with separate source-health signals. |
 | #66 Add fixture-based Ynet end-to-end regression test after web-search source exists | Converted to test | Fixture-backed coverage now protects the Ynet source-targeted taxonomy search path for the known February 12, 2026 article through candidate normalization, provenance, source-adapter materialization, and pre-classification ingest handoff. |
-| #71 Mako source completely failing due to browser navigation issues | Open | Active high-priority source-health issue. Live Mako diagnostics must be run with browser runtime installed. |
-| #72 Major Israeli news sources returning zero results | Open | Active system-level health issue treated by the search-backed discovery/backfill follow-through: live diagnostics reproduced Ynet, Walla, Maariv, and ICE source-zero/stale patterns while the query builders now add domain-constrained taxonomy fallback searches. |
-| #74 Mako source experiencing complete failure with browser navigation | Open | Active but likely duplicate/continuation of #71. Verify whether both can be collapsed after the experiment. |
-| #88 Optimize backfill batch aggregate counts in discovery persistence | Open | Active optimization, not a correctness blocker. Measure batch/candidate counts but do not prioritize unless local runs show aggregation is materially slow. |
+| #71 Mako source completely failing due to browser navigation issues | Open | Phase C triage recommends closing as duplicate/stale Mako runtime hygiene: the 2026-05-03 Chromium-backed Mako all-source and source-specific probes passed. |
+| #72 Major Israeli news sources returning zero results | Open | Active system-level health issue. The 2026-05-03 all-source diagnostic still fired the 4-source guardrail for Ynet, Walla, Maariv, and ICE while Mako and Haaretz passed. |
+| #74 Mako source experiencing complete failure with browser navigation | Open | Phase C triage recommends closing as duplicate/stale with #71 unless a future Chromium-backed Mako probe regresses. |
+| #88 Optimize backfill batch aggregate counts in discovery persistence | Open | Active optimization, not a correctness blocker. The 2026-05-03 source-health triage did not exercise or expose batch aggregation slowness, so keep it later. |
 | #97 Share validation taxonomy rules between lint and finalize | Treated | The validation follow-up now routes taxonomy pair/version, legacy category compatibility, and `index_relevant` row checks through shared validation code used by both lint and reviewed-row finalize/import. |
 
 ### Initial local-state warning
@@ -562,17 +562,17 @@ Create `reports/final_experiment_summary.md` with these sections:
 
 The experiment should not assume these are true, but these are the current hypotheses:
 
-1. `DL-PR-12` is not the only plausible next step. The fresh Phase C source-health run showed the
-   4+ affected-source guardrail firing, so the #72 follow-through expanded search-backed discovery
-   and backfill with source-targeted taxonomy searches.
-2. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
-   experiment, regardless of what implementation work comes next.
-3. Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
+1. The 2026-05-03 Phase C source-health triage used isolated state under
+   `data/may_26_followup/20260503T074131Z/state`, installed Chromium before Mako probing, and found
+   the existing diagnostics structured enough to make the issue decision without code changes.
+2. Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
    after `python -m playwright install chromium`; the current Mako diagnostics are healthy with the
    browser runtime installed.
-4. #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
+3. #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
    Maariv, and ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and
    Haaretz pass, with search-backed fallback coverage now broadened for those domains.
+4. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
+   experiment, regardless of what implementation work comes next.
 5. #65 is treated by the Ynet category-page backstop, and #66 is converted to fixture-backed
    coverage over the stable search-backed source-domain path.
 6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -558,29 +558,35 @@ Create `reports/final_experiment_summary.md` with these sections:
 10. `Recommended Next PR`
    - one concrete next PR with labels/milestone suggestions and acceptance criteria.
 
+## Observed Phase C Source-Health Outcome
+
+The 2026-05-03 Phase C source-health triage used isolated state under
+`data/may_26_followup/20260503T074131Z/state`, installed Chromium before Mako probing, and found the
+existing diagnostics structured enough to make the issue decision without code changes. The durable
+evidence summary is checked in at
+[`phase_c_source_health_triage_2026_05_03.md`](phase_c_source_health_triage_2026_05_03.md).
+
+- Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
+  after `.venv/bin/python -m playwright install chromium`; the current Mako diagnostics are healthy
+  with the browser runtime installed.
+- #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
+  Maariv, and ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and
+  Haaretz pass, with search-backed fallback coverage now broadened for those domains.
+- #88 should stay lower priority unless bounded backfill demonstrates real local slowness.
+
 ## Likely Outcomes to Validate
 
 The experiment should not assume these are true, but these are the current hypotheses:
 
-1. The 2026-05-03 Phase C source-health triage used isolated state under
-   `data/may_26_followup/20260503T074131Z/state`, installed Chromium before Mako probing, and found
-   the existing diagnostics structured enough to make the issue decision without code changes.
-2. Mako issues #71 and #74 are duplicates or near-duplicates unless a future Mako live probe fails
-   after `python -m playwright install chromium`; the current Mako diagnostics are healthy with the
-   browser runtime installed.
-3. #72 remains the central source-native reliability signal: the current evidence shows Ynet, Walla,
-   Maariv, and ICE remain affected by source-native zero/stale/keyword-zero patterns while Mako and
-   Haaretz pass, with search-backed fallback coverage now broadened for those domains.
-4. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
+1. `PLAN.md` and `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` likely need status updates after the
    experiment, regardless of what implementation work comes next.
-5. #65 is treated by the Ynet category-page backstop, and #66 is converted to fixture-backed
+2. #65 is treated by the Ynet category-page backstop, and #66 is converted to fixture-backed
    coverage over the stable search-backed source-domain path.
-6. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
+3. #52 and #53 appear treated by PR #96's public Maariv/ICE diagnostic helpers; close or update the
    issues with that evidence if they remain open.
-7. #88 should stay lower priority unless bounded backfill demonstrates real local slowness.
-8. `DL-PR-12` provides structured scrape-failure diagnostics and self-heal eligibility hooks, but
+4. `DL-PR-12` provides structured scrape-failure diagnostics and self-heal eligibility hooks, but
    full AI repair remains future work.
-9. The repo needs a first-class experiment or live-check CLI if these checks are going to be run more
+5. The repo needs a first-class experiment or live-check CLI if these checks are going to be run more
    than once.
 
 ## Completion Criteria

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -1,0 +1,71 @@
+# Phase C Source-Health Triage Evidence: 2026-05-03
+
+This note preserves the durable evidence summary for the Phase C source-health triage decision.
+Raw live diagnostic artifacts were generated under ignored `data/` paths and are not committed.
+
+## Run Context
+
+- Timestamp: `2026-05-03T07:41:32.027408Z`
+- Branch: `codex/phase-c-source-health-triage`
+- Config: `agents/news/local.yaml`
+- Isolated state root: `data/may_26_followup/20260503T074131Z/state`
+- Browser setup: `.venv/bin/python -m playwright install chromium`
+- All-source diagnostic command:
+
+```bash
+DENBUST_STATE_ROOT="data/may_26_followup/20260503T074131Z/state" \
+.venv/bin/denbust diagnose-sources \
+  --config agents/news/local.yaml \
+  --live-only \
+  --sample-keyword "זנות" \
+  --sample-keyword "בית בושת" \
+  --sample-keyword "סחר בבני אדם" \
+  --format json \
+  --output "data/may_26_followup/20260503T074131Z/artifacts/diagnose_sources_live_all.json"
+```
+
+Source-specific diagnostics used the same state root and sample keywords with repeated
+`--source <source>` runs for `ynet`, `walla`, `mako`, `maariv`, `haaretz`, and `ice`.
+
+## Source-Zero Summary
+
+| Field | Value |
+|---|---:|
+| threshold | 4 |
+| enabled sources | 6 |
+| selected sources | 6 |
+| affected sources | 4 |
+| systemic source-zero suspected | true |
+
+Affected sources: `ynet`, `walla`, `maariv`, `ice`.
+
+## Source Results
+
+| Source | Status | Failure bucket | Evidence |
+|---|---|---|---|
+| `ynet` | `warn` | `keyword_filter_zeroed_results` | RSS returned HTTP 200 with 30 entries and 0 sampled keyword matches; category page returned HTTP 200, parsed 40 articles, and had 0 sampled keyword matches. |
+| `walla` | `warn` | `keyword_filter_zeroed_results` | May 2026 archive URLs for sections 1 and 10 returned 404; April 2026 archive pages returned HTTP 200 with 50 recent entries each and 0 sampled keyword matches. |
+| `mako` | `ok` | none | Search probes for `זנות` and `בית בושת` returned parsed keyword-matching articles; `סחר בבני אדם` rendered but parsed zero; section page parsed 30 articles with 0 sampled keyword matches. |
+| `maariv` | `warn` | `keyword_filter_zeroed_results` | Live probe returned HTTP 200, parsed 13 articles, and had 0 sampled keyword matches. |
+| `haaretz` | `ok` | none | Search probe for `זנות` returned HTTP 200 with 2 recent entries and 1 keyword match; other sampled searches returned no current keyword match. |
+| `ice` | `warn` | `stale_results` | All sampled search pages returned HTTP 200 but only stale candidates outside the cutoff window. |
+
+## Issue Decisions
+
+- #71: recommend closing as duplicate or stale Mako runtime hygiene unless a future
+  Chromium-backed Mako probe regresses.
+- #74: recommend closing as duplicate or stale with #71 unless a future Chromium-backed Mako probe
+  regresses.
+- #72: keep active and use as the next narrow source-native reliability follow-up because the
+  4-source guardrail still fires for Ynet, Walla, Maariv, and ICE.
+- #88: keep as later optimization; this source-health triage did not exercise or expose backfill
+  aggregate-count slowness.
+
+## Validation
+
+- `.venv/bin/python scripts/validate_agent_plan.py`
+- `.venv/bin/ruff format .`
+- `.venv/bin/ruff check .`
+- `.venv/bin/mypy src/`
+- `.venv/bin/pytest -q tests/unit/test_validate_agent_plan.py`
+- `.venv/bin/pytest -q tests/unit/test_source_health.py tests/unit/test_cli.py -k 'diagnose_sources or source_zero or mako or ynet'`

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -6,15 +6,14 @@ Raw live diagnostic artifacts were generated under ignored `data/` paths and are
 ## Run Context
 
 - Timestamp: `2026-05-03T07:41:32.027408Z`
-- Branch: `codex/phase-c-source-health-triage`
 - Config: `agents/news/local.yaml`
 - Isolated state root: `data/may_26_followup/20260503T074131Z/state`
-- Browser setup: `.venv/bin/python -m playwright install chromium`
+- Browser setup: `python -m playwright install chromium`
 - All-source diagnostic command:
 
 ```bash
 DENBUST_STATE_ROOT="data/may_26_followup/20260503T074131Z/state" \
-.venv/bin/denbust diagnose-sources \
+denbust diagnose-sources \
   --config agents/news/local.yaml \
   --live-only \
   --sample-keyword "זנות" \
@@ -23,6 +22,9 @@ DENBUST_STATE_ROOT="data/may_26_followup/20260503T074131Z/state" \
   --format json \
   --output "data/may_26_followup/20260503T074131Z/artifacts/diagnose_sources_live_all.json"
 ```
+
+In the local shell used for this run, commands were invoked through `.venv/bin/...` because bare
+`python` was not on `PATH`. The portable commands above assume the project environment is activated.
 
 Source-specific diagnostics used the same state root and sample keywords with repeated
 `--source <source>` runs for `ynet`, `walla`, `mako`, `maariv`, `haaretz`, and `ice`.

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -264,6 +264,13 @@ This lets the system treat:
 
 as different producers of the same candidate object type.
 
+Current Phase C source-health evidence supports keeping this producer model but prioritizing
+source-native reliability before broader repair automation. The 2026-05-03 Chromium-backed triage
+pass showed Mako and Haaretz live probes healthy while Ynet, Walla, Maariv, and ICE still triggered
+the 4-source zero/stale guardrail. That keeps #72 active as a source-native follow-up and leaves
+full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
+outside the next narrow PR.
+
 ---
 
 ## Core models

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -481,6 +481,18 @@ The recommended order is:
 - future self-heal orchestration can select eligible failed candidates and record
   `self_heal_retry` attempts, but no automatic repair runs yet
 
+### After Phase C source-health triage
+- the 2026-05-03 Chromium-backed source-health pass is the current evidence baseline
+- Mako passes in both all-source and source-specific live diagnostics, so #71/#74 should be treated
+  as duplicate or stale runtime hygiene unless a future Chromium-backed Mako probe regresses
+- Haaretz passes live diagnostics
+- Ynet, Walla, Maariv, and ICE still trigger the 4-source
+  `source_zero_summary.systemic_source_zero_suspected` guardrail through zero, stale-result, or
+  keyword-zero outcomes
+- the next implementation PR should stay narrow to #72 source-native reliability; full AI repair,
+  selector rewriting, automatic source creation, and live-network-dependent CI tests remain out of
+  scope
+
 ---
 
 ## What should explicitly wait until later


### PR DESCRIPTION
## Summary
- Records the fresh 2026-05-03 Phase C source-health diagnostic pass in `.agent-plan.md`, `PLAN.md`, `README.md`, and discovery/source-health docs.
- Keeps the existing diagnostics scaffolding unchanged because the current output already distinguishes Mako runtime hygiene from the systemic source-zero guardrail.
- Updates the mainline plan so the next implementation PR is the narrow #72 source-native reliability follow-up, while #71/#74 are recommended as duplicate or stale Mako runtime hygiene and #88 remains later.

## Diagnostic Evidence
- Chromium was installed/verified locally before probing Mako with `.venv/bin/python -m playwright install chromium`. A bare `python -m playwright install chromium` attempt failed because this shell has no `python` alias.
- Live diagnostics used `agents/news/local.yaml` with isolated state under `data/may_26_followup/20260503T074131Z/state`; generated live artifacts remain untracked under `data/`.
- All-source `denbust diagnose-sources --live-only` result: Mako `ok`, Haaretz `ok`, and `source_zero_summary.systemic_source_zero_suspected=true` with affected sources `ynet`, `walla`, `maariv`, and `ice` at the 4-source threshold.
- Per-source Mako diagnostic also passed: sampled searches for `זנות` and `בית בושת` returned parsed keyword-matching articles, while the Mako section check parsed 30 articles with no sampled keyword hits.
- Per-source details: Ynet RSS/category parsed but had zero sampled keyword hits; Walla current-month archive URLs 404 while April archives parsed recent entries with zero sampled keyword hits; Maariv parsed 13 articles with zero sampled keyword hits; ICE returned stale candidates only.

## Issue Decisions Recommended
- #71: close as duplicate/stale Mako runtime hygiene unless a future Chromium-backed Mako probe regresses.
- #74: close as duplicate/stale with #71 unless a future Chromium-backed Mako probe regresses.
- #72: keep active and use as the next narrow source-native reliability PR because the 4+ source-zero guardrail still fires for Ynet, Walla, Maariv, and ICE.
- #88: keep later; this triage did not exercise or expose backfill aggregate-count slowness.

## Scope
- No source repair, selector rewriting, automatic source creation, AI repair, or live-network-dependent CI tests.
- No generated live artifacts are committed.
- Documentation and plan state only.

## Validation
- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_validate_agent_plan.py`
- `.venv/bin/pytest -q tests/unit/test_source_health.py tests/unit/test_cli.py -k 'diagnose_sources or source_zero or mako or ynet'`
- Pre-push hooks passed after retrying with `.venv/bin` on PATH so hook-invoked `python` resolves to Python 3.12.
