### PR TITLE
Optimize backfill aggregate counts

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,11 @@
 
 ## Mainline Status
 
-- Last merged PR on main: Phase C #72 source-native reliability narrows the source-zero guardrail
-  to hard source failures, keeps keyword-zero as a per-source warning, and expands Walla/ICE
-  source-native recall terms with fixture-backed diagnostics coverage.
-- Next planned PR: keep #88 as the next available lower-priority optimization only if bounded
-  backfill evidence shows aggregate-count updates are a real bottleneck.
+- Last merged PR on main: #88 backfill aggregate counts now use a persistence-layer aggregate
+  count API, with Supabase exact-count requests and state-repo streaming counts preserving existing
+  batch status semantics without materializing rows in the pipeline.
+- Next planned PR: wait for fresh local or CI evidence before taking another bounded source-health,
+  Mako runtime, backfill, or self-healing follow-up.
 - Current blockers on main: no Mako runtime blocker is known after Chromium install; #71/#74 are
   duplicate or stale Mako runtime hygiene unless a future Chromium-backed probe regresses;
   source-native keyword-zero remains visible per source but no longer trips the systemic hard
@@ -52,8 +52,10 @@
 - [done] Implement the narrow #72 source-native reliability follow-up by expanding Walla/ICE
   source-native recall terms and refining the source-zero guardrail so keyword-zero evidence stays
   visible without masquerading as hard source failure.
-- [next] Keep #88 as a later bounded optimization unless backfill evidence shows aggregate-count
-  updates are a real local bottleneck.
+- [done] Replace the #88 backfill aggregate-count row-listing path with a narrow aggregate count
+  API and fixture-backed pipeline/storage coverage.
+- [next] Wait for fresh local or CI evidence before selecting another bounded source-health, Mako
+  runtime, backfill, or self-healing follow-up.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -52,21 +52,29 @@ keyword-zero visible both per source and in separate report-level keyword-zero c
 source-zero/stale/fetch/parse failures so healthy pages with no sampled keyword hit no longer
 masquerade as systemic source outage evidence.
 
+The #88 backfill reliability/performance follow-up keeps the backfill behavior unchanged while
+moving aggregate candidate counts behind the discovery persistence boundary. Batch status refreshes
+now ask persistence for merged and scrape-eligible counts directly; the Supabase backend uses
+PostgREST exact-count metadata, and the state-repo backend streams candidate JSONL count fields
+without hydrating full `PersistentCandidate` models for this pipeline path.
+
 A fresh Phase C source-health triage pass on 2026-05-03 used an isolated
 `data/may_26_followup/20260503T074131Z/state` root and Chromium installed through Playwright before
 live Mako probing. The all-source run showed Mako `ok` and Haaretz `ok`; Ynet, Walla, Maariv, and
 ICE still produced source-zero, stale-result, or keyword-zero diagnostics under the then-current
 guardrail. The per-source Mako run also passed, which makes #71/#74 duplicate or stale Mako runtime
 hygiene rather than the next correctness fix. #72 is now addressed by the narrow source-native
-recall/guardrail follow-up. #88 remains a later persistence optimization because this diagnostic pass
-did not exercise or expose backfill aggregate-count slowness. The auditable evidence summary is
-checked in at
+recall/guardrail follow-up. #88 is now addressed by the narrow aggregate-count persistence API; no
+broader backfill storage refactor or source-health work is included. The auditable Phase C evidence
+summary remains checked in at
 [`docs/phase_c_source_health_triage_2026_05_03.md`](docs/phase_c_source_health_triage_2026_05_03.md).
 
 ### What is already in place
 
 - Candidate persistence, scrape attempts, queue state, fallback retention, and backfill jobs already
   exist under `src/denbust/discovery/` and `src/denbust/pipeline.py`.
+- Backfill batch aggregate refreshes use persistence-layer candidate counts instead of listing all
+  batch candidates in the pipeline.
 - Discovery diagnostics already flow through `src/denbust/diagnostics/discovery.py` and
   `denbust diagnose-discovery`.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
@@ -102,8 +110,8 @@ checked in at
 
 1. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-2. Keep #88 lower priority unless bounded backfill evidence shows aggregate-count updates are a real
