### PR TITLE
Add Chrome CDP mode for browser-backed scrapers

### DIFF
--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -1,0 +1,307 @@
+# January 2026 Backfill Wet-Test Plan
+
+Date authored: 2026-05-03
+
+## Purpose
+
+This plan defines the first bounded January 2026 backfill evidence pass. It is a wet test, not a
+full historical recovery run. The goal is to prove that the January backfill path can produce and
+drain candidates while the new queue-drain diagnostics explain selection order, source mix, budget
+cap behavior, scrape failures, and remaining eligible backlog.
+
+The first attempt should use the first seven complete UTC days of January 2026. Expand to the full
+month only after the 7-day evidence pass looks sane.
+
+## Preconditions
+
+- Work from latest `main`.
+- Load local secrets before model-backed scrape/classification:
+
+```bash
+eval "$(direnv export bash)"
+```
+
+- If the project environment is not activated, prefix commands with `.venv/bin/`.
+- Use a real local Google Chrome instance for browser-backed local scraping. This mode does not
+  require Playwright's downloaded test Chromium.
+- Confirm Chrome is already running with a DevTools endpoint before the scrape phase:
+
+```bash
+curl -fsS http://127.0.0.1:9222/json/version
+```
+
+- If no attachable Chrome is running, start normal Google Chrome with remote debugging and a
+  dedicated wet-test profile, then pause so the operator can log into source accounts and handle
+  any browser challenges before continuing:
+
+```bash
+open -na "Google Chrome" --args \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.config/denbust/chrome-wet-test"
+```
+
+- Do not write this wet-test output into the default `data/` state root. Use a fresh ignored
+  experiment root.
+
+## Evidence Root
+
+Create one timestamped follow-up root:
+
+```bash
+export FOLLOWUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+export FOLLOWUP_ROOT="data/may_26_followup/${FOLLOWUP_ID}"
+export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
+export DENBUST_BROWSER_MODE=chrome_cdp
+export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
+mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts,reports,summaries}
+```
+
+Every command should write stdout/stderr to `logs/` and machine-readable output to `artifacts/`
+where supported. Do not commit the generated `data/` bundle.
+
+`DENBUST_BROWSER_MODE=chrome_cdp` applies only to browser-backed source scrapers such as Mako and
+Haaretz. HTTP fallback fetching and API-backed discovery/search engines continue to use their
+existing non-browser paths.
+
+## Phase 0 - Static Guardrails
+
+Run the narrow static checks that prove the checked-out code and plan format are healthy before live
+work:
+
+```bash
+.venv/bin/python scripts/validate_agent_plan.py \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/00_validate_agent_plan.log"
+
+.venv/bin/ruff check . \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/01_ruff_check.log"
+
+.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_cli.py -k 'diagnose_discovery or queue_drain or select_candidates_for_scrape' \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/02_queue_diagnostics_tests.log"
+```
+
+Stop if any static guardrail fails.
+
+## Phase 1 - Empty-State Baseline
+
+Capture diagnostics before writing January candidates:
+
+```bash
+.venv/bin/denbust diagnose-discovery \
+  --config agents/news/local.yaml \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_before.json" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/03_diagnose_discovery_before.log"
+
+.venv/bin/denbust diagnose-sources \
+  --config agents/news/local.yaml \
+  --artifacts-only \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_artifact_only_before.json" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/04_diagnose_sources_artifact_only_before.log"
+```
+
+Expected baseline:
+
+- `diagnose-discovery` reports no persisted candidates or attempts under the fresh root.
+- `diagnose-sources --artifacts-only` may skip sources because no ingest debug summaries exist.
+  Treat this as artifact-shape evidence, not source-health evidence.
+
+## Phase 2 - Bounded January Discovery
+
+Run only January 1-7 first:
+
+```bash
+export DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00
+export DENBUST_BACKFILL_DATE_TO=2026-01-07T23:59:59+00:00
+
+.venv/bin/denbust run \
+  --dataset news_items \
+  --job backfill_discover \
+  --config agents/news/local.yaml \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/05_backfill_discover_2026_01_01_07.log"
+```
+
+Then capture discovery diagnostics:
+
+```bash
+.venv/bin/denbust diagnose-discovery \
+  --config agents/news/local.yaml \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_after_discover.json" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/06_diagnose_discovery_after_discover.log"
+```
+
+Record:
+
+- total persisted candidates;
+- candidates by source and producer;
+- backfill batch id(s);
+- queue health and scrape-eligible count;
+- whether source-targeted taxonomy queries were capped as expected.
+
+Stop before scrape if discovery produces zero candidates and no useful diagnostic clue. In that case,
+write a short report explaining whether the next action should be source/search input adjustment
+rather than scrape behavior work.
+
+## Phase 3 - First Bounded Scrape Drain
+
+Drain one eligible backfill batch with the default scrape cap:
+
+```bash
+curl -fsS "${DENBUST_CHROME_CDP_URL}/json/version" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/07a_chrome_cdp_preflight.log"
+
+.venv/bin/denbust run \
+  --dataset news_items \
+  --job backfill_scrape \
+  --config agents/news/local.yaml \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/07_backfill_scrape_2026_01_01_07.log"
+```
+
+Then capture the queue-drain diagnostics:
+
+```bash
+.venv/bin/denbust diagnose-discovery \
+  --config agents/news/local.yaml \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_after_scrape.json" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/08_diagnose_discovery_after_scrape.log"
+```
+
+The key evidence is the `queue_drain` object:
+
+- `max_candidate_budget`;
+- `persisted_attempted_candidate_count`;
+- `persisted_scrape_attempt_count`;
+- `attempted_source_mix`;
+- `remaining_eligible_candidate_count`;
+- `remaining_eligible_source_mix`;
+- `persisted_attempted_candidate_order`;
+- `remaining_eligible_candidate_order`;
+- `inferred_stop_reason`.
+
+## Phase 4 - Source Artifact Check
+
+Run artifact-only source diagnostics after the scrape pass:
+
+```bash
+.venv/bin/denbust diagnose-sources \
+  --config agents/news/local.yaml \
+  --artifacts-only \
+  --format json \
+  --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_artifact_only_after_scrape.json" \
+  2>&1 | tee "${FOLLOWUP_ROOT}/logs/09_diagnose_sources_artifact_only_after_scrape.log"
+```
+
+Record whether this path can read the produced artifacts. If it skips because the run produced
+`backfill_scrape` or `scrape_candidates` summaries rather than ingest summaries, treat that as an
+artifact compatibility gap, not as source-health evidence.
+
+## Phase 5 - Human Summary
+
+Write a short Markdown report:
+
+```bash
+cat > "${FOLLOWUP_ROOT}/reports/january_2026_backfill_wet_test_summary.md" <<'EOF'
+# January 2026 Backfill Wet-Test Summary
+
+## Window
+
+- From: 2026-01-01T00:00:00+00:00
+- To: 2026-01-07T23:59:59+00:00
+
+## Commands
+
+- Static guardrails:
+- Empty-state diagnostics:
+- Backfill discover:
+- Backfill scrape:
+- Post-scrape diagnostics:
+
+## Discovery Results
+
+- Persisted candidates:
+- Candidate source mix:
+- Backfill batch id(s):
+- Scrape-eligible candidates:
+
+## Scrape Results
+
+- Persisted attempted candidates:
+- Persisted scrape attempts:
+- Attempted source mix:
+- Scrape succeeded:
+- Scrape failed:
+- Retry backlog:
+- Self-heal eligible:
+- Remaining eligible candidates:
+- Remaining eligible source mix:
+- Inferred stop reason:
+
+## Interpretation
+
+- Queue contract appears sane / ambiguous / wrong:
+- Evidence for or against prioritization/fairness change:
+- Source-health or artifact-diagnostic gaps:
+
+## Decision
+
+- Expand to the full January 2026 month:
+- Run another 7-day slice first:
+- Open a code PR:
+- Do not proceed until:
+EOF
+```
+
+Fill the report from the JSON artifacts before deciding whether to expand.
+
+## Expansion Decision
+
+Expand from the 7-day wet test to the full January 2026 window only if all of these are true:
+
+- `backfill_discover` produced candidates or produced a clearly understood zero-candidate result;
+- `backfill_scrape` completed without fatal credential/provider/runtime failures, and browser-backed
+  Mako/Haaretz activity either attached to Chrome over CDP or reported the CDP endpoint as
+  unavailable before live scraping proceeded;
+- `queue_drain.inferred_stop_reason` is explainable from the configured candidate cap and remaining
+  eligible queue;
+- attempted and remaining source mix do not show an obviously pathological single-source drain that
+  contradicts the intended queue contract;
+- scrape failures are either low-volume or grouped into actionable diagnostics;
+- no self-heal or retry backlog pattern suggests a code fix should happen before more live work.
+
+If those conditions pass, run the full month:
+
+```bash
+export DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00
+export DENBUST_BACKFILL_DATE_TO=2026-01-31T23:59:59+00:00
+export DENBUST_BROWSER_MODE=chrome_cdp
+export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
+
+.venv/bin/denbust run --dataset news_items --job backfill_discover --config agents/news/local.yaml
+.venv/bin/denbust run --dataset news_items --job backfill_scrape --config agents/news/local.yaml
+.venv/bin/denbust diagnose-discovery --config agents/news/local.yaml --format json
+```
+
+If the 7-day pass is ambiguous, run a second adjacent slice before changing code:
+
+```bash
+export DENBUST_BACKFILL_DATE_FROM=2026-01-08T00:00:00+00:00
+export DENBUST_BACKFILL_DATE_TO=2026-01-14T23:59:59+00:00
+```
+
+## Code-Change Decision Rules
+
+Open a follow-up code PR only when the wet test shows one of these concrete defects:
+
+- queue diagnostics cannot explain candidate selection order or remaining eligible backlog;
+- `inferred_stop_reason` is inconsistent with persisted candidates, attempts, and configured cap;
+- attempted source mix repeatedly drains one source while older or higher-priority eligible
+  candidates from other sources remain contrary to the queue contract;
+- scrape failures cluster by source/domain/error code with enough volume to justify source-health or
+  self-heal selection work;
+- artifact-only diagnostics cannot consume the produced backfill/scrape debug summaries and that gap
+  blocks operator interpretation.
+
+Do not implement queue fairness, prioritization, selector repair, or AI self-healing from a single
+successful bounded wet test.

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -53,6 +53,41 @@ class OutputFormat(StrEnum):
     EMAIL = "email"
 
 
