### PR TITLE
Keep wet-test state root unset during static checks

### DIFF
--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -50,14 +50,15 @@ Create one timestamped follow-up root:
 ```bash
 export FOLLOWUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 export FOLLOWUP_ROOT="data/may_26_followup/${FOLLOWUP_ID}"
-export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
-export DENBUST_BROWSER_MODE=chrome_cdp
-export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
 mkdir -p "${FOLLOWUP_ROOT}"/{logs,artifacts,reports,summaries}
 ```
 
 Every command should write stdout/stderr to `logs/` and machine-readable output to `artifacts/`
 where supported. Do not commit the generated `data/` bundle.
+
+Do not export the wet-test `DENBUST_STATE_ROOT` until Phase 1. Phase 0 runs tests that intentionally
+write fixture candidate state, and exporting the wet-test state root too early can pollute the
+empty-state baseline.
 
 `DENBUST_BROWSER_MODE=chrome_cdp` applies only to browser-backed source scrapers such as Mako and
 Haaretz. HTTP fallback fetching and API-backed discovery/search engines continue to use their
@@ -86,6 +87,10 @@ Stop if any static guardrail fails.
 Capture diagnostics before writing January candidates:
 
 ```bash
+export DENBUST_STATE_ROOT="${FOLLOWUP_ROOT}/state"
+export DENBUST_BROWSER_MODE=chrome_cdp
+export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
+
 .venv/bin/denbust diagnose-discovery \
   --config agents/news/local.yaml \
   --format json \


### PR DESCRIPTION
## Summary

Updates the January 2026 backfill wet-test plan so Phase 0 static guardrails cannot pollute the fresh wet-test state root.

The evidence-root setup now creates only `FOLLOWUP_ROOT` and log/artifact directories before static checks. `DENBUST_STATE_ROOT`, `DENBUST_BROWSER_MODE`, and `DENBUST_CHROME_CDP_URL` are exported at the start of Phase 1, immediately before empty-state diagnostics and live wet-test work.

This prevents fixture-writing tests in Phase 0 from creating candidate JSONL files under the wet-test state directory before the empty-state baseline.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- Commit hooks: mypy and smoke tests passed.
- Pre-push hooks: unit tests and integration tests passed.