-   local bottleneck.
+2. Wait for fresh bounded evidence before selecting another Mako runtime, source-health, backfill,
+   or self-healing follow-up.
 3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Planned future datasets:
 - Plans historical backfill windows and persists durable `backfill_batches` metadata for slow-drain
   discovery/scrape work
 - Drains one historical backfill batch at a time with oldest-window-first scrape prioritization
+- Refreshes backfill batch aggregate counts through the discovery persistence layer, including
+  Supabase exact-count requests, without materializing full candidate rows in the pipeline
 - Provides an opt-in `agents/news/local_search.yaml` config for local source-native + Brave + Exa
   + Google CSE discovery experiments
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
@@ -325,6 +327,8 @@ DL-PR-06 now builds on the earlier discovery milestones:
   and runs historical search-engine discovery plus capability-based source-native discovery
 - a real `news_items / backfill_scrape` job that drains one historical batch at a time through the
   existing scrape-to-ingest path
+- persistence-layer aggregate count API used by backfill batch status refreshes, with Supabase
+  exact-count requests and state-repo streaming counts preserving existing aggregate semantics
 - `news_items / ingest` now uses the candidate scrape layer for source-native candidates while
   preserving the existing direct-fetch convenience flow as a compatibility fallback
 - Supabase migrations for:

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -33,6 +33,10 @@ denbust run --dataset news_items --job backfill_scrape --config agents/news/loca
 `discover` writes into the candidate-layer namespace under `news_items/discover/`.
 `ingest` remains the article-processing job and still owns `news_items/ingest/`.
 Backfill jobs also read and write the shared `news_items/discover/` candidate-layer state.
+Backfill batch status updates refresh merged and scrape-eligible candidate counts through the
+discovery persistence layer; Supabase-backed runs use server-side exact-count metadata, while
+state-repo runs stream the candidate JSONL count fields without hydrating full candidate models for
+that aggregate path.
 The search-engine side of `discover` and `backfill_discover` now emits `taxonomy_targeted` queries
 from the packaged TFHT taxonomy in addition to the coarse operator keyword list.
 When source-targeted taxonomy expansion is enabled for backfill, each window is capped by
@@ -123,8 +127,9 @@ true because Ynet, Walla, Maariv, and ICE were affected by zero, stale, or keywo
 After the #72 follow-up, keyword-zero remains a per-source warning but no longer counts toward the
 report-level hard source-zero guardrail; it is tracked separately in the source-zero summary as
 keyword-zero recall evidence. Operators should treat #71/#74 as duplicate or stale Mako runtime