+class BrowserMode(StrEnum):
+    """Browser session mode for browser-backed source scrapers."""
+
+    PLAYWRIGHT_HEADLESS = "playwright_headless"
+    CHROME_CDP = "chrome_cdp"
+
+
+class BrowserConfig(BaseModel):
+    """Shared browser configuration for browser-backed source scrapers."""
+
+    mode: BrowserMode = BrowserMode.PLAYWRIGHT_HEADLESS
+    chrome_cdp_url: str = "http://127.0.0.1:9222"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_env_overrides(cls, data: object) -> object:
+        """Apply browser mode overrides from the environment."""
+        if data is None:
+            normalized: dict[str, object] = {}
+        elif isinstance(data, dict):
+            normalized = dict(data)
+        else:
+            return data
+
+        env_mode = os.environ.get("DENBUST_BROWSER_MODE")
+        if env_mode:
+            normalized["mode"] = env_mode
+
+        env_cdp_url = os.environ.get("DENBUST_CHROME_CDP_URL")
+        if env_cdp_url:
+            normalized["chrome_cdp_url"] = env_cdp_url
+
+        return normalized
+
+
 class OutputConfig(BaseModel):
     """Configuration for output."""
 
@@ -387,6 +422,7 @@ class Config(BaseModel):
     classifier: ClassifierConfig = Field(default_factory=ClassifierConfig)
     dedup: DedupConfig = Field(default_factory=DedupConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
+    browser: BrowserConfig = Field(default_factory=BrowserConfig)
     store: StoreConfig = Field(default_factory=StoreConfig)
     operational: OperationalConfig = Field(default_factory=OperationalConfig)
     discovery: DiscoveryConfig = Field(default_factory=DiscoveryConfig)

--- a/src/denbust/diagnostics/source_health.py
+++ b/src/denbust/diagnostics/source_health.py
@@ -1692,6 +1692,8 @@ def _classify_mako_exception(exc: Exception) -> MakoFailureMode:
     if (
         "playwright is not installed" in message
         or "chromium could not be launched" in message
+        or "could not attach" in message
+        or "chrome over cdp" in message
         or "executable doesn't exist" in message
         or "browser executable not found" in message
     ):

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -188,13 +188,13 @@ def create_sources(config: Config) -> list[Source]:
 
         elif source_cfg.type == SourceType.SCRAPER:
             if source_cfg.name == "mako":
-                sources.append(create_mako_source())
+                sources.append(create_mako_source(browser_config=config.browser))
             elif source_cfg.name == "maariv":
                 sources.append(create_maariv_source())
             elif source_cfg.name == "ice":
                 sources.append(create_ice_source())
             elif source_cfg.name == "haaretz":
-                sources.append(create_haaretz_source())
+                sources.append(create_haaretz_source(browser_config=config.browser))
             elif source_cfg.name == "walla":
                 sources.append(create_walla_source())
             else:

--- a/src/denbust/sources/browser.py
+++ b/src/denbust/sources/browser.py
@@ -1,0 +1,258 @@
+"""Shared Playwright browser sessions for source scrapers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypedDict
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+from denbust.config import BrowserConfig, BrowserMode
+
+if TYPE_CHECKING:
+    from playwright.async_api import Browser, BrowserContext, Page, Playwright
+
+
+PLAYWRIGHT_INSTALL_HINT = "python -m playwright install chromium"
+DEFAULT_CHROME_CDP_URL = "http://127.0.0.1:9222"
+CHROME_CDP_START_HINT = (
+    'open -na "Google Chrome" --args --remote-debugging-port=9222 '
+    '--user-data-dir="$HOME/.config/denbust/chrome-wet-test"'
+)
+
+
+class ViewportSize(TypedDict):
+    """Viewport dimensions for Playwright browser pages."""
+
+    width: int
+    height: int
+
+
+RouteHandler = Callable[[Any], Awaitable[None]]
+
+
+@dataclass
+class ScraperBrowserSession:
+    """Open browser resources for a single source fetch cycle."""
+
+    manager: Any
+    browser: Browser
+    context: BrowserContext
+    page: Page
+    mode: BrowserMode
+    attached_to_chrome: bool
+    cdp_url: str | None
+    route_handler: RouteHandler | None
+    route_scope: str | None
+    requested_user_agent: str | None
+    effective_user_agent: str | None
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return non-secret browser-session diagnostics."""
+        return {
+            "mode": self.mode.value,
+            "attached_to_chrome": self.attached_to_chrome,
+            "launched_managed_chromium": not self.attached_to_chrome,
+            "cdp_url": self.cdp_url,
+            "route_scope": self.route_scope,
+            "requested_user_agent": self.requested_user_agent,
+            "effective_user_agent": self.effective_user_agent,
+            "user_agent": self.effective_user_agent,
+        }
+
+
+async def open_scraper_browser_session(
+    *,
+    source_name: str,
+    browser_config: BrowserConfig,
+    user_agent: str,
+    locale: str,
+    viewport: ViewportSize,
+    route_handler: RouteHandler | None,
+) -> ScraperBrowserSession:
+    """Open a browser session using the configured scraper browser mode."""
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as e:
+        raise RuntimeError(
+            "Playwright is not installed. Install it with `python -m pip install playwright`. "
+            f"Managed Chromium mode also requires `{PLAYWRIGHT_INSTALL_HINT}`."
+        ) from e
+
+    manager = async_playwright()
+    playwright = await manager.__aenter__()
+
+    try:
+        if browser_config.mode is BrowserMode.CHROME_CDP:
+            return await _connect_chrome_cdp_session(
+                manager=manager,
+                playwright=playwright,
+                source_name=source_name,
+                cdp_url=browser_config.chrome_cdp_url,
+                requested_user_agent=user_agent,
+                viewport=viewport,
+                route_handler=route_handler,
+            )
+
+        return await _launch_headless_session(
+            manager=manager,
+            playwright=playwright,
+            user_agent=user_agent,
+            locale=locale,
+            viewport=viewport,
+            route_handler=route_handler,
+        )
+    except Exception as e:
+        await manager.__aexit__(type(e), e, e.__traceback__)
+        raise
+
+
+async def _launch_headless_session(
+    *,
+    manager: Any,
+    playwright: Playwright,
+    user_agent: str,
+    locale: str,
+    viewport: ViewportSize,
+    route_handler: RouteHandler | None,
+) -> ScraperBrowserSession:
+    """Launch the backward-compatible managed Chromium session."""
+    try:
+        browser = await playwright.chromium.launch(headless=True)
+        context = await browser.new_context(
+            user_agent=user_agent,
+            locale=locale,
+            viewport=viewport,
+        )
+        if route_handler is not None:
+            await context.route("**/*", route_handler)
+        page = await context.new_page()
+        effective_user_agent = await _get_effective_user_agent(page)
+    except Exception as e:
+        raise RuntimeError(
+            "Chromium could not be launched for browser-backed scraping. "
+            f"Install it with `{PLAYWRIGHT_INSTALL_HINT}` or set "
+            "`DENBUST_BROWSER_MODE=chrome_cdp` to attach to a running Chrome instance."
+        ) from e
+
+    return ScraperBrowserSession(
+        manager=manager,
+        browser=browser,
+        context=context,
+        page=page,
+        mode=BrowserMode.PLAYWRIGHT_HEADLESS,
+        attached_to_chrome=False,
+        cdp_url=None,
+        route_handler=route_handler,
+        route_scope="context" if route_handler is not None else None,
+        requested_user_agent=user_agent,
+        effective_user_agent=effective_user_agent,
+    )
+
+
+async def _connect_chrome_cdp_session(
+    *,
+    manager: Any,
+    playwright: Playwright,
+    source_name: str,
+    cdp_url: str,
+    requested_user_agent: str,
+    viewport: ViewportSize,
+    route_handler: RouteHandler | None,
+) -> ScraperBrowserSession:
+    """Attach to an already-running local Chrome instance over CDP."""
+    sanitized_cdp_url = sanitize_cdp_url(cdp_url)
+    try:
+        browser = await playwright.chromium.connect_over_cdp(cdp_url)
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not attach {source_name} scraper to Chrome over CDP at {sanitized_cdp_url}. "
+            "Start normal Google Chrome with remote debugging, log in or clear challenges, "
+            f"then retry. On macOS: `{CHROME_CDP_START_HINT}`."
+        ) from e
+
+    context = browser.contexts[0] if browser.contexts else await browser.new_context()
+    page = await context.new_page()
+    await page.set_viewport_size(viewport)
+    if route_handler is not None:
+        await page.route("**/*", route_handler)
+    effective_user_agent = await _get_effective_user_agent(page)
+
+    return ScraperBrowserSession(
+        manager=manager,
+        browser=browser,
+        context=context,
+        page=page,
+        mode=BrowserMode.CHROME_CDP,
+        attached_to_chrome=True,
+        cdp_url=sanitized_cdp_url,
+        route_handler=route_handler,
+        route_scope="page" if route_handler is not None else None,
+        requested_user_agent=requested_user_agent,
+        effective_user_agent=effective_user_agent,
+    )
+
+
+async def close_scraper_browser_session(session: ScraperBrowserSession) -> None:
+    """Close scraper-owned browser resources without closing a user's Chrome profile."""
+    try:
+        if session.route_handler is not None:
+            if session.route_scope == "page":
+                await session.page.unroute("**/*", session.route_handler)
+            elif session.route_scope == "context":
+                await session.context.unroute("**/*", session.route_handler)
+    except Exception:
+        pass
+
+    try:
+        await session.page.close()
+    finally:
+        try:
+            if session.attached_to_chrome:
+                await session.browser.close()
+            else:
+                await session.context.close()
+                await session.browser.close()
+        finally:
+            await session.manager.__aexit__(None, None, None)
+
+
+async def _get_effective_user_agent(page: Page) -> str | None:
+    """Return the effective page user agent when Playwright can evaluate it."""
+    try:
+        user_agent = await page.evaluate("() => navigator.userAgent")
+    except Exception:
+        return None
+    return user_agent if isinstance(user_agent, str) else None
+
+
+def sanitize_cdp_url(cdp_url: str) -> str:
+    """Strip credentials and other sensitive URL components from a CDP endpoint."""
+    try:
+        parsed = urlsplit(cdp_url)
+    except ValueError:
+        return cdp_url.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0]
+
+    if not parsed.netloc:
+        return cdp_url.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0]
+
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+
+    if port is not None:
+        host = f"{host}:{port}"
+
+    sanitized = SplitResult(
+        scheme=parsed.scheme,
+        netloc=host,
+        path=parsed.path,
+        query="",
+        fragment="",
+    )
+    return urlunsplit(sanitized)

