### PR TITLE
Phase C QD: Add queue-drain diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #109 was squash-merged as `201c247`.
-- Next planned PR: add a narrow queue-drain diagnostic follow-up that makes candidate selection
-  order, source mix, and budget-cap behavior visible enough to validate whether the current
-  candidate-drain contract is behaving as intended.
+- Last merged PR on main: #110 was squash-merged as `8c89d91`.
+- Next planned PR: run another bounded candidate-drain evidence pass using the new queue-drain
+  diagnostics before deciding whether queue prioritization or fairness behavior needs to change.
 - Current blockers on main: no open GitHub issues are present; no Mako runtime blocker is known
   after Chromium install; the 2026-05-03T15:31:23Z candidate-drain pass produced no scrape-failure
-  groups and no self-heal-eligible candidates; artifact-only source-health was inconclusive because
-  that diagnostic path skipped `scrape_candidates` debug summaries.
+  groups and no self-heal-eligible candidates; queue-drain diagnostics now expose selection order,
+  selected/remaining source mix, configured cap behavior, and stop reason for the next evidence
+  pass.
 
 ## Task Ledger
 
@@ -64,9 +64,12 @@
   eligible candidates, inconclusive artifact-only source-health because only `scrape_candidates`
   debug summaries existed, and no conditional backfill window because the first pass produced
   scrapeable candidates.
-- [next] Implement a narrow queue-drain diagnostic PR that reports candidate selection order, source
+- [done] Implement a narrow queue-drain diagnostic PR that reports candidate selection order, source
   mix, and budget-cap behavior so operators can validate the queue contract before changing
   prioritization or fairness behavior.
+- [next] Run another bounded candidate-drain evidence pass using the new diagnostics; change queue
+  prioritization or fairness only if the reported selection order, source mix, and stop reason show
+  the current contract is wrong or insufficient.
 
 ## Planning Workflow
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -127,12 +127,12 @@ Candidate-drain summary:
 | Implementation recommendation | addressed by PR #110 / `8c89d91`: queue-drain diagnostics scoped to candidate selection visibility and contract validation |
 
 PR `#110` was squash-merged into `main` as `8c89d91`. `denbust diagnose-discovery` now includes a
-`queue_drain` section with the configured candidate cap, matching scrape-attempt budget field,
-latest attempted candidate order inferred from persisted attempts, selected source mix, remaining
-eligible candidate order, remaining eligible source mix, and stop reason (`budget_cap_reached`,
-`no_eligible_candidates`, `no_scrape_attempts_recorded`, or `another_reason`). The implementation
-does not change candidate prioritization or fairness behavior; it only exposes enough evidence to
-validate the existing contract.
+`queue_drain` section with the configured candidate cap, persisted attempted-candidate order,
+persisted scrape-attempt count, attempted source mix derived from actual scrape attempts, remaining
+eligible candidate order, remaining eligible source mix, and inferred stop reason
+(`budget_cap_reached`, `no_eligible_candidates`, `no_scrape_attempts_recorded`, or
+`another_reason`). The implementation does not change candidate prioritization or fairness
+behavior; it only exposes enough evidence to validate the existing contract.
 
 ### What is already in place
 
@@ -142,8 +142,9 @@ validate the existing contract.
   batch candidates in the pipeline.
 - Discovery diagnostics already flow through `src/denbust/diagnostics/discovery.py` and
   `denbust diagnose-discovery`.
-- Discovery diagnostics now expose queue-drain selection order, selected/remaining source mix,
-  configured cap behavior, and stop reason for bounded `scrape_candidates` passes.
+- Discovery diagnostics now expose queue-drain selection order, attempted/remaining source mix,
+  configured candidate cap, persisted scrape-attempt count, and inferred stop reason for bounded
+  `scrape_candidates` passes.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
   cases.
 - Source-health diagnostics include a `source_zero_summary` that flags the 4+ hard affected-source

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ This repo currently has one main plan and two important sub-plans.
 2. Read `docs/MILESTONE_3_VALIDATION_PR_BREAKDOWN.md` when working specifically on Milestone 3 validation follow-through.
 3. Read `docs/tfht_discovery_layer_implementation_plan.md` when advancing the discovery/candidacy architecture work in the `DL-PR-*` series.
 
-## Current Next Focus: Post-#109 Phase C Queue-Drain Follow-Up
+## Current Next Focus: Post-#110 Phase C Queue-Drain Evidence Pass
 
 PR `#95` added the May 2026 local experiment plan. PR `#96` hardened that plan's execution path so
 local validation data problems and Anthropic provider failures fail visibly before operators trust
@@ -124,7 +124,15 @@ Candidate-drain summary:
 | Scrape failures / retry backlog / self-heal eligible | `0` / `0` / `0` |
 | `diagnose-sources --artifacts-only` source results | inconclusive: six `skip` results because this path expects ingest debug summaries, while the run produced `scrape_candidates` debug summaries |
 | Conditional backfill window | not used because the first pass produced scrapeable candidates |
-| Implementation recommendation | queue-drain diagnostic PR scoped to candidate selection visibility and contract validation |
+| Implementation recommendation | addressed by PR #110 / `8c89d91`: queue-drain diagnostics scoped to candidate selection visibility and contract validation |
+
+PR `#110` was squash-merged into `main` as `8c89d91`. `denbust diagnose-discovery` now includes a
+`queue_drain` section with the configured candidate cap, matching scrape-attempt budget field,
+latest attempted candidate order inferred from persisted attempts, selected source mix, remaining
+eligible candidate order, remaining eligible source mix, and stop reason (`budget_cap_reached`,
+`no_eligible_candidates`, `no_scrape_attempts_recorded`, or `another_reason`). The implementation
+does not change candidate prioritization or fairness behavior; it only exposes enough evidence to
+validate the existing contract.
 
 ### What is already in place
 
@@ -134,6 +142,8 @@ Candidate-drain summary:
   batch candidates in the pipeline.
 - Discovery diagnostics already flow through `src/denbust/diagnostics/discovery.py` and
   `denbust diagnose-discovery`.
+- Discovery diagnostics now expose queue-drain selection order, selected/remaining source mix,
+  configured cap behavior, and stop reason for bounded `scrape_candidates` passes.
 - Source-health diagnostics already cover selector drift, parse-zero, stale-result, and keyword-zero
   cases.
 - Source-health diagnostics include a `source_zero_summary` that flags the 4+ hard affected-source
@@ -167,10 +177,9 @@ Candidate-drain summary:
 
 1. Treat #71/#74 as closed stale/duplicate Mako runtime/navigation diagnostic hygiene unless a
    future live Mako run fails after Chromium is installed.