-hygiene unless a Chromium-backed Mako probe regresses, and leave #88 as a later optimization unless
-backfill aggregation is observed as a real bottleneck. The durable evidence summary is checked in at
+hygiene unless a Chromium-backed Mako probe regresses. The #88 aggregate-count path is addressed by
+the narrow persistence count API; choose further backfill work only from fresh bottleneck evidence.
+The durable evidence summary is checked in at
 [phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
 ## GitHub Actions Run Path

--- a/docs/tfht_discovery_layer_design_amended.md
+++ b/docs/tfht_discovery_layer_design_amended.md
@@ -868,6 +868,11 @@ state repo, with `news_items / backfill_discover` reading
 invocation. Historical source-native discovery is capability-based and records warnings for sources
 that do not implement explicit window fetching.
 
+Backfill batch aggregate refreshes now read merged and scrape-eligible candidate counts through the
+discovery persistence boundary. Supabase-backed runs use exact-count metadata instead of downloading
+candidate rows for those totals, and state-repo runs stream the candidate JSONL count fields while
+preserving the existing batch status/count semantics.
+
 ---
 
 ## Self-healing support

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -328,6 +328,9 @@ Implemented.
   window fetching are skipped with warnings rather than treated as fatal
 - `news_items / backfill_scrape` drains one historical batch at a time with oldest-window-first
   ordering and reuses the existing scrape-to-ingest path
+- backfill batch status refreshes use persistence-layer candidate counts for merged and
+  scrape-eligible totals; Supabase uses server-side exact-count metadata, and state-repo runs stream
+  JSONL count fields without materializing full candidates in the pipeline
 
 ### Out of scope
 - no self-healing yet

--- a/src/denbust/discovery/persistence.py
+++ b/src/denbust/discovery/persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from denbust.discovery.models import (
     BackfillBatch,
@@ -14,6 +15,14 @@ from denbust.discovery.models import (
     PersistentCandidate,
     ScrapeAttempt,
 )
+
+
+@dataclass(frozen=True)
+class BackfillCandidateCounts:
+    """Candidate aggregate counts for one historical backfill batch."""
+
+    merged_candidate_count: int
+    queued_for_scrape_count: int
 
 
 class DiscoveryRunStore(ABC):
@@ -44,6 +53,24 @@ class CandidateStore(ABC):
         limit: int | None = None,
     ) -> list[PersistentCandidate]:
         """List durable candidates, optionally filtered by status and batch."""
+
+    @abstractmethod
+    def count_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        """Count durable candidates, optionally filtered by status and batch."""
+
+    @abstractmethod
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: Sequence[CandidateStatus],
+    ) -> BackfillCandidateCounts:
+        """Count all candidates and scrape-eligible candidates for one backfill batch."""
 
     @abstractmethod
     def find_candidate_by_urls(

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ from denbust.discovery.models import (
 )
 from denbust.discovery.persistence import (
     BackfillBatchStore,
+    BackfillCandidateCounts,
     CandidateStore,
     DiscoveryRunStore,
     ProvenanceStore,
@@ -70,6 +72,24 @@ class NullDiscoveryPersistence(DiscoveryPersistence):
     ) -> list[PersistentCandidate]:
         del statuses, backfill_batch_id, limit
         return []
+
+    def count_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        del statuses, backfill_batch_id
+        return 0
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: Sequence[CandidateStatus],
+    ) -> BackfillCandidateCounts:
+        del batch_id, scrapeable_statuses
+        return BackfillCandidateCounts(merged_candidate_count=0, queued_for_scrape_count=0)
 
     def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
         del batches
@@ -244,6 +264,69 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
         if limit is not None:
             return candidates[:limit]
         return candidates
+
+    def count_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        allowed_statuses = {status.value for status in statuses} if statuses is not None else None
+        candidate_path = (
+            self.paths.backfill_queue_path
+            if backfill_batch_id is not None
+            else self.paths.latest_candidates_path
+        )
+        if not candidate_path.exists():
+            return 0
+
+        count = 0
+        with open(candidate_path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                if (
+                    backfill_batch_id is not None
+                    and row.get("backfill_batch_id") != backfill_batch_id
+                ):
+                    continue
+                if (
+                    allowed_statuses is not None
+                    and row.get("candidate_status") not in allowed_statuses
+                ):
+                    continue
+                count += 1
+        return count
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: Sequence[CandidateStatus],
+    ) -> BackfillCandidateCounts:
+        scrapeable_status_values = {status.value for status in scrapeable_statuses}
+        if not self.paths.backfill_queue_path.exists():
+            return BackfillCandidateCounts(merged_candidate_count=0, queued_for_scrape_count=0)
+
+        merged_candidate_count = 0
+        queued_for_scrape_count = 0
+        with open(self.paths.backfill_queue_path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                if row.get("backfill_batch_id") != batch_id:
+                    continue
+                merged_candidate_count += 1
+                if row.get("candidate_status") in scrapeable_status_values:
+                    queued_for_scrape_count += 1
+        return BackfillCandidateCounts(
+            merged_candidate_count=merged_candidate_count,
+            queued_for_scrape_count=queued_for_scrape_count,
+        )
 
     def find_candidate_by_urls(
         self,
@@ -436,6 +519,44 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
             return [PersistentCandidate.model_validate(item) for item in payload]
         return []
 
+    def count_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        params: dict[str, str] = {"select": "candidate_id", "limit": "1"}
+        if statuses:
+            joined = ",".join(status.value for status in statuses)
+            params["candidate_status"] = f"in.({joined})"
+        if backfill_batch_id is not None:
+            params["backfill_batch_id"] = f"eq.{backfill_batch_id}"
+        response = self._request(
+            "GET",
+            self._table_names["persistent_candidates"],
+            params=params,
+            extra_headers={"Prefer": "count=exact"},
+        )
+        content_range = response.headers.get("content-range")
+        if content_range is not None and "/" in content_range:
+            return int(content_range.rsplit("/", 1)[1])
+        payload = response.json()
+        return len(payload) if isinstance(payload, list) else 0
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: Sequence[CandidateStatus],
+    ) -> BackfillCandidateCounts:
+        return BackfillCandidateCounts(
+            merged_candidate_count=self.count_candidates(backfill_batch_id=batch_id),
+            queued_for_scrape_count=self.count_candidates(
+                statuses=scrapeable_statuses,
+                backfill_batch_id=batch_id,
+            ),
+        )
+
     def find_candidate_by_urls(
         self,
         *,
@@ -557,9 +678,11 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
         self,
         primary: DiscoveryPersistence,
         mirrors: Sequence[DiscoveryPersistence],
+        count_source: DiscoveryPersistence | None = None,
     ) -> None:
         self.primary = primary
         self.mirrors = list(mirrors)
+        self.count_source = count_source or primary
 
     def close(self) -> None:
         self.primary.close()
@@ -598,6 +721,28 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
             statuses=statuses,
             backfill_batch_id=backfill_batch_id,
             limit=limit,
+        )
+
+    def count_candidates(
+        self,
+        *,
+        statuses: Sequence[CandidateStatus] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        return self.count_source.count_candidates(
+            statuses=statuses,
+            backfill_batch_id=backfill_batch_id,
+        )
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: Sequence[CandidateStatus],
+    ) -> BackfillCandidateCounts:
+        return self.count_source.count_backfill_batch_candidates(
+            batch_id=batch_id,
+            scrapeable_statuses=scrapeable_statuses,
         )
 
     def list_backfill_batches(
@@ -666,5 +811,9 @@ def create_discovery_persistence(config: Config) -> DiscoveryPersistence:
                 "scrape_attempts": config.candidates.scrape_attempts_table,
             },
         )
