### PR TITLE
Phase C #72: Harden source-native reliability diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: Phase C source-health triage records a fresh Chromium-backed local
-  diagnostic pass: Mako passes, Haaretz passes, and the 4-source zero/stale guardrail still fires
-  for Ynet, Walla, Maariv, and ICE.
-- Next planned PR: implement the narrow #72 source-native reliability follow-up for the affected
-  zero/stale sources while treating #71/#74 as duplicate or stale Mako runtime hygiene.
-- Current blockers on main: source-native recall remains diagnostics-visible for Ynet, Walla,
-  Maariv, and ICE; no Mako runtime blocker is known after Chromium install; search-backed fallback
-  coverage and fixture-backed Ynet recall remain in place; self-healing is scaffolded but not
-  automated.
+- Last merged PR on main: Phase C #72 source-native reliability narrows the source-zero guardrail
+  to hard source failures, keeps keyword-zero as a per-source warning, and expands Walla/ICE
+  source-native recall terms with fixture-backed diagnostics coverage.
+- Next planned PR: keep #88 as the next available lower-priority optimization only if bounded
+  backfill evidence shows aggregate-count updates are a real bottleneck.
+- Current blockers on main: no Mako runtime blocker is known after Chromium install; #71/#74 are
+  duplicate or stale Mako runtime hygiene unless a future Chromium-backed probe regresses;
+  source-native keyword-zero remains visible per source but no longer trips the systemic hard
+  source-zero guardrail by itself; self-healing is scaffolded but not automated.
 
 ## Task Ledger
 
@@ -49,9 +49,11 @@
 - [done] Run a fresh Chromium-backed local source-health diagnostic pass: Mako is healthy, Haaretz
   is healthy, and the systemic 4-source zero/stale guardrail still fires for Ynet, Walla, Maariv,
   and ICE.
-- [next] Implement the narrow #72 source-native reliability follow-up for the affected zero/stale
-  sources, using the Phase C diagnostic evidence while keeping AI repair, selector rewriting,
-  automatic source creation, and live-network-dependent CI tests out of scope.
+- [done] Implement the narrow #72 source-native reliability follow-up by expanding Walla/ICE
+  source-native recall terms and refining the source-zero guardrail so keyword-zero evidence stays
+  visible without masquerading as hard source failure.
+- [next] Keep #88 as a later bounded optimization unless backfill evidence shows aggregate-count
+  updates are a real local bottleneck.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: #72 Source-Native Reliability Follow-Through
+## Current Next Focus: Post-#72 Source-Health Follow-Through
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -44,15 +44,22 @@ diagnostic buckets, the queue reports self-heal-eligible candidates, generic fet
 attempts carry stable failure-stage diagnostics, and future orchestration can select
 self-heal-eligible failed candidates without running AI repair.
 
+The #72 source-native reliability follow-through keeps the fix intentionally narrow. Walla archive
+filtering and ICE search now use targeted supplemental Hebrew recall terms, matching the
+source-native relaxation already present for Ynet and Maariv. Source-health diagnostics still report
+keyword-zero as a per-source warning, but the report-level `source_zero_summary` guardrail now
+counts hard source-zero/stale/fetch/parse failures only, so healthy pages with no sampled keyword
+hit no longer masquerade as systemic source outage evidence.
+
 A fresh Phase C source-health triage pass on 2026-05-03 used an isolated
 `data/may_26_followup/20260503T074131Z/state` root and Chromium installed through Playwright before
 live Mako probing. The all-source run showed Mako `ok` and Haaretz `ok`; Ynet, Walla, Maariv, and
-ICE still produced source-zero, stale-result, or keyword-zero diagnostics, so
-`source_zero_summary.systemic_source_zero_suspected` remains true at the 4-source threshold. The
-per-source Mako run also passed, which makes #71/#74 duplicate or stale Mako runtime hygiene rather
-than the next correctness fix. #72 remains active as the narrow source-native reliability follow-up.
-#88 remains a later persistence optimization because this diagnostic pass did not exercise or expose
-backfill aggregate-count slowness. The auditable evidence summary is checked in at
+ICE still produced source-zero, stale-result, or keyword-zero diagnostics under the then-current
+guardrail. The per-source Mako run also passed, which makes #71/#74 duplicate or stale Mako runtime
+hygiene rather than the next correctness fix. #72 is now addressed by the narrow source-native
+recall/guardrail follow-up. #88 remains a later persistence optimization because this diagnostic pass
+did not exercise or expose backfill aggregate-count slowness. The auditable evidence summary is
+checked in at
 [`docs/phase_c_source_health_triage_2026_05_03.md`](docs/phase_c_source_health_triage_2026_05_03.md).
 
 ### What is already in place
@@ -63,8 +70,9 @@ backfill aggregate-count slowness. The auditable evidence summary is checked in 
   `denbust diagnose-discovery`.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
   cases.
-- Source-health diagnostics include a `source_zero_summary` that flags the 4+ affected-source
-  guardrail used to decide whether a run is systemic rather than source-specific.
+- Source-health diagnostics include a `source_zero_summary` that flags the 4+ hard affected-source
+  guardrail used to decide whether a run is systemic rather than source-specific; keyword-zero
+  outcomes stay visible on individual source checks without counting as hard source-zero evidence.
 - Discovery diagnostics include structured scrape-failure groups keyed by attempt kind, fetch
   status, error code, source adapter, and domain, including self-heal-eligible counts.
 - Candidate scrape failures mark durable candidates as `self_heal_eligible`, and the candidate queue
@@ -72,6 +80,8 @@ backfill aggregate-count slowness. The auditable evidence summary is checked in 
 - Mako live diagnostics distinguish missing browser runtime, navigation timeout, context destroyed,
   redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero failure modes where the
   rendered state supports that classification.
+- Walla and ICE source-native paths use targeted supplemental Hebrew recall terms for diagnostics
+  and discovery, matching the source-specific relaxation already present for Ynet and Maariv.
 - Ynet source-health diagnostics now split RSS and category-page checks so RSS low coverage,
   category HTTP failure, category parse-zero, and category keyword-zero outcomes are visible.
 - Search-backed discovery and backfill now emit source-targeted taxonomy queries for every enabled
@@ -88,13 +98,11 @@ backfill aggregate-count slowness. The auditable evidence summary is checked in 
 
 ### What comes next
 