-2. Implement a narrow queue-drain diagnostic follow-up from the candidate-drain evidence. The first
-   target should report candidate selection order, source mix, and budget-cap behavior so operators
-   can validate whether the current queue contract is behaving as intended before changing
-   prioritization or fairness behavior.
+2. Run another bounded candidate-drain evidence pass with the new `queue_drain` diagnostics. Only
+   implement queue prioritization or fairness changes if the reported selection order, source mix,
+   and stop reason show the current contract is wrong or insufficient.
 3. Keep full AI repair, selector rewriting, and automatic source creation out of scope until a later
    self-heal implementation PR has fresh failure evidence.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Planned future datasets:
   + Google CSE discovery experiments
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
+- Reports queue-drain selection order, selected and remaining eligible source mix, configured
+  candidate/scrape-attempt budget, and stop reason for bounded candidate scrape passes
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains
@@ -372,9 +374,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, spent all 30 scrape
   attempts on ICE, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
   produced no scrape failures, retry backlog, or self-heal backlog. Artifact-only source-health was
-  inconclusive because that diagnostic path skipped `scrape_candidates` debug summaries. The next
-  narrow implementation target is queue-drain diagnostics focused on selection visibility and
-  contract validation before changing prioritization or fairness behavior
+  inconclusive because that diagnostic path skipped `scrape_candidates` debug summaries
+- PR #110 was squash-merged as `8c89d91`; `diagnose-discovery` now emits `queue_drain` diagnostics
+  for bounded candidate scrape passes, including candidate order, source mix, configured cap fields,
+  and stop reason, without changing queue prioritization or fairness behavior
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Planned future datasets:
   + Google CSE discovery experiments
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
-- Reports queue-drain selection order, selected and remaining eligible source mix, configured
-  candidate/scrape-attempt budget, and stop reason for bounded candidate scrape passes
+- Reports queue-drain selection order, attempted and remaining eligible source mix, configured
+  candidate cap, persisted scrape-attempt count, and inferred stop reason for bounded candidate
+  scrape passes
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains
@@ -376,8 +377,9 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   produced no scrape failures, retry backlog, or self-heal backlog. Artifact-only source-health was
   inconclusive because that diagnostic path skipped `scrape_candidates` debug summaries
 - PR #110 was squash-merged as `8c89d91`; `diagnose-discovery` now emits `queue_drain` diagnostics
-  for bounded candidate scrape passes, including candidate order, source mix, configured cap fields,
-  and stop reason, without changing queue prioritization or fairness behavior
+  for bounded candidate scrape passes, including persisted attempted order, actual-attempt source
+  mix, remaining eligible order/source mix, configured candidate cap, persisted scrape-attempt
+  count, and inferred stop reason, without changing queue prioritization or fairness behavior
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/PHASE_C_PLAN.md
+++ b/docs/PHASE_C_PLAN.md
@@ -491,8 +491,9 @@ PR `#109` was then squash-merged as `201c247`. The bounded candidate-drain evide
 scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
 produced no scrape failures or self-heal backlog. Artifact-only source-health was inconclusive
 because the diagnostic path skipped `scrape_candidates` debug summaries. PR `#110` was then
-squash-merged as `8c89d91` and added queue-drain diagnostics for candidate selection order, source
-mix, configured cap behavior, and stop reason without changing prioritization or fairness behavior.
+squash-merged as `8c89d91` and added queue-drain diagnostics for candidate selection order,
+attempted/remaining source mix, configured candidate cap, persisted scrape-attempt count, and
+inferred stop reason without changing prioritization or fairness behavior.
 The next Phase C decision should come from another bounded candidate-drain evidence pass using those
 diagnostics.
 

--- a/docs/PHASE_C_PLAN.md
+++ b/docs/PHASE_C_PLAN.md
@@ -484,15 +484,17 @@ of `DL-PR-09`, which shipped in PR `#87` on 2026-04-21. That sequencing question
 closed: `C-8` shipped after the full `DL-PR-*` discovery rollout, including `DL-PR-10` and
 `DL-PR-11`.
 
-Post-#109 planning note: PR `#108` was squash-merged as `dea6406` and closed the Mako runtime
+Post-#110 planning note: PR `#108` was squash-merged as `dea6406` and closed the Mako runtime
 hygiene issues #71/#74. A fresh repo-connector issue search on 2026-05-03 returned no open issues.
 PR `#109` was then squash-merged as `201c247`. The bounded candidate-drain evidence pass under
 `data/may_26_followup/20260503T153123Z/state` persisted 63 candidates, recorded 30 successful ICE
 scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
 produced no scrape failures or self-heal backlog. Artifact-only source-health was inconclusive
-because the diagnostic path skipped `scrape_candidates` debug summaries. The next narrow Phase C
-change should add queue-drain diagnostics for candidate selection order, source mix, and budget-cap
-behavior before changing prioritization or fairness behavior.
+because the diagnostic path skipped `scrape_candidates` debug summaries. PR `#110` was then
+squash-merged as `8c89d91` and added queue-drain diagnostics for candidate selection order, source
+mix, configured cap behavior, and stop reason without changing prioritization or fairness behavior.
+The next Phase C decision should come from another bounded candidate-drain evidence pass using those
+diagnostics.
 
 ---
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -152,9 +152,14 @@ successful ICE scrape attempts, left 33 candidates from Haaretz, ICE, Maariv, Ma
 scraped, and produced no scrape failures, retry backlog, or self-heal backlog. Artifact-only
 source-health was inconclusive because the diagnostic path skipped the `scrape_candidates` debug
 summaries. Because the first pass produced scrapeable candidates, no latest-seven-complete-UTC-days
-backfill window was added. Treat the next narrow follow-up as queue-drain diagnostic work: report
-candidate selection order, source mix, and budget-cap behavior before changing queue prioritization
-or fairness behavior.
+backfill window was added.
+
+After PR #110 was squash-merged as `8c89d91`, `denbust diagnose-discovery` reports bounded
+queue-drain diagnostics in its JSON and text output. The `queue_drain` section includes the
+configured candidate cap, matching scrape-attempt budget field, latest attempted candidate order,
+selected source mix, remaining eligible candidate order, remaining eligible source mix, and the
+inferred stop reason. Use those fields in the next bounded candidate-drain evidence pass before
+changing queue prioritization or fairness behavior.
 
 ## GitHub Actions Run Path
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -156,10 +156,10 @@ backfill window was added.
 
 After PR #110 was squash-merged as `8c89d91`, `denbust diagnose-discovery` reports bounded
 queue-drain diagnostics in its JSON and text output. The `queue_drain` section includes the
