### PR TITLE
Phase C: document candidate-drain evidence and next queue follow-up

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,17 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #108 Mako runtime hygiene closure was squash-merged as `dea6406` and
-  closed #71/#74 after fresh Chromium-backed Mako evidence showed no runtime/navigation regression.
-- Next planned PR: run one bounded candidate-drain evidence pass under
-  `data/may_26_followup/<timestamp>/state` using `discover`, `scrape_candidates`,
-  `diagnose-discovery`, and `diagnose-sources --artifacts-only` against all sources in
-  `agents/news/local.yaml`; include one latest-seven-complete-UTC-days backfill window only if the
-  first pass produces no scrapeable candidates, then choose the next narrow implementation PR from
-  the documented triage matrix.
+- Last merged PR on main: #109 was squash-merged as `201c247`.
+- Next planned PR: add a narrow backfill/queue reliability follow-up focused on candidate-drain
+  selection visibility or fairness, using the 2026-05-03T15:31:23Z evidence that the bounded drain
+  spent all 30 scrape attempts on ICE while 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla
+  remained `new` / `candidate_only`.
 - Current blockers on main: no open GitHub issues are present; no Mako runtime blocker is known
-  after Chromium install; source-native keyword-zero remains visible per source but no longer trips
-  the systemic hard source-zero guardrail by itself; self-healing is scaffolded but not automated.
+  after Chromium install; the 2026-05-03T15:31:23Z candidate-drain pass produced no hard
+  source-zero summary, no scrape-failure groups, and no self-heal-eligible candidates; self-healing
+  remains scaffolded but not automated.
 
 ## Task Ledger
 
@@ -61,9 +59,15 @@
 - [done] Reset Phase C planning after #108 with a 2026-05-03 GitHub issue check showing zero open
   issues and isolated artifact-only diagnostics showing no persisted candidates, scrape attempts, or
   ingest debug artifact under `data/may_26_followup/20260503T134102Z/state`.
-- [next] Produce `data/may_26_followup/<timestamp>/reports/candidate_drain_summary.md` with command
-  results, queue-health counts, source-health artifact results, scrape-failure groups, backfill
-  timing when used, and the selected triage-matrix outcome for the next narrow implementation PR.
+- [done] Produce `data/may_26_followup/20260503T153123Z/reports/candidate_drain_summary.md` from a
+  bounded candidate-drain pass: 63 persisted candidates, 30 ICE scrape attempts, 30 scrape
+  successes, 33 never-scraped candidates, no scrape failures, no retry backlog, no self-heal
+  eligible candidates, no hard source-zero summary, and no conditional backfill window because the
+  first pass produced scrapeable candidates.
+- [next] Implement a narrow backfill/queue reliability PR that makes candidate-drain selection
+  behavior visible and, if the existing queue contract supports it, less source-monocentric for
+  bounded drains where one source can consume the full scrape budget while other configured-source
+  candidates remain pending.
 
 ## Planning Workflow
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -7,14 +7,13 @@
 ## Mainline Status
 
 - Last merged PR on main: #109 was squash-merged as `201c247`.
-- Next planned PR: add a narrow backfill/queue reliability follow-up focused on candidate-drain
-  selection visibility or fairness, using the 2026-05-03T15:31:23Z evidence that the bounded drain
-  spent all 30 scrape attempts on ICE while 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla
-  remained `new` / `candidate_only`.
+- Next planned PR: add a narrow queue-drain diagnostic follow-up that makes candidate selection
+  order, source mix, and budget-cap behavior visible enough to validate whether the current
+  candidate-drain contract is behaving as intended.
 - Current blockers on main: no open GitHub issues are present; no Mako runtime blocker is known
-  after Chromium install; the 2026-05-03T15:31:23Z candidate-drain pass produced no hard
-  source-zero summary, no scrape-failure groups, and no self-heal-eligible candidates; self-healing
-  remains scaffolded but not automated.
+  after Chromium install; the 2026-05-03T15:31:23Z candidate-drain pass produced no scrape-failure
+  groups and no self-heal-eligible candidates; artifact-only source-health was inconclusive because
+  that diagnostic path skipped `scrape_candidates` debug summaries.
 
 ## Task Ledger
 