--- a/src/denbust/sources/haaretz.py
+++ b/src/denbust/sources/haaretz.py
@@ -13,8 +13,14 @@ from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 from bs4 import BeautifulSoup, Tag
 from pydantic import HttpUrl
 
+from denbust.config import BrowserConfig
 from denbust.data_models import RawArticle
 from denbust.sources.base import Source
+from denbust.sources.browser import (
+    ScraperBrowserSession,
+    close_scraper_browser_session,
+    open_scraper_browser_session,
+)
 
 if TYPE_CHECKING:
     from playwright.async_api import Page
@@ -78,16 +84,6 @@ VIEWPORT: _ViewportSize = {"width": 1440, "height": 2000}
 
 
 @dataclass
-class _BrowserSession:
-    """Open Playwright browser resources for a single fetch cycle."""
-
-    manager: Any
-    browser: Any
-    context: Any
-    page: Page
-
-
-@dataclass
 class _HaaretzSearchEntry:
     """Parsed Haaretz search result entry before keyword filtering."""
 
@@ -100,13 +96,23 @@ class _HaaretzSearchEntry:
 class HaaretzScraper(Source):
     """Browser-backed search scraper for Haaretz."""
 
-    def __init__(self, rate_limit_delay_seconds: float = DEFAULT_RATE_LIMIT_DELAY_SECONDS) -> None:
+    def __init__(
+        self,
+        rate_limit_delay_seconds: float = DEFAULT_RATE_LIMIT_DELAY_SECONDS,
+        browser_config: BrowserConfig | None = None,
+    ) -> None:
         self._name = "haaretz"
         self._rate_limit_delay_seconds = rate_limit_delay_seconds