-configured candidate cap, matching scrape-attempt budget field, latest attempted candidate order,
-selected source mix, remaining eligible candidate order, remaining eligible source mix, and the
-inferred stop reason. Use those fields in the next bounded candidate-drain evidence pass before
-changing queue prioritization or fairness behavior.
+configured candidate cap, persisted attempted-candidate order, persisted scrape-attempt count,
+attempted source mix derived from actual scrape attempts, remaining eligible candidate order,
+remaining eligible source mix, and the inferred stop reason. Use those fields in the next bounded
+candidate-drain evidence pass before changing queue prioritization or fairness behavior.
 
 ## GitHub Actions Run Path
 

--- a/docs/may_26_experiment_plan.md
+++ b/docs/may_26_experiment_plan.md
@@ -46,6 +46,9 @@ The original May 2026 survey found 21 issues through the repo-specific GitHub MC
 at that time. After PR #108 was squash-merged into `main` as `dea6406`, a fresh 2026-05-03 GitHub
 issue search returned zero open issues. The historical table below is retained as provenance for
 how the experiment selected #71/#72/#74/#88/#97 follow-ups, not as the current issue backlog.
+After PR #110 was squash-merged as `8c89d91`, the next experiment pass should use
+`diagnose-discovery` queue-drain diagnostics to distinguish budget-cap behavior from a source
+prioritization or fairness defect before changing queue ordering.
 
 | Issue | State | Experiment treatment |
 |---|---:|---|

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -144,22 +144,22 @@ needed for their closure.
   scrapeable candidates and successful scrape attempts.
 - Triage outcome: do not open a source-health reliability PR or self-healing orchestration PR from
   this evidence alone. PR #110 / `8c89d91` addresses the next narrow implementation step by adding
-  queue-drain diagnostics for candidate selection order, selected and remaining source mix,
-  configured budget fields, and stop reason before any queue prioritization or fairness behavior
-  change.
+  queue-drain diagnostics for candidate selection order, attempted and remaining source mix,
+  configured candidate cap, persisted scrape-attempt count, and inferred stop reason before any
+  queue prioritization or fairness behavior change.
 
 ## Queue-Drain Diagnostic Follow-Up
 
 - PR #110 was squash-merged into `main` as `8c89d91`.
 - `denbust diagnose-discovery` now emits a `queue_drain` section in JSON and text output.
 - The diagnostic reports:
-  - latest attempted candidate order inferred from persisted scrape attempts;
-  - source mix for attempted candidates;
+  - persisted attempted-candidate order inferred from scrape attempts;
+  - source mix for attempted candidates derived from actual scrape attempts;
   - remaining eligible candidate order under the existing queue contract;
   - source mix for remaining eligible candidates;
-  - configured candidate cap and matching scrape-attempt budget field;
-  - stop reason, including `budget_cap_reached` when a bounded pass hits the cap while eligible
-    candidates remain.
+  - configured candidate cap and persisted scrape-attempt count;
+  - inferred stop reason, including `budget_cap_reached` when persisted attempts meet the cap while
+    eligible candidates remain.
 - Candidate selection behavior is unchanged. The current contract still sorts eligible candidates
   by retry priority, due retry state/time, newest `last_seen_at`, and candidate id.
 - Next decision point: rerun a bounded candidate-drain pass with the new diagnostics. Implement

--- a/docs/phase_c_source_health_triage_2026_05_03.md
+++ b/docs/phase_c_source_health_triage_2026_05_03.md
@@ -143,9 +143,28 @@ needed for their closure.
 - The latest-seven-complete-UTC-days backfill window was not run because the first pass produced
   scrapeable candidates and successful scrape attempts.
 - Triage outcome: do not open a source-health reliability PR or self-healing orchestration PR from
-  this evidence alone. The next narrow implementation PR should be a queue-drain diagnostic
-  follow-up that reports candidate selection order, source mix, and budget-cap behavior before
-  changing queue prioritization or fairness behavior.
+  this evidence alone. PR #110 / `8c89d91` addresses the next narrow implementation step by adding
+  queue-drain diagnostics for candidate selection order, selected and remaining source mix,
+  configured budget fields, and stop reason before any queue prioritization or fairness behavior
+  change.
+
+## Queue-Drain Diagnostic Follow-Up
+
+- PR #110 was squash-merged into `main` as `8c89d91`.
+- `denbust diagnose-discovery` now emits a `queue_drain` section in JSON and text output.
+- The diagnostic reports:
+  - latest attempted candidate order inferred from persisted scrape attempts;
+  - source mix for attempted candidates;
+  - remaining eligible candidate order under the existing queue contract;
+  - source mix for remaining eligible candidates;
+  - configured candidate cap and matching scrape-attempt budget field;
+  - stop reason, including `budget_cap_reached` when a bounded pass hits the cap while eligible
+    candidates remain.
+- Candidate selection behavior is unchanged. The current contract still sorts eligible candidates
+  by retry priority, due retry state/time, newest `last_seen_at`, and candidate id.
+- Next decision point: rerun a bounded candidate-drain pass with the new diagnostics. Implement
+  queue prioritization or fairness only if that evidence shows the current contract is wrong or
+  insufficient.
 
 Use this triage matrix for the next implementation choice:
 

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -504,8 +504,9 @@ The recommended order is:
   produced no scrape failures or self-heal backlog; artifact-only source-health was inconclusive
   because that diagnostic path skipped `scrape_candidates` debug summaries
 - PR #110 was squash-merged as `8c89d91`; discovery diagnostics now report bounded queue-drain
-  selection order, selected and remaining source mix, configured cap behavior, and stop reason
-  without changing prioritization or fairness behavior
+  selection order, attempted and remaining source mix, configured candidate cap, persisted
+  scrape-attempt count, and inferred stop reason without changing prioritization or fairness
+  behavior
 - the next decision point is another bounded candidate-drain evidence pass using those diagnostics;
   prioritize or rebalance the queue only if that evidence shows the current contract is wrong or
   insufficient

--- a/docs/tfht_discovery_layer_implementation_plan.md
+++ b/docs/tfht_discovery_layer_implementation_plan.md
@@ -503,9 +503,12 @@ The recommended order is:
   successfully, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and
   produced no scrape failures or self-heal backlog; artifact-only source-health was inconclusive
   because that diagnostic path skipped `scrape_candidates` debug summaries