-        return CompositeDiscoveryPersistence(state_store, [supabase_store])
+        return CompositeDiscoveryPersistence(
+            state_store,
+            [supabase_store],
+            count_source=supabase_store,
+        )
     return state_store

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -503,13 +503,11 @@ def _batch_candidate_counts(
     batch_id: str,
 ) -> tuple[int, int]:
     """Return merged-candidate and queued-for-scrape counts for one backfill batch."""
-    batch_candidates = persistence.list_candidates(backfill_batch_id=batch_id)
-    queued_for_scrape_count = sum(
-        1
-        for candidate in batch_candidates
-        if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
+    counts = persistence.count_backfill_batch_candidates(
+        batch_id=batch_id,
+        scrapeable_statuses=SCRAPEABLE_CANDIDATE_STATUSES,
     )
-    return len(batch_candidates), queued_for_scrape_count
+    return counts.merged_candidate_count, counts.queued_for_scrape_count
 
 
 def _update_backfill_batch_state(

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -24,10 +24,11 @@ from denbust.discovery.models import (
     DiscoveryRunStatus,
     PersistentCandidate,
 )
+from denbust.discovery.persistence import BackfillCandidateCounts
 from denbust.discovery.scrape_queue import CandidateScrapeBatch
 from denbust.discovery.source_native import PersistedSourceDiscovery
 from denbust.discovery.state_paths import resolve_discovery_state_paths
-from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.discovery.storage import NullDiscoveryPersistence, StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName, JobName
 from denbust.models.runs import RunSnapshot
 from denbust.pipeline import run_news_backfill_discover_job, run_news_backfill_scrape_job
@@ -193,6 +194,41 @@ def select_stub(
     return persistence.list_candidates(limit=limit)
 
 
+class CountingOnlyPersistence(NullDiscoveryPersistence):
+    """Persistence fixture that exposes counts but fails if rows are listed."""
+
+    def __init__(self) -> None:
+        self.aggregate_calls: list[tuple[str, tuple[CandidateStatus, ...]]] = []
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: list[CandidateStatus] | tuple[CandidateStatus, ...],
+    ) -> BackfillCandidateCounts:
+        self.aggregate_calls.append((batch_id, tuple(scrapeable_statuses)))
+        return BackfillCandidateCounts(merged_candidate_count=8, queued_for_scrape_count=5)
+
+    def count_candidates(
+        self,
+        *,
+        statuses: list[CandidateStatus] | tuple[CandidateStatus, ...] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        del statuses, backfill_batch_id
+        raise AssertionError("aggregate counts should not use separate candidate counts")
+
+    def list_candidates(
+        self,
+        *,
+        statuses: list[CandidateStatus] | tuple[CandidateStatus, ...] | None = None,
+        backfill_batch_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[PersistentCandidate]:
+        del statuses, backfill_batch_id, limit
+        raise AssertionError("aggregate counts should not materialize candidate rows")
+
+
 @pytest.mark.asyncio
 async def test_tag_backfill_discovered_candidates_adds_metadata() -> None:
     """Backfill tagging should merge existing metadata with batch window metadata."""
@@ -283,6 +319,19 @@ def test_batch_candidate_counts_uses_batch_filter(tmp_path: Path) -> None:
 
     assert merged_count == 2
     assert queued_count == 2
+
+
+def test_batch_candidate_counts_uses_persistence_count_api() -> None:
+    """Aggregate refresh should use one persistence aggregate instead of listing rows."""
+    store = CountingOnlyPersistence()
+
+    merged_count, queued_count = pipeline_module._batch_candidate_counts(store, batch_id="batch-1")
+
+    assert merged_count == 8
+    assert queued_count == 5
+    assert store.aggregate_calls == [
+        ("batch-1", pipeline_module.SCRAPEABLE_CANDIDATE_STATUSES),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -23,6 +23,7 @@ from denbust.discovery.models import (
     ScrapeAttempt,
     ScrapeAttemptKind,
 )
+from denbust.discovery.persistence import BackfillCandidateCounts
 from denbust.discovery.source_native import (
     SourceDiscoveryAdapter,
     persist_discovered_candidates,
@@ -155,6 +156,8 @@ class RecordingPersistence(NullDiscoveryPersistence):
 
     def __init__(self) -> None:
         self.find_calls = 0
+        self.count_calls = 0
+        self.aggregate_count_calls = 0
         self.written_run: DiscoveryRun | None = None
         self.candidates: list[PersistentCandidate] = []
         self.provenance: list[CandidateProvenance] = []
@@ -174,6 +177,26 @@ class RecordingPersistence(NullDiscoveryPersistence):
 
     def append_provenance(self, events: list[CandidateProvenance]) -> None:
         self.provenance = list(events)
+
+    def count_candidates(
+        self,
+        *,
+        statuses: list[CandidateStatus] | tuple[CandidateStatus, ...] | None = None,
+        backfill_batch_id: str | None = None,
+    ) -> int:
+        del statuses, backfill_batch_id
+        self.count_calls += 1
+        return 11
+
+    def count_backfill_batch_candidates(
+        self,
+        *,
+        batch_id: str,
+        scrapeable_statuses: list[CandidateStatus] | tuple[CandidateStatus, ...],
+    ) -> BackfillCandidateCounts:
+        del batch_id, scrapeable_statuses
+        self.aggregate_count_calls += 1
+        return BackfillCandidateCounts(merged_candidate_count=13, queued_for_scrape_count=7)
 
 
 def test_source_discovery_adapter_name_and_discovered_at_override() -> None:
@@ -382,6 +405,11 @@ def test_null_discovery_persistence_is_noop() -> None:
 
     assert store.get_candidate("missing") is None
     assert store.list_candidates() == []
+    assert store.count_candidates() == 0
+    assert store.count_backfill_batch_candidates(
+        batch_id="batch-1",
+        scrapeable_statuses=[CandidateStatus.NEW],
+    ) == BackfillCandidateCounts(merged_candidate_count=0, queued_for_scrape_count=0)
     assert store.get_backfill_batch("missing") is None
     assert store.list_backfill_batches() == []
     assert (
@@ -425,6 +453,19 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
         == "queued"
     )
     assert store.list_candidates(backfill_batch_id="batch-1", limit=1)[0].candidate_id == "backfill"
+    assert store.count_candidates(backfill_batch_id="batch-1") == 1
+    assert store.count_candidates(statuses=[CandidateStatus.QUEUED]) == 1
+    assert (
+        store.count_candidates(
+            statuses=[CandidateStatus.QUEUED],
+            backfill_batch_id="batch-1",
+        )
+        == 0
+    )
+    assert store.count_backfill_batch_candidates(
+        batch_id="batch-1",
+        scrapeable_statuses=[CandidateStatus.SCRAPE_FAILED],
+    ) == BackfillCandidateCounts(merged_candidate_count=1, queued_for_scrape_count=1)
     assert (
         store.find_candidate_by_urls(
             canonical_url="https://www.walla.co.il/item",
@@ -458,6 +499,7 @@ def test_state_repo_discovery_persistence_handles_missing_and_blank_jsonl(tmp_pa
     paths.latest_candidates_path.parent.mkdir(parents=True, exist_ok=True)
     paths.latest_backfill_batches_path.parent.mkdir(parents=True, exist_ok=True)
     paths.latest_candidates_path.write_text("\n\n", encoding="utf-8")
+    paths.backfill_queue_path.write_text("\n\n", encoding="utf-8")
     paths.latest_backfill_batches_path.write_text("\n\n", encoding="utf-8")
     store.append_provenance([])
     store.append_attempts([])
@@ -465,6 +507,11 @@ def test_state_repo_discovery_persistence_handles_missing_and_blank_jsonl(tmp_pa
     store.upsert_backfill_batches([])
 
     assert store.list_candidates() == []
+    assert store.count_candidates() == 0
+    assert store.count_backfill_batch_candidates(
+        batch_id="batch-1",
+        scrapeable_statuses=[CandidateStatus.NEW],
+    ) == BackfillCandidateCounts(merged_candidate_count=0, queued_for_scrape_count=0)
     assert store.get_backfill_batch("missing") is None
     assert store.list_backfill_batches(statuses=[BackfillBatchStatus.RUNNING]) == []
 
@@ -577,6 +624,59 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
     assert headers["Authorization"] == "Bearer service-role"
 
 
+def test_supabase_discovery_persistence_counts_candidates_server_side() -> None:
+    """Supabase candidate counts should use PostgREST exact-count metadata."""
+    client = FakeHttpClient(
+        [
+            httpx.Response(200, json=[], headers={"content-range": "0-0/12"}),
+            httpx.Response(200, json=[], headers={"content-range": "*/5"}),
+            httpx.Response(200, json=[], headers={"content-range": "0-0/12"}),
+            httpx.Response(200, json=[], headers={"content-range": "*/5"}),
+            httpx.Response(200, json=[{"candidate_id": "fallback"}]),
+        ]
+    )
+    store = SupabaseDiscoveryPersistence(
+        base_url="https://supabase.example.com",
+        service_role_key="service-role",
+        schema="public",
+        table_names={
+            "discovery_runs": "discovery_runs",
+            "persistent_candidates": "persistent_candidates",
+            "backfill_batches": "backfill_batches",
+            "candidate_provenance": "candidate_provenance",
+            "scrape_attempts": "scrape_attempts",
+        },
+        client=client,
+    )
+
+    assert store.count_candidates(backfill_batch_id="batch-1") == 12
+    assert (
+        store.count_candidates(
+            statuses=[CandidateStatus.NEW, CandidateStatus.SCRAPE_FAILED],
+            backfill_batch_id="batch-1",
+        )
+        == 5
+    )
+    assert store.count_backfill_batch_candidates(
+        batch_id="batch-1",
+        scrapeable_statuses=[CandidateStatus.NEW, CandidateStatus.SCRAPE_FAILED],
+    ) == BackfillCandidateCounts(merged_candidate_count=12, queued_for_scrape_count=5)
+    assert store.count_candidates(backfill_batch_id="batch-1") == 1
+
+    first_call = client.calls[0]
+    assert first_call["params"] == {
+        "select": "candidate_id",
+        "limit": "1",
+        "backfill_batch_id": "eq.batch-1",
+    }
+    first_headers = first_call["headers"]
+    assert isinstance(first_headers, dict)
+    assert first_headers["Prefer"] == "count=exact"
+    second_params = client.calls[1]["params"]
+    assert isinstance(second_params, dict)
+    assert second_params["candidate_status"] == "in.(new,scrape_failed)"
+
+
 def test_supabase_discovery_persistence_handles_empty_payload_shapes() -> None:
     """Non-list responses should degrade to empty reads rather than crashing."""
     client = FakeHttpClient(
@@ -652,11 +752,12 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
         )
     )
     mirror = RecordingPersistence()
+    count_source = RecordingPersistence()
     batch = build_backfill_batch()
     candidate = build_candidate(backfill_batch_id=batch.batch_id)
     provenance = build_provenance()
     attempt = build_attempt()
-    composite = CompositeDiscoveryPersistence(primary, [mirror])
+    composite = CompositeDiscoveryPersistence(primary, [mirror], count_source=count_source)
 
     composite.write_run(DiscoveryRun(run_id="run-1"))
     composite.upsert_candidates([candidate])
@@ -670,6 +771,11 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
     assert composite.list_candidates(backfill_batch_id=batch.batch_id, limit=1)[0].candidate_id == (
         candidate.candidate_id
     )
+    assert composite.count_candidates(backfill_batch_id=batch.batch_id) == 11
+    assert composite.count_backfill_batch_candidates(
+        batch_id=batch.batch_id,
+        scrapeable_statuses=[CandidateStatus.NEW],
+    ) == BackfillCandidateCounts(merged_candidate_count=13, queued_for_scrape_count=7)
     assert composite.list_backfill_batches(limit=1)[0].batch_id == batch.batch_id
     assert (
         composite.find_candidate_by_urls(
@@ -689,6 +795,8 @@ def test_composite_discovery_persistence_fans_out_writes_and_reads_from_primary(
     assert mirror.written_run is not None
     assert mirror.candidates[0].candidate_id == candidate.candidate_id
     assert mirror.provenance[0].candidate_id == candidate.candidate_id
+    assert count_source.count_calls == 1
+    assert count_source.aggregate_count_calls == 1
     composite.close()
 
 
@@ -711,4 +819,5 @@ def test_create_discovery_persistence_selects_state_or_composite(
     assert isinstance(composite, CompositeDiscoveryPersistence)
     assert isinstance(composite.primary, StateRepoDiscoveryPersistence)
     assert isinstance(composite.mirrors[0], SupabaseDiscoveryPersistence)
+    assert isinstance(composite.count_source, SupabaseDiscoveryPersistence)
     composite.close()


### PR DESCRIPTION
## Summary

Closes #88.

This is the smallest bounded backfill aggregate-count follow-up supported by local evidence. The existing pipeline path refreshed backfill batch aggregates by listing every candidate row for a batch and deriving counts client-side. That preserved semantics, but it was the wrong abstraction for larger batches where the pipeline only needs aggregate totals.

## Changes

- Add a `BackfillCandidateCounts` aggregate and `CandidateStore.count_backfill_batch_candidates()` persistence API.
- Keep `count_candidates()` available for simple filtered counts, but move the backfill pipeline to a single aggregate call for merged and scrape-eligible totals.
- Implement aggregate support for:
  - `StateRepoDiscoveryPersistence`, streaming `backfill_queue.jsonl` once for both totals.
  - `SupabaseDiscoveryPersistence`, using PostgREST `Prefer: count=exact` and `Content-Range` metadata with the same status and batch filters.
  - `CompositeDiscoveryPersistence`, with an explicit `count_source`; the factory sets this to Supabase when Supabase persistence is configured while preserving state as the primary row-read source.
  - `NullDiscoveryPersistence`.
- Add deterministic unit evidence that the pipeline aggregate path does not call `list_candidates()` or two separate candidate counts.
- Add factory/composite coverage proving Supabase is the count source in normal Supabase-enabled persistence.
- Update `.agent-plan.md`, `README.md`, `PLAN.md`, and discovery docs so post-merge mainline state reflects #88 as addressed.

## Scope Notes

- No live network tests.
- No broader discovery storage refactor.
- No source-health, AI repair, selector rewriting, or automatic source creation work.
- Existing backfill batch status/count semantics are preserved.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_backfill_pipeline.py tests/unit/test_discovery_storage.py`
- `.venv/bin/pytest -q`