+        self._browser_config = browser_config or BrowserConfig()
+        self._debug_state: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
         return self._name
+
+    def get_debug_state(self) -> dict[str, Any] | None:
+        """Return structured runtime telemetry for debug logs."""
+        return self._debug_state or None
 
     async def fetch(self, days: int, keywords: list[str]) -> list[RawArticle]:
         """Fetch recent keyword-matching articles from Haaretz search results."""
@@ -117,10 +123,23 @@ class HaaretzScraper(Source):
 
         cutoff = datetime.now(UTC) - timedelta(days=days)
         articles: list[RawArticle] = []
+        self._debug_state = {
+            "days": days,
+            "keywords": list(keywords),
+            "browser_session": {"status": "pending"},
+        }
 
         try:
             session = await self._open_browser_session()
+            self._debug_state["browser_session"] = {
+                "status": "ok",
+                **self._browser_session_diagnostics(session),
+            }
         except Exception as e:
+            self._debug_state["browser_session"] = {
+                "status": "error",
+                "error": str(e),
+            }
             logger.exception("Haaretz browser session could not be opened: %s", e)
             return []
 
@@ -156,49 +175,32 @@ class HaaretzScraper(Source):
             return
         await asyncio.sleep(self._rate_limit_delay_seconds)
 
-    async def _open_browser_session(self) -> _BrowserSession:
+    def _browser_session_diagnostics(self, session: object) -> dict[str, Any]:
+        """Return browser diagnostics when the concrete session provides them."""
+        diagnostics = getattr(session, "diagnostics", None)
+        if callable(diagnostics):
+            session_diagnostics = diagnostics()
+            if isinstance(session_diagnostics, dict):
+                return session_diagnostics
+        return {}
+
+    async def _open_browser_session(self) -> ScraperBrowserSession:
         """Open a Playwright browser session for Haaretz scraping."""
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError as e:
-            raise RuntimeError(
-                "Playwright is not installed. Install it and Chromium with "
-                "`python -m pip install playwright` and `python -m playwright install chromium`."
-            ) from e
+        return await open_scraper_browser_session(
+            source_name=self._name,
+            browser_config=self._browser_config,
+            user_agent=USER_AGENT,
+            locale="he-IL",
+            viewport=VIEWPORT,
+            route_handler=self._handle_browser_route,
+        )
 