-- the next narrow implementation PR should use that evidence for queue-drain diagnostics that report
-  candidate selection order, source mix, and budget-cap behavior before changing prioritization or
-  fairness behavior
+- PR #110 was squash-merged as `8c89d91`; discovery diagnostics now report bounded queue-drain
+  selection order, selected and remaining source mix, configured cap behavior, and stop reason
+  without changing prioritization or fairness behavior
+- the next decision point is another bounded candidate-drain evidence pass using those diagnostics;
+  prioritize or rebalance the queue only if that evidence shows the current contract is wrong or
+  insufficient
 - full AI repair, selector rewriting, automatic source creation, and live-network-dependent CI tests
   remain out of scope until a later repair PR has fresh evidence
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -45,6 +45,7 @@ _STALE_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (
     CandidateStatus.PARTIALLY_SCRAPED,
     CandidateStatus.UNSUPPORTED_SOURCE,
 )
+_QUEUE_DRAIN_TEXT_ORDER_LIMIT = 10
 
 
 class EngineOverlapMetrics(BaseModel):
@@ -176,14 +177,13 @@ class QueueDrainDiagnostics(BaseModel):
     """Selection-order, source-mix, and budget-cap diagnostics for bounded drains."""
 
     max_candidate_budget: int
-    max_scrape_attempt_budget: int
-    latest_attempted_candidate_count: int = 0
-    latest_scrape_attempt_count: int = 0
+    persisted_attempted_candidate_count: int = 0
+    persisted_scrape_attempt_count: int = 0
     remaining_eligible_candidate_count: int = 0
-    stop_reason: str = "no_eligible_candidates"
-    latest_attempted_candidate_order: list[QueueDrainCandidate] = Field(default_factory=list)
+    inferred_stop_reason: str = "no_eligible_candidates"
+    persisted_attempted_candidate_order: list[QueueDrainCandidate] = Field(default_factory=list)
     remaining_eligible_candidate_order: list[QueueDrainCandidate] = Field(default_factory=list)
-    selected_source_mix: list[SourceMixEntry] = Field(default_factory=list)
+    attempted_source_mix: list[SourceMixEntry] = Field(default_factory=list)
     remaining_eligible_source_mix: list[SourceMixEntry] = Field(default_factory=list)
 
 
@@ -233,10 +233,7 @@ class DiscoveryDiagnosticReport(BaseModel):
     top_failure_codes: list[FailureSummary] = Field(default_factory=list)
     scrape_failure_diagnostics: list[ScrapeFailureDiagnostic] = Field(default_factory=list)
     queue_drain: QueueDrainDiagnostics = Field(
-        default_factory=lambda: QueueDrainDiagnostics(
-            max_candidate_budget=0,
-            max_scrape_attempt_budget=0,
-        )
+        default_factory=lambda: QueueDrainDiagnostics(max_candidate_budget=0)
     )
     source_suggestions: SourceSuggestionReport = Field(default_factory=SourceSuggestionReport)
 
@@ -468,17 +465,16 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
     lines.append("Queue drain")
     lines.append(
         "  max_candidates={max_candidate_budget} "
-        "max_scrape_attempt_budget={max_scrape_attempt_budget} "
-        "latest_attempted_candidates={latest_attempted_candidate_count} "
-        "latest_scrape_attempts={latest_scrape_attempt_count} "
+        "persisted_attempted_candidates={persisted_attempted_candidate_count} "
+        "persisted_scrape_attempts={persisted_scrape_attempt_count} "
         "remaining_eligible={remaining_eligible_candidate_count} "
-        "stop_reason={stop_reason}".format(**drain.model_dump(mode="json"))
+        "inferred_stop_reason={inferred_stop_reason}".format(**drain.model_dump(mode="json"))
     )
-    if drain.selected_source_mix:
+    if drain.attempted_source_mix:
         lines.append(
-            "  selected_source_mix: "
+            "  attempted_source_mix: "
             + ", ".join(
-                f"{entry.source}={entry.candidate_count}" for entry in drain.selected_source_mix
+                f"{entry.source}={entry.candidate_count}" for entry in drain.attempted_source_mix
             )
         )
     if drain.remaining_eligible_source_mix:
@@ -489,20 +485,20 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
                 for entry in drain.remaining_eligible_source_mix
             )
         )
-    if drain.latest_attempted_candidate_order:
-        lines.append("  latest_attempted_order:")
-        for candidate in drain.latest_attempted_candidate_order:
-            lines.append(
-                "    {position}. {candidate_id} source={source} status={status} "
-                "priority={retry_priority}".format(**candidate.model_dump(mode="json"))
-            )
+    if drain.persisted_attempted_candidate_order:
+        _append_queue_drain_order_lines(
+            lines,
+            label="persisted_attempted_order",
+            candidates=drain.persisted_attempted_candidate_order,
+            total_count=drain.persisted_attempted_candidate_count,
+        )
     if drain.remaining_eligible_candidate_order:
-        lines.append("  remaining_eligible_order:")
-        for candidate in drain.remaining_eligible_candidate_order:
-            lines.append(
-                "    {position}. {candidate_id} source={source} status={status} "
-                "priority={retry_priority}".format(**candidate.model_dump(mode="json"))
-            )
+        _append_queue_drain_order_lines(
+            lines,
+            label="remaining_eligible_order",
+            candidates=drain.remaining_eligible_candidate_order,
+            total_count=drain.remaining_eligible_candidate_count,
+        )
     if report.source_suggestions.suggestions:
         lines.append("")
         lines.append("Source suggestions")
@@ -517,6 +513,23 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
         lines.append("Notes")
         lines.extend(f"  - {note}" for note in report.notes)
     return "\n".join(lines)
+
+
+def _append_queue_drain_order_lines(
+    lines: list[str],
+    *,
+    label: str,
+    candidates: list[QueueDrainCandidate],
+    total_count: int,
+) -> None:
+    shown = candidates[:_QUEUE_DRAIN_TEXT_ORDER_LIMIT]
+    suffix = f" showing first {len(shown)} of {total_count}" if total_count > len(shown) else ""
+    lines.append(f"  {label}:{suffix}")
+    for candidate in shown:
+        lines.append(
+            "    {position}. {candidate_id} source={source} status={status} "
+            "priority={retry_priority}".format(**candidate.model_dump(mode="json"))
+        )
 
 
 def _read_jsonl(
@@ -871,6 +884,27 @@ def _source_mix(candidates: list[PersistentCandidate]) -> list[SourceMixEntry]:
     ]
 
 
