### PR TITLE
WET-PR-EVIDENCE-CONFIG: Document Brave Exa wet-test evidence config

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #116 was squash-merged as `946139a`.
-- Next planned PR: `WET-PR-EVIDENCE-CONFIG` records the January 1-7 Chrome-CDP wet-test evidence
-  and makes the Brave+Exa/no-Google local search mode reproducible.
-- Current blockers on main: Google CSE returned `403 PERMISSION_DENIED` in local wet-test setup, so
-  the bounded January 1-7 evidence pass used Brave+Exa discovery; the Chrome-CDP scrape completed
-  with Mako/Haaretz browser activity, 100 attempted candidates, 189 scrape attempts, 28 provisional
-  operational rows, 88 partial pages, 12 scrape failures, and a budget-cap stop reason. Queue
-  behavior is explainable enough for reporting, but follow-up PRs should separate config/docs,
-  candidate-noise filtering, partial-page diagnostics, and source-family expansion.
+- Last merged PR on main: #117 was squash-merged as `576e05f`.
+- Next planned PR: `DISC-PR-NOISE-FILTERS` filters or deprioritizes non-article search-result
+  surfaces before they consume scrape-drain budget.
+- Current blockers on main: Google CSE support remains in code, but local wet tests may need
+  `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
+  access. The January 1-7 Chrome-CDP evidence is summarized in
+  `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`; the first no-CDP scrape attempt was
+  aborted/reset and should not be interpreted as valid scrape evidence. Follow-up PRs should focus
+  on candidate-noise filtering, partial-page diagnostics, and source-family expansion.
 
 ## Task Ledger
 
@@ -72,10 +72,10 @@
   candidates, scrape attempted 100 candidates across seven source labels, recorded 189 scrape
   attempts, retained 28 provisional rows, left 2,689 eligible candidates, and stopped at the
   configured budget cap rather than a queue-contract failure.
-- [next] `WET-PR-EVIDENCE-CONFIG`: add a tracked Brave+Exa/no-Google local search config, document
+- [done] `WET-PR-EVIDENCE-CONFIG`: add a tracked Brave+Exa/no-Google local search config, document
   the Google CSE `403` fallback, check in a concise January 1-7 Chrome-CDP wet-test evidence
   summary, and update planning state.
-- [later] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
+- [next] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
   as `x.com`, app-store links, social profiles, dictionaries, and other obvious metadata-poor pages
   before they consume scrape-drain budget.
 - [later] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
@@ -107,6 +107,7 @@
 
 - Phase C plan: [docs/PHASE_C_PLAN.md](docs/PHASE_C_PLAN.md)
 - Phase C source-health triage evidence: [docs/phase_c_source_health_triage_2026_05_03.md](docs/phase_c_source_health_triage_2026_05_03.md)
+- January 1-7 Chrome-CDP wet-test evidence: [docs/january_2026_backfill_wet_test_evidence_2026_05_13.md](docs/january_2026_backfill_wet_test_evidence_2026_05_13.md)
 - Discovery rollout plan: [docs/tfht_discovery_layer_implementation_plan.md](docs/tfht_discovery_layer_implementation_plan.md)
 - Discovery operations: [docs/discovery_operations.md](docs/discovery_operations.md)
 - Broader implementation backlog: [docs/IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Planned future datasets:
   Supabase exact-count requests, without materializing full candidate rows in the pipeline
 - Provides an opt-in `agents/news/local_search.yaml` config for local source-native + Brave + Exa
   + Google CSE discovery experiments
+- Provides `agents/news/local_search_brave_exa.yaml` for local Brave+Exa wet tests when Google CSE
+  returns `403 PERMISSION_DENIED` / no API access; Google CSE remains supported in code and in the
+  full local search config
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
 - Reports queue-drain selection order, attempted and remaining eligible source mix, configured
@@ -343,6 +346,11 @@ DL-PR-06 now builds on the earlier discovery milestones:
 
 The current daily monitoring flow remains operational, and the durable candidate substrate now
 accepts source-native discovery plus Brave, Exa, and Google CSE search results.
+
+Local operators can use `agents/news/local_search_brave_exa.yaml` for wet tests when the Google
+Programmable Search API is unavailable locally. That config disables only the Google CSE engine and
+keeps Brave and Exa enabled; browser-backed scraping still uses `DENBUST_BROWSER_MODE=chrome_cdp`
+and `DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222` when the run needs Chrome CDP.
 
 DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 

--- a/agents/news/local_search_brave_exa.yaml
+++ b/agents/news/local_search_brave_exa.yaml
@@ -1,0 +1,107 @@
+# Explicit local Brave+Exa search configuration for enforcement news experiments.
+#
+# Keep this file in sync with local_search.yaml except for `name` and
+# `discovery.engines.google_cse.enabled`. The duplication is intentional because
+# the runtime does not currently support YAML includes/overrides for local
+# operator configs.
+#
+# This variant intentionally disables Google CSE so local wet tests can proceed
+# when the operator's Google Programmable Search API setup returns
+# PERMISSION_DENIED.
+name: enforcement-news-local-search-brave-exa
+dataset_name: news_items
+job_name: ingest
+days: 21
+max_articles: 30
+
+sources:
+  - name: ynet
+    type: rss
+    url: https://www.ynet.co.il/Integration/StoryRss190.xml
+    enabled: true
+
+  - name: walla
+    type: scraper
+    enabled: true
+
+  - name: mako
+    type: scraper
+    enabled: true
+
+  - name: maariv
+    type: scraper
+    enabled: true
+
+  - name: haaretz
+    type: scraper
+    enabled: true
+
+  - name: ice
+    type: scraper
+    enabled: true
+
+keywords:
+  - זנות
+  - בית בושת
+  - סרסור
+  - סחר בבני אדם
+  - צו סגירה
+  - צו הגבלת שימוש
+  - ליווי
+  - נערות ליווי
+  - תעשיית המין
+  - עיסוי חשוד
+  - זירת זנות
+  - נישואין בכפייה
+  - עבדות מינית
+  - זנות מקוונת
+  - קנס צריכת זנות
+  - החזקת מקום לשם זנות
+  - השכרת מקום לשם זנות
+  - פרסום זנות
+
+classifier:
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+
+dedup:
+  similarity_threshold: 0.7
+
+discovery:
+  enabled: true
+  persist_candidates: true
+  engines:
+    brave:
+      enabled: true
+      api_key_env: DENBUST_BRAVE_SEARCH_API_KEY
+      max_results_per_query: 20
+    exa:
+      enabled: true
+      api_key_env: DENBUST_EXA_API_KEY
+      max_results_per_query: 20
+      allow_find_similar: true
+    google_cse:
+      enabled: false
+      api_key_env: DENBUST_GOOGLE_CSE_API_KEY
+      cse_id_env: DENBUST_GOOGLE_CSE_ID
+      max_results_per_query: 10
+
+source_discovery:
+  enabled: true
+  persist_candidates: true
+
+backfill:
+  enabled: true
+  batch_window_days: 7
+  max_candidates_per_run: 500
+  max_scrape_attempts_per_run: 100
+
+output:
+  formats:
+    - cli
+
+store:
+  state_root: data
+
+operational:
+  provider: local_json

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -62,6 +62,24 @@ denbust run --dataset news_items --job backfill_discover --config agents/news/lo
 
 Missing search keys are surfaced by the discovery run errors. They are not hidden by the config.
 
+If local Google CSE setup returns `403 PERMISSION_DENIED` / no API access, use the tracked
+Brave+Exa/no-Google config instead of a one-off `/tmp` YAML file:
+
+```bash
+denbust run --dataset news_items --job discover --config agents/news/local_search_brave_exa.yaml
+DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00 \
+DENBUST_BACKFILL_DATE_TO=2026-01-07T23:59:59+00:00 \
+denbust run --dataset news_items --job backfill_discover --config agents/news/local_search_brave_exa.yaml
+```
+
+`local_search_brave_exa.yaml` keeps Brave and Exa enabled, disables Google CSE, and requires only:
+
+- `DENBUST_BRAVE_SEARCH_API_KEY`
+- `DENBUST_EXA_API_KEY`
+
+This is an operator-local wet-test mode. It does not remove Google CSE support from code or from
+`local_search.yaml`.
+
 The local Google Programmable Search Engine backing `DENBUST_GOOGLE_CSE_ID` includes the current
 repo-supported sources, Facebook public search, and additional Israeli news domains that should be
 eligible for Google CSE-backed discovery. The current domain set is:
@@ -197,6 +215,22 @@ configured candidate cap, persisted attempted-candidate order, persisted scrape-
 attempted source mix derived from actual scrape attempts, remaining eligible candidate order,
 remaining eligible source mix, and the inferred stop reason. Use those fields in the next bounded
 candidate-drain evidence pass before changing queue prioritization or fairness behavior.
+
+After PR #117 was squash-merged as `576e05f`, the January 1-7 wet-test follow-up used a local
+Brave+Exa/no-Google search mode because Google CSE returned `403 PERMISSION_DENIED` / no API access
+in local setup. The Chrome-CDP retry scrape used:
+
+```bash
+export DENBUST_BROWSER_MODE=chrome_cdp
+export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
+```
+
+The durable checked-in evidence summary is
+[january_2026_backfill_wet_test_evidence_2026_05_13.md](january_2026_backfill_wet_test_evidence_2026_05_13.md).
+It records 3,116 persisted candidates, 100 attempted candidates, 189 scrape attempts, 28 retained
+provisional operational rows, 88 partial pages, 12 scrape failures, 2,689 remaining eligible
+candidates, and `budget_cap_reached`. The first no-CDP scrape attempt was aborted/reset and should
+not be used as valid scrape evidence.
 
 ## GitHub Actions Run Path
 

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -1,0 +1,102 @@
+# January 1-7, 2026 Backfill Wet-Test Evidence
+
+Date summarized: 2026-05-13
+
+This is the checked-in evidence summary for the bounded January 1-7 Chrome-CDP wet test. The
+generated logs and JSON artifacts remain local under `data/may_26_followup/20260503T214851Z/` and
+are not part of the repository.
+
+Exact local evidence files used:
+
+- Discovery log:
+  `data/may_26_followup/20260503T214851Z/logs/05c_backfill_discover_2026_01_01_07_brave_exa.log`
+- Post-discovery diagnostic:
+  `data/may_26_followup/20260503T214851Z/artifacts/diagnose_discovery_after_discover_brave_exa.json`
+- Chrome CDP preflight log:
+  `data/may_26_followup/20260503T214851Z/logs/07a_chrome_cdp_preflight_brave_exa_retry.log`
+- Retry scrape log:
+  `data/may_26_followup/20260503T214851Z/logs/07c_backfill_scrape_2026_01_01_07_brave_exa_retry.log`
+- Post-scrape diagnostic:
+  `data/may_26_followup/20260503T214851Z/artifacts/diagnose_discovery_after_scrape_brave_exa_chrome_cdp.json`
+
+## Scope
+
+- Window: `2026-01-01T00:00:00+00:00` through `2026-01-07T23:59:59+00:00`
+- Discovery mode: Brave + Exa search, with Google CSE disabled for this local run
+- Scrape mode: browser-backed scraping attached to a local Chrome DevTools endpoint
+- Browser environment:
+  - `DENBUST_BROWSER_MODE=chrome_cdp`
+  - `DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222`
+
+## Why Google CSE Was Bypassed
+
+The local Google CSE setup returned `403 PERMISSION_DENIED` / API-access failure during the wet-test
+setup path. The evidence pass therefore used a Brave+Exa/no-Google search config to exercise the
+backfill path without depending on that local API access.
+
+This does not remove or deprecate Google CSE support in code. It only records a reproducible local
+operator mode for wet tests where Google Programmable Search API access is unavailable or
+misconfigured.
+
+## Discovery Evidence
+
+The post-discovery diagnostic artifact reported:
+
+| Figure | Value | JSON path |
+| --- | ---: | --- |
+| Persisted candidates | 3,116 | `queue_health.total_candidates` |
+| Brave candidates | 1,602 | `engine_overlap.brave` |
+| Exa candidates | 1,517 | `engine_overlap.exa` |
+| Brave/Exa overlap | 3 | `engine_overlap.brave_exa_shared` |
+| Google CSE candidates | 0 | `engine_overlap.google_cse` |
+| Search-engine-only candidates | 3,116 | `source_search_coverage.search_engine_only_candidates` |
+| Initial scrape-eligible candidates after discovery | 2,701 | `queue_drain.remaining_eligible_candidate_count` |
+
+Google CSE was disabled for this local run, which is why the Google CSE candidate count is zero.
+
+## Scrape Evidence
+
+The valid Chrome-CDP retry scrape and post-scrape diagnostic artifact reported:
+
+| Figure | Value | JSON path |
+| --- | ---: | --- |
+| Attempted candidates | 100 | `queue_drain.persisted_attempted_candidate_count` |
+| Persisted scrape attempts | 189 | `queue_drain.persisted_scrape_attempt_count` |
+| Provisional operational rows retained | 28 | `candidate_conversion.operational_record_matches` |
+| Partial pages | 88 | `queue_health.partial_page_candidates` |
+| Scrape failures | 12 | `queue_health.scrape_failed_candidates` |
+| Remaining eligible candidates | 2,689 | `queue_drain.remaining_eligible_candidate_count` |
+| Inferred stop reason | `budget_cap_reached` | `queue_drain.inferred_stop_reason` |
+
+Attempted candidate source mix:
+
+| Source | Attempted candidates |
+| --- | ---: |
+| Brave | 11 |
+| Haaretz | 34 |
+| ICE | 2 |
+| Maariv | 7 |
+| Mako | 17 |
+| Walla | 15 |
+| Ynet | 14 |
+
+Source mix comes from `queue_drain.attempted_source_mix`.
+
+The scrape run actually exercised Chrome-CDP browser-backed source paths. The retry scrape log shows
+Haaretz browser navigation across search keywords and Mako browser navigation across search keywords
+plus the `men-news` section.
+
+## Invalid First Scrape Attempt
+
+The first no-CDP scrape attempt was aborted/reset before it could serve as valid scrape evidence.
+Do not use that attempt to evaluate browser-backed scraping, queue-drain behavior, or scrape
+conversion. The figures above come from the Chrome-CDP retry scrape and the matching post-scrape
+diagnostic artifact.
+
+## Interpretation
+
+The bounded scrape reached the configured budget cap with a large eligible backlog still available,
+so the stop reason is explainable as a budget limit rather than a queue-contract failure. The run
+also exposed candidate-quality noise, including social/profile/app-store/dictionary-like surfaces
+that can consume scrape budget. That follow-up belongs in `DISC-PR-NOISE-FILTERS`, not in this
+config-and-evidence slice.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -64,6 +64,22 @@ empty-state baseline.
 Haaretz. HTTP fallback fetching and API-backed discovery/search engines continue to use their
 existing non-browser paths.
 
+Use one config path consistently across the run. The default source-native local path is:
+
+```bash
+export DENBUST_CONFIG=agents/news/local.yaml
+```
+
+When intentionally exercising local Brave+Exa search without Google CSE, use:
+
+```bash
+export DENBUST_CONFIG=agents/news/local_search_brave_exa.yaml
+```
+
+The Brave+Exa/no-Google config is for local wet tests where Google CSE returns
+`403 PERMISSION_DENIED` / no API access. It does not remove Google CSE support from code or from
+`agents/news/local_search.yaml`.
+
 ## Phase 0 - Static Guardrails
 
 Run the narrow static checks that prove the checked-out code and plan format are healthy before live
@@ -92,13 +108,13 @@ export DENBUST_BROWSER_MODE=chrome_cdp
 export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
 
 .venv/bin/denbust diagnose-discovery \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   --format json \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_before.json" \
   2>&1 | tee "${FOLLOWUP_ROOT}/logs/03_diagnose_discovery_before.log"
 
 .venv/bin/denbust diagnose-sources \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   --artifacts-only \
   --format json \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_artifact_only_before.json" \
@@ -122,7 +138,7 @@ export DENBUST_BACKFILL_DATE_TO=2026-01-07T23:59:59+00:00
 .venv/bin/denbust run \
   --dataset news_items \
   --job backfill_discover \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   2>&1 | tee "${FOLLOWUP_ROOT}/logs/05_backfill_discover_2026_01_01_07.log"
 ```
 
