### PR TITLE
Plan post-wet-test follow-up PR slices

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #110 was squash-merged as `8c89d91`.
-- Next planned PR: run another bounded candidate-drain evidence pass using the new queue-drain
-  diagnostics before deciding whether queue prioritization or fairness behavior needs to change.
-- Current blockers on main: no open GitHub issues are present; no Mako runtime blocker is known
-  after Chromium install; the 2026-05-03T15:31:23Z candidate-drain pass produced no scrape-failure
-  groups and no self-heal-eligible candidates; queue-drain diagnostics now expose selection order,
-  selected/remaining source mix, configured cap behavior, and stop reason for the next evidence
-  pass.
+- Last merged PR on main: #116 was squash-merged as `946139a`.
+- Next planned PR: `WET-PR-EVIDENCE-CONFIG` records the January 1-7 Chrome-CDP wet-test evidence
+  and makes the Brave+Exa/no-Google local search mode reproducible.
+- Current blockers on main: Google CSE returned `403 PERMISSION_DENIED` in local wet-test setup, so
+  the bounded January 1-7 evidence pass used Brave+Exa discovery; the Chrome-CDP scrape completed
+  with Mako/Haaretz browser activity, 100 attempted candidates, 189 scrape attempts, 28 provisional
+  operational rows, 88 partial pages, 12 scrape failures, and a budget-cap stop reason. Queue
+  behavior is explainable enough for reporting, but follow-up PRs should separate config/docs,
+  candidate-noise filtering, partial-page diagnostics, and source-family expansion.
 
 ## Task Ledger
 
@@ -67,9 +68,27 @@
 - [done] Implement a narrow queue-drain diagnostic PR that reports candidate selection order, source
   mix, and budget-cap behavior so operators can validate the queue contract before changing
   prioritization or fairness behavior.
-- [next] Run another bounded candidate-drain evidence pass using the new diagnostics; change queue
-  prioritization or fairness only if the reported selection order, source mix, and stop reason show
-  the current contract is wrong or insufficient.
+- [done] Run the January 1-7 Brave+Exa Chrome-CDP wet-test evidence pass: discovery persisted 3,116
+  candidates, scrape attempted 100 candidates across seven source labels, recorded 189 scrape
+  attempts, retained 28 provisional rows, left 2,689 eligible candidates, and stopped at the
+  configured budget cap rather than a queue-contract failure.
+- [next] `WET-PR-EVIDENCE-CONFIG`: add a tracked Brave+Exa/no-Google local search config, document
+  the Google CSE `403` fallback, check in a concise January 1-7 Chrome-CDP wet-test evidence
+  summary, and update planning state.
+- [later] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
+  as `x.com`, app-store links, social profiles, dictionaries, and other obvious metadata-poor pages
+  before they consume scrape-drain budget.
+- [later] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
+  distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
+  classifier parse/taxonomy warnings.
+- [later] `SRC-PR-GLOBES-THEMARKER`: add or improve source-family support for Globes/TheMarker if
+  wet-test diagnostics keep showing high-value unsupported or partial candidates there.
+- [later] `SRC-PR-ISRAELHAYOM`: add or improve source-family support for Israel Hayom if bounded
+  scrape diagnostics show enough high-value unsupported or partial candidates.
+- [later] `SRC-PR-KAN`: add or improve source-family support for Kan if the broader CSE/search
+  corpus keeps surfacing relevant candidates that current generic fetch cannot handle well.
+- [later] `SRC-PR-NEWS1`: add or improve source-family support for News1 if repeated wet-test
+  slices show relevant candidates and generic fetch/metadata extraction is insufficient.
 
 ## Planning Workflow
 

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -310,3 +310,36 @@ Open a follow-up code PR only when the wet test shows one of these concrete defe
 
 Do not implement queue fairness, prioritization, selector repair, or AI self-healing from a single
 successful bounded wet test.
+
+## Follow-Up PR Map
+
+Use stable planning IDs for the post-wet-test slices so they are not confused with GitHub pull
+request numbers. The current map is three simple cross-cutting PRs followed by four source-family
+PRs, for seven planned follow-ups total:
+
+1. `WET-PR-EVIDENCE-CONFIG` - planning/config evidence only.
+   Add a tracked Brave+Exa/no-Google local search config, document that local operators may bypass
+   Google CSE when the API returns `403 PERMISSION_DENIED`, check in a concise January 1-7
+   Chrome-CDP wet-test evidence summary, and update `.agent-plan.md`.
+2. `DISC-PR-NOISE-FILTERS` - discovery candidate quality.
+   Filter or deprioritize obvious non-article search-result surfaces before they consume scrape
+   budget, including `x.com`, app-store links, social profiles, dictionary pages, and other
+   metadata-poor utility pages.
+3. `SCRAPE-PR-PARTIAL-DIAGNOSTICS` - scrape interpretation.
+   Make partial-page diagnostics sharper so operators can distinguish retained provisional rows,
+   metadata-only partial pages, blocked generic fetches, and classifier parse/taxonomy warnings.
+4. `SRC-PR-GLOBES-THEMARKER` - source-family expansion.
+   Add or improve source support for the Globes/TheMarker family if repeated diagnostics keep
+   showing high-value unsupported or partial candidates.
+5. `SRC-PR-ISRAELHAYOM` - source-family expansion.
+   Add or improve Israel Hayom support if bounded scrape diagnostics show enough high-value
+   unsupported or partial candidates.
+6. `SRC-PR-KAN` - source-family expansion.
+   Add or improve Kan support if the broader search corpus keeps surfacing relevant candidates that
+   current generic fetch cannot handle well.
+7. `SRC-PR-NEWS1` - source-family expansion.
+   Add or improve News1 support if repeated wet-test slices show relevant candidates and generic
+   fetch/metadata extraction is insufficient.
+
+Do not bundle the source-family work into one large scraper PR. Promote each source-family PR only
+after the latest diagnostics justify it.


### PR DESCRIPTION
## Summary
- updates `.agent-plan.md` with the January 1-7 Brave+Exa Chrome-CDP wet-test evidence and the next planned slice
- adds stable planning IDs for three cross-cutting follow-ups and four source-family follow-ups
- documents the seven-PR follow-up map in the January 2026 wet-test plan

## Validation
- `.venv/bin/python scripts/validate_agent_plan.py`
- commit hooks: mypy, smoke tests
- pre-push hooks: unit tests, integration tests

## Notes
This is planning-only and intentionally does not change scraper behavior.