-1. Implement a narrow #72 source-native reliability PR for Ynet, Walla, Maariv, and ICE using the
-   fresh Phase C diagnostic evidence.
-2. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
+1. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-3. Keep #88 lower priority unless bounded backfill evidence shows aggregate-count updates are a real
+2. Keep #88 lower priority unless bounded backfill evidence shows aggregate-count updates are a real
    local bottleneck.
-4. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
+3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 
 ### Likely code touchpoints

--- a/PLAN.md
+++ b/PLAN.md
@@ -46,10 +46,11 @@ self-heal-eligible failed candidates without running AI repair.
 
 The #72 source-native reliability follow-through keeps the fix intentionally narrow. Walla archive
 filtering and ICE search now use targeted supplemental Hebrew recall terms, matching the
-source-native relaxation already present for Ynet and Maariv. Source-health diagnostics still report
-keyword-zero as a per-source warning, but the report-level `source_zero_summary` guardrail now
-counts hard source-zero/stale/fetch/parse failures only, so healthy pages with no sampled keyword
-hit no longer masquerade as systemic source outage evidence.
+source-native relaxation already present for Ynet and Maariv. Source-health diagnostics now keep
+keyword-zero visible both per source and in separate report-level keyword-zero counts, while
+`source_zero_summary.systemic_source_zero_suspected` is reserved for hard
+source-zero/stale/fetch/parse failures so healthy pages with no sampled keyword hit no longer
+masquerade as systemic source outage evidence.
 
 A fresh Phase C source-health triage pass on 2026-05-03 used an isolated
 `data/may_26_followup/20260503T074131Z/state` root and Chromium installed through Playwright before
@@ -72,7 +73,8 @@ checked in at
   cases.
 - Source-health diagnostics include a `source_zero_summary` that flags the 4+ hard affected-source
   guardrail used to decide whether a run is systemic rather than source-specific; keyword-zero
-  outcomes stay visible on individual source checks without counting as hard source-zero evidence.
+  outcomes stay visible through separate report-level keyword-zero counts and individual source
+  checks without counting as hard source-zero evidence.
 - Discovery diagnostics include structured scrape-failure groups keyed by attempt kind, fetch
   status, error code, source adapter, and domain, including self-heal-eligible counts.
 - Candidate scrape failures mark durable candidates as `self_heal_eligible`, and the candidate queue

--- a/README.md
+++ b/README.md
@@ -349,9 +349,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - Ynet source-health diagnostics now report separate RSS and category-page checks, distinguishing
   RSS low coverage, category HTTP failure, category parse-zero, and category keyword-zero cases
 - source-health diagnostics now include a report-level `source_zero_summary` for the Phase C
-  4+ hard affected-source guardrail, keep keyword-zero outcomes visible as per-source warnings, and
-  include Mako `failure_mode` details for missing Chromium, navigation timeout, context teardown,
-  redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero outcomes
+  4+ hard affected-source guardrail, keep keyword-zero outcomes visible through separate
+  report-level counts and per-source warnings, and include Mako `failure_mode` details for missing
+  Chromium, navigation timeout, context teardown, redirect/anti-bot, selector drift, parse-zero, and
+  stale/keyword-zero outcomes
 - the 2026-05-03 Phase C source-health triage pass, run with an isolated
   `DENBUST_STATE_ROOT` and Chromium installed before Mako probing, showed Mako and Haaretz healthy
   while the then-current 4-source guardrail still fired for Ynet, Walla, Maariv, and ICE; the #72

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Planned future datasets:
   search-engine recall
 - Adds source-targeted taxonomy queries for each configured news domain so search-backed discovery
   and capped historical backfill can compensate when source-native pages produce zero recent matches
+- Expands source-native recall terms for Walla archive filtering and ICE search so diagnostics and
+  discovery exercise targeted Hebrew phrases beyond the coarse operator keyword sample
 - Protects the Ynet source-targeted taxonomy search path with fixture-backed recall coverage for a
   known February 12, 2026 article, including candidate provenance and pre-classification handoff
 - Keeps Ynet RSS as the primary משפט ופלילים source while adding a non-browser category-page
@@ -347,13 +349,14 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - Ynet source-health diagnostics now report separate RSS and category-page checks, distinguishing
   RSS low coverage, category HTTP failure, category parse-zero, and category keyword-zero cases
 - source-health diagnostics now include a report-level `source_zero_summary` for the Phase C
-  4+ affected-source guardrail, plus Mako `failure_mode` details for missing Chromium, navigation
-  timeout, context teardown, redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero
-  outcomes
+  4+ hard affected-source guardrail, keep keyword-zero outcomes visible as per-source warnings, and
+  include Mako `failure_mode` details for missing Chromium, navigation timeout, context teardown,
+  redirect/anti-bot, selector drift, parse-zero, and stale/keyword-zero outcomes
 - the 2026-05-03 Phase C source-health triage pass, run with an isolated
   `DENBUST_STATE_ROOT` and Chromium installed before Mako probing, showed Mako and Haaretz healthy
-  while the systemic 4-source guardrail still fired for Ynet, Walla, Maariv, and ICE; this keeps
-  #72 active and makes #71/#74 duplicate or stale Mako runtime hygiene unless Mako regresses again
+  while the then-current 4-source guardrail still fired for Ynet, Walla, Maariv, and ICE; the #72
+  follow-up narrows that guardrail to hard source failures and makes #71/#74 duplicate or stale Mako
+  runtime hygiene unless Mako regresses again
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -121,10 +121,10 @@ The 2026-05-03 triage run used this shape under
 Haaretz passed, and the then-current `source_zero_summary.systemic_source_zero_suspected` stayed
 true because Ynet, Walla, Maariv, and ICE were affected by zero, stale, or keyword-zero evidence.
 After the #72 follow-up, keyword-zero remains a per-source warning but no longer counts toward the