@@ -130,7 +146,7 @@ Then capture discovery diagnostics:
 
 ```bash
 .venv/bin/denbust diagnose-discovery \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   --format json \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_after_discover.json" \
   2>&1 | tee "${FOLLOWUP_ROOT}/logs/06_diagnose_discovery_after_discover.log"
@@ -159,7 +175,7 @@ curl -fsS "${DENBUST_CHROME_CDP_URL}/json/version" \
 .venv/bin/denbust run \
   --dataset news_items \
   --job backfill_scrape \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   2>&1 | tee "${FOLLOWUP_ROOT}/logs/07_backfill_scrape_2026_01_01_07.log"
 ```
 
@@ -167,7 +183,7 @@ Then capture the queue-drain diagnostics:
 
 ```bash
 .venv/bin/denbust diagnose-discovery \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   --format json \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_discovery_after_scrape.json" \
   2>&1 | tee "${FOLLOWUP_ROOT}/logs/08_diagnose_discovery_after_scrape.log"
@@ -191,7 +207,7 @@ Run artifact-only source diagnostics after the scrape pass:
 
 ```bash
 .venv/bin/denbust diagnose-sources \
-  --config agents/news/local.yaml \
+  --config "${DENBUST_CONFIG}" \
   --artifacts-only \
   --format json \
   --output "${FOLLOWUP_ROOT}/artifacts/diagnose_sources_artifact_only_after_scrape.json" \