+def _attempted_source_mix(
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+) -> list[SourceMixEntry]:
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    source_by_candidate_id: dict[str, str] = {}
+    for attempt in sorted(attempts, key=lambda item: (item.started_at, item.attempt_id)):
+        if attempt.candidate_id not in candidate_by_id:
+            continue
+        if attempt.source_adapter_name is None and attempt.candidate_id in source_by_candidate_id:
+            continue
+        source_by_candidate_id[attempt.candidate_id] = (
+            attempt.source_adapter_name or _candidate_source(candidate_by_id[attempt.candidate_id])
+        )
+    counts = Counter(source_by_candidate_id.values())
+    return [
+        SourceMixEntry(source=source, candidate_count=count)
+        for source, count in sorted(counts.items())
+    ]
+
+
 def _queue_drain_candidate(
     candidate: PersistentCandidate,
     *,
@@ -888,7 +922,7 @@ def _queue_drain_candidate(
     )
 
 
-def _latest_attempted_candidates(
+def _persisted_attempted_candidates(
     candidates: list[PersistentCandidate],
     attempts: list[ScrapeAttempt],
 ) -> list[PersistentCandidate]:
@@ -916,19 +950,19 @@ def _latest_attempted_candidates(
 
 def _queue_drain_stop_reason(
     *,
-    latest_attempted_candidate_count: int,
+    persisted_attempted_candidate_count: int,
     remaining_eligible_candidate_count: int,
     max_candidate_budget: int,
 ) -> str:
     if (
         max_candidate_budget > 0
-        and latest_attempted_candidate_count >= max_candidate_budget
+        and persisted_attempted_candidate_count >= max_candidate_budget
         and remaining_eligible_candidate_count > 0
     ):
         return "budget_cap_reached"
     if remaining_eligible_candidate_count == 0:
         return "no_eligible_candidates"
-    if latest_attempted_candidate_count == 0:
+    if persisted_attempted_candidate_count == 0:
         return "no_scrape_attempts_recorded"
     return "another_reason"
 
@@ -946,28 +980,27 @@ def _build_queue_drain_diagnostics(
         if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
     ]
     remaining_eligible = order_scrape_eligible_candidates(eligible_candidates, now=now)
-    latest_attempted = _latest_attempted_candidates(candidates, attempts)
+    persisted_attempted = _persisted_attempted_candidates(candidates, attempts)
     max_candidate_budget = config.max_articles
     return QueueDrainDiagnostics(
         max_candidate_budget=max_candidate_budget,
-        max_scrape_attempt_budget=max_candidate_budget,
-        latest_attempted_candidate_count=len(latest_attempted),
-        latest_scrape_attempt_count=len(attempts),
+        persisted_attempted_candidate_count=len(persisted_attempted),
+        persisted_scrape_attempt_count=len(attempts),
         remaining_eligible_candidate_count=len(remaining_eligible),
-        stop_reason=_queue_drain_stop_reason(
-            latest_attempted_candidate_count=len(latest_attempted),
+        inferred_stop_reason=_queue_drain_stop_reason(
+            persisted_attempted_candidate_count=len(persisted_attempted),
             remaining_eligible_candidate_count=len(remaining_eligible),
             max_candidate_budget=max_candidate_budget,
         ),
-        latest_attempted_candidate_order=[
+        persisted_attempted_candidate_order=[
             _queue_drain_candidate(candidate, position=index)
-            for index, candidate in enumerate(latest_attempted, start=1)
+            for index, candidate in enumerate(persisted_attempted, start=1)
         ],
         remaining_eligible_candidate_order=[
             _queue_drain_candidate(candidate, position=index)
             for index, candidate in enumerate(remaining_eligible, start=1)
         ],
-        selected_source_mix=_source_mix(latest_attempted),
+        attempted_source_mix=_attempted_source_mix(candidates, attempts),
         remaining_eligible_source_mix=_source_mix(remaining_eligible),
     )
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -19,6 +19,10 @@ from denbust.discovery.models import (
     ScrapeAttempt,
 )
 from denbust.discovery.queries import enabled_source_domains
+from denbust.discovery.scrape_queue import (
+    SCRAPEABLE_CANDIDATE_STATUSES,
+    order_scrape_eligible_candidates,
+)
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
@@ -148,6 +152,41 @@ class ScrapeFailureDiagnostic(BaseModel):
     latest_attempt_at: datetime | None = None
 
 
+class SourceMixEntry(BaseModel):
+    """Candidate counts grouped by inferred source for queue-drain diagnostics."""
+
+    source: str
+    candidate_count: int = 0
+
+
+class QueueDrainCandidate(BaseModel):
+    """One candidate in a diagnostic queue-drain order."""
+
+    position: int
+    candidate_id: str
+    source: str
+    status: str
+    retry_priority: int = 0
+    next_scrape_attempt_at: datetime | None = None
+    last_seen_at: datetime
+    current_url: str
+
+
+class QueueDrainDiagnostics(BaseModel):
+    """Selection-order, source-mix, and budget-cap diagnostics for bounded drains."""
+
+    max_candidate_budget: int
+    max_scrape_attempt_budget: int
+    latest_attempted_candidate_count: int = 0
+    latest_scrape_attempt_count: int = 0
+    remaining_eligible_candidate_count: int = 0
+    stop_reason: str = "no_eligible_candidates"
+    latest_attempted_candidate_order: list[QueueDrainCandidate] = Field(default_factory=list)
+    remaining_eligible_candidate_order: list[QueueDrainCandidate] = Field(default_factory=list)
+    selected_source_mix: list[SourceMixEntry] = Field(default_factory=list)
+    remaining_eligible_source_mix: list[SourceMixEntry] = Field(default_factory=list)
+
+
 class SourceSuggestion(BaseModel):
     """Advisory suggestion for a candidate-heavy unseen domain."""
 
@@ -193,6 +232,12 @@ class DiscoveryDiagnosticReport(BaseModel):
     top_failure_domains: list[FailureSummary] = Field(default_factory=list)
     top_failure_codes: list[FailureSummary] = Field(default_factory=list)
     scrape_failure_diagnostics: list[ScrapeFailureDiagnostic] = Field(default_factory=list)
+    queue_drain: QueueDrainDiagnostics = Field(
+        default_factory=lambda: QueueDrainDiagnostics(
+            max_candidate_budget=0,
+            max_scrape_attempt_budget=0,
+        )
+    )
     source_suggestions: SourceSuggestionReport = Field(default_factory=SourceSuggestionReport)
 
 
@@ -269,6 +314,12 @@ def build_discovery_diagnostic_report(
         top_failure_domains=_build_failure_summaries(candidates, attempts, key="domain"),
         top_failure_codes=_build_failure_summaries(candidates, attempts, key="error_code"),
         scrape_failure_diagnostics=_build_scrape_failure_diagnostics(candidates, attempts),
+        queue_drain=_build_queue_drain_diagnostics(
+            config=config,
+            candidates=candidates,
+            attempts=attempts,
+            now=now,
+        ),
         source_suggestions=_build_source_suggestion_report(
             config=config,
             candidates=candidates,
@@ -411,6 +462,46 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
                 "self_heal_eligible={self_heal_eligible_count}".format(
                     **failure.model_dump(mode="json")
                 )
+            )
+    drain = report.queue_drain
+    lines.append("")
+    lines.append("Queue drain")
+    lines.append(
+        "  max_candidates={max_candidate_budget} "
+        "max_scrape_attempt_budget={max_scrape_attempt_budget} "
+        "latest_attempted_candidates={latest_attempted_candidate_count} "
+        "latest_scrape_attempts={latest_scrape_attempt_count} "
+        "remaining_eligible={remaining_eligible_candidate_count} "
+        "stop_reason={stop_reason}".format(**drain.model_dump(mode="json"))
+    )
+    if drain.selected_source_mix:
+        lines.append(
+            "  selected_source_mix: "
+            + ", ".join(
+                f"{entry.source}={entry.candidate_count}" for entry in drain.selected_source_mix
+            )
+        )
+    if drain.remaining_eligible_source_mix:
+        lines.append(
+            "  remaining_eligible_source_mix: "
+            + ", ".join(
+                f"{entry.source}={entry.candidate_count}"
+                for entry in drain.remaining_eligible_source_mix
+            )
+        )
+    if drain.latest_attempted_candidate_order:
+        lines.append("  latest_attempted_order:")
+        for candidate in drain.latest_attempted_candidate_order:
+            lines.append(
+                "    {position}. {candidate_id} source={source} status={status} "
+                "priority={retry_priority}".format(**candidate.model_dump(mode="json"))
+            )
+    if drain.remaining_eligible_candidate_order:
+        lines.append("  remaining_eligible_order:")
+        for candidate in drain.remaining_eligible_candidate_order:
+            lines.append(
+                "    {position}. {candidate_id} source={source} status={status} "
+                "priority={retry_priority}".format(**candidate.model_dump(mode="json"))
             )
     if report.source_suggestions.suggestions:
         lines.append("")
@@ -761,6 +852,124 @@ def _build_scrape_failure_diagnostics(
             item.domain,
         ),
     )[:10]
+
+
+def _candidate_source(candidate: PersistentCandidate) -> str:
+    if candidate.source_hints:
+        return candidate.source_hints[0]
+    for producer in candidate.discovered_via:
+        if producer not in _SEARCH_ENGINE_NAMES:
+            return producer
+    return candidate.domain or "unknown"
+
+
+def _source_mix(candidates: list[PersistentCandidate]) -> list[SourceMixEntry]:
+    counts = Counter(_candidate_source(candidate) for candidate in candidates)
+    return [
+        SourceMixEntry(source=source, candidate_count=count)
+        for source, count in sorted(counts.items())
+    ]
+
+
+def _queue_drain_candidate(
+    candidate: PersistentCandidate,
+    *,
+    position: int,
+) -> QueueDrainCandidate:
+    return QueueDrainCandidate(
+        position=position,
+        candidate_id=candidate.candidate_id,
+        source=_candidate_source(candidate),
+        status=candidate.candidate_status.value,
+        retry_priority=candidate.retry_priority,
+        next_scrape_attempt_at=candidate.next_scrape_attempt_at,
+        last_seen_at=candidate.last_seen_at,
+        current_url=str(candidate.current_url),
+    )
+
+
+def _latest_attempted_candidates(
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+) -> list[PersistentCandidate]:
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    ordered_attempts = sorted(
+        attempts,
+        key=lambda attempt: (
+            attempt.started_at,
+            attempt.finished_at or attempt.started_at,
+            attempt.attempt_id,
+        ),
+    )
+    seen_ids: set[str] = set()
+    attempted_candidates: list[PersistentCandidate] = []
+    for attempt in ordered_attempts:
+        if attempt.candidate_id in seen_ids:
+            continue
+        candidate = candidate_by_id.get(attempt.candidate_id)
+        if candidate is None:
+            continue
+        attempted_candidates.append(candidate)
+        seen_ids.add(attempt.candidate_id)
+    return attempted_candidates
+
+
+def _queue_drain_stop_reason(
+    *,
+    latest_attempted_candidate_count: int,
+    remaining_eligible_candidate_count: int,
+    max_candidate_budget: int,
+) -> str:
+    if (
+        max_candidate_budget > 0
+        and latest_attempted_candidate_count >= max_candidate_budget
+        and remaining_eligible_candidate_count > 0
+    ):
+        return "budget_cap_reached"
+    if remaining_eligible_candidate_count == 0:
+        return "no_eligible_candidates"
+    if latest_attempted_candidate_count == 0:
+        return "no_scrape_attempts_recorded"
+    return "another_reason"
+
+
+def _build_queue_drain_diagnostics(
+    *,
+    config: Config,
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+    now: datetime,
+) -> QueueDrainDiagnostics:
+    eligible_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
+    ]
+    remaining_eligible = order_scrape_eligible_candidates(eligible_candidates, now=now)
+    latest_attempted = _latest_attempted_candidates(candidates, attempts)
+    max_candidate_budget = config.max_articles
+    return QueueDrainDiagnostics(
+        max_candidate_budget=max_candidate_budget,
+        max_scrape_attempt_budget=max_candidate_budget,
+        latest_attempted_candidate_count=len(latest_attempted),
+        latest_scrape_attempt_count=len(attempts),
+        remaining_eligible_candidate_count=len(remaining_eligible),
+        stop_reason=_queue_drain_stop_reason(
+            latest_attempted_candidate_count=len(latest_attempted),
+            remaining_eligible_candidate_count=len(remaining_eligible),
+            max_candidate_budget=max_candidate_budget,
+        ),
+        latest_attempted_candidate_order=[
+            _queue_drain_candidate(candidate, position=index)
+            for index, candidate in enumerate(latest_attempted, start=1)
+        ],
+        remaining_eligible_candidate_order=[
+            _queue_drain_candidate(candidate, position=index)
+            for index, candidate in enumerate(remaining_eligible, start=1)
+        ],
+        selected_source_mix=_source_mix(latest_attempted),
+        remaining_eligible_source_mix=_source_mix(remaining_eligible),
+    )
 
 
 def _build_source_suggestion_report(

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -71,6 +71,16 @@ def select_candidates_for_scrape(
     """Return eligible durable candidates for scraping."""
     current_time = now or datetime.now(UTC)
     candidates = persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+    return order_scrape_eligible_candidates(candidates, now=current_time)[:limit]
+
+
+def order_scrape_eligible_candidates(
+    candidates: list[PersistentCandidate],
+    *,
+    now: datetime | None = None,
+) -> list[PersistentCandidate]:
+    """Return scrape-eligible candidates in the queue contract order."""
+    current_time = now or datetime.now(UTC)
     eligible = [
         candidate
         for candidate in candidates
@@ -88,7 +98,7 @@ def select_candidates_for_scrape(
             candidate.candidate_id,
         ),
     )
-    return ordered[:limit]
+    return ordered
 
 
 def select_candidates_for_self_heal(

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -191,6 +191,103 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
     assert "Structured scrape failures" in render_discovery_diagnostic_report(report)
 
 
+def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(
+    tmp_path: Path,
+) -> None:
+    """Queue-drain diagnostics should expose selection order, source mix, and cap stops."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    config = Config(store={"state_root": tmp_path}, max_articles=2)
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    first = _candidate(
+        "selected-ice-1",
+        url="https://www.ice.co.il/article/1",
+        discovered_via=["ice"],
+        status=CandidateStatus.SCRAPE_SUCCEEDED,
+        first_seen_at=now - timedelta(hours=3),
+        last_seen_at=now - timedelta(minutes=20),
+        content_basis=ContentBasis.FULL_ARTICLE_PAGE,
+    )
+    second = _candidate(
+        "selected-ice-2",
+        url="https://www.ice.co.il/article/2",
+        discovered_via=["ice"],
+        status=CandidateStatus.SCRAPE_SUCCEEDED,
+        first_seen_at=now - timedelta(hours=3),
+        last_seen_at=now - timedelta(minutes=10),
+        content_basis=ContentBasis.FULL_ARTICLE_PAGE,
+    )
+    pending_mako = _candidate(
+        "pending-mako",
+        url="https://www.mako.co.il/news/article/pending",
+        discovered_via=["mako"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now - timedelta(hours=2),
+        last_seen_at=now - timedelta(minutes=5),
+    )
+    pending_haaretz = _candidate(
+        "pending-haaretz",
+        url="https://www.haaretz.co.il/news/article/pending",
+        discovered_via=["haaretz"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now - timedelta(hours=2),
+        last_seen_at=now - timedelta(minutes=15),
+    )
+    persistence.upsert_candidates([first, second, pending_mako, pending_haaretz])
+    attempts = [
+        ScrapeAttempt(
+            candidate_id="selected-ice-1",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.SUCCESS,
+            source_adapter_name="ice",
+        ),
+        ScrapeAttempt(
+            candidate_id="selected-ice-2",
+            started_at=now + timedelta(seconds=1),
+            finished_at=now + timedelta(seconds=1),
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.SUCCESS,
+            source_adapter_name="ice",
+        ),
+    ]
+    persistence.append_attempts(attempts)
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        attempts_override=attempts,
+        candidates_override=persistence.list_candidates(),
+        include_operational_matches=False,
+    )
+
+    assert report.queue_drain.max_candidate_budget == 2
+    assert report.queue_drain.max_scrape_attempt_budget == 2
+    assert report.queue_drain.latest_attempted_candidate_count == 2
+    assert report.queue_drain.latest_scrape_attempt_count == 2
+    assert report.queue_drain.remaining_eligible_candidate_count == 2
+    assert report.queue_drain.stop_reason == "budget_cap_reached"
+    assert [item.candidate_id for item in report.queue_drain.latest_attempted_candidate_order] == [
+        "selected-ice-1",
+        "selected-ice-2",
+    ]
+    assert [
+        item.candidate_id for item in report.queue_drain.remaining_eligible_candidate_order
+    ] == ["pending-mako", "pending-haaretz"]
+    assert [item.model_dump(mode="json") for item in report.queue_drain.selected_source_mix] == [
+        {"source": "ice", "candidate_count": 2}
+    ]
+    assert [
+        item.model_dump(mode="json") for item in report.queue_drain.remaining_eligible_source_mix
+    ] == [
+        {"source": "haaretz", "candidate_count": 1},
+        {"source": "mako", "candidate_count": 1},
+    ]
+    rendered = render_discovery_diagnostic_report(report)
+    assert "Queue drain" in rendered
+    assert "stop_reason=budget_cap_reached" in rendered
+    assert "selected_source_mix: ice=2" in rendered
+
+
 def test_persist_discovery_diagnostic_artifacts_writes_latest_files(tmp_path: Path) -> None:
     """The diagnostics artifact writer should persist both JSON reports."""
     config = Config(store={"state_root": tmp_path})

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -14,6 +14,7 @@ from denbust.diagnostics.discovery import (
     DiscoveryDiagnosticReport,
     _build_failure_summaries,
     _build_scrape_failure_diagnostics,
+    _candidate_source,
     _load_operational_record_urls,
     _normalize_domain,
     _read_jsonl,
@@ -261,19 +262,17 @@ def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(
     )
 
     assert report.queue_drain.max_candidate_budget == 2
-    assert report.queue_drain.max_scrape_attempt_budget == 2
-    assert report.queue_drain.latest_attempted_candidate_count == 2
-    assert report.queue_drain.latest_scrape_attempt_count == 2
+    assert report.queue_drain.persisted_attempted_candidate_count == 2
+    assert report.queue_drain.persisted_scrape_attempt_count == 2
     assert report.queue_drain.remaining_eligible_candidate_count == 2
-    assert report.queue_drain.stop_reason == "budget_cap_reached"
-    assert [item.candidate_id for item in report.queue_drain.latest_attempted_candidate_order] == [
-        "selected-ice-1",
-        "selected-ice-2",
-    ]
+    assert report.queue_drain.inferred_stop_reason == "budget_cap_reached"
+    assert [
+        item.candidate_id for item in report.queue_drain.persisted_attempted_candidate_order
+    ] == ["selected-ice-1", "selected-ice-2"]
     assert [
         item.candidate_id for item in report.queue_drain.remaining_eligible_candidate_order
     ] == ["pending-mako", "pending-haaretz"]
-    assert [item.model_dump(mode="json") for item in report.queue_drain.selected_source_mix] == [
+    assert [item.model_dump(mode="json") for item in report.queue_drain.attempted_source_mix] == [
         {"source": "ice", "candidate_count": 2}
     ]
     assert [
@@ -284,8 +283,158 @@ def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(
     ]
     rendered = render_discovery_diagnostic_report(report)
     assert "Queue drain" in rendered
-    assert "stop_reason=budget_cap_reached" in rendered
-    assert "selected_source_mix: ice=2" in rendered
+    assert "inferred_stop_reason=budget_cap_reached" in rendered
+    assert "attempted_source_mix: ice=2" in rendered
+
+
+def test_queue_drain_attempted_source_mix_uses_attempt_adapter_names(
+    tmp_path: Path,
+) -> None:
+    """Attempted source mix should prefer the source adapter that actually ran."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    config = Config(store={"state_root": tmp_path}, max_articles=5)
+    candidate = _candidate(
+        "search-produced",
+        url="https://www.mako.co.il/news/article/search-produced",
+        discovered_via=["brave"],
+        status=CandidateStatus.SCRAPE_FAILED,
+        first_seen_at=now - timedelta(hours=1),
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": ["mako"]})
+    attempts = [
+        ScrapeAttempt(
+            candidate_id="search-produced",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.FAILED,
+            source_adapter_name="ynet",
+        ),
+        ScrapeAttempt(
+            candidate_id="search-produced",
+            started_at=now + timedelta(seconds=1),
+            finished_at=now + timedelta(seconds=1),
+            attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+            fetch_status=FetchStatus.FAILED,
+        ),
+    ]
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        candidates_override=[candidate],
+        attempts_override=attempts,
+        include_operational_matches=False,
+    )
+
+    assert [item.model_dump(mode="json") for item in report.queue_drain.attempted_source_mix] == [
+        {"source": "ynet", "candidate_count": 1}
+    ]
+
+
+def test_queue_drain_attempted_candidates_skip_duplicates_and_missing_candidates(
+    tmp_path: Path,
+) -> None:
+    """Persisted attempted order should count each known candidate once."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    config = Config(store={"state_root": tmp_path}, max_articles=5)
+    candidate = _candidate(
+        "known",
+        url="https://www.walla.co.il/news/article/known",
+        discovered_via=["walla"],
+        status=CandidateStatus.SCRAPE_SUCCEEDED,
+        first_seen_at=now - timedelta(hours=1),
+        last_seen_at=now,
+    )
+    attempts = [
+        ScrapeAttempt(
+            candidate_id="known",
+            started_at=now,
+            finished_at=now,
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.SUCCESS,
+            source_adapter_name="walla",
+        ),
+        ScrapeAttempt(
+            candidate_id="known",
+            started_at=now + timedelta(seconds=1),
+            finished_at=now + timedelta(seconds=1),
+            attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+            fetch_status=FetchStatus.SUCCESS,
+        ),
+        ScrapeAttempt(
+            candidate_id="missing",
+            started_at=now + timedelta(seconds=2),
+            finished_at=now + timedelta(seconds=2),
+            attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            fetch_status=FetchStatus.SUCCESS,
+            source_adapter_name="mako",
+        ),
+    ]
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        candidates_override=[candidate],
+        attempts_override=attempts,
+        include_operational_matches=False,
+    )
+
+    assert report.queue_drain.persisted_attempted_candidate_count == 1
+    assert [
+        item.candidate_id for item in report.queue_drain.persisted_attempted_candidate_order
+    ] == ["known"]
+
+
+def test_candidate_source_falls_back_to_non_search_producer_then_domain() -> None:
+    """Candidate-source inference should cover non-search producers and domain fallback."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    source_native = _candidate(
+        "source-native",
+        url="https://example.com/source-native",
+        discovered_via=["source_native"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
+    domain_only = _candidate(
+        "domain-only",
+        url="https://example.com/domain-only",
+        discovered_via=["brave"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
+
+    assert _candidate_source(source_native) == "source_native"
+    assert _candidate_source(domain_only) == "example.com"
+
+
+def test_render_discovery_diagnostic_report_caps_queue_order_text(tmp_path: Path) -> None:
+    """Text diagnostics should summarize long orders without dumping the whole queue."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    config = Config(store={"state_root": tmp_path}, max_articles=5)
+    candidates = [
+        _candidate(
+            f"pending-{index:02d}",
+            url=f"https://www.mako.co.il/news/article/pending-{index:02d}",
+            discovered_via=["mako"],
+            status=CandidateStatus.NEW,
+            first_seen_at=now - timedelta(hours=1),
+            last_seen_at=now - timedelta(minutes=index),
+        )
+        for index in range(12)
+    ]
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        candidates_override=candidates,
+        attempts_override=[],
+        include_operational_matches=False,
+    )
+    rendered = render_discovery_diagnostic_report(report)
+
+    assert "remaining_eligible_order: showing first 10 of 12" in rendered
+    assert "pending-00" in rendered
+    assert "pending-10" not in rendered
 
 
 def test_persist_discovery_diagnostic_artifacts_writes_latest_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Planning notation

- Notation: Phase C QD
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `PLAN.md`, and `docs/phase_c_source_health_triage_2026_05_03.md`

## Summary

This PR adds a narrow diagnostic follow-up for the 2026-05-03T15:31:23Z candidate-drain evidence pass. That pass persisted 63 candidates, spent all 30 scrape attempts on ICE, left 33 candidates from Haaretz, ICE, Maariv, Mako, and Walla never scraped, and produced no scrape failures, retry backlog, or self-heal backlog. The change keeps queue behavior unchanged and makes the current bounded drain contract visible before any prioritization or fairness change.

## Diagnostic fields added

`denbust diagnose-discovery` now emits `queue_drain` in JSON and text output with:

- `max_candidate_budget`
- `max_scrape_attempt_budget`
- `latest_attempted_candidate_count`
- `latest_scrape_attempt_count`
- `remaining_eligible_candidate_count`
- `stop_reason`
- `latest_attempted_candidate_order`
- `remaining_eligible_candidate_order`
- `selected_source_mix`
- `remaining_eligible_source_mix`

Stop reasons include `budget_cap_reached`, `no_eligible_candidates`, `no_scrape_attempts_recorded`, and `another_reason`.

## Queue contract interpretation

The existing scrape candidate contract is preserved. Eligible candidates are ordered by retry priority, immediate vs scheduled retry state, retry due time, newest `last_seen_at`, and candidate id. `run_news_scrape_candidates_job` still caps selection at `config.max_articles`. This PR only factors the existing ordering into a reusable helper and reports how persisted attempts and remaining eligible candidates line up with that contract.

## Docs and planning

- Updates `.agent-plan.md` as mainline truth with #110 / `8c89d91` as the latest merged PR and exactly one `[next]` item.
- Updates `PLAN.md`, `README.md`, `docs/discovery_operations.md`, `docs/phase_c_source_health_triage_2026_05_03.md`, `docs/PHASE_C_PLAN.md`, `docs/tfht_discovery_layer_implementation_plan.md`, and `docs/may_26_experiment_plan.md` for the post-merge state.
- Sets the next decision point to another bounded candidate-drain evidence pass using the new diagnostics before deciding on queue fairness or prioritization.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_cli.py -k 'diagnose_discovery or queue_drain or select_candidates_for_scrape'`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_cli.py tests/unit/test_pipeline_core.py`
- Pre-push hooks with the repo venv on `PATH` passed unit and integration hooks.

## Follow-up decision

Run another bounded candidate-drain evidence pass with `diagnose-discovery` after this merges. Implement queue prioritization or fairness only if the reported candidate order, source mix, and stop reason show that the current contract is wrong or insufficient.