@@ -62,12 +61,12 @@
 - [done] Produce `data/may_26_followup/20260503T153123Z/reports/candidate_drain_summary.md` from a
   bounded candidate-drain pass: 63 persisted candidates, 30 ICE scrape attempts, 30 scrape
   successes, 33 never-scraped candidates, no scrape failures, no retry backlog, no self-heal
-  eligible candidates, no hard source-zero summary, and no conditional backfill window because the
-  first pass produced scrapeable candidates.
-- [next] Implement a narrow backfill/queue reliability PR that makes candidate-drain selection
-  behavior visible and, if the existing queue contract supports it, less source-monocentric for
-  bounded drains where one source can consume the full scrape budget while other configured-source
-  candidates remain pending.
+  eligible candidates, inconclusive artifact-only source-health because only `scrape_candidates`
+  debug summaries existed, and no conditional backfill window because the first pass produced
+  scrapeable candidates.
+- [next] Implement a narrow queue-drain diagnostic PR that reports candidate selection order, source
+  mix, and budget-cap behavior so operators can validate the queue contract before changing
+  prioritization or fairness behavior.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: Post-#108 Phase C Evidence Gate
+## Current Next Focus: Post-#109 Phase C Queue-Drain Follow-Up
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -86,6 +86,18 @@ used `data/may_26_followup/20260503T134102Z/state` and ran artifact-only diagnos
 summary. That is useful isolation evidence, but it does not identify a source-health, backfill, or
 self-healing code defect by itself.
 
+PR `#109` was squash-merged into `main` as `201c247`. A fresh 2026-05-03 GitHub issue check returned
+zero open issues. The bounded candidate-drain evidence pass under
+`data/may_26_followup/20260503T153123Z/state` ran `discover`, `scrape_candidates`,
+`diagnose-discovery`, and `diagnose-sources --artifacts-only` against `agents/news/local.yaml`.
+The first `scrape_candidates` command failed fast because the Anthropic key was not in the shell
+environment; rerunning with the local `.env.local` environment completed. The pass persisted 63
+latest candidates, recorded 30 scrape attempts, marked 30 ICE candidates as `scrape_succeeded`, and
+left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla as never scraped. It produced no
+scrape-failure groups, retry backlog, self-heal-eligible candidates, hard source-zero summary, or
+relevant classified items. Because the first pass produced scrapeable candidates, the conditional
+latest-seven-complete-UTC-days backfill window was not used.
+
 Durable reset summary:
 
 | Signal | Value |
@@ -96,6 +108,21 @@ Durable reset summary:
 | `diagnose-discovery` scrape failures | no failure groups |
 | `diagnose-sources --artifacts-only` source results | six `skip` results because no ingest debug summary exists |
 | Implementation recommendation | no code PR from empty-state evidence alone |
+
+Candidate-drain summary:
+
+| Signal | Value |
+|---|---:|
+| Open GitHub issues | `0` |
+| Evidence root | `data/may_26_followup/20260503T153123Z/` |
+| Persisted latest candidates | `63` |
+| Scrape attempts | `30` |
+| Scrape-succeeded candidates | `30`, all from `ice` |
+| Never-scraped candidates | `33` across `haaretz`, `ice`, `maariv`, `mako`, and `walla` |
+| Scrape failures / retry backlog / self-heal eligible | `0` / `0` / `0` |
+| `diagnose-sources --artifacts-only` source results | six `skip` results because this path expects ingest debug summaries, while the run produced `scrape_candidates` debug summaries |
+| Conditional backfill window | not used because the first pass produced scrapeable candidates |
+| Implementation recommendation | backfill/queue reliability PR scoped to candidate-drain selection visibility or fairness |
 
 ### What is already in place
 