@@ -275,17 +291,33 @@ Expand from the 7-day wet test to the full January 2026 window only if all of th
 - scrape failures are either low-volume or grouped into actionable diagnostics;
 - no self-heal or retry backlog pattern suggests a code fix should happen before more live work.
 
-If those conditions pass, run the full month:
+If those conditions pass, run the full month with the same config mode used for the 7-day pass.
+For the default source-native path:
 
 ```bash
+export DENBUST_CONFIG=agents/news/local.yaml
 export DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00
 export DENBUST_BACKFILL_DATE_TO=2026-01-31T23:59:59+00:00
 export DENBUST_BROWSER_MODE=chrome_cdp
 export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
 
-.venv/bin/denbust run --dataset news_items --job backfill_discover --config agents/news/local.yaml
-.venv/bin/denbust run --dataset news_items --job backfill_scrape --config agents/news/local.yaml
-.venv/bin/denbust diagnose-discovery --config agents/news/local.yaml --format json
+.venv/bin/denbust run --dataset news_items --job backfill_discover --config "${DENBUST_CONFIG}"
+.venv/bin/denbust run --dataset news_items --job backfill_scrape --config "${DENBUST_CONFIG}"
+.venv/bin/denbust diagnose-discovery --config "${DENBUST_CONFIG}" --format json
+```
+
+For the Brave+Exa/no-Google local search fallback:
+
+```bash
+export DENBUST_CONFIG=agents/news/local_search_brave_exa.yaml
+export DENBUST_BACKFILL_DATE_FROM=2026-01-01T00:00:00+00:00
+export DENBUST_BACKFILL_DATE_TO=2026-01-31T23:59:59+00:00
+export DENBUST_BROWSER_MODE=chrome_cdp
+export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
+
+.venv/bin/denbust run --dataset news_items --job backfill_discover --config "${DENBUST_CONFIG}"
+.venv/bin/denbust run --dataset news_items --job backfill_scrape --config "${DENBUST_CONFIG}"
+.venv/bin/denbust diagnose-discovery --config "${DENBUST_CONFIG}" --format json
 ```
 
 If the 7-day pass is ambiguous, run a second adjacent slice before changing code:


