### PR TITLE
Phase C: Close stale Mako runtime hygiene issues

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,13 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #88 backfill aggregate counts now use a persistence-layer aggregate
-  count API, with Supabase exact-count requests and state-repo streaming counts preserving existing
-  batch status semantics without materializing rows in the pipeline.
+- Last merged PR on main: #107 closed #88 by moving backfill aggregate counts to a
+  persistence-layer aggregate count API, with Supabase exact-count requests and state-repo
+  streaming counts preserving existing batch status semantics without materializing rows in the
+  pipeline.
 - Next planned PR: wait for fresh local or CI evidence before taking another bounded source-health,
   Mako runtime, backfill, or self-healing follow-up.
 - Current blockers on main: no Mako runtime blocker is known after Chromium install; #71/#74 are
-  duplicate or stale Mako runtime hygiene unless a future Chromium-backed probe regresses;
+  closed as stale/duplicate Mako runtime hygiene by a fresh 2026-05-03 Chromium-backed Mako probe;
   source-native keyword-zero remains visible per source but no longer trips the systemic hard
   source-zero guardrail by itself; self-healing is scaffolded but not automated.
 
@@ -54,6 +55,8 @@
   visible without masquerading as hard source failure.
 - [done] Replace the #88 backfill aggregate-count row-listing path with a narrow aggregate count
   API and fixture-backed pipeline/storage coverage.
+- [done] Close #71/#74 as stale/duplicate Mako runtime hygiene after a fresh 2026-05-03
+  Chromium-backed source-specific Mako diagnostic pass returned `ok`.
 - [next] Wait for fresh local or CI evidence before selecting another bounded source-health, Mako
   runtime, backfill, or self-healing follow-up.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -73,9 +73,10 @@ A fresh source-specific Mako follow-up on 2026-05-03T13:13:10Z used
 `data/may_26_followup/20260503T131309Z/state`, installed Chromium through Playwright first, and
 reran the same sampled Mako diagnostic probe. Mako again returned `ok`, with parsed
 keyword-matching search results for `זנות` and `בית בושת`, zero affected sources in the
-source-zero summary, and no runtime/navigation regression. #71/#74 are therefore closed as
-stale/duplicate Mako runtime hygiene; no scraper behavior, selector rewrite, retry path, or
-live-network-dependent test is added for that closure.
+source-zero summary, and no reproduction of the original runtime/navigation failures in the local
+Chromium-backed diagnostic path. #71/#74 are therefore closed as stale/duplicate Mako runtime
+hygiene; no scraper behavior, selector rewrite, retry path, or live-network-dependent test is added
+for that closure.
 
 ### What is already in place
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: Post-#72 Source-Health Follow-Through
+## Current Next Focus: Post-Mako Runtime Hygiene Follow-Through
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -69,6 +69,14 @@ broader backfill storage refactor or source-health work is included. The auditab
 summary remains checked in at
 [`docs/phase_c_source_health_triage_2026_05_03.md`](docs/phase_c_source_health_triage_2026_05_03.md).
 
+A fresh source-specific Mako follow-up on 2026-05-03T13:13:10Z used
+`data/may_26_followup/20260503T131309Z/state`, installed Chromium through Playwright first, and
+reran the same sampled Mako diagnostic probe. Mako again returned `ok`, with parsed
+keyword-matching search results for `זנות` and `בית בושת`, zero affected sources in the
+source-zero summary, and no runtime/navigation regression. #71/#74 are therefore closed as
+stale/duplicate Mako runtime hygiene; no scraper behavior, selector rewrite, retry path, or
+live-network-dependent test is added for that closure.
+
 ### What is already in place
 
 - Candidate persistence, scrape attempts, queue state, fallback retention, and backfill jobs already
@@ -108,7 +116,7 @@ summary remains checked in at
 
 ### What comes next
 
-1. Treat #71/#74 as duplicate or near-duplicate Mako runtime/navigation diagnostic hygiene unless a
+1. Treat #71/#74 as closed stale/duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
 2. Wait for fresh bounded evidence before selecting another Mako runtime, source-health, backfill,
    or self-healing follow-up.

--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   while the then-current 4-source guardrail still fired for Ynet, Walla, Maariv, and ICE; the #72
   follow-up narrows that guardrail to hard source failures and makes #71/#74 duplicate or stale Mako
   runtime hygiene unless Mako regresses again