@@ -138,14 +165,10 @@ Durable reset summary:
 
 1. Treat #71/#74 as closed stale/duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-2. Produce a bounded candidate-drain evidence bundle from a fresh local or CI run before selecting
-   another source-health, backfill, or self-healing implementation PR. The required first pass is:
-   `discover`, `scrape_candidates`, `diagnose-discovery`, and
-   `diagnose-sources --artifacts-only` under `data/may_26_followup/<timestamp>/state` against all
-   sources in `agents/news/local.yaml`. Add one latest-seven-complete-UTC-days backfill
-   discover/scrape window only if the first pass produces no scrapeable candidates. Summarize the
-   bundle in `reports/candidate_drain_summary.md` with queue-health counts, source-health artifact
-   results, scrape-failure groups, optional backfill timing, and a triage-matrix outcome.
+2. Implement a narrow backfill/queue reliability follow-up from the candidate-drain evidence. The
+   first target should be candidate-drain selection visibility or fairness so bounded drains do not
+   silently spend the full scrape budget on one source while other configured-source candidates
+   remain pending.
 3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -94,9 +94,11 @@ The first `scrape_candidates` command failed fast because the Anthropic key was 
 environment; rerunning with the local `.env.local` environment completed. The pass persisted 63
 latest candidates, recorded 30 scrape attempts, marked 30 ICE candidates as `scrape_succeeded`, and
 left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla as never scraped. It produced no
-scrape-failure groups, retry backlog, self-heal-eligible candidates, hard source-zero summary, or
-relevant classified items. Because the first pass produced scrapeable candidates, the conditional
-latest-seven-complete-UTC-days backfill window was not used.
+scrape-failure groups, retry backlog, self-heal-eligible candidates, or relevant classified items.
+`diagnose-sources --artifacts-only` was inconclusive for source health because that diagnostic path
+expects ingest debug summaries and this run produced `scrape_candidates` debug summaries. Because
+the first pass produced scrapeable candidates, the conditional latest-seven-complete-UTC-days
+backfill window was not used.
 
 Durable reset summary:
 
@@ -120,9 +122,9 @@ Candidate-drain summary:
 | Scrape-succeeded candidates | `30`, all from `ice` |
 | Never-scraped candidates | `33` across `haaretz`, `ice`, `maariv`, `mako`, and `walla` |
 | Scrape failures / retry backlog / self-heal eligible | `0` / `0` / `0` |
-| `diagnose-sources --artifacts-only` source results | six `skip` results because this path expects ingest debug summaries, while the run produced `scrape_candidates` debug summaries |
+| `diagnose-sources --artifacts-only` source results | inconclusive: six `skip` results because this path expects ingest debug summaries, while the run produced `scrape_candidates` debug summaries |
 | Conditional backfill window | not used because the first pass produced scrapeable candidates |
-| Implementation recommendation | backfill/queue reliability PR scoped to candidate-drain selection visibility or fairness |
+| Implementation recommendation | queue-drain diagnostic PR scoped to candidate selection visibility and contract validation |
 
 ### What is already in place
 
@@ -165,10 +167,10 @@ Candidate-drain summary:
 
 1. Treat #71/#74 as closed stale/duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-2. Implement a narrow backfill/queue reliability follow-up from the candidate-drain evidence. The
-   first target should be candidate-drain selection visibility or fairness so bounded drains do not
-   silently spend the full scrape budget on one source while other configured-source candidates
-   remain pending.
+2. Implement a narrow queue-drain diagnostic follow-up from the candidate-drain evidence. The first
+   target should report candidate selection order, source mix, and budget-cap behavior so operators
+   can validate whether the current queue contract is behaving as intended before changing
+   prioritization or fairness behavior.
 3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 

--- a/README.md
+++ b/README.md
@@ -365,11 +365,15 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - the 2026-05-03T13:13:10Z source-specific Mako follow-up reran the Chromium-backed probe under
   `data/may_26_followup/20260503T131309Z/state`; Mako again returned `ok`, so #71/#74 are closed as
   stale/duplicate runtime hygiene without changing scraper behavior