-        manager = async_playwright()
-        playwright = await manager.__aenter__()
-
-        try:
-            browser = await playwright.chromium.launch(headless=True)
-            context = await browser.new_context(
-                user_agent=USER_AGENT,
-                locale="he-IL",
-                viewport=VIEWPORT,
-            )
-            await context.route("**/*", self._handle_browser_route)
-            page = await context.new_page()
-        except Exception as e:
-            await manager.__aexit__(type(e), e, e.__traceback__)
-            raise RuntimeError(
-                "Chromium could not be launched for Haaretz scraping. "
-                "Install it with `python -m playwright install chromium`."
-            ) from e
-
-        return _BrowserSession(manager=manager, browser=browser, context=context, page=page)
-
-    async def _close_browser_session(self, session: _BrowserSession) -> None:
+    async def _close_browser_session(self, session: ScraperBrowserSession) -> None:
         """Close all Playwright resources for Haaretz scraping."""
-        try:
-            await session.context.close()
-        finally:
-            try:
-                await session.browser.close()
-            finally:
-                await session.manager.__aexit__(None, None, None)
+        await close_scraper_browser_session(session)
 
     async def _search_keyword(
-        self, session: _BrowserSession, keyword: str, cutoff: datetime
+        self, session: ScraperBrowserSession, keyword: str, cutoff: datetime
     ) -> list[RawArticle]:
         """Search Haaretz for a specific keyword across paginated results."""
         articles: list[RawArticle] = []
@@ -420,6 +422,6 @@ class HaaretzScraper(Source):
         await route.continue_()
 
 
-def create_haaretz_source() -> HaaretzScraper:
+def create_haaretz_source(browser_config: BrowserConfig | None = None) -> HaaretzScraper:
     """Create Haaretz scraper source."""
-    return HaaretzScraper()
+    return HaaretzScraper(browser_config=browser_config)

--- a/src/denbust/sources/mako.py
+++ b/src/denbust/sources/mako.py
@@ -14,8 +14,15 @@ from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 from bs4 import BeautifulSoup, Tag
 from pydantic import HttpUrl
 
+from denbust.config import BrowserConfig
 from denbust.data_models import RawArticle
 from denbust.sources.base import Source
+from denbust.sources.browser import (
+    PLAYWRIGHT_INSTALL_HINT,
+    ScraperBrowserSession,
+    close_scraper_browser_session,
+    open_scraper_browser_session,
+)
 
 if TYPE_CHECKING:
     from playwright.async_api import Page
@@ -41,7 +48,6 @@ MAKO_SEARCH_URL = f"{MAKO_BASE_URL}/Search"
 MAKO_SEARCH_CHANNEL_ID = "3d385dd2dd5d4110VgnVCM100000290c10acRCRD"
 # Men section often has crime/enforcement news
 MAKO_MEN_NEWS_URL = "https://www.mako.co.il/men-men_news"