-report-level hard source-zero guardrail. Operators should treat #71/#74 as duplicate or stale Mako
-runtime hygiene unless a Chromium-backed Mako probe regresses, and leave #88 as a later optimization
-unless backfill aggregation is observed as a real bottleneck. The durable evidence summary is
-checked in at
+report-level hard source-zero guardrail; it is tracked separately in the source-zero summary as
+keyword-zero recall evidence. Operators should treat #71/#74 as duplicate or stale Mako runtime
+hygiene unless a Chromium-backed Mako probe regresses, and leave #88 as a later optimization unless
+backfill aggregation is observed as a real bottleneck. The durable evidence summary is checked in at
 [phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
 ## GitHub Actions Run Path

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -118,11 +118,13 @@ with `.venv/bin/`.
 
 The 2026-05-03 triage run used this shape under
 `data/may_26_followup/20260503T074131Z/`. Mako passed in both all-source and source-specific runs,
-Haaretz passed, and `source_zero_summary.systemic_source_zero_suspected` stayed true because Ynet,
-Walla, Maariv, and ICE were affected. Operators should treat #71/#74 as duplicate or stale Mako
-runtime hygiene unless a Chromium-backed Mako probe regresses, keep #72 active for source-native
-reliability work, and leave #88 as a later optimization unless backfill aggregation is observed as a
-real bottleneck. The durable evidence summary is checked in at
+Haaretz passed, and the then-current `source_zero_summary.systemic_source_zero_suspected` stayed
+true because Ynet, Walla, Maariv, and ICE were affected by zero, stale, or keyword-zero evidence.
+After the #72 follow-up, keyword-zero remains a per-source warning but no longer counts toward the
+report-level hard source-zero guardrail. Operators should treat #71/#74 as duplicate or stale Mako
+runtime hygiene unless a Chromium-backed Mako probe regresses, and leave #88 as a later optimization
+unless backfill aggregation is observed as a real bottleneck. The durable evidence summary is
+checked in at
 [phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
 ## GitHub Actions Run Path

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -58,9 +58,8 @@ Affected sources: `ynet`, `walla`, `maariv`, `ice`.
   Chromium-backed Mako probe regresses.
 - #74: recommend closing as duplicate or stale with #71 unless a future Chromium-backed Mako probe
   regresses.
-- #72: addressed by the narrow source-native reliability follow-up that expands Walla/ICE targeted
-  recall terms and refines the report-level guardrail so keyword-zero remains visible per source
-  without counting as hard systemic source-zero evidence.
+- #72: keep active and use as the next narrow source-native reliability follow-up because the
+  4-source guardrail still fires for Ynet, Walla, Maariv, and ICE.
 - #88: keep as later optimization; this source-health triage did not exercise or expose backfill
   aggregate-count slowness.
 

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -58,8 +58,9 @@ Affected sources: `ynet`, `walla`, `maariv`, `ice`.
   Chromium-backed Mako probe regresses.
 - #74: recommend closing as duplicate or stale with #71 unless a future Chromium-backed Mako probe
   regresses.
-- #72: keep active and use as the next narrow source-native reliability follow-up because the
-  4-source guardrail still fires for Ynet, Walla, Maariv, and ICE.
+- #72: addressed by the narrow source-native reliability follow-up that expands Walla/ICE targeted
+  recall terms and refines the report-level guardrail so keyword-zero remains visible per source
+  without counting as hard systemic source-zero evidence.
 - #88: keep as later optimization; this source-health triage did not exercise or expose backfill
   aggregate-count slowness.
 

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -269,9 +269,9 @@ repair automation without fresh failure evidence. The 2026-05-03 Chromium-backed
 Mako and Haaretz live probes healthy while Ynet, Walla, Maariv, and ICE triggered the then-current
 zero/stale/keyword-zero guardrail. The #72 follow-up keeps source-native reliability narrow by
 expanding Walla/ICE targeted recall terms and by reserving the report-level hard source-zero
-guardrail for fetch/feed/stale/parse failures rather than keyword-zero warnings alone. Full AI
-repair, selector rewriting, automatic source creation, and live-network-dependent CI tests remain
-outside this narrow source-health path.
+guardrail for fetch/feed/stale/parse failures while keeping keyword-zero recall gaps visible through
+separate summary fields. Full AI repair, selector rewriting, automatic source creation, and
+live-network-dependent CI tests remain outside this narrow source-health path.
 
 ---
 

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -264,12 +264,14 @@ This lets the system treat:
 
 as different producers of the same candidate object type.
 
-Current Phase C source-health evidence supports keeping this producer model but prioritizing
-source-native reliability before broader repair automation. The 2026-05-03 Chromium-backed triage
-pass showed Mako and Haaretz live probes healthy while Ynet, Walla, Maariv, and ICE still triggered
-the 4-source zero/stale guardrail. That keeps #72 active as a source-native follow-up and leaves
-full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
-outside the next narrow PR.
+Current Phase C source-health evidence supports keeping this producer model while avoiding broader
+repair automation without fresh failure evidence. The 2026-05-03 Chromium-backed triage pass showed
+Mako and Haaretz live probes healthy while Ynet, Walla, Maariv, and ICE triggered the then-current
+zero/stale/keyword-zero guardrail. The #72 follow-up keeps source-native reliability narrow by
+expanding Walla/ICE targeted recall terms and by reserving the report-level hard source-zero
+guardrail for fetch/feed/stale/parse failures rather than keyword-zero warnings alone. Full AI
+repair, selector rewriting, automatic source creation, and live-network-dependent CI tests remain
+outside this narrow source-health path.
 
 ---
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -486,12 +486,11 @@ The recommended order is:
 - Mako passes in both all-source and source-specific live diagnostics, so #71/#74 should be treated
   as duplicate or stale runtime hygiene unless a future Chromium-backed Mako probe regresses
 - Haaretz passes live diagnostics
-- Ynet, Walla, Maariv, and ICE still trigger the 4-source
-  `source_zero_summary.systemic_source_zero_suspected` guardrail through zero, stale-result, or
-  keyword-zero outcomes
-- the next implementation PR should stay narrow to #72 source-native reliability; full AI repair,
-  selector rewriting, automatic source creation, and live-network-dependent CI tests remain out of
-  scope
+- #72 is addressed narrowly: Walla archive filtering and ICE search use targeted supplemental
+  Hebrew recall terms, and `source_zero_summary.systemic_source_zero_suspected` now counts hard
+  source-zero/stale/fetch/parse failures rather than keyword-zero warnings alone
+- full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
+  remain out of scope until a later repair PR has fresh evidence
 
 ---
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -488,7 +488,8 @@ The recommended order is:
 - Haaretz passes live diagnostics
 - #72 is addressed narrowly: Walla archive filtering and ICE search use targeted supplemental
   Hebrew recall terms, and `source_zero_summary.systemic_source_zero_suspected` now counts hard
-  source-zero/stale/fetch/parse failures rather than keyword-zero warnings alone
+  source-zero/stale/fetch/parse failures while keyword-zero recall gaps remain visible through
+  separate summary fields
 - full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
   remain out of scope until a later repair PR has fresh evidence
 

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -63,7 +63,6 @@ SOURCE_ZERO_GUARDRAIL_BUCKETS = {
     FailureBucket.FEED_FETCH_FAILED,
     FailureBucket.FEED_EMPTY_OR_STALE,
     FailureBucket.STALE_RESULTS,
-    FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
     FailureBucket.HTTP_FETCH_FAILED,
     FailureBucket.UNEXPECTED_REDIRECT,
     FailureBucket.SELECTOR_DRIFT_SUSPECTED,
@@ -997,6 +996,7 @@ async def _probe_ice(
     sample_keywords: list[str],
 ) -> SourceDiagnosticResult:
     cutoff = datetime.now(UTC) - timedelta(days=days)
+    search_terms = ice_source.effective_ice_search_terms(sample_keywords)
     checks: list[ProbeCheck] = []
     saw_successful_page = False
     saw_results_container = False
@@ -1009,7 +1009,7 @@ async def _probe_ice(
         headers={"User-Agent": ice_source.USER_AGENT},
         follow_redirects=True,
     ) as client:
-        for keyword in sample_keywords:
+        for keyword in search_terms:
             page_url = ice_source.build_ice_search_url(keyword, page_number=1)
             try:
                 fetch_result = await _fetch_text(
@@ -1066,6 +1066,8 @@ async def _probe_ice(
                         "status_code": fetch_result.status_code,
                         "content_type": fetch_result.content_type,
                         "payload_length": len(fetch_result.text),
+                        "sample_keyword_count": len(sample_keywords),
+                        "effective_search_term_count": len(search_terms),
                         "candidate_count": parsed.candidate_count,
                         "parsed_article_count": parsed.parsed_article_count,
                         "stale_candidate_count": parsed.stale_candidate_count,
@@ -1139,6 +1141,7 @@ async def _probe_walla(
     entry_total = 0
     recent_entry_total = 0
     keyword_match_total = 0
+    effective_keywords = walla_source.effective_walla_keywords(sample_keywords)
 
     async with httpx.AsyncClient(
         timeout=30.0,
@@ -1175,7 +1178,7 @@ async def _probe_walla(
                 keyword_matches = [
                     entry
                     for entry in recent_entries
-                    if scraper._matches_keywords(entry, sample_keywords)
+                    if scraper._matches_keywords(entry, effective_keywords)
                 ]
 
                 entry_total += len(entries)
@@ -1206,6 +1209,8 @@ async def _probe_walla(
                             "status_code": fetch_result.status_code,
                             "content_type": fetch_result.content_type,
                             "payload_length": len(fetch_result.text),
+                            "sample_keyword_count": len(sample_keywords),
+                            "effective_keyword_count": len(effective_keywords),
                             "entry_count": len(entries),
                             "recent_entry_count": len(recent_entries),
                             "keyword_match_count": len(keyword_matches),

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -112,7 +112,10 @@ class SourceZeroSummary(BaseModel):
     selected_source_count: int
     affected_source_count: int
     affected_sources: list[str] = Field(default_factory=list)
+    keyword_zero_source_count: int = 0
+    keyword_zero_sources: list[str] = Field(default_factory=list)
     systemic_source_zero_suspected: bool
+    systemic_keyword_zero_suspected: bool = False
 
 
 class SourceDiagnosticReport(BaseModel):
@@ -273,13 +276,20 @@ def render_source_diagnostic_report(report: SourceDiagnosticReport) -> str:
     if report.source_zero_summary is not None:
         summary = report.source_zero_summary
         sources = ", ".join(summary.affected_sources) if summary.affected_sources else "-"
+        keyword_zero_sources = (
+            ", ".join(summary.keyword_zero_sources) if summary.keyword_zero_sources else "-"
+        )
         lines.append(
             "Source-zero guardrail: "
             f"{summary.affected_source_count}/{summary.enabled_source_count} enabled affected "
             f"(threshold={summary.threshold}; "
             f"selected={summary.selected_source_count}; "
             f"systemic={str(summary.systemic_source_zero_suspected).lower()}; "
-            f"sources={sources})"
+            f"sources={sources}; "
+            f"keyword_zero={summary.keyword_zero_source_count}; "
+            f"systemic_keyword_zero="
+            f"{str(summary.systemic_keyword_zero_suspected).lower()}; "
+            f"keyword_zero_sources={keyword_zero_sources})"
         )
         lines.append("")
 
@@ -996,7 +1006,11 @@ async def _probe_ice(
     sample_keywords: list[str],
 ) -> SourceDiagnosticResult:
     cutoff = datetime.now(UTC) - timedelta(days=days)
-    search_terms = ice_source.effective_ice_search_terms(sample_keywords)
+    supplemental_terms = [
+        term
+        for term in ice_source.effective_ice_search_terms(sample_keywords)
+        if term not in set(sample_keywords)
+    ]
     checks: list[ProbeCheck] = []
     saw_successful_page = False
     saw_results_container = False
@@ -1009,7 +1023,7 @@ async def _probe_ice(
         headers={"User-Agent": ice_source.USER_AGENT},
         follow_redirects=True,
     ) as client:
-        for keyword in search_terms:
+        for keyword in sample_keywords:
             page_url = ice_source.build_ice_search_url(keyword, page_number=1)
             try:
                 fetch_result = await _fetch_text(
@@ -1067,7 +1081,8 @@ async def _probe_ice(
                         "content_type": fetch_result.content_type,
                         "payload_length": len(fetch_result.text),
                         "sample_keyword_count": len(sample_keywords),
-                        "effective_search_term_count": len(search_terms),
+                        "supplemental_search_term_count": len(supplemental_terms),
+                        "probe_phase": "sampled_keywords",
                         "candidate_count": parsed.candidate_count,
                         "parsed_article_count": parsed.parsed_article_count,
                         "stale_candidate_count": parsed.stale_candidate_count,
@@ -1076,6 +1091,88 @@ async def _probe_ice(
                     },
                 )
             )
+
+        sampled_keyword_article_total = parsed_article_total
+        if sampled_keyword_article_total == 0:
+            for keyword in supplemental_terms:
+                page_url = ice_source.build_ice_search_url(keyword, page_number=1)
+                try:
+                    fetch_result = await _fetch_text(
+                        page_url,
+                        user_agent=ice_source.USER_AGENT,
+                        client=client,
+                    )
+                except Exception as exc:
+                    checks.append(
+                        ProbeCheck(
+                            name=f"supplemental_search:{keyword}",
+                            status=DiagnosticStatus.FAIL,
+                            summary=f"Supplemental search fetch failed: {exc}",
+                            details={
+                                "url": page_url,
+                                "probe_phase": "supplemental_fallback",
+                            },
+                        )
+                    )
+                    continue
+
+                saw_successful_page = True
+                if _is_unexpected_redirect(fetch_result.final_url, page_url):
+                    unexpected_redirect = True
+
+                parsed = ice_source.diagnose_ice_search_html(fetch_result.text, cutoff=cutoff)
+                if parsed.has_results_container:
+                    saw_results_container = True
+
+                parsed_article_total += parsed.parsed_article_count
+                stale_candidate_total += parsed.stale_candidate_count
+                if not parsed.has_results_container:
+                    status = DiagnosticStatus.FAIL
+                    summary = (
+                        "Supplemental search page did not expose the expected ICE results container"
+                    )
+                elif (
+                    parsed.parsed_article_count == 0
+                    and parsed.stale_candidate_count == parsed.candidate_count
+                    and parsed.candidate_count
+                ):
+                    status = DiagnosticStatus.WARN
+                    summary = (
+                        "Supplemental search page returned only stale candidates "
+                        "outside the cutoff window"
+                    )
+                elif parsed.parsed_article_count == 0:
+                    status = DiagnosticStatus.WARN
+                    summary = (
+                        "Supplemental search page contains candidates but parsing "
+                        "returned zero articles"
+                    )
+                else:
+                    status = DiagnosticStatus.OK
+                    summary = "Supplemental search page returned parsed articles"
+
+                checks.append(
+                    ProbeCheck(
+                        name=f"supplemental_search:{keyword}",
+                        status=status,
+                        summary=summary,
+                        details={
+                            "requested_url": page_url,
+                            "final_url": fetch_result.final_url,
+                            "status_code": fetch_result.status_code,
+                            "content_type": fetch_result.content_type,
+                            "payload_length": len(fetch_result.text),
+                            "sample_keyword_count": len(sample_keywords),
+                            "supplemental_search_term_count": len(supplemental_terms),
+                            "probe_phase": "supplemental_fallback",
+                            "candidate_count": parsed.candidate_count,
+                            "parsed_article_count": parsed.parsed_article_count,
+                            "stale_candidate_count": parsed.stale_candidate_count,
+                            "unparseable_date_count": parsed.unparseable_date_count,
+                            "has_results_container": parsed.has_results_container,
+                        },
+                    )
+                )
 
     if not saw_successful_page:
         return _live_result(
@@ -1541,6 +1638,11 @@ def _build_source_zero_summary(
         for result in results
         if result.failure_bucket in SOURCE_ZERO_GUARDRAIL_BUCKETS
     ]
+    keyword_zero_sources = [
+        result.source_name
+        for result in results
+        if result.failure_bucket is FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS
+    ]
     selected_source_count = len(results)
     full_coverage = selected_source_count == enabled_source_count
     return SourceZeroSummary(
@@ -1549,7 +1651,10 @@ def _build_source_zero_summary(
         selected_source_count=selected_source_count,
         affected_source_count=len(affected_sources),
         affected_sources=affected_sources,
+        keyword_zero_source_count=len(keyword_zero_sources),
+        keyword_zero_sources=keyword_zero_sources,
         systemic_source_zero_suspected=full_coverage and len(affected_sources) >= threshold,
+        systemic_keyword_zero_suspected=full_coverage and len(keyword_zero_sources) >= threshold,
     )
 
 

--- a/src/denbust/sources/ice.py
+++ b/src/denbust/sources/ice.py
@@ -23,6 +23,18 @@ ICE_BASE_URL = "https://www.ice.co.il"
 ICE_SEARCH_URL_PREFIX = f"{ICE_BASE_URL}/list/searchresult"
 MAX_SEARCH_PAGES = 5
 DEFAULT_RATE_LIMIT_DELAY_SECONDS = 1.5
+ICE_SUPPLEMENTAL_SEARCH_TERMS = [
+    "חשד לבית בושת",
+    "בית בושת אותר",
+    "חשד לזנות",
+    "שידול לזנות",
+    "סרסרות",
+    "סרסורות",
+    "סחר בנשים",
+    "סחר מיני",
+    "מכון עיסוי",
+    "מכון ליווי",
+]
 
 
 @dataclass(frozen=True)
@@ -44,6 +56,24 @@ def build_ice_search_url(keyword: str, page_number: int = 1) -> str:
     if page_number > 1:
         url = f"{url}/page-{page_number}"
     return url
+
+
+def effective_ice_search_terms(keywords: list[str]) -> list[str]:
+    """Return ICE search terms with targeted supplemental recall phrases."""
+    seen: set[str] = set()
+    values: list[str] = []
+
+    for keyword in [*keywords, *ICE_SUPPLEMENTAL_SEARCH_TERMS]:
+        candidate = " ".join(keyword.split()).strip()
+        if not candidate:
+            continue
+        key = candidate.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        values.append(candidate)
+
+    return values
 
 
 def diagnose_ice_search_html(
@@ -99,6 +129,9 @@ class IceScraper(Source):
 
         articles: list[RawArticle] = []
         cutoff = datetime.now(UTC) - timedelta(days=days)
+        supplemental_terms = [
+            term for term in effective_ice_search_terms(keywords) if term not in set(keywords)
+        ]
 
         async with httpx.AsyncClient(
             timeout=30.0,
@@ -110,6 +143,11 @@ class IceScraper(Source):
             for keyword in keywords:
                 await self._rate_limit()
                 articles.extend(await self._search_keyword(keyword, cutoff))
+
+            if not articles:
+                for keyword in supplemental_terms:
+                    await self._rate_limit()
+                    articles.extend(await self._search_keyword(keyword, cutoff))
 
             self._client = None
 

--- a/src/denbust/sources/walla.py
+++ b/src/denbust/sources/walla.py
@@ -22,6 +22,18 @@ WALLA_BASE_URL = "https://news.walla.co.il"
 WALLA_ARCHIVE_CATEGORY_IDS = (1, 10)
 DEFAULT_RATE_LIMIT_DELAY_SECONDS = 1.5
 MAX_ARCHIVE_PAGES_PER_MONTH = 12
+WALLA_SUPPLEMENTAL_KEYWORDS = [
+    "חשד לבית בושת",
+    "בית בושת אותר",
+    "חשד לזנות",
+    "שידול לזנות",
+    "סרסרות",
+    "סרסורות",
+    "סחר בנשים",
+    "סחר מיני",
+    "מכון עיסוי",
+    "מכון ליווי",
+]
 
 
 class WallaArchiveEntry(NamedTuple):
@@ -31,6 +43,24 @@ class WallaArchiveEntry(NamedTuple):
     title: str
     snippet: str
     date: datetime
+
+
+def effective_walla_keywords(keywords: list[str]) -> list[str]:
+    """Return Walla's effective keyword set with targeted supplemental phrases."""
+    seen: set[str] = set()
+    values: list[str] = []
+
+    for keyword in [*keywords, *WALLA_SUPPLEMENTAL_KEYWORDS]:
+        candidate = " ".join(keyword.split()).strip()
+        if not candidate:
+            continue
+        key = candidate.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        values.append(candidate)
+
+    return values
 
 
 class WallaScraper(Source):
@@ -56,6 +86,7 @@ class WallaScraper(Source):
 
         now = datetime.now(UTC)
         cutoff = now - timedelta(days=days)
+        effective_keywords = effective_walla_keywords(keywords)
         months = list(self._iter_months(cutoff, now))
         articles: list[RawArticle] = []
 
@@ -70,7 +101,9 @@ class WallaScraper(Source):
                 for year, month in months:
                     await self._rate_limit()
                     articles.extend(
-                        await self._scrape_archive_month(category_id, year, month, cutoff, keywords)
+                        await self._scrape_archive_month(
+                            category_id, year, month, cutoff, effective_keywords
+                        )
                     )
 
             self._client = None

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -19,7 +19,12 @@ from denbust.sources.haaretz import (
     _HaaretzSearchEntry,
     create_haaretz_source,
 )
-from denbust.sources.ice import IceScraper, create_ice_source
+from denbust.sources.ice import (
+    IceScraper,
+    build_ice_search_url,
+    create_ice_source,
+    effective_ice_search_terms,
+)
 from denbust.sources.maariv import MaarivScraper, create_maariv_source
 from denbust.sources.mako import SEARCH_POLL_INTERVAL_MS, MakoScraper, create_mako_source
 from denbust.sources.rss import RSSSource, YnetRSSSource, diagnose_ynet_category_html
@@ -1526,6 +1531,68 @@ class TestIceScraper:
         articles = await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=[keyword])
 
         assert len(articles) == 2
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_uses_supplemental_terms_after_primary_keywords_return_zero(self) -> None:
+        """Supplemental ICE searches should run only after explicit keywords produce no articles."""
+        scraper = self._create_scraper()
+        keyword = "זנות"
+        supplemental = "חשד לבית בושת"
+        primary_route = respx.get(scraper._build_search_url(keyword)).mock(
+            return_value=Response(
+                200,
+                text="""
+                <html><body><h1>תוצאות חיפוש</h1><article><ul>
+                <li><div>missing article link</div></li>
+                </ul></article></body></html>
+                """,
+            )
+        )
+        supplemental_route = respx.get(build_ice_search_url(supplemental)).mock(
+            return_value=Response(
+                200,
+                text="""
+                <html>
+                  <body>
+                    <main>
+                      <h1>נמצאו 1 תוצאות חיפוש של חשד לבית בושת</h1>
+                      <article>
+                        <ul>
+                          <li>
+                            <a href="/law/news/article/1099999">חשד לבית בושת בבניין מגורים</a>
+                            <a href="/law/news/article/1099999">המשטרה עצרה חשוד</a>
+                            <span>12/3/2026 7:46</span>
+                          </li>
+                        </ul>
+                      </article>
+                    </main>
+                  </body>
+                </html>
+                """,
+            )
+        )
+        for term in effective_ice_search_terms([keyword]):
+            if term in {keyword, supplemental}:
+                continue
+            respx.get(build_ice_search_url(term)).mock(
+                return_value=Response(
+                    200,
+                    text="""
+                    <html><body><h1>תוצאות חיפוש</h1><article><ul>
+                    <li><div>missing article link</div></li>
+                    </ul></article></body></html>
+                    """,
+                )
+            )
+
+        articles = await scraper.fetch(days=TEST_LOOKBACK_DAYS, keywords=[keyword])
+
+        assert primary_route.called is True
+        assert supplemental_route.called is True
+        assert [str(article.url) for article in articles] == [
+            "https://www.ice.co.il/law/news/article/1099999"
+        ]
 
 
 class TestHaaretzScraper:

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -468,9 +468,12 @@ def test_build_source_zero_summary_flags_systemic_source_zero_for_hard_buckets()
     assert summary.enabled_source_count == 6
     assert summary.selected_source_count == 6
     assert summary.affected_sources == ["ynet", "walla", "mako", "maariv"]
+    assert summary.keyword_zero_source_count == 0
+    assert summary.keyword_zero_sources == []
+    assert summary.systemic_keyword_zero_suspected is False
 
 
-def test_build_source_zero_summary_keeps_keyword_zero_out_of_systemic_guardrail() -> None:
+def test_build_source_zero_summary_keeps_keyword_zero_as_separate_recall_signal() -> None:
     summary = source_health._build_source_zero_summary(
         [
             SourceDiagnosticResult(
@@ -497,6 +500,16 @@ def test_build_source_zero_summary_keeps_keyword_zero_out_of_systemic_guardrail(
                 live_status=DiagnosticStatus.WARN,
                 failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
             ),
+            SourceDiagnosticResult(
+                source_name="mako",
+                status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.OK,
+            ),
+            SourceDiagnosticResult(
+                source_name="haaretz",
+                status=DiagnosticStatus.OK,
+                live_status=DiagnosticStatus.OK,
+            ),
         ],
         enabled_source_count=6,
     )
@@ -504,6 +517,9 @@ def test_build_source_zero_summary_keeps_keyword_zero_out_of_systemic_guardrail(
     assert summary.affected_sources == []
     assert summary.affected_source_count == 0
     assert summary.systemic_source_zero_suspected is False
+    assert summary.keyword_zero_sources == ["ynet", "walla", "maariv", "ice"]
+    assert summary.keyword_zero_source_count == 4
+    assert summary.systemic_keyword_zero_suspected is True
 
 
 def test_build_source_zero_summary_ignores_generic_warns_without_source_zero_bucket() -> None:
@@ -1373,10 +1389,11 @@ async def test_probe_ice_reports_successful_page(monkeypatch: pytest.MonkeyPatch
 
     assert result.live_status == DiagnosticStatus.OK
     assert result.failure_bucket is None
+    assert result.checks[0].details["probe_phase"] == "sampled_keywords"
 
 
 @pytest.mark.asyncio
-async def test_probe_ice_queries_supplemental_search_terms(
+async def test_probe_ice_skips_supplemental_terms_when_sampled_keywords_return_articles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     requested_urls: list[str] = []
@@ -1413,9 +1430,64 @@ async def test_probe_ice_queries_supplemental_search_terms(
     result = await source_health._probe_ice(days=21, sample_keywords=["זנות"])
 
     assert result.live_status == DiagnosticStatus.OK
+    assert build_ice_search_url("זנות") in requested_urls
+    assert build_ice_search_url("חשד לבית בושת") not in requested_urls
+    assert all(check.details["probe_phase"] == "sampled_keywords" for check in result.checks)
+
+
+@pytest.mark.asyncio
+async def test_probe_ice_queries_supplemental_terms_after_sampled_keywords_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        requested_urls.append(url)
+        html = """
+        <html>
+          <body>
+            <h1>תוצאות חיפוש</h1>
+            <article><ul><li><div>missing article link</div></li></ul></article>
+          </body>
+        </html>
+        """
+        if url == build_ice_search_url("חשד לבית בושת"):
+            html = """
+            <html>
+              <body>
+                <h1>תוצאות חיפוש</h1>
+                <article>
+                  <ul>
+                    <li>
+                      <a href="/article/123">בית בושת אותר</a>
+                      <span>01/01/2099 12:00</span>
+                    </li>
+                  </ul>
+                </article>
+              </body>
+            </html>
+            """
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_ice(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.OK
     assert build_ice_search_url("חשד לבית בושת") in requested_urls
     assert result.checks[0].details["sample_keyword_count"] == 1
-    assert result.checks[0].details["effective_search_term_count"] > 1
+    assert result.checks[0].details["supplemental_search_term_count"] > 1
+    assert result.checks[0].details["probe_phase"] == "sampled_keywords"
+    assert any(check.details["probe_phase"] == "supplemental_fallback" for check in result.checks)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -21,8 +21,13 @@ from denbust.diagnostics.source_health import (
     _FetchResult,
 )
 from denbust.sources.base import Source
-from denbust.sources.ice import build_ice_search_url, diagnose_ice_search_html
+from denbust.sources.ice import (
+    build_ice_search_url,
+    diagnose_ice_search_html,
+    effective_ice_search_terms,
+)
 from denbust.sources.maariv import diagnose_maariv_section_html
+from denbust.sources.walla import effective_walla_keywords
 
 
 def _config_with_state_root(state_root: Path) -> Config:
@@ -125,6 +130,24 @@ def test_ice_diagnostic_helper_reports_public_parse_counts() -> None:
     assert result.stale_candidate_count == 0
     assert result.unparseable_date_count == 0
     assert result.article_urls == ["https://www.ice.co.il/article/123"]
+
+
+def test_walla_effective_keywords_add_source_native_recall_phrases() -> None:
+    keywords = effective_walla_keywords(["זנות", "בית בושת"])
+
+    assert keywords[:2] == ["זנות", "בית בושת"]
+    assert "חשד לבית בושת" in keywords
+    assert "מכון עיסוי" in keywords
+    assert len(keywords) == len(set(keywords))
+
+
+def test_ice_effective_search_terms_add_source_native_recall_phrases() -> None:
+    terms = effective_ice_search_terms(["זנות", "בית בושת"])
+
+    assert terms[:2] == ["זנות", "בית בושת"]
+    assert "חשד לבית בושת" in terms
+    assert "סחר מיני" in terms
+    assert len(terms) == len(set(terms))
 
 
 def test_source_health_diagnostics_do_not_call_maariv_or_ice_private_parse_methods() -> None:
@@ -399,14 +422,14 @@ def test_merge_status_and_derive_bucket_and_live_result() -> None:
     assert result.checks[0].details["failure_bucket"] == FailureBucket.UNEXPECTED_REDIRECT.value
 
 
-def test_build_source_zero_summary_flags_systemic_source_zero_for_relevant_buckets() -> None:
+def test_build_source_zero_summary_flags_systemic_source_zero_for_hard_buckets() -> None:
     summary = source_health._build_source_zero_summary(
         [
             SourceDiagnosticResult(
                 source_name="ynet",
                 status=DiagnosticStatus.WARN,
                 live_status=DiagnosticStatus.WARN,
-                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+                failure_bucket=FailureBucket.FEED_EMPTY_OR_STALE,
             ),
             SourceDiagnosticResult(
                 source_name="walla",
@@ -445,6 +468,42 @@ def test_build_source_zero_summary_flags_systemic_source_zero_for_relevant_bucke
     assert summary.enabled_source_count == 6
     assert summary.selected_source_count == 6
     assert summary.affected_sources == ["ynet", "walla", "mako", "maariv"]
+
+
+def test_build_source_zero_summary_keeps_keyword_zero_out_of_systemic_guardrail() -> None:
+    summary = source_health._build_source_zero_summary(
+        [
+            SourceDiagnosticResult(
+                source_name="ynet",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            ),
+            SourceDiagnosticResult(
+                source_name="walla",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            ),
+            SourceDiagnosticResult(
+                source_name="maariv",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            ),
+            SourceDiagnosticResult(
+                source_name="ice",
+                status=DiagnosticStatus.WARN,
+                live_status=DiagnosticStatus.WARN,
+                failure_bucket=FailureBucket.KEYWORD_FILTER_ZEROED_RESULTS,
+            ),
+        ],
+        enabled_source_count=6,
+    )
+
+    assert summary.affected_sources == []
+    assert summary.affected_source_count == 0
+    assert summary.systemic_source_zero_suspected is False
 
 
 def test_build_source_zero_summary_ignores_generic_warns_without_source_zero_bucket() -> None:
@@ -488,7 +547,7 @@ def test_build_source_zero_summary_preserves_enabled_count_for_scoped_runs() -> 
 
     assert summary.enabled_source_count == 6
     assert summary.selected_source_count == 1
-    assert summary.affected_source_count == 1
+    assert summary.affected_source_count == 0
     assert summary.systemic_source_zero_suspected is False
 
 
@@ -1317,6 +1376,49 @@ async def test_probe_ice_reports_successful_page(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_probe_ice_queries_supplemental_search_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        requested_urls.append(url)
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html>
+              <body>
+                <h1>תוצאות חיפוש</h1>
+                <article>
+                  <ul>
+                    <li>
+                      <a href="/article/123">בית בושת אותר</a>
+                      <span>01/01/2099 12:00</span>
+                    </li>
+                  </ul>
+                </article>
+              </body>
+            </html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_ice(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.OK
+    assert build_ice_search_url("חשד לבית בושת") in requested_urls
+    assert result.checks[0].details["sample_keyword_count"] == 1
+    assert result.checks[0].details["effective_search_term_count"] > 1
+
+
+@pytest.mark.asyncio
 async def test_probe_ice_handles_nested_heading_text(monkeypatch: pytest.MonkeyPatch) -> None:
     html = """
     <html>
@@ -1537,6 +1639,48 @@ async def test_probe_walla_reports_success(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert result.live_status == DiagnosticStatus.OK
     assert result.failure_bucket is None
+
+
+@pytest.mark.asyncio
+async def test_probe_walla_uses_source_specific_relaxed_keywords(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    html = """
+    <html>
+      <body>
+        <li>
+          <a href="https://news.walla.co.il/item/3823239">
+            <article>
+              <h3>חשד לבית בושת בבני ברק</h3>
+              <p>המשטרה עצרה חשודים.</p>
+              <span class="pub-date">12:00 01/01/2099</span>
+            </article>
+          </a>
+        </li>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        return _FetchResult(
+            requested_url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_walla(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.OK
+    assert result.failure_bucket is None
+    assert result.checks[0].details["sample_keyword_count"] == 1
+    assert result.checks[0].details["effective_keyword_count"] > 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -133,7 +133,7 @@ def test_ice_diagnostic_helper_reports_public_parse_counts() -> None:
 
 
 def test_walla_effective_keywords_add_source_native_recall_phrases() -> None:
-    keywords = effective_walla_keywords(["זנות", "בית בושת"])
+    keywords = effective_walla_keywords(["זנות", "בית בושת", "", "  ", "בית בושת"])
 
     assert keywords[:2] == ["זנות", "בית בושת"]
     assert "חשד לבית בושת" in keywords
@@ -142,7 +142,7 @@ def test_walla_effective_keywords_add_source_native_recall_phrases() -> None:
 
 
 def test_ice_effective_search_terms_add_source_native_recall_phrases() -> None:
-    terms = effective_ice_search_terms(["זנות", "בית בושת"])
+    terms = effective_ice_search_terms(["זנות", "בית בושת", "", "  ", "בית בושת"])
 
     assert terms[:2] == ["זנות", "בית בושת"]
     assert "חשד לבית בושת" in terms
@@ -1488,6 +1488,45 @@ async def test_probe_ice_queries_supplemental_terms_after_sampled_keywords_zero(
     assert result.checks[0].details["supplemental_search_term_count"] > 1
     assert result.checks[0].details["probe_phase"] == "sampled_keywords"
     assert any(check.details["probe_phase"] == "supplemental_fallback" for check in result.checks)
+
+
+@pytest.mark.asyncio
+async def test_probe_ice_reports_supplemental_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(
+        url: str, *, user_agent: str, client: httpx.AsyncClient | None = None
+    ) -> _FetchResult:
+        del user_agent, client
+        final_url = url
+        if url == build_ice_search_url("חשד לבית בושת"):
+            final_url = "https://example.com/redirect"
+        return _FetchResult(
+            requested_url=url,
+            final_url=final_url,
+            status_code=200,
+            content_type="text/html",
+            text="""
+            <html>
+              <body>
+                <h1>תוצאות חיפוש</h1>
+                <article><ul><li><div>missing article link</div></li></ul></article>
+              </body>
+            </html>
+            """,
+        )
+
+    monkeypatch.setattr(source_health, "_fetch_text", fake_fetch)
+
+    result = await source_health._probe_ice(days=21, sample_keywords=["זנות"])
+
+    assert result.live_status == DiagnosticStatus.WARN
+    assert result.failure_bucket == FailureBucket.UNEXPECTED_REDIRECT
+    assert any(
+        check.details["probe_phase"] == "supplemental_fallback"
+        and check.details["final_url"] == "https://example.com/redirect"
+        for check in result.checks
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Planning notation

- Notation: Phase C #72
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/phase_c_source_health_triage_2026_05_03.md`

## Summary

This is the narrow Phase C #72 source-native reliability follow-up from the 2026-05-03 source-health triage evidence.

- Expands Walla archive filtering with targeted supplemental Hebrew recall phrases so source-native archive pages can match source-specific enforcement wording beyond the coarse sampled keywords.
- Expands ICE source-native search terms with the same targeted phrase set, but only spends supplemental runtime searches after the explicit keyword set returns no articles.
- Keeps `denbust diagnose-sources` more exhaustive for ICE by probing the full effective ICE term set in diagnostics.
- Refines the report-level `source_zero_summary` guardrail so hard source-zero/stale/fetch/parse failures still count, while `keyword_filter_zeroed_results` remains visible as a per-source warning instead of counting as a systemic hard source outage.
- Updates `.agent-plan.md`, `README.md`, `PLAN.md`, and source-health/discovery docs to describe the post-merge state.

## Why

PR #105 preserved durable evidence that Mako and Haaretz were healthy after Chromium was installed, while Ynet, Walla, Maariv, and ICE still produced zero/stale/keyword-zero evidence. That made #72 the active correctness follow-up, but the evidence did not justify selector rewriting, AI repair, automatic source creation, or live-network-dependent CI tests.

This PR turns the repeatable part of that evidence into fixture-backed behavior: source-native paths get deterministic recall-term expansion where they need it, and diagnostics stop treating healthy pages with sampled keyword misses as equivalent to hard source outages.

## Issue follow-up

Closes #72.

Recommend closing #71 and #74 as duplicate or stale Mako runtime hygiene unless a future Chromium-backed Mako probe regresses. The 2026-05-03 all-source and source-specific Mako probes both passed after Chromium installation.

Keep #88 later unless bounded backfill evidence shows aggregate-count updates are a real bottleneck.

## Out of scope

- No AI repair loop.
- No selector rewriting.
- No automatic source creation.
- No live-network-dependent CI tests.
- No Mako runtime changes.
- No #88 backfill persistence optimization.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_source_health.py`
- `.venv/bin/pytest -q tests/integration/test_scrapers.py::TestIceScraper tests/unit/test_source_health.py`
- `.venv/bin/pytest -q` (`932 passed`, one existing `test_cli` runtime warning)
- pre-push hooks with `.venv/bin` on PATH: ruff, ruff format, unit tests, integration tests