-- PR #108 was squash-merged as `dea6406` and left no open GitHub issue backlog; the next Phase C
-  step is a bounded candidate-drain evidence bundle using `discover`, `scrape_candidates`,
-  `diagnose-discovery`, and `diagnose-sources --artifacts-only`, because the fresh artifact-only
-  reset under `data/may_26_followup/20260503T134102Z/state` correctly showed an empty isolated
-  diagnostics baseline rather than a new code defect
+- PR #108 was squash-merged as `dea6406` and left no open GitHub issue backlog; the post-#108
+  artifact-only reset under `data/may_26_followup/20260503T134102Z/state` correctly showed an empty
+  isolated diagnostics baseline rather than a new code defect
+- PR #109 was squash-merged as `201c247`; the 2026-05-03 candidate-drain evidence pass under
+  `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, spent all 30 scrape
+  attempts on ICE, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
+  produced no scrape failures, retry backlog, self-heal backlog, or hard source-zero summary. The
+  next narrow implementation target is backfill/queue reliability focused on drain selection
+  visibility or fairness
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/README.md
+++ b/README.md
@@ -371,9 +371,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - PR #109 was squash-merged as `201c247`; the 2026-05-03 candidate-drain evidence pass under
   `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, spent all 30 scrape
   attempts on ICE, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
-  produced no scrape failures, retry backlog, self-heal backlog, or hard source-zero summary. The
-  next narrow implementation target is backfill/queue reliability focused on drain selection
-  visibility or fairness
+  produced no scrape failures, retry backlog, or self-heal backlog. Artifact-only source-health was
+  inconclusive because that diagnostic path skipped `scrape_candidates` debug summaries. The next
+  narrow implementation target is queue-drain diagnostics focused on selection visibility and
+  contract validation before changing prioritization or fairness behavior
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/PHASE_C_PLAN.md
+++ b/docs/PHASE_C_PLAN.md
@@ -489,9 +489,10 @@ hygiene issues #71/#74. A fresh repo-connector issue search on 2026-05-03 return
 PR `#109` was then squash-merged as `201c247`. The bounded candidate-drain evidence pass under
 `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, recorded 30 successful ICE
 scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
-produced no scrape failures, self-heal backlog, or hard source-zero summary. The next narrow Phase C
-change belongs in backfill/queue reliability and should focus on candidate-drain selection
-visibility or fairness.
+produced no scrape failures or self-heal backlog. Artifact-only source-health was inconclusive
+because the diagnostic path skipped `scrape_candidates` debug summaries. The next narrow Phase C
+change should add queue-drain diagnostics for candidate selection order, source mix, and budget-cap
+behavior before changing prioritization or fairness behavior.
 
 ---
 

--- a/docs/PHASE_C_PLAN.md
+++ b/docs/PHASE_C_PLAN.md
@@ -484,14 +484,14 @@ of `DL-PR-09`, which shipped in PR `#87` on 2026-04-21. That sequencing question
 closed: `C-8` shipped after the full `DL-PR-*` discovery rollout, including `DL-PR-10` and
 `DL-PR-11`.
 
-Post-#108 planning note: PR `#108` was squash-merged as `dea6406` and closed the Mako runtime
+Post-#109 planning note: PR `#108` was squash-merged as `dea6406` and closed the Mako runtime
 hygiene issues #71/#74. A fresh repo-connector issue search on 2026-05-03 returned no open issues.