-PLAYWRIGHT_INSTALL_HINT = "python -m playwright install chromium"
 SECTION_READY_SELECTORS = [
     "a[href*='Article']",
     "article",
@@ -89,16 +95,6 @@ BLOCKED_RESOURCE_URL_FRAGMENTS = (
 
 
 @dataclass
-class _BrowserSession:
-    """Open Playwright browser resources for a single fetch cycle."""
-
-    manager: Any
-    browser: Any
-    context: Any
-    page: Page
-
-
-@dataclass
 class _SearchPageSnapshot:
     """Rendered Mako search page state at a point in time."""
 
@@ -112,10 +108,15 @@ class _SearchPageSnapshot:
 class MakoScraper(Source):
     """Scraper for Mako news website."""
 
-    def __init__(self, rate_limit_delay_seconds: float = DEFAULT_RATE_LIMIT_DELAY_SECONDS) -> None:
+    def __init__(
+        self,
+        rate_limit_delay_seconds: float = DEFAULT_RATE_LIMIT_DELAY_SECONDS,
+        browser_config: BrowserConfig | None = None,
+    ) -> None:
         """Initialize Mako scraper."""
         self._name = "mako"
         self._rate_limit_delay_seconds = rate_limit_delay_seconds
+        self._browser_config = browser_config or BrowserConfig()
         self._debug_state: dict[str, Any] = {}
 
     @property
@@ -147,8 +148,7 @@ class MakoScraper(Source):
             session = await self._open_browser_session()
             self._debug_state["browser_session"] = {
                 "status": "ok",
-                "headless": True,
-                "user_agent": USER_AGENT,
+                **self._browser_session_diagnostics(session),
             }
         except Exception as e:
             self._debug_state["browser_session"] = {
@@ -217,6 +217,15 @@ class MakoScraper(Source):
         if isinstance(bucket, list):
             bucket.append(entry)
 
+    def _browser_session_diagnostics(self, session: object) -> dict[str, Any]:
+        """Return browser diagnostics when the concrete session provides them."""
+        diagnostics = getattr(session, "diagnostics", None)
+        if callable(diagnostics):
+            session_diagnostics = diagnostics()
+            if isinstance(session_diagnostics, dict):
+                return session_diagnostics
+        return {}
+
     async def _rate_limit(self) -> None:
         """Sleep between Mako requests unless disabled for tests."""
         if self._rate_limit_delay_seconds <= 0:
@@ -224,54 +233,23 @@ class MakoScraper(Source):
 
         await asyncio.sleep(self._rate_limit_delay_seconds)
 
-    async def _open_browser_session(self) -> _BrowserSession:
+    async def _open_browser_session(self) -> ScraperBrowserSession:
         """Open a Playwright browser session for Mako scraping."""
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError as e:
-            raise RuntimeError(
-                "Playwright is not installed. Install it and Chromium with "
-                f"`python -m pip install playwright` and `{PLAYWRIGHT_INSTALL_HINT}`."
-            ) from e
-
-        manager = async_playwright()
-        playwright = await manager.__aenter__()
-
-        try:
-            browser = await playwright.chromium.launch(headless=True)
-            context = await browser.new_context(
-                user_agent=USER_AGENT,
-                locale="he-IL",
-                viewport=VIEWPORT,
-            )
-            await context.route("**/*", self._handle_browser_route)
-            page = await context.new_page()
-        except Exception as e:
-            await manager.__aexit__(type(e), e, e.__traceback__)
-            raise RuntimeError(
-                "Chromium could not be launched for Mako scraping. "
-                f"Install it with `{PLAYWRIGHT_INSTALL_HINT}`."
-            ) from e
-
-        return _BrowserSession(
-            manager=manager,
-            browser=browser,
-            context=context,
-            page=page,
+        return await open_scraper_browser_session(
+            source_name=self._name,
+            browser_config=self._browser_config,
+            user_agent=USER_AGENT,
+            locale="he-IL",
+            viewport=VIEWPORT,
+            route_handler=self._handle_browser_route,
         )
 
-    async def _close_browser_session(self, session: _BrowserSession) -> None:
+    async def _close_browser_session(self, session: ScraperBrowserSession) -> None:
         """Close all Playwright resources for Mako scraping."""
-        try:
-            await session.context.close()
-        finally:
-            try:
-                await session.browser.close()
-            finally:
-                await session.manager.__aexit__(None, None, None)
+        await close_scraper_browser_session(session)
 
     async def _search_keyword(
-        self, session: _BrowserSession, keyword: str, cutoff: datetime
+        self, session: ScraperBrowserSession, keyword: str, cutoff: datetime
     ) -> list[RawArticle]:
         """Search Mako for a specific keyword."""
         search_url = self._build_search_url(keyword)
@@ -314,7 +292,7 @@ class MakoScraper(Source):
         return parsed_articles
 
     async def _scrape_section(
-        self, session: _BrowserSession, url: str, cutoff: datetime, keywords: list[str]
+        self, session: ScraperBrowserSession, url: str, cutoff: datetime, keywords: list[str]
     ) -> list[RawArticle]:
         """Scrape a Mako section page."""
         page = getattr(session, "page", None)
@@ -365,12 +343,12 @@ class MakoScraper(Source):
             return title if isinstance(title, str) else ""
         return ""
 
-    async def _fetch_search_html(self, session: _BrowserSession, keyword: str) -> str | None:
+    async def _fetch_search_html(self, session: ScraperBrowserSession, keyword: str) -> str | None:
         """Fetch rendered search page HTML via Playwright."""
         url = self._build_search_url(keyword)
         return await self._fetch_search_results_html(session.page, url, keyword)
 
-    async def _fetch_section_html(self, session: _BrowserSession, url: str) -> str:
+    async def _fetch_section_html(self, session: ScraperBrowserSession, url: str) -> str:
         """Fetch rendered section page HTML via Playwright."""
         return await self._fetch_rendered_html(
             session.page,
@@ -764,6 +742,6 @@ class MakoScraper(Source):
         return any(kw.lower() in text for kw in keywords)
 
 
-def create_mako_source() -> MakoScraper:
+def create_mako_source(browser_config: BrowserConfig | None = None) -> MakoScraper:
     """Create Mako scraper source."""
-    return MakoScraper()
+    return MakoScraper(browser_config=browser_config)

--- a/tests/integration/test_scrapers.py
+++ b/tests/integration/test_scrapers.py
@@ -632,7 +632,8 @@ class TestMakoScraper:
         events: list[str] = []
 
         class FakePage:
-            pass
+            async def close(self) -> None:
+                events.append("page_close")
 
         class FakeContext:
             def __init__(self) -> None:
@@ -647,6 +648,11 @@ class TestMakoScraper:
                 assert pattern == "**/*"
                 self.route_handler = handler
                 events.append("route")
+
+            async def unroute(self, pattern: str, handler: Any) -> None:
+                assert pattern == "**/*"
+                assert handler is self.route_handler
+                events.append("unroute")
 
             async def close(self) -> None:
                 events.append("context_close")
@@ -696,6 +702,8 @@ class TestMakoScraper:
             "new_context",
             "route",
             "new_page",
+            "unroute",
+            "page_close",
             "context_close",
             "browser_close",
             "exit",
@@ -1935,7 +1943,8 @@ class TestHaaretzScraper:
         events: list[str] = []
 
         class FakePage:
-            pass
+            async def close(self) -> None:
+                events.append("page_close")
 
         class FakeContext:
             def __init__(self) -> None:
@@ -1947,8 +1956,13 @@ class TestHaaretzScraper:
 
             async def route(self, pattern: str, handler: Any) -> None:
                 assert pattern == "**/*"
-                del handler
+                self.route_handler = handler
                 events.append("route")
+
+            async def unroute(self, pattern: str, handler: Any) -> None:
+                assert pattern == "**/*"
+                assert handler is self.route_handler
+                events.append("unroute")
 
             async def close(self) -> None:
                 events.append("context_close")
@@ -1997,6 +2011,8 @@ class TestHaaretzScraper:
             "new_context",
             "route",
             "new_page",
+            "unroute",
+            "page_close",
             "context_close",
             "browser_close",
             "exit",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,8 @@ import pytest
 
 from denbust.config import (
     BackfillConfig,
+    BrowserConfig,
+    BrowserMode,
     CandidatesConfig,
     Config,
     DedupConfig,
@@ -41,6 +43,8 @@ class TestConfig:
         assert config.dedup.similarity_threshold == 0.7
         assert config.output.format == OutputFormat.CLI
         assert config.output.formats == [OutputFormat.CLI]
+        assert config.browser.mode == BrowserMode.PLAYWRIGHT_HEADLESS
+        assert config.browser.chrome_cdp_url == "http://127.0.0.1:9222"
         assert config.store.state_root == Path("data")
         assert config.store.seen_path is None
         assert config.store.runs_dir is None
@@ -149,6 +153,18 @@ class TestConfig:
 
         assert config.telegram_bot_token == "bot-token"
         assert config.telegram_chat_id == "chat-id"
+
+    def test_browser_config_env_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Browser scraper mode should be configurable through environment variables."""
+        monkeypatch.setenv("DENBUST_BROWSER_MODE", "chrome_cdp")
+        monkeypatch.setenv("DENBUST_CHROME_CDP_URL", "http://127.0.0.1:9333")
+
+        config = Config()
+
+        assert config.browser == BrowserConfig(
+            mode=BrowserMode.CHROME_CDP,
+            chrome_cdp_url="http://127.0.0.1:9333",
+        )
 
     def test_email_port_validation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Invalid SMTP ports should raise a clear error."""

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -226,13 +226,21 @@ class TestCreateSourcesWarnings:
         )
 
         monkeypatch.setattr("denbust.pipeline.create_walla_source", lambda: FakeSource("walla", []))
-        monkeypatch.setattr("denbust.pipeline.create_mako_source", lambda: FakeSource("mako", []))
+
+        def create_fake_mako_source(browser_config: object | None = None) -> FakeSource:
+            del browser_config
+            return FakeSource("mako", [])
+
+        monkeypatch.setattr("denbust.pipeline.create_mako_source", create_fake_mako_source)
         monkeypatch.setattr(
             "denbust.pipeline.create_maariv_source", lambda: FakeSource("maariv", [])
         )
-        monkeypatch.setattr(
-            "denbust.pipeline.create_haaretz_source", lambda: FakeSource("haaretz", [])
-        )
+
+        def create_fake_haaretz_source(browser_config: object | None = None) -> FakeSource:
+            del browser_config
+            return FakeSource("haaretz", [])
+
+        monkeypatch.setattr("denbust.pipeline.create_haaretz_source", create_fake_haaretz_source)
 
         sources = create_sources(config)
 

--- a/tests/unit/test_scraper_browser.py
+++ b/tests/unit/test_scraper_browser.py
@@ -1,0 +1,186 @@
+"""Tests for shared scraper browser session selection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from denbust.config import BrowserConfig, BrowserMode
+from denbust.sources.browser import (
+    CHROME_CDP_START_HINT,
+    close_scraper_browser_session,
+    open_scraper_browser_session,
+    sanitize_cdp_url,
+)
+
+
+@pytest.mark.asyncio
+async def test_open_scraper_browser_session_connects_to_chrome_cdp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CDP mode should attach to the default Chrome context and avoid closing it."""
+    import playwright.async_api as playwright_async_api
+
+    events: list[str] = []
+
+    async def route_handler(route: Any) -> None:
+        del route
+
+    class FakePage:
+        async def set_viewport_size(self, viewport: dict[str, int]) -> None:
+            events.append(f"viewport:{viewport['width']}x{viewport['height']}")
+
+        async def route(self, pattern: str, handler: Any) -> None:
+            assert pattern == "**/*"
+            assert handler is route_handler
+            events.append("page_route")
+
+        async def unroute(self, pattern: str, handler: Any) -> None:
+            assert pattern == "**/*"
+            assert handler is route_handler
+            events.append("page_unroute")
+
+        async def evaluate(self, expression: str) -> str:
+            assert expression == "() => navigator.userAgent"
+            events.append("evaluate_user_agent")
+            return "Real Chrome UA"
+
+        async def close(self) -> None:
+            events.append("page_close")
+
+    class FakeContext:
+        async def route(self, pattern: str, handler: Any) -> None:
+            assert pattern == "**/*"
+            assert handler is route_handler
+            events.append("context_route")
+
+        async def unroute(self, pattern: str, handler: Any) -> None:
+            assert pattern == "**/*"
+            assert handler is route_handler
+            events.append("context_unroute")
+
+        async def new_page(self) -> FakePage:
+            events.append("new_page")
+            return FakePage()
+
+        async def close(self) -> None:
+            events.append("context_close")
+
+    class FakeBrowser:
+        def __init__(self) -> None:
+            self.contexts = [FakeContext()]
+
+        async def close(self) -> None:
+            events.append("browser_disconnect")
+
+    class FakeChromium:
+        async def connect_over_cdp(self, url: str) -> FakeBrowser:
+            events.append(f"connect:{url}")
+            return FakeBrowser()
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+    class FakeManager:
+        async def __aenter__(self) -> FakePlaywright:
+            events.append("enter")
+            return FakePlaywright()
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            del exc_type, exc, tb
+            events.append("exit")
+
+    monkeypatch.setattr(playwright_async_api, "async_playwright", lambda: FakeManager())
+
+    session = await open_scraper_browser_session(
+        source_name="mako",
+        browser_config=BrowserConfig(
+            mode=BrowserMode.CHROME_CDP,
+            chrome_cdp_url="http://127.0.0.1:9222",
+        ),
+        user_agent="Mozilla/5.0",
+        locale="he-IL",
+        viewport={"width": 1440, "height": 2000},
+        route_handler=route_handler,
+    )
+
+    assert session.diagnostics() == {
+        "mode": "chrome_cdp",
+        "attached_to_chrome": True,
+        "launched_managed_chromium": False,
+        "cdp_url": "http://127.0.0.1:9222",
+        "route_scope": "page",
+        "requested_user_agent": "Mozilla/5.0",
+        "effective_user_agent": "Real Chrome UA",
+        "user_agent": "Real Chrome UA",
+    }
+
+    await close_scraper_browser_session(session)
+
+    assert events == [
+        "enter",
+        "connect:http://127.0.0.1:9222",
+        "new_page",
+        "viewport:1440x2000",
+        "page_route",
+        "evaluate_user_agent",
+        "page_unroute",
+        "page_close",
+        "browser_disconnect",
+        "exit",
+    ]
+    assert "context_close" not in events
+    assert "context_route" not in events
+    assert "context_unroute" not in events
+
+
+@pytest.mark.asyncio
+async def test_open_scraper_browser_session_reports_cdp_attach_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CDP attach failures should tell operators how to start local Chrome."""
+    import playwright.async_api as playwright_async_api
+
+    class FakeChromium:
+        async def connect_over_cdp(self, url: str) -> object:
+            assert url == "http://user:secret@127.0.0.1:9222/json?token=secret#frag"
+            raise RuntimeError("connection refused")
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+    class FakeManager:
+        async def __aenter__(self) -> FakePlaywright:
+            return FakePlaywright()
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            del exc_type, exc, tb
+
+    monkeypatch.setattr(playwright_async_api, "async_playwright", lambda: FakeManager())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await open_scraper_browser_session(
+            source_name="haaretz",
+            browser_config=BrowserConfig(
+                mode=BrowserMode.CHROME_CDP,
+                chrome_cdp_url="http://user:secret@127.0.0.1:9222/json?token=secret#frag",
+            ),
+            user_agent="Mozilla/5.0",
+            locale="he-IL",
+            viewport={"width": 1440, "height": 2000},
+            route_handler=None,
+        )
+
+    assert "Could not attach haaretz scraper to Chrome over CDP" in str(exc_info.value)
+    assert "http://127.0.0.1:9222/json" in str(exc_info.value)
+    assert "secret" not in str(exc_info.value)
+    assert CHROME_CDP_START_HINT in str(exc_info.value)
+
+
+def test_sanitize_cdp_url_strips_credentials_query_and_fragment() -> None:
+    """Diagnostics should not leak CDP URL credentials or bearer-like query values."""
+    assert (
+        sanitize_cdp_url("http://user:secret@127.0.0.1:9222/json/version?token=secret#frag")
+        == "http://127.0.0.1:9222/json/version"
+    )

--- a/tests/unit/test_source_health.py
+++ b/tests/unit/test_source_health.py
@@ -640,6 +640,7 @@ def test_classify_mako_exception_distinguishes_navigation_failure_modes(
     [
         "Playwright is not installed. Install it and Chromium.",
         "Chromium could not be launched for Mako scraping.",
+        "Could not attach mako scraper to Chrome over CDP at http://127.0.0.1:9222.",
         "browser executable not found",
     ],
 )


### PR DESCRIPTION
## Summary

Adds a shared browser-session path for browser-backed source scrapers with two modes:

- `playwright_headless`, the default, preserving the existing Playwright-managed headless Chromium behavior for CI and backward compatibility.
- `chrome_cdp`, an opt-in local mode controlled by `DENBUST_BROWSER_MODE=chrome_cdp` and `DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222`, which attaches to an already-running normal Google Chrome instance through Playwright `chromium.connect_over_cdp(...)`.

This change is intentionally scoped to browser-backed source scraping. Mako and Haaretz now use the shared browser session helper. The httpx candidate fallback fetch path and API-backed discovery/search engines are unchanged.

## Browser Diagnostics

The scraper debug state now reports the browser mode, whether the session attached to Chrome or launched managed Chromium, and the CDP URL when CDP mode is used. CDP attach failures produce an actionable error that tells operators how to start Chrome with remote debugging and pause for login/challenge handling before retrying. Source-health classification treats CDP attach failures as browser runtime/setup failures rather than selector/content failures.

## January 2026 Wet-Test Plan

`docs/january_2026_backfill_wet_test_plan.md` now uses real local Chrome/CDP for local wet tests instead of requiring Playwright Chromium installation. It documents the macOS Chrome startup command:

```bash
open -na "Google Chrome" --args \
  --remote-debugging-port=9222 \
  --user-data-dir="$HOME/.config/denbust/chrome-wet-test"
```

The plan tells operators to log in and handle browser challenges before continuing, then run the January backfill commands with:

```bash
export DENBUST_BROWSER_MODE=chrome_cdp
export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
```

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_pipeline_core.py::TestCreateSourcesWarnings::test_create_sources_skips_disabled_and_builds_known_sources tests/unit/test_config.py tests/unit/test_scraper_browser.py tests/unit/test_source_health.py tests/integration/test_scrapers.py -k 'browser or cdp or missing_browser_runtime or open_and_close_browser_session or open_browser_session_reports_launch_failure or open_browser_session_handles_launch_failure or open_browser_session_reports_missing_playwright or test_create_sources_skips_disabled_and_builds_known_sources'`
- Pre-push hooks with `.venv/bin` on `PATH`: unit tests and integration tests passed.

No live January wet test was run in this PR.