+- the 2026-05-03T13:13:10Z source-specific Mako follow-up reran the Chromium-backed probe under
+  `data/may_26_followup/20260503T131309Z/state`; Mako again returned `ok`, so #71/#74 are closed as
+  stale/duplicate runtime hygiene without changing scraper behavior
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -132,6 +132,12 @@ the narrow persistence count API; choose further backfill work only from fresh b
 The durable evidence summary is checked in at
 [phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
+The 2026-05-03T13:13:10Z Mako-only follow-up used the same shape under
+`data/may_26_followup/20260503T131309Z/` after `.venv/bin/python -m playwright install chromium`.
+Mako returned `ok`, with parsed keyword-matching search results for `זנות` and `בית בושת`; the
+selected-source `source_zero_summary` had zero affected sources. That closes #71/#74 as
+stale/duplicate Mako runtime hygiene unless a later Chromium-backed probe regresses.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -132,11 +132,12 @@ the narrow persistence count API; choose further backfill work only from fresh b
 The durable evidence summary is checked in at
 [phase_c_source_health_triage_2026_05_03.md](phase_c_source_health_triage_2026_05_03.md).
 
-The 2026-05-03T13:13:10Z Mako-only follow-up used the same shape under
-`data/may_26_followup/20260503T131309Z/` after `.venv/bin/python -m playwright install chromium`.
-Mako returned `ok`, with parsed keyword-matching search results for `זנות` and `בית בושת`; the
-selected-source `source_zero_summary` had zero affected sources. That closes #71/#74 as
-stale/duplicate Mako runtime hygiene unless a later Chromium-backed probe regresses.
+The 2026-05-03T13:13:10Z Mako-only follow-up used the same isolated-root pattern under
+`data/may_26_followup/20260503T131309Z/`, but only reran the Mako source-specific probe after
+`.venv/bin/python -m playwright install chromium`. Mako returned `ok`, with parsed
+keyword-matching search results for `זנות` and `בית בושת`; the selected-source
+`source_zero_summary` had zero affected sources. That closes #71/#74 as stale/duplicate Mako
+runtime hygiene unless a later Chromium-backed probe regresses.
 
 ## GitHub Actions Run Path
 

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -57,10 +57,11 @@ Affected sources: `ynet`, `walla`, `maariv`, `ice`.
 - #71: close as duplicate or stale Mako runtime hygiene unless a future Chromium-backed Mako probe
   regresses.
 - #74: close as duplicate or stale with #71 unless a future Chromium-backed Mako probe regresses.
-- #72: keep active and use as the next narrow source-native reliability follow-up because the
-  4-source guardrail still fires for Ynet, Walla, Maariv, and ICE.
-- #88: keep as later optimization; this source-health triage did not exercise or expose backfill
-  aggregate-count slowness.
+- #72: addressed by the later source-native reliability follow-up, which expanded Walla/ICE recall
+  terms and narrowed the hard source-zero guardrail so keyword-zero evidence stays visible without
+  counting as systemic source outage evidence.
+- #88: addressed by PR #107, which moved backfill aggregate candidate counts behind the discovery
+  persistence boundary.
 
 ## Mako Runtime Hygiene Follow-Up
 

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -54,14 +54,44 @@ Affected sources: `ynet`, `walla`, `maariv`, `ice`.
 
 ## Issue Decisions
 
-- #71: recommend closing as duplicate or stale Mako runtime hygiene unless a future
-  Chromium-backed Mako probe regresses.
-- #74: recommend closing as duplicate or stale with #71 unless a future Chromium-backed Mako probe
+- #71: close as duplicate or stale Mako runtime hygiene unless a future Chromium-backed Mako probe
   regresses.
+- #74: close as duplicate or stale with #71 unless a future Chromium-backed Mako probe regresses.
 - #72: keep active and use as the next narrow source-native reliability follow-up because the
   4-source guardrail still fires for Ynet, Walla, Maariv, and ICE.
 - #88: keep as later optimization; this source-health triage did not exercise or expose backfill
   aggregate-count slowness.
+
+## Mako Runtime Hygiene Follow-Up
+
+- Timestamp: `2026-05-03T13:13:10.260820Z`
+- Config: `agents/news/local.yaml`
+- Isolated state root: `data/may_26_followup/20260503T131309Z/state`
+- Browser setup: `.venv/bin/python -m playwright install chromium`
+- Source-specific diagnostic command:
+
+```bash
+DENBUST_STATE_ROOT="data/may_26_followup/20260503T131309Z/state" \
+.venv/bin/denbust diagnose-sources \
+  --config agents/news/local.yaml \
+  --live-only \
+  --source mako \
+  --sample-keyword "זנות" \
+  --sample-keyword "בית בושת" \
+  --sample-keyword "סחר בבני אדם" \
+  --format json \
+  --output "data/may_26_followup/20260503T131309Z/artifacts/diagnose_sources_live_mako.json"
+```
+
+Result: Mako returned `ok`; `source_zero_summary.affected_source_count` was `0` for the selected
+source. The `זנות` and `בית בושת` search probes returned parsed keyword-matching articles. The
+`סחר בבני אדם` search probe rendered but parsed zero articles, and the `men-men_news` section page
+parsed 30 articles with zero sampled keyword matches; those warnings did not indicate browser
+runtime, navigation, context-destruction, redirect/anti-bot, or selector-drift regression.
+
+This confirms #71/#74 are stale/duplicate Mako runtime hygiene after Chromium-backed verification.
+No scraper behavior, selector rewrite, retry path, or live-network-dependent regression test is
+needed for their closure.
 
 ## Validation
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -485,9 +485,10 @@ The recommended order is:
   `self_heal_retry` attempts, but no automatic repair runs yet
 
 ### After Phase C source-health triage
-- the 2026-05-03 Chromium-backed source-health pass is the current evidence baseline
-- Mako passes in both all-source and source-specific live diagnostics, so #71/#74 should be treated
-  as duplicate or stale runtime hygiene unless a future Chromium-backed Mako probe regresses
+- the 2026-05-03 Chromium-backed source-health pass and the 2026-05-03T13:13:10Z Mako-only
+  follow-up are the current evidence baseline
+- Mako passes in both all-source and source-specific live diagnostics, so #71/#74 are closed as
+  duplicate or stale runtime hygiene unless a future Chromium-backed Mako probe regresses
 - Haaretz passes live diagnostics
 - #72 is addressed narrowly: Walla archive filtering and ICE search use targeted supplemental
   Hebrew recall terms, and `source_zero_summary.systemic_source_zero_suspected` now counts hard


### PR DESCRIPTION
## Summary

Closes #71.
Closes #74.

This PR resolves the remaining Mako browser/navigation daily-ai-review issues as stale/duplicate runtime hygiene after a fresh Chromium-backed local diagnostic pass. It does not change scraper behavior because the fresh probe did not reproduce a Mako runtime, navigation, context-destruction, redirect/anti-bot, or selector-drift regression.

## Evidence

- Installed/verified Chromium with `.venv/bin/python -m playwright install chromium`.
- Ran a fresh source-specific Mako diagnostic pass under ignored state root `data/may_26_followup/20260503T131309Z/state`.
- Command output was written locally to `data/may_26_followup/20260503T131309Z/artifacts/diagnose_sources_live_mako.json` and summarized in the checked-in Phase C evidence note.
- Result: Mako returned `ok`; `source_zero_summary.affected_source_count` was `0` for the selected source.
- The `זנות` and `בית בושת` probes returned parsed keyword-matching articles. The remaining warnings were parse-zero / keyword-zero observations, not browser runtime hygiene regressions.

## Changes

- Update `.agent-plan.md` as mainline truth with #107 as the last merged PR and #71/#74 closed as stale/duplicate Mako runtime hygiene.
- Update `PLAN.md`, `README.md`, and discovery/source-health docs with the new 2026-05-03T13:13:10Z Mako verification evidence.
- Preserve the existing scope boundary: no AI repair, selector rewriting, automatic source creation, scraper behavior change, or live-network-dependent test.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `git diff --check`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_validate_agent_plan.py`
- `.venv/bin/pytest -q tests/unit/test_source_health.py tests/unit/test_cli.py -k 'diagnose_sources or source_zero or mako'`
- pre-push hooks with `PATH="$PWD/.venv/bin:$PATH" git push -u origin codex/phase-c-mako-issue-hygiene`