-The next Phase C step is therefore not another speculative implementation PR; it is a bounded
-candidate-drain evidence bundle. Run `discover`, `scrape_candidates`, `diagnose-discovery`, and
-`diagnose-sources --artifacts-only` under a fresh ignored state root, add one latest-seven-complete
-UTC days backfill window only if the first pass produces no scrapeable candidates, then use the
-triage matrix in the source-health evidence note to choose whether the next narrow change belongs in
-source-health, backfill, or self-healing scaffolding follow-through.
+PR `#109` was then squash-merged as `201c247`. The bounded candidate-drain evidence pass under
+`data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, recorded 30 successful ICE
+scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
+produced no scrape failures, self-heal backlog, or hard source-zero summary. The next narrow Phase C
+change belongs in backfill/queue reliability and should focus on candidate-drain selection
+visibility or fairness.
 
 ---
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -144,11 +144,15 @@ After PR #108 was squash-merged as `dea6406`, the 2026-05-03T13:41:02Z planning 
 root, `denbust diagnose-discovery` reported no persisted candidates, scrape attempts, or
 operational records, and `denbust diagnose-sources --artifacts-only` skipped all configured sources
 because no ingest debug summary existed under that root. Treat this as a clean empty-state baseline,
-not as source-health evidence. The next evidence gate should run `discover`, `scrape_candidates`,
-`diagnose-discovery`, and `diagnose-sources --artifacts-only` under a fresh ignored state root and
-write `reports/candidate_drain_summary.md`. If that first pass produces no scrapeable candidates,
-add one latest-seven-complete-UTC-days `backfill_discover` / `backfill_scrape` window before
-proposing more source-health, backfill, or self-healing code.
+not as source-health evidence.
+
+After PR #109 was squash-merged as `201c247`, the 2026-05-03T15:31:23Z candidate-drain evidence
+pass used `data/may_26_followup/20260503T153123Z/state`. It persisted 63 candidates, recorded 30
+successful ICE scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never
+scraped, and produced no scrape failures, retry backlog, self-heal backlog, or hard source-zero
+summary. Because the first pass produced scrapeable candidates, no latest-seven-complete-UTC-days
+backfill window was added. Treat the next narrow follow-up as backfill/queue reliability work
+focused on candidate-drain selection visibility or fairness, not source-health or self-healing.
 
 ## GitHub Actions Run Path
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -149,10 +149,12 @@ not as source-health evidence.
 After PR #109 was squash-merged as `201c247`, the 2026-05-03T15:31:23Z candidate-drain evidence
 pass used `data/may_26_followup/20260503T153123Z/state`. It persisted 63 candidates, recorded 30
 successful ICE scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never
-scraped, and produced no scrape failures, retry backlog, self-heal backlog, or hard source-zero
-summary. Because the first pass produced scrapeable candidates, no latest-seven-complete-UTC-days
-backfill window was added. Treat the next narrow follow-up as backfill/queue reliability work
-focused on candidate-drain selection visibility or fairness, not source-health or self-healing.
+scraped, and produced no scrape failures, retry backlog, or self-heal backlog. Artifact-only
+source-health was inconclusive because the diagnostic path skipped the `scrape_candidates` debug
+summaries. Because the first pass produced scrapeable candidates, no latest-seven-complete-UTC-days
+backfill window was added. Treat the next narrow follow-up as queue-drain diagnostic work: report
+candidate selection order, source mix, and budget-cap behavior before changing queue prioritization
+or fairness behavior.
 
 ## GitHub Actions Run Path
 

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -116,6 +116,37 @@ needed for their closure.
   latest-seven-complete-UTC-days backfill discover/scrape window only if that first pass produces no
   scrapeable candidates.
 
+## Candidate-Drain Evidence Follow-Up
+
+- PR #109 was squash-merged into `main` as `201c247`.
+- A fresh 2026-05-03 GitHub issue check returned zero open issues.
+- Evidence root: `data/may_26_followup/20260503T153123Z/`.
+- Config: `agents/news/local.yaml`.
+- Commands run under `DENBUST_STATE_ROOT=data/may_26_followup/20260503T153123Z/state`:
+  - `discover`;
+  - `scrape_candidates`;
+  - `diagnose-discovery --format json`;
+  - `diagnose-sources --artifacts-only --format json`.
+- The first `scrape_candidates` command failed fast with `fatal: missing anthropic api key`; the
+  rerun sourced local `.env.local` variables inside the subprocess and completed.
+- `diagnose-discovery` reported 63 total candidates, 30 scrape-succeeded candidates, 33
+  never-scraped candidates, 0 scrape-failed candidates, 0 retry-backlog candidates, and 0
+  self-heal-eligible candidates.
+- The 30 scrape attempts all landed on ICE candidates; 33 candidates remained `new` /
+  `candidate_only`: 1 Haaretz, 11 ICE, 1 Maariv, 14 Mako, and 6 Walla.
+- `scrape_candidates` classified 30 unseen ICE articles and rejected all 30 as `not_relevant`,
+  producing no unified items.
+- `diagnose-sources --artifacts-only` returned six `skip` results because this diagnostic path
+  looks for ingest debug summaries, while the bounded pass produced `scrape_candidates` debug
+  summaries. Its report-level `source_zero_summary` did not trigger:
+  `affected_source_count = 0`, `keyword_zero_source_count = 0`, and
+  `systemic_source_zero_suspected = false`.
+- The latest-seven-complete-UTC-days backfill window was not run because the first pass produced
+  scrapeable candidates and successful scrape attempts.
+- Triage outcome: do not open a source-health reliability PR or self-healing orchestration PR from
+  this evidence. The next narrow implementation PR should be a backfill/queue reliability follow-up
+  focused on candidate-drain selection visibility or fairness.
+
 Use this triage matrix for the next implementation choice:
 
 | Evidence outcome | Next PR |

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -138,14 +138,14 @@ needed for their closure.
   producing no unified items.
 - `diagnose-sources --artifacts-only` returned six `skip` results because this diagnostic path
   looks for ingest debug summaries, while the bounded pass produced `scrape_candidates` debug
-  summaries. Its report-level `source_zero_summary` did not trigger:
-  `affected_source_count = 0`, `keyword_zero_source_count = 0`, and
-  `systemic_source_zero_suspected = false`.
+  summaries. Treat source-health artifact diagnosis as inconclusive for this run; the zero-valued
+  report-level `source_zero_summary` reflects skipped source checks, not a clean source-health pass.
 - The latest-seven-complete-UTC-days backfill window was not run because the first pass produced
   scrapeable candidates and successful scrape attempts.
 - Triage outcome: do not open a source-health reliability PR or self-healing orchestration PR from
-  this evidence. The next narrow implementation PR should be a backfill/queue reliability follow-up
-  focused on candidate-drain selection visibility or fairness.
+  this evidence alone. The next narrow implementation PR should be a queue-drain diagnostic
+  follow-up that reports candidate selection order, source mix, and budget-cap behavior before
+  changing queue prioritization or fairness behavior.
 
 Use this triage matrix for the next implementation choice:
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -498,11 +498,12 @@ The recommended order is:
   GitHub issues, and an isolated artifact-only diagnostic reset under
   `data/may_26_followup/20260503T134102Z/state` showed an empty state baseline rather than a new
   implementation defect
-- the next narrow implementation PR should be chosen only after `discover`, `scrape_candidates`,
-  `diagnose-discovery`, and `diagnose-sources --artifacts-only` produce a bounded candidate-drain
-  bundle under a fresh ignored state root; add one latest-seven-complete-UTC-days backfill window
-  only if the first pass produces no scrapeable candidates, then use the triage matrix in the Phase
-  C evidence note to justify the change
+- PR #109 was squash-merged as `201c247`; the bounded candidate-drain evidence pass under
+  `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, scraped 30 ICE candidates
+  successfully, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
+  produced no scrape failures, self-heal backlog, or hard source-zero summary
+- the next narrow implementation PR should use that evidence for a backfill/queue reliability
+  follow-up focused on candidate-drain selection visibility or fairness
 - full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
   remain out of scope until a later repair PR has fresh evidence
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -501,9 +501,11 @@ The recommended order is:
 - PR #109 was squash-merged as `201c247`; the bounded candidate-drain evidence pass under
   `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, scraped 30 ICE candidates
   successfully, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
-  produced no scrape failures, self-heal backlog, or hard source-zero summary
-- the next narrow implementation PR should use that evidence for a backfill/queue reliability
-  follow-up focused on candidate-drain selection visibility or fairness
+  produced no scrape failures or self-heal backlog; artifact-only source-health was inconclusive
+  because that diagnostic path skipped `scrape_candidates` debug summaries
+- the next narrow implementation PR should use that evidence for queue-drain diagnostics that report
+  candidate selection order, source mix, and budget-cap behavior before changing prioritization or
+  fairness behavior
 - full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
   remain out of scope until a later repair PR has fresh evidence
 


### PR DESCRIPTION
## Summary

This PR creates the next Phase C evidence handoff after PR #109 / `201c247` by documenting the bounded candidate-drain pass and updating the planning surfaces to select the next narrow implementation PR.

The raw evidence was generated under `data/may_26_followup/20260503T153123Z/` and remains uncommitted because `data/may_26_*` is ignored. The local report file is `data/may_26_followup/20260503T153123Z/reports/candidate_drain_summary.md`.

## Evidence Pass

Commands run against `agents/news/local.yaml` with `DENBUST_STATE_ROOT=data/may_26_followup/20260503T153123Z/state`:

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/denbust run --dataset news_items --job discover --config agents/news/local.yaml`
- `.venv/bin/denbust run --dataset news_items --job scrape_candidates --config agents/news/local.yaml`
- `.venv/bin/denbust diagnose-discovery --config agents/news/local.yaml --format json --output data/may_26_followup/20260503T153123Z/artifacts/diagnose_discovery_after_candidate_drain.json`
- `.venv/bin/denbust diagnose-sources --config agents/news/local.yaml --artifacts-only --format json --output data/may_26_followup/20260503T153123Z/artifacts/diagnose_sources_artifact_only_after_candidate_drain.json`