### PR DESCRIPTION
## Planning notation

`WET-PR-EVIDENCE-CONFIG` under the Phase C wet-test follow-up plan in `.agent-plan.md` and `docs/january_2026_backfill_wet_test_plan.md`.

## Summary

- Adds `agents/news/local_search_brave_exa.yaml`, a tracked local Brave+Exa search config with Google CSE disabled.
- Documents that Google CSE may return `403 PERMISSION_DENIED` / no API access in local setup, and that local wet tests can bypass that failure with the Brave+Exa/no-Google config.
- Keeps Google CSE support intact in code and in the full `agents/news/local_search.yaml` config.
- Checks in a concise January 1-7 Chrome-CDP wet-test evidence summary, including the 3,116 persisted candidates, 100 attempted candidates, 189 scrape attempts, 28 retained provisional rows, 88 partial pages, 12 scrape failures, 2,689 remaining eligible candidates, and `budget_cap_reached` stop reason.
- Updates `.agent-plan.md`, `README.md`, and operations docs so `DISC-PR-NOISE-FILTERS` is the sole next planning item after merge.

## Operator notes

Browser-backed scraping still uses:

```bash
export DENBUST_BROWSER_MODE=chrome_cdp
export DENBUST_CHROME_CDP_URL=http://127.0.0.1:9222
```

The first no-CDP scrape attempt from the local wet-test artifacts was aborted/reset and is documented as invalid scrape evidence. The checked-in evidence summary uses the Chrome-CDP retry scrape and matching diagnostic artifact.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/python - <<'PY' ...` YAML parse/assertions for `local_search_brave_exa.yaml`
- Commit hook: check yaml, mypy, smoke tests
- Push hook: check yaml, unit tests, integration tests

No full manual pytest run was needed for this docs/config-only slice; no runtime behavior changed.