The first `scrape_candidates` invocation failed fast with `fatal: missing anthropic api key`; rerunning with the local `.env.local` environment loaded completed successfully.

## Result

- GitHub open issues: `0`.
- Persisted latest candidates: `63`.
- Scrape attempts: `30`.
- Scrape-succeeded candidates: `30`, all from ICE.
- Never-scraped candidates: `33` across Haaretz, ICE, Maariv, Mako, and Walla.
- Scrape failures / retry backlog / self-heal eligible: `0` / `0` / `0`.
- `scrape_candidates` classified 30 unseen ICE articles and rejected all as `not_relevant`.
- `diagnose-sources --artifacts-only` returned six `skip` results because it expects ingest debug summaries, while this bounded pass produced `scrape_candidates` debug summaries.
- No latest-seven-complete-UTC-days backfill window was run because the first pass produced scrapeable candidates and successful scrape attempts.

## Triage Outcome

This does not justify a source-health reliability PR: there was no hard source-zero summary, no Mako runtime failure, and no scrape-failure group. It also does not justify a self-healing orchestration PR: there were no failed scrape attempts and no self-heal-eligible candidates.

The selected next implementation PR is a narrow backfill/queue reliability follow-up focused on candidate-drain selection visibility or fairness, because the bounded drain spent all 30 scrape attempts on ICE while other configured-source candidates remained pending.

## Planning Updates

- `.agent-plan.md` now records #109 / `201c247`, marks the candidate-drain evidence task done, and keeps exactly one `[next]` item for the queue-drain follow-up.
- `PLAN.md`, `README.md`, `docs/phase_c_source_health_triage_2026_05_03.md`, `docs/PHASE_C_PLAN.md`, `docs/discovery_operations.md`, and `docs/tfht_discovery_layer_implementation_plan.md` summarize the evidence and selected next PR.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- Commit hooks: passed
- Pre-push hooks: passed after prepending `.venv/bin` to `PATH` so the hook runner could resolve `python`

No targeted pytest was added or run manually because this PR changes planning/docs only and does not change code or validator behavior.
