### PR TITLE
DISC-PR-NOISE-FILTERS: filter search-result noise before scraping

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -78,8 +78,8 @@
   the Google CSE `403` fallback, check in a concise January 1-7 Chrome-CDP wet-test evidence
   summary, and update planning state.
 - [done] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
-  as `x.com`, app-store links, social profiles, dictionaries, and other obvious metadata-poor pages
-  before they consume scrape-drain budget.
+  as social profiles, app-store detail pages, dictionaries, and other obvious metadata-poor pages
+  before they consume scrape-drain budget while leaving post-like social URLs scrape-eligible.
 - [next] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
   distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
   classifier parse/taxonomy warnings.

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,17 @@
 
 ## Mainline Status
 
-- Last merged PR on main: #117 was squash-merged as `576e05f`.
-- Next planned PR: `DISC-PR-NOISE-FILTERS` filters or deprioritizes non-article search-result
-  surfaces before they consume scrape-drain budget.
+- Last merged PR on main: `DISC-PR-NOISE-FILTERS` marked obvious non-article search-result
+  surfaces `unsupported_source` before they can consume scrape-drain budget.
+- Next planned PR: `SCRAPE-PR-PARTIAL-DIAGNOSTICS` hardens partial-page reporting so operators can
+  distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
+  classifier parse/taxonomy warnings.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
   `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`; the first no-CDP scrape attempt was
   aborted/reset and should not be interpreted as valid scrape evidence. Follow-up PRs should focus
-  on candidate-noise filtering, partial-page diagnostics, and source-family expansion.
+  on partial-page diagnostics and source-family expansion.
 
 ## Task Ledger
 
@@ -75,10 +77,10 @@
 - [done] `WET-PR-EVIDENCE-CONFIG`: add a tracked Brave+Exa/no-Google local search config, document
   the Google CSE `403` fallback, check in a concise January 1-7 Chrome-CDP wet-test evidence
   summary, and update planning state.
-- [next] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
+- [done] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
   as `x.com`, app-store links, social profiles, dictionaries, and other obvious metadata-poor pages
   before they consume scrape-drain budget.
-- [later] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
+- [next] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
   distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
   classifier parse/taxonomy warnings.
 - [later] `SRC-PR-GLOBES-THEMARKER`: add or improve source-family support for Globes/TheMarker if

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Planned future datasets:
 - Provides `agents/news/local_search_brave_exa.yaml` for local Brave+Exa wet tests when Google CSE
   returns `403 PERMISSION_DENIED` / no API access; Google CSE remains supported in code and in the
   full local search config
-- Retains obvious non-article search-result noise as provenance while marking new `x.com` /
-  Twitter, app-store, social-profile, dictionary, translation, and reference-utility candidates
-  `unsupported_source` before they can consume scrape-drain budget, with diagnostics exposing the
-  filter reason counts
+- Retains obvious non-article search-result noise as provenance while marking social profiles,
+  app-store detail pages, dictionary, translation, and reference-utility candidates
+  `unsupported_source` before they can consume scrape-drain budget; post-like social URLs and
+  non-app store paths remain eligible, and diagnostics expose durable filter reason counts
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
 - Reports queue-drain selection order, attempted and remaining eligible source mix, configured

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Planned future datasets:
   full local search config
 - Retains obvious non-article search-result noise as provenance while marking new `x.com` /
   Twitter, app-store, social-profile, dictionary, translation, and reference-utility candidates
-  `unsupported_source` before they can consume scrape-drain budget
+  `unsupported_source` before they can consume scrape-drain budget, with diagnostics exposing the
+  filter reason counts
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
 - Reports queue-drain selection order, attempted and remaining eligible source mix, configured

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Planned future datasets:
 - Provides `agents/news/local_search_brave_exa.yaml` for local Brave+Exa wet tests when Google CSE
   returns `403 PERMISSION_DENIED` / no API access; Google CSE remains supported in code and in the
   full local search config
+- Retains obvious non-article search-result noise as provenance while marking new `x.com` /
+  Twitter, app-store, social-profile, dictionary, translation, and reference-utility candidates
+  `unsupported_source` before they can consume scrape-drain budget
 - Writes discovery overlap/queue/conversion diagnostics artifacts and exposes
   `denbust diagnose-discovery`
 - Reports queue-drain selection order, attempted and remaining eligible source mix, configured

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -234,10 +234,14 @@ not be used as valid scrape evidence.
 
 After `DISC-PR-NOISE-FILTERS`, search-engine results that are obvious non-article surfaces are
 still retained with candidate provenance, but new matches are marked `unsupported_source` before
-they can consume scrape-drain budget. The filter covers `x.com` / Twitter, app-store URLs, social
-profile pages, and dictionary/translation/reference utility domains such as Morfix, Reverso,
-Wiktionary, and Pealim. Queue fairness and source prioritization are intentionally unchanged; the
-filter only removes known low-value search-result surfaces from scrape eligibility.
+they can consume scrape-drain budget. Existing unattempted candidate-only matches are demoted the
+same way when they are rediscovered, while attempted or content-bearing candidates keep their
+current status. The filter covers `x.com` / Twitter, app-store URLs, social profile pages, and
+dictionary/translation/reference utility domains such as Morfix, Reverso, Wiktionary, and Pealim.
+Queue fairness and source prioritization are intentionally unchanged; the filter only removes known
+low-value search-result surfaces from scrape eligibility. `denbust diagnose-discovery` reports
+`queue_health.search_noise_filter_reason_counts` so operators can distinguish social-profile noise
+from unsupported search domains.
 
 ## GitHub Actions Run Path
 

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -232,6 +232,13 @@ provisional operational rows, 88 partial pages, 12 scrape failures, 2,689 remain
 candidates, and `budget_cap_reached`. The first no-CDP scrape attempt was aborted/reset and should
 not be used as valid scrape evidence.
 
+After `DISC-PR-NOISE-FILTERS`, search-engine results that are obvious non-article surfaces are
+still retained with candidate provenance, but new matches are marked `unsupported_source` before
+they can consume scrape-drain budget. The filter covers `x.com` / Twitter, app-store URLs, social
+profile pages, and dictionary/translation/reference utility domains such as Morfix, Reverso,
+Wiktionary, and Pealim. Queue fairness and source prioritization are intentionally unchanged; the
+filter only removes known low-value search-result surfaces from scrape eligibility.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -236,12 +236,16 @@ After `DISC-PR-NOISE-FILTERS`, search-engine results that are obvious non-articl
 still retained with candidate provenance, but new matches are marked `unsupported_source` before
 they can consume scrape-drain budget. Existing unattempted candidate-only matches are demoted the
 same way when they are rediscovered, while attempted or content-bearing candidates keep their
-current status. The filter covers `x.com` / Twitter, app-store URLs, social profile pages, and
+current status. The filter covers profile-like `x.com` / Twitter, Facebook, Instagram, LinkedIn,
+TikTok, and YouTube pages; Google Play / Apple app detail pages; and
 dictionary/translation/reference utility domains such as Morfix, Reverso, Wiktionary, and Pealim.
-Queue fairness and source prioritization are intentionally unchanged; the filter only removes known
-low-value search-result surfaces from scrape eligibility. `denbust diagnose-discovery` reports
-`queue_health.search_noise_filter_reason_counts` so operators can distinguish social-profile noise
-from unsupported search domains.
+Post-like social URLs and non-app store paths are left scrape-eligible so the filter does not become
+a broad domain denylist. Queue fairness and source prioritization are intentionally unchanged; the
+filter only removes known low-value search-result surfaces from scrape eligibility. Durable
+candidate metadata stores `unsupported_source_filter=search_noise`,
+`unsupported_source_reason`, and `unsupported_source_domain`, and `denbust diagnose-discovery`
+reports `queue_health.search_noise_filter_reason_counts` so operators can distinguish app-store,
+social-profile, and unsupported utility-domain noise.
 
 ## GitHub Actions Run Path
 

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -354,9 +354,11 @@ PRs, for seven planned follow-ups total:
    Google CSE when the API returns `403 PERMISSION_DENIED`, check in a concise January 1-7
    Chrome-CDP wet-test evidence summary, and update `.agent-plan.md`.
 2. `DISC-PR-NOISE-FILTERS` - discovery candidate quality.
-   Filter or deprioritize obvious non-article search-result surfaces before they consume scrape
-   budget, including `x.com`, app-store links, social profiles, dictionary pages, and other
-   metadata-poor utility pages.
+   Implemented as a central persistence-time search-result noise filter: obvious non-article
+   surfaces are retained with provenance but marked `unsupported_source` before scrape-drain budget
+   can select them. Covered classes include `x.com` / Twitter, app-store links, social profiles,
+   dictionary/translation/reference pages, and other metadata-poor utility pages. This intentionally
+   leaves queue fairness and prioritization unchanged.
 3. `SCRAPE-PR-PARTIAL-DIAGNOSTICS` - scrape interpretation.
    Make partial-page diagnostics sharper so operators can distinguish retained provisional rows,
    metadata-only partial pages, blocked generic fetches, and classifier parse/taxonomy warnings.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -357,10 +357,11 @@ PRs, for seven planned follow-ups total:
    Implemented as a central persistence-time search-result noise filter: obvious non-article
    surfaces are retained with provenance but marked `unsupported_source` before scrape-drain budget
    can select them. Existing unattempted candidate-only noise is demoted on rediscovery; attempted
-   or content-bearing candidates keep their status. Covered classes include `x.com` / Twitter,
-   app-store links, social profiles, dictionary/translation/reference pages, and other
-   metadata-poor utility pages. Diagnostics expose reason counts, and queue fairness/prioritization
-   intentionally remain unchanged.
+   or content-bearing candidates keep their status. Covered classes include profile-like `x.com` /
+   Twitter and other social pages, Google Play / Apple app detail links,
+   dictionary/translation/reference pages, and other metadata-poor utility pages. Post-like social
+   URLs and non-app store paths remain scrape-eligible. Diagnostics expose durable reason counts,
+   and queue fairness/prioritization intentionally remain unchanged.
 3. `SCRAPE-PR-PARTIAL-DIAGNOSTICS` - scrape interpretation.
    Make partial-page diagnostics sharper so operators can distinguish retained provisional rows,
    metadata-only partial pages, blocked generic fetches, and classifier parse/taxonomy warnings.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -356,9 +356,11 @@ PRs, for seven planned follow-ups total:
 2. `DISC-PR-NOISE-FILTERS` - discovery candidate quality.
    Implemented as a central persistence-time search-result noise filter: obvious non-article
    surfaces are retained with provenance but marked `unsupported_source` before scrape-drain budget
-   can select them. Covered classes include `x.com` / Twitter, app-store links, social profiles,
-   dictionary/translation/reference pages, and other metadata-poor utility pages. This intentionally
-   leaves queue fairness and prioritization unchanged.
+   can select them. Existing unattempted candidate-only noise is demoted on rediscovery; attempted
+   or content-bearing candidates keep their status. Covered classes include `x.com` / Twitter,
+   app-store links, social profiles, dictionary/translation/reference pages, and other
+   metadata-poor utility pages. Diagnostics expose reason counts, and queue fairness/prioritization
+   intentionally remain unchanged.
 3. `SCRAPE-PR-PARTIAL-DIAGNOSTICS` - scrape interpretation.
    Make partial-page diagnostics sharper so operators can distinguish retained provisional rows,
    metadata-only partial pages, blocked generic fetches, and classifier parse/taxonomy warnings.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -99,6 +99,7 @@ class QueueHealthMetrics(BaseModel):
     stale_candidates: int = 0
     retry_backlog_candidates: int = 0
     self_heal_eligible_candidates: int = 0
+    search_noise_filter_reason_counts: dict[str, int] = Field(default_factory=dict)
 
 
 class ProducerConversionMetrics(BaseModel):
@@ -416,6 +417,14 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
             **queue.model_dump(mode="json")
         )
     )
+    if queue.search_noise_filter_reason_counts:
+        lines.append(
+            "  search_noise_filters "
+            + ", ".join(
+                f"{reason}={count}"
+                for reason, count in queue.search_noise_filter_reason_counts.items()
+            )
+        )
     lines.append("")
     lines.append("Conversion")
     lines.append(
@@ -650,6 +659,13 @@ def _build_queue_health_metrics(
             stale += 1
     status_counts = Counter(candidate.candidate_status for candidate in candidates)
     basis_counts = Counter(candidate.content_basis for candidate in candidates)
+    search_noise_filter_reason_counts = Counter(
+        reason
+        for candidate in candidates
+        if candidate.candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
+        for reason in [_search_noise_filter_reason(candidate)]
+        if reason is not None
+    )
     return QueueHealthMetrics(
         total_candidates=len(candidates),
         new_candidates=status_counts[CandidateStatus.NEW],
@@ -670,7 +686,16 @@ def _build_queue_health_metrics(
             if candidate.candidate_status is CandidateStatus.SCRAPE_FAILED
             and candidate.self_heal_eligible
         ),
+        search_noise_filter_reason_counts=dict(sorted(search_noise_filter_reason_counts.items())),
     )
+
+
+def _search_noise_filter_reason(candidate: PersistentCandidate) -> str | None:
+    latest_discovery_metadata = candidate.metadata.get("latest_discovery_metadata")
+    if not isinstance(latest_discovery_metadata, dict):
+        return None
+    reason = latest_discovery_metadata.get("search_noise_filter_reason")
+    return reason if isinstance(reason, str) and reason else None
 
 
 def _candidate_identity_urls(candidate: PersistentCandidate) -> set[str]:

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -691,11 +691,18 @@ def _build_queue_health_metrics(
 
 
 def _search_noise_filter_reason(candidate: PersistentCandidate) -> str | None:
+    reason = candidate.metadata.get("unsupported_source_reason")
+    if (
+        candidate.metadata.get("unsupported_source_filter") == "search_noise"
+        and isinstance(reason, str)
+        and reason
+    ):
+        return reason
     latest_discovery_metadata = candidate.metadata.get("latest_discovery_metadata")
     if not isinstance(latest_discovery_metadata, dict):
         return None
-    reason = latest_discovery_metadata.get("search_noise_filter_reason")
-    return reason if isinstance(reason, str) and reason else None
+    legacy_reason = latest_discovery_metadata.get("search_noise_filter_reason")
+    return legacy_reason if isinstance(legacy_reason, str) and legacy_reason else None
 
 
 def _candidate_identity_urls(candidate: PersistentCandidate) -> set[str]:

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -1,0 +1,132 @@
+"""Candidate-level filtering policy for discovery search results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from denbust.discovery.models import DiscoveredCandidate, ProducerKind
+
+_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS: frozenset[str] = frozenset(
+    {
+        "x.com",
+        "twitter.com",
+        "play.google.com",
+        "apps.apple.com",
+        "itunes.apple.com",
+        "morfix.co.il",
+        "context.reverso.net",
+        "dictionary.reverso.net",
+        "wiktionary.org",
+        "pealim.com",
+    }
+)
+
+_SOCIAL_PROFILE_DOMAINS: frozenset[str] = frozenset(
+    {
+        "instagram.com",
+        "linkedin.com",
+        "tiktok.com",
+        "youtube.com",
+    }
+)
+
+_SOCIAL_PROFILE_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
+    "linkedin.com": ("/company/", "/in/", "/school/", "/showcase/"),
+    "youtube.com": ("/@", "/channel/", "/c/", "/user/"),
+}
+
+_SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
+    "instagram.com": ("/p/", "/reel/", "/tv/"),
+}
+
+
+@dataclass(frozen=True)
+class SearchNoiseClassification:
+    """Classification for a retained but non-scrapeable search-result surface."""
+
+    reason: str
+    matched_domain: str
+
+
+def normalize_domain(domain: str | None) -> str | None:
+    """Normalize hosts for candidate-filter comparisons."""
+    if domain is None:
+        return None
+    normalized = domain.strip().casefold()
+    if not normalized:
+        return None
+    if normalized.startswith("www."):
+        normalized = normalized[4:]
+    return normalized or None
+
+
+def candidate_domain(discovered: DiscoveredCandidate) -> str | None:
+    """Return the normalized candidate host, preferring explicit model domain."""
+    normalized_domain = normalize_domain(discovered.domain)
+    if normalized_domain is not None:
+        return normalized_domain
+    return normalize_domain(
+        urlparse(str(discovered.canonical_url or discovered.candidate_url)).netloc
+    )
+
+
+def candidate_path(discovered: DiscoveredCandidate) -> str:
+    """Return the path for the current candidate identity URL."""
+    parsed = urlparse(str(discovered.canonical_url or discovered.candidate_url))
+    return parsed.path or "/"
+
+
+def match_domain(domain: str | None, configured_domains: frozenset[str]) -> str | None:
+    """Return the configured base domain matched by a host, including subdomains."""
+    if domain is None:
+        return None
+    return next(
+        (
+            configured
+            for configured in sorted(configured_domains, key=len, reverse=True)
+            if domain == configured or domain.endswith(f".{configured}")
+        ),
+        None,
+    )
+
+
+def _is_social_profile_candidate(discovered: DiscoveredCandidate) -> bool:
+    domain = candidate_domain(discovered)
+    matched_domain = match_domain(domain, _SOCIAL_PROFILE_DOMAINS)
+    if matched_domain is None:
+        return False
+    path = candidate_path(discovered)
+    if matched_domain in _SOCIAL_PROFILE_PATH_PREFIXES:
+        return any(
+            path.startswith(prefix) for prefix in _SOCIAL_PROFILE_PATH_PREFIXES[matched_domain]
+        )
+    if matched_domain in _SOCIAL_POST_PATH_PREFIXES:
+        return not any(
+            path.startswith(prefix) for prefix in _SOCIAL_POST_PATH_PREFIXES[matched_domain]
+        )
+    if matched_domain == "tiktok.com":
+        return "/video/" not in path
+    return False
+
+
+def classify_search_noise(
+    discovered: DiscoveredCandidate,
+) -> SearchNoiseClassification | None:
+    """Classify obvious non-article search-result surfaces before scrape selection."""
+    if discovered.producer_kind is not ProducerKind.SEARCH_ENGINE:
+        return None
+    domain = candidate_domain(discovered)
+    if (matched_domain := match_domain(domain, _ALWAYS_UNSUPPORTED_SEARCH_DOMAINS)) is not None:
+        return SearchNoiseClassification(
+            reason="unsupported_search_domain",
+            matched_domain=matched_domain,
+        )
+    if _is_social_profile_candidate(discovered):
+        matched_domain = match_domain(domain, _SOCIAL_PROFILE_DOMAINS)
+        if matched_domain is not None:
+            return SearchNoiseClassification(
+                reason="social_profile",
+                matched_domain=matched_domain,
+            )
+    return None

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from urllib.parse import urlparse
 
 from denbust.discovery.models import DiscoveredCandidate, ProducerKind
 
-_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS: frozenset[str] = frozenset(
+_UTILITY_SEARCH_DOMAINS: frozenset[str] = frozenset(
     {
-        "x.com",
-        "twitter.com",
-        "play.google.com",
-        "apps.apple.com",
-        "itunes.apple.com",
         "morfix.co.il",
         "context.reverso.net",
         "dictionary.reverso.net",
@@ -22,11 +18,18 @@ _ALWAYS_UNSUPPORTED_SEARCH_DOMAINS: frozenset[str] = frozenset(
     }
 )
 
+_APP_STORE_DOMAINS: frozenset[str] = frozenset(
+    {"play.google.com", "apps.apple.com", "itunes.apple.com"}
+)
+
 _SOCIAL_PROFILE_DOMAINS: frozenset[str] = frozenset(
     {
+        "facebook.com",
         "instagram.com",
         "linkedin.com",
         "tiktok.com",
+        "twitter.com",
+        "x.com",
         "youtube.com",
     }
 )
@@ -37,15 +40,26 @@ _SOCIAL_PROFILE_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
 }
 
 _SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
+    "facebook.com": ("/permalink.php", "/posts/", "/share/", "/story.php", "/watch/"),
     "instagram.com": ("/p/", "/reel/", "/tv/"),
+    "linkedin.com": ("/feed/update/", "/posts/", "/pulse/"),
+    "youtube.com": ("/shorts/", "/watch"),
 }
+
+
+class SearchNoiseReason(StrEnum):
+    """Stable reason values for search-result noise classification."""
+
+    APP_STORE = "app_store"
+    SOCIAL_PROFILE = "social_profile"
+    UNSUPPORTED_SEARCH_DOMAIN = "unsupported_search_domain"
 
 
 @dataclass(frozen=True)
 class SearchNoiseClassification:
     """Classification for a retained but non-scrapeable search-result surface."""
 
-    reason: str
+    reason: SearchNoiseReason
     matched_domain: str
 
 
@@ -74,7 +88,7 @@ def candidate_domain(discovered: DiscoveredCandidate) -> str | None:
 def candidate_path(discovered: DiscoveredCandidate) -> str:
     """Return the path for the current candidate identity URL."""
     parsed = urlparse(str(discovered.canonical_url or discovered.candidate_url))
-    return parsed.path or "/"
+    return (parsed.path or "/").casefold()
 
 
 def match_domain(domain: str | None, configured_domains: frozenset[str]) -> str | None:
@@ -91,12 +105,50 @@ def match_domain(domain: str | None, configured_domains: frozenset[str]) -> str 
     )
 
 
+def _is_app_store_url(discovered: DiscoveredCandidate) -> bool:
+    domain = candidate_domain(discovered)
+    matched_domain = match_domain(domain, _APP_STORE_DOMAINS)
+    if matched_domain is None:
+        return False
+    path = candidate_path(discovered)
+    if matched_domain == "play.google.com":
+        return path.startswith("/store/apps/")
+    return path == "/app" or "/app/" in path
+
+
+def _is_x_or_twitter_post_path(path: str) -> bool:
+    segments = [segment for segment in path.split("/") if segment]
+    return (
+        len(segments) >= 3 and segments[1] in {"status", "statuses"} and segments[2].isdigit()
+    ) or (
+        len(segments) >= 4
+        and segments[0] == "i"
+        and segments[1] == "web"
+        and segments[2] == "status"
+        and segments[3].isdigit()
+    )
+
+
+def _is_tiktok_video_path(path: str) -> bool:
+    segments = [segment for segment in path.split("/") if segment]
+    return (
+        len(segments) >= 3
+        and segments[0].startswith("@")
+        and segments[1] == "video"
+        and segments[2].isdigit()
+    )
+
+
 def _is_social_profile_candidate(discovered: DiscoveredCandidate) -> bool:
     domain = candidate_domain(discovered)
     matched_domain = match_domain(domain, _SOCIAL_PROFILE_DOMAINS)
     if matched_domain is None:
         return False
     path = candidate_path(discovered)
+    if matched_domain in {"x.com", "twitter.com"}:
+        return not _is_x_or_twitter_post_path(path)
+    if matched_domain == "tiktok.com":
+        return not _is_tiktok_video_path(path)
     if matched_domain in _SOCIAL_PROFILE_PATH_PREFIXES:
         return any(
             path.startswith(prefix) for prefix in _SOCIAL_PROFILE_PATH_PREFIXES[matched_domain]
@@ -105,8 +157,6 @@ def _is_social_profile_candidate(discovered: DiscoveredCandidate) -> bool:
         return not any(
             path.startswith(prefix) for prefix in _SOCIAL_POST_PATH_PREFIXES[matched_domain]
         )
-    if matched_domain == "tiktok.com":
-        return "/video/" not in path
     return False
 
 
@@ -117,16 +167,23 @@ def classify_search_noise(
     if discovered.producer_kind is not ProducerKind.SEARCH_ENGINE:
         return None
     domain = candidate_domain(discovered)
-    if (matched_domain := match_domain(domain, _ALWAYS_UNSUPPORTED_SEARCH_DOMAINS)) is not None:
+    if _is_app_store_url(discovered):
+        matched_domain = match_domain(domain, _APP_STORE_DOMAINS)
+        if matched_domain is not None:
+            return SearchNoiseClassification(
+                reason=SearchNoiseReason.APP_STORE,
+                matched_domain=matched_domain,
+            )
+    if (matched_domain := match_domain(domain, _UTILITY_SEARCH_DOMAINS)) is not None:
         return SearchNoiseClassification(
-            reason="unsupported_search_domain",
+            reason=SearchNoiseReason.UNSUPPORTED_SEARCH_DOMAIN,
             matched_domain=matched_domain,
         )
     if _is_social_profile_candidate(discovered):
         matched_domain = match_domain(domain, _SOCIAL_PROFILE_DOMAINS)
         if matched_domain is not None:
             return SearchNoiseClassification(
-                reason="social_profile",
+                reason=SearchNoiseReason.SOCIAL_PROFILE,
                 matched_domain=matched_domain,
             )
     return None

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -14,7 +14,6 @@ from denbust.discovery.base import SourceCandidateProducer, SourceDiscoveryConte
 from denbust.discovery.candidate_filters import (
     candidate_domain,
     classify_search_noise,
-    match_domain,
     normalize_domain,
 )
 from denbust.discovery.models import (
@@ -28,7 +27,6 @@ from denbust.discovery.models import (
     PersistentCandidate,
     ProducerKind,
 )
-from denbust.discovery.queries import SOCIAL_DISCOVERY_DOMAINS
 from denbust.discovery.scrape_queue import SCRAPEABLE_CANDIDATE_STATUSES
 from denbust.discovery.storage import DiscoveryPersistence
 from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
@@ -39,13 +37,6 @@ def _normalize_domain(domain: str | None) -> str | None:
     return normalize_domain(domain)
 
 
-_NORMALIZED_SOCIAL_DISCOVERY_DOMAINS = frozenset(
-    normalized
-    for domain in SOCIAL_DISCOVERY_DOMAINS
-    if (normalized := _normalize_domain(domain)) is not None
-)
-
-
 def _candidate_domain(discovered: DiscoveredCandidate) -> str | None:
     return candidate_domain(discovered)
 
@@ -53,10 +44,9 @@ def _candidate_domain(discovered: DiscoveredCandidate) -> str | None:
 def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> DiscoveredCandidate:
     """Normalize search-engine social results into the social-search producer family."""
     query_kind = discovered.metadata.get("query_kind")
-    if discovered.producer_kind is ProducerKind.SEARCH_ENGINE and (
-        query_kind == DiscoveryQueryKind.SOCIAL_TARGETED.value
-        or match_domain(_candidate_domain(discovered), _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS)
-        is not None
+    if (
+        discovered.producer_kind is ProducerKind.SEARCH_ENGINE
+        and query_kind == DiscoveryQueryKind.SOCIAL_TARGETED.value
     ):
         return discovered.model_copy(update={"producer_kind": ProducerKind.SOCIAL_SEARCH})
     return discovered
@@ -64,10 +54,6 @@ def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> Discover
 
 def _is_social_candidate(discovered: DiscoveredCandidate) -> bool:
     return discovered.producer_kind is ProducerKind.SOCIAL_SEARCH
-
-
-def _is_search_noise_candidate(discovered: DiscoveredCandidate) -> bool:
-    return classify_search_noise(discovered) is not None
 
 
 def _can_demote_existing_noise_candidate(existing: PersistentCandidate) -> bool:
@@ -179,7 +165,8 @@ def merge_discovered_candidate(
     if discovered.metadata:
         existing_metadata["latest_discovery_metadata"] = discovered.metadata
     is_social = _is_social_candidate(discovered)
-    is_search_noise = _is_search_noise_candidate(discovered)
+    search_noise_classification = classify_search_noise(discovered)
+    is_search_noise = search_noise_classification is not None
     candidate_status = existing.candidate_status if existing else CandidateStatus.NEW
     if (is_social or is_search_noise) and existing is None:
         candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
@@ -189,6 +176,13 @@ def merge_discovered_candidate(
         and _can_demote_existing_noise_candidate(existing)
     ):
         candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
+    if (
+        candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
+        and search_noise_classification is not None
+    ):
+        existing_metadata["unsupported_source_filter"] = "search_noise"
+        existing_metadata["unsupported_source_reason"] = search_noise_classification.reason.value
+        existing_metadata["unsupported_source_domain"] = search_noise_classification.matched_domain
 
     return PersistentCandidate(
         candidate_id=existing.candidate_id
@@ -240,7 +234,7 @@ def merge_discovered_candidate(
         last_scrape_error_message=existing.last_scrape_error_message if existing else None,
         content_basis=existing.content_basis if existing else ContentBasis.CANDIDATE_ONLY,
         retry_priority=existing.retry_priority if existing else 0,
-        needs_review=(existing.needs_review if existing else False) or is_social or is_search_noise,
+        needs_review=(existing.needs_review if existing else False) or is_social,
         backfill_batch_id=backfill_batch_id or (existing.backfill_batch_id if existing else None),
         self_heal_eligible=existing.self_heal_eligible if existing else False,
         source_discovery_only=(
@@ -279,7 +273,7 @@ def persist_discovered_candidates(
                 update={
                     "metadata": {
                         **discovered.metadata,
-                        "search_noise_filter_reason": classification.reason,
+                        "search_noise_filter_reason": classification.reason.value,
                         "search_noise_filter_domain": classification.matched_domain,
                     }
                 }

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -6,12 +6,17 @@ import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import cast
-from urllib.parse import urlparse
 
 from pydantic import HttpUrl
 
 from denbust.data_models import RawArticle
 from denbust.discovery.base import SourceCandidateProducer, SourceDiscoveryContext
+from denbust.discovery.candidate_filters import (
+    candidate_domain,
+    classify_search_noise,
+    match_domain,
+    normalize_domain,
+)
 from denbust.discovery.models import (
     CandidateProvenance,
     CandidateStatus,
@@ -24,20 +29,14 @@ from denbust.discovery.models import (
     ProducerKind,
 )
 from denbust.discovery.queries import SOCIAL_DISCOVERY_DOMAINS
+from denbust.discovery.scrape_queue import SCRAPEABLE_CANDIDATE_STATUSES
 from denbust.discovery.storage import DiscoveryPersistence
 from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
 from denbust.sources.base import HistoricalSource, Source
 
 
 def _normalize_domain(domain: str | None) -> str | None:
-    if domain is None:
-        return None
-    normalized = domain.strip().casefold()
-    if not normalized:
-        return None
-    if normalized.startswith("www."):
-        normalized = normalized[4:]
-    return normalized or None
+    return normalize_domain(domain)
 
 
 _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS = frozenset(
@@ -46,91 +45,9 @@ _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS = frozenset(
     if (normalized := _normalize_domain(domain)) is not None
 )
 
-_NORMALIZED_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS = frozenset(
-    normalized
-    for domain in (
-        "x.com",
-        "twitter.com",
-        "play.google.com",
-        "apps.apple.com",
-        "itunes.apple.com",
-        "morfix.co.il",
-        "context.reverso.net",
-        "dictionary.reverso.net",
-        "wiktionary.org",
-        "pealim.com",
-    )
-    if (normalized := _normalize_domain(domain)) is not None
-)
-
-_NORMALIZED_SOCIAL_PROFILE_DOMAINS = frozenset(
-    normalized
-    for domain in (
-        "instagram.com",
-        "linkedin.com",
-        "tiktok.com",
-        "youtube.com",
-    )
-    if (normalized := _normalize_domain(domain)) is not None
-)
-
-_SOCIAL_PROFILE_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
-    "linkedin.com": ("/company/", "/in/", "/school/", "/showcase/"),
-    "youtube.com": ("/@", "/channel/", "/c/", "/user/"),
-}
-
-_SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
-    "instagram.com": ("/p/", "/reel/", "/tv/"),
-}
-
 
 def _candidate_domain(discovered: DiscoveredCandidate) -> str | None:
-    normalized_domain = _normalize_domain(discovered.domain)
-    if normalized_domain is not None:
-        return normalized_domain
-    return _normalize_domain(
-        urlparse(str(discovered.canonical_url or discovered.candidate_url)).netloc
-    )
-
-
-def _candidate_path(discovered: DiscoveredCandidate) -> str:
-    parsed = urlparse(str(discovered.canonical_url or discovered.candidate_url))
-    return parsed.path or "/"
-
-
-def _domain_matches(domain: str | None, configured_domains: frozenset[str]) -> bool:
-    if domain is None:
-        return False
-    return any(
-        domain == configured or domain.endswith(f".{configured}")
-        for configured in configured_domains
-    )
-
-
-def _is_social_profile_candidate(discovered: DiscoveredCandidate) -> bool:
-    domain = _candidate_domain(discovered)
-    if not _domain_matches(domain, _NORMALIZED_SOCIAL_PROFILE_DOMAINS):
-        return False
-    assert domain is not None
-    path = _candidate_path(discovered)
-    if domain in _SOCIAL_PROFILE_PATH_PREFIXES:
-        return any(path.startswith(prefix) for prefix in _SOCIAL_PROFILE_PATH_PREFIXES[domain])
-    if domain in _SOCIAL_POST_PATH_PREFIXES:
-        return not any(path.startswith(prefix) for prefix in _SOCIAL_POST_PATH_PREFIXES[domain])
-    if domain == "tiktok.com":
-        return "/video/" not in path
-    return False
-
-
-def _search_noise_filter_reason(discovered: DiscoveredCandidate) -> str | None:
-    if discovered.producer_kind is not ProducerKind.SEARCH_ENGINE:
-        return None
-    domain = _candidate_domain(discovered)
-    if _domain_matches(domain, _NORMALIZED_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS):
-        return "unsupported_search_domain"
-    if _is_social_profile_candidate(discovered):
-        return "social_profile"
-    return None
+    return candidate_domain(discovered)
 
 
 def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> DiscoveredCandidate:
@@ -138,7 +55,8 @@ def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> Discover
     query_kind = discovered.metadata.get("query_kind")
     if discovered.producer_kind is ProducerKind.SEARCH_ENGINE and (
         query_kind == DiscoveryQueryKind.SOCIAL_TARGETED.value
-        or _candidate_domain(discovered) in _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS
+        or match_domain(_candidate_domain(discovered), _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS)
+        is not None
     ):
         return discovered.model_copy(update={"producer_kind": ProducerKind.SOCIAL_SEARCH})
     return discovered
@@ -149,7 +67,15 @@ def _is_social_candidate(discovered: DiscoveredCandidate) -> bool:
 
 
 def _is_search_noise_candidate(discovered: DiscoveredCandidate) -> bool:
-    return _search_noise_filter_reason(discovered) is not None
+    return classify_search_noise(discovered) is not None
+
+
+def _can_demote_existing_noise_candidate(existing: PersistentCandidate) -> bool:
+    return (
+        existing.candidate_status in SCRAPEABLE_CANDIDATE_STATUSES
+        and existing.scrape_attempt_count == 0
+        and existing.content_basis is ContentBasis.CANDIDATE_ONLY
+    )
 
 
 def build_candidate_id(identity_url: str) -> str:
@@ -257,6 +183,12 @@ def merge_discovered_candidate(
     candidate_status = existing.candidate_status if existing else CandidateStatus.NEW
     if (is_social or is_search_noise) and existing is None:
         candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
+    if (
+        (is_social or is_search_noise)
+        and existing is not None
+        and _can_demote_existing_noise_candidate(existing)
+    ):
+        candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
 
     return PersistentCandidate(
         candidate_id=existing.candidate_id
@@ -342,12 +274,13 @@ def persist_discovered_candidates(
 
     for discovered in discovered_candidates:
         discovered = _normalize_discovered_candidate(discovered)
-        if (noise_reason := _search_noise_filter_reason(discovered)) is not None:
+        if (classification := classify_search_noise(discovered)) is not None:
             discovered = discovered.model_copy(
                 update={
                     "metadata": {
                         **discovered.metadata,
-                        "search_noise_filter_reason": noise_reason,
+                        "search_noise_filter_reason": classification.reason,
+                        "search_noise_filter_domain": classification.matched_domain,
                     }
                 }
             )

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -46,6 +46,43 @@ _NORMALIZED_SOCIAL_DISCOVERY_DOMAINS = frozenset(
     if (normalized := _normalize_domain(domain)) is not None
 )
 
+_NORMALIZED_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS = frozenset(
+    normalized
+    for domain in (
+        "x.com",
+        "twitter.com",
+        "play.google.com",
+        "apps.apple.com",
+        "itunes.apple.com",
+        "morfix.co.il",
+        "context.reverso.net",
+        "dictionary.reverso.net",
+        "wiktionary.org",
+        "pealim.com",
+    )
+    if (normalized := _normalize_domain(domain)) is not None
+)
+
+_NORMALIZED_SOCIAL_PROFILE_DOMAINS = frozenset(
+    normalized
+    for domain in (
+        "instagram.com",
+        "linkedin.com",
+        "tiktok.com",
+        "youtube.com",
+    )
+    if (normalized := _normalize_domain(domain)) is not None
+)
+
+_SOCIAL_PROFILE_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
+    "linkedin.com": ("/company/", "/in/", "/school/", "/showcase/"),
+    "youtube.com": ("/@", "/channel/", "/c/", "/user/"),
+}
+
+_SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
+    "instagram.com": ("/p/", "/reel/", "/tv/"),
+}
+
 
 def _candidate_domain(discovered: DiscoveredCandidate) -> str | None:
     normalized_domain = _normalize_domain(discovered.domain)
@@ -54,6 +91,46 @@ def _candidate_domain(discovered: DiscoveredCandidate) -> str | None:
     return _normalize_domain(
         urlparse(str(discovered.canonical_url or discovered.candidate_url)).netloc
     )
+
+
+def _candidate_path(discovered: DiscoveredCandidate) -> str:
+    parsed = urlparse(str(discovered.canonical_url or discovered.candidate_url))
+    return parsed.path or "/"
+
+
+def _domain_matches(domain: str | None, configured_domains: frozenset[str]) -> bool:
+    if domain is None:
+        return False
+    return any(
+        domain == configured or domain.endswith(f".{configured}")
+        for configured in configured_domains
+    )
+
+
+def _is_social_profile_candidate(discovered: DiscoveredCandidate) -> bool:
+    domain = _candidate_domain(discovered)
+    if not _domain_matches(domain, _NORMALIZED_SOCIAL_PROFILE_DOMAINS):
+        return False
+    assert domain is not None
+    path = _candidate_path(discovered)
+    if domain in _SOCIAL_PROFILE_PATH_PREFIXES:
+        return any(path.startswith(prefix) for prefix in _SOCIAL_PROFILE_PATH_PREFIXES[domain])
+    if domain in _SOCIAL_POST_PATH_PREFIXES:
+        return not any(path.startswith(prefix) for prefix in _SOCIAL_POST_PATH_PREFIXES[domain])
+    if domain == "tiktok.com":
+        return "/video/" not in path
+    return False
+
+
+def _search_noise_filter_reason(discovered: DiscoveredCandidate) -> str | None:
+    if discovered.producer_kind is not ProducerKind.SEARCH_ENGINE:
+        return None
+    domain = _candidate_domain(discovered)
+    if _domain_matches(domain, _NORMALIZED_ALWAYS_UNSUPPORTED_SEARCH_DOMAINS):
+        return "unsupported_search_domain"
+    if _is_social_profile_candidate(discovered):
+        return "social_profile"
+    return None
 
 
 def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> DiscoveredCandidate:
@@ -69,6 +146,10 @@ def _normalize_discovered_candidate(discovered: DiscoveredCandidate) -> Discover
 
 def _is_social_candidate(discovered: DiscoveredCandidate) -> bool:
     return discovered.producer_kind is ProducerKind.SOCIAL_SEARCH
+
+
+def _is_search_noise_candidate(discovered: DiscoveredCandidate) -> bool:
+    return _search_noise_filter_reason(discovered) is not None
 
 
 def build_candidate_id(identity_url: str) -> str:
@@ -172,8 +253,9 @@ def merge_discovered_candidate(
     if discovered.metadata:
         existing_metadata["latest_discovery_metadata"] = discovered.metadata
     is_social = _is_social_candidate(discovered)
+    is_search_noise = _is_search_noise_candidate(discovered)
     candidate_status = existing.candidate_status if existing else CandidateStatus.NEW
-    if is_social and existing is None:
+    if (is_social or is_search_noise) and existing is None:
         candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
 
     return PersistentCandidate(
@@ -226,7 +308,7 @@ def merge_discovered_candidate(
         last_scrape_error_message=existing.last_scrape_error_message if existing else None,
         content_basis=existing.content_basis if existing else ContentBasis.CANDIDATE_ONLY,
         retry_priority=existing.retry_priority if existing else 0,
-        needs_review=(existing.needs_review if existing else False) or is_social,
+        needs_review=(existing.needs_review if existing else False) or is_social or is_search_noise,
         backfill_batch_id=backfill_batch_id or (existing.backfill_batch_id if existing else None),
         self_heal_eligible=existing.self_heal_eligible if existing else False,
         source_discovery_only=(
@@ -260,6 +342,15 @@ def persist_discovered_candidates(
 
     for discovered in discovered_candidates:
         discovered = _normalize_discovered_candidate(discovered)
+        if (noise_reason := _search_noise_filter_reason(discovered)) is not None:
+            discovered = discovered.model_copy(
+                update={
+                    "metadata": {
+                        **discovered.metadata,
+                        "search_noise_filter_reason": noise_reason,
+                    }
+                }
+            )
         canonical_url = (
             str(discovered.canonical_url) if discovered.canonical_url is not None else None
         )

--- a/tests/unit/test_discovery_candidate_filters.py
+++ b/tests/unit/test_discovery_candidate_filters.py
@@ -1,0 +1,92 @@
+"""Unit tests for discovery candidate filtering policy."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import HttpUrl
+
+from denbust.discovery.candidate_filters import classify_search_noise
+from denbust.discovery.models import DiscoveredCandidate, ProducerKind
+
+
+def _search_candidate(url: str) -> DiscoveredCandidate:
+    return DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl(url),
+        canonical_url=HttpUrl(url),
+        discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "reason", "matched_domain"),
+    [
+        ("https://x.com/example_profile", "unsupported_search_domain", "x.com"),
+        ("https://mobile.twitter.com/example_profile", "unsupported_search_domain", "twitter.com"),
+        (
+            "https://play.google.com/store/apps/details?id=com.example",
+            "unsupported_search_domain",
+            "play.google.com",
+        ),
+        (
+            "https://apps.apple.com/il/app/example/id123456789",
+            "unsupported_search_domain",
+            "apps.apple.com",
+        ),
+        ("https://morfix.co.il/example", "unsupported_search_domain", "morfix.co.il"),
+        (
+            "https://context.reverso.net/translation/hebrew-english/example",
+            "unsupported_search_domain",
+            "context.reverso.net",
+        ),
+        (
+            "https://dictionary.reverso.net/hebrew-english/example",
+            "unsupported_search_domain",
+            "dictionary.reverso.net",
+        ),
+        ("https://en.wiktionary.org/wiki/example", "unsupported_search_domain", "wiktionary.org"),
+        ("https://www.pealim.com/dict/1", "unsupported_search_domain", "pealim.com"),
+        ("https://m.linkedin.com/company/example-org", "social_profile", "linkedin.com"),
+        ("https://www.instagram.com/example_profile/", "social_profile", "instagram.com"),
+        ("https://m.youtube.com/@example", "social_profile", "youtube.com"),
+        ("https://www.tiktok.com/@example", "social_profile", "tiktok.com"),
+    ],
+)
+def test_classify_search_noise_marks_expected_noise_domains(
+    url: str,
+    reason: str,
+    matched_domain: str,
+) -> None:
+    """Each configured noise URL should produce its exact reason and matched base domain."""
+    classification = classify_search_noise(_search_candidate(url))
+
+    assert classification is not None
+    assert classification.reason == reason
+    assert classification.matched_domain == matched_domain
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.ynet.co.il/news/article/abc123",
+        "https://www.instagram.com/p/example-post/",
+        "https://www.instagram.com/reel/example-post/",
+        "https://www.tiktok.com/@example/video/123456789",
+    ],
+)
+def test_classify_search_noise_keeps_article_and_social_post_urls(url: str) -> None:
+    """Supported news article URLs and obvious social posts should remain scrapeable candidates."""
+    assert classify_search_noise(_search_candidate(url)) is None
+
+
+def test_classify_search_noise_ignores_source_native_candidates() -> None:
+    """Source-native article discovery should not be filtered by search-result policy."""
+    candidate = _search_candidate("https://x.com/example_profile").model_copy(
+        update={"producer_kind": ProducerKind.SOURCE_NATIVE}
+    )
+
+    assert classify_search_noise(candidate) is None

--- a/tests/unit/test_discovery_candidate_filters.py
+++ b/tests/unit/test_discovery_candidate_filters.py
@@ -25,16 +25,16 @@ def _search_candidate(url: str) -> DiscoveredCandidate:
 @pytest.mark.parametrize(
     ("url", "reason", "matched_domain"),
     [
-        ("https://x.com/example_profile", "unsupported_search_domain", "x.com"),
-        ("https://mobile.twitter.com/example_profile", "unsupported_search_domain", "twitter.com"),
+        ("https://x.com/example_profile", "social_profile", "x.com"),
+        ("https://mobile.twitter.com/example_profile", "social_profile", "twitter.com"),
         (
             "https://play.google.com/store/apps/details?id=com.example",
-            "unsupported_search_domain",
+            "app_store",
             "play.google.com",
         ),
         (
             "https://apps.apple.com/il/app/example/id123456789",
-            "unsupported_search_domain",
+            "app_store",
             "apps.apple.com",
         ),
         ("https://morfix.co.il/example", "unsupported_search_domain", "morfix.co.il"),
@@ -50,6 +50,7 @@ def _search_candidate(url: str) -> DiscoveredCandidate:
         ),
         ("https://en.wiktionary.org/wiki/example", "unsupported_search_domain", "wiktionary.org"),
         ("https://www.pealim.com/dict/1", "unsupported_search_domain", "pealim.com"),
+        ("https://m.facebook.com/profile.php?id=123", "social_profile", "facebook.com"),
         ("https://m.linkedin.com/company/example-org", "social_profile", "linkedin.com"),
         ("https://www.instagram.com/example_profile/", "social_profile", "instagram.com"),
         ("https://m.youtube.com/@example", "social_profile", "youtube.com"),
@@ -73,13 +74,18 @@ def test_classify_search_noise_marks_expected_noise_domains(
     "url",
     [
         "https://www.ynet.co.il/news/article/abc123",
+        "https://x.com/example/status/123456789",
+        "https://mobile.twitter.com/example/status/123456789",
+        "https://facebook.com/story.php?story_fbid=5&id=6",
         "https://www.instagram.com/p/example-post/",
         "https://www.instagram.com/reel/example-post/",
         "https://www.tiktok.com/@example/video/123456789",
+        "https://play.google.com/books/reader?id=example",
+        "https://apps.apple.com/us/story/id123456789",
     ],
 )
 def test_classify_search_noise_keeps_article_and_social_post_urls(url: str) -> None:
-    """Supported news article URLs and obvious social posts should remain scrapeable candidates."""
+    """Article/post-like URLs and non-app store paths should remain scrapeable candidates."""
     assert classify_search_noise(_search_candidate(url)) is None
 
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -209,10 +209,13 @@ def test_build_discovery_diagnostic_report_counts_search_noise_reasons(tmp_path:
                 first_seen_at=now - timedelta(days=1),
                 last_seen_at=now,
                 metadata={
+                    "unsupported_source_filter": "search_noise",
+                    "unsupported_source_reason": "social_profile",
+                    "unsupported_source_domain": "x.com",
                     "latest_discovery_metadata": {
-                        "search_noise_filter_reason": "unsupported_search_domain",
+                        "search_noise_filter_reason": "social_profile",
                         "search_noise_filter_domain": "x.com",
-                    }
+                    },
                 },
             ),
             _candidate(
@@ -223,10 +226,13 @@ def test_build_discovery_diagnostic_report_counts_search_noise_reasons(tmp_path:
                 first_seen_at=now - timedelta(days=1),
                 last_seen_at=now,
                 metadata={
+                    "unsupported_source_filter": "search_noise",
+                    "unsupported_source_reason": "social_profile",
+                    "unsupported_source_domain": "instagram.com",
                     "latest_discovery_metadata": {
                         "search_noise_filter_reason": "social_profile",
                         "search_noise_filter_domain": "instagram.com",
-                    }
+                    },
                 },
             ),
             _candidate(
@@ -245,10 +251,9 @@ def test_build_discovery_diagnostic_report_counts_search_noise_reasons(tmp_path:
 
     assert report.queue_health.unsupported_source_candidates == 3
     assert report.queue_health.search_noise_filter_reason_counts == {
-        "social_profile": 1,
-        "unsupported_search_domain": 1,
+        "social_profile": 2,
     }
-    assert "search_noise_filters social_profile=1, unsupported_search_domain=1" in rendered
+    assert "search_noise_filters social_profile=2" in rendered
 
 
 def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -49,6 +49,7 @@ def _candidate(
     next_scrape_attempt_at: datetime | None = None,
     content_basis: ContentBasis = ContentBasis.CANDIDATE_ONLY,
     self_heal_eligible: bool = False,
+    metadata: dict[str, object] | None = None,
 ) -> PersistentCandidate:
     return PersistentCandidate(
         candidate_id=candidate_id,
@@ -64,6 +65,7 @@ def _candidate(
         last_seen_at=last_seen_at,
         next_scrape_attempt_at=next_scrape_attempt_at,
         self_heal_eligible=self_heal_eligible,
+        metadata=metadata or {},
     )
 
 
@@ -190,6 +192,63 @@ def test_build_discovery_diagnostic_report_summarizes_state(tmp_path: Path) -> N
     assert report.scrape_failure_diagnostics[0].self_heal_eligible_count == 1
     assert "Overlap" in render_discovery_diagnostic_report(report)
     assert "Structured scrape failures" in render_discovery_diagnostic_report(report)
+
+
+def test_build_discovery_diagnostic_report_counts_search_noise_reasons(tmp_path: Path) -> None:
+    """Diagnostics should explain why unsupported search-result noise was filtered."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    persistence.upsert_candidates(
+        [
+            _candidate(
+                "candidate-x",
+                url="https://x.com/example_profile",
+                discovered_via=["brave"],
+                status=CandidateStatus.UNSUPPORTED_SOURCE,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now,
+                metadata={
+                    "latest_discovery_metadata": {
+                        "search_noise_filter_reason": "unsupported_search_domain",
+                        "search_noise_filter_domain": "x.com",
+                    }
+                },
+            ),
+            _candidate(
+                "candidate-instagram",
+                url="https://www.instagram.com/example_profile/",
+                discovered_via=["exa"],
+                status=CandidateStatus.UNSUPPORTED_SOURCE,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now,
+                metadata={
+                    "latest_discovery_metadata": {
+                        "search_noise_filter_reason": "social_profile",
+                        "search_noise_filter_domain": "instagram.com",
+                    }
+                },
+            ),
+            _candidate(
+                "candidate-facebook",
+                url="https://facebook.com/story.php?story_fbid=3&id=4",
+                discovered_via=["brave"],
+                status=CandidateStatus.UNSUPPORTED_SOURCE,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now,
+            ),
+        ]
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+    rendered = render_discovery_diagnostic_report(report)
+
+    assert report.queue_health.unsupported_source_candidates == 3
+    assert report.queue_health.search_noise_filter_reason_counts == {
+        "social_profile": 1,
+        "unsupported_search_domain": 1,
+    }
+    assert "search_noise_filters social_profile=1, unsupported_search_domain=1" in rendered
 
 
 def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -188,6 +188,84 @@ def test_persist_discovered_candidates_marks_social_domains_unsupported_without_
     assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
 
 
+def test_persist_discovered_candidates_marks_search_noise_unsupported(
+    tmp_path: Path,
+) -> None:
+    """Obvious non-article search results should be retained but not scrape-eligible."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    discoveries = [
+        DiscoveredCandidate(
+            producer_name="brave",
+            producer_kind=ProducerKind.SEARCH_ENGINE,
+            query_text="בית בושת",
+            candidate_url=HttpUrl(url),
+            canonical_url=HttpUrl(url),
+            title="noise",
+            snippet="metadata-poor result",
+            discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+            metadata={"query_kind": "broad"},
+        )
+        for url in [
+            "https://x.com/example_profile",
+            "https://play.google.com/store/apps/details?id=com.example",
+            "https://apps.apple.com/il/app/example/id123456789",
+            "https://morfix.co.il/example",
+            "https://context.reverso.net/translation/hebrew-english/example",
+            "https://en.wiktionary.org/wiki/example",
+            "https://www.linkedin.com/company/example-org",
+            "https://www.instagram.com/example_profile/",
+        ]
+    ]
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-search-noise"),
+        discovered_candidates=discoveries,
+        persistence=persistence,
+    )
+
+    assert {candidate.candidate_status.value for candidate in persisted.candidates} == {
+        "unsupported_source"
+    }
+    assert all(candidate.needs_review for candidate in persisted.candidates)
+    assert {event.producer_kind for event in persisted.provenance} == {ProducerKind.SEARCH_ENGINE}
+    assert {
+        candidate.metadata["latest_discovery_metadata"]["search_noise_filter_reason"]
+        for candidate in persisted.candidates
+    } == {"unsupported_search_domain", "social_profile"}
+
+
+def test_persist_discovered_candidates_keeps_supported_news_articles_scrapeable(
+    tmp_path: Path,
+) -> None:
+    """Noise filtering should not suppress normal article URLs from supported news domains."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    discovery = DiscoveredCandidate(
+        producer_name="exa",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl("https://www.ynet.co.il/news/article/abc123"),
+        canonical_url=HttpUrl("https://www.ynet.co.il/news/article/abc123"),
+        title="כתבת חדשות רגילה",
+        snippet="חשד לבית בושת",
+        discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        source_hint="ynet",
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-supported-news"),
+        discovered_candidates=[discovery],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_status.value == "new"
+    assert candidate.needs_review is False
+    assert "search_noise_filter_reason" not in candidate.metadata["latest_discovery_metadata"]
+
+
 def test_source_native_domain_helpers_normalize_and_fallback() -> None:
     """Source-native social classification should use canonical host normalization."""
     discovered = DiscoveredCandidate(

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -162,10 +162,10 @@ def test_persist_discovered_candidates_marks_social_search_candidates_unsupporte
     assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
 
 
-def test_persist_discovered_candidates_marks_social_domains_unsupported_without_social_query_kind(
+def test_persist_discovered_candidates_keeps_social_posts_scrapeable_without_social_query_kind(
     tmp_path: Path,
 ) -> None:
-    """Configured social domains should remain reference-only even from broad discovery."""
+    """Broad social post-like URLs should not be suppressed as social profiles."""
     paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
     persistence = StateRepoDiscoveryPersistence(paths)
     discovery = DiscoveredCandidate(
@@ -189,23 +189,23 @@ def test_persist_discovered_candidates_marks_social_domains_unsupported_without_
 
     candidate = persisted.candidates[0]
     provenance = persisted.provenance[0]
-    assert candidate.candidate_status.value == "unsupported_source"
-    assert candidate.needs_review is True
-    assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
+    assert candidate.candidate_status.value == "new"
+    assert candidate.needs_review is False
+    assert provenance.producer_kind is ProducerKind.SEARCH_ENGINE
 
 
-def test_persist_discovered_candidates_marks_social_subdomains_unsupported(
+def test_persist_discovered_candidates_marks_social_profile_subdomains_unsupported(
     tmp_path: Path,
 ) -> None:
-    """Configured social subdomains should use the same non-scrapeable social handling."""
+    """Social profile subdomains should stay out of scrape eligibility."""
     paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
     persistence = StateRepoDiscoveryPersistence(paths)
     discovery = DiscoveredCandidate(
         producer_name="brave",
         producer_kind=ProducerKind.SEARCH_ENGINE,
         query_text="בית בושת",
-        candidate_url=HttpUrl("https://m.facebook.com/story.php?story_fbid=5&id=6"),
-        canonical_url=HttpUrl("https://m.facebook.com/story.php?story_fbid=5&id=6"),
+        candidate_url=HttpUrl("https://m.facebook.com/profile.php?id=6"),
+        canonical_url=HttpUrl("https://m.facebook.com/profile.php?id=6"),
         title="פוסט פייסבוק רחב",
         snippet="חשד לבית בושת",
         discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
@@ -222,8 +222,11 @@ def test_persist_discovered_candidates_marks_social_subdomains_unsupported(
     candidate = persisted.candidates[0]
     provenance = persisted.provenance[0]
     assert candidate.candidate_status.value == "unsupported_source"
-    assert candidate.needs_review is True
-    assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
+    assert candidate.needs_review is False
+    assert candidate.metadata["unsupported_source_filter"] == "search_noise"
+    assert candidate.metadata["unsupported_source_reason"] == "social_profile"
+    assert candidate.metadata["unsupported_source_domain"] == "facebook.com"
+    assert provenance.producer_kind is ProducerKind.SEARCH_ENGINE
 
 
 def test_persist_discovered_candidates_marks_search_noise_unsupported(
@@ -265,12 +268,30 @@ def test_persist_discovered_candidates_marks_search_noise_unsupported(
     assert {candidate.candidate_status.value for candidate in persisted.candidates} == {
         "unsupported_source"
     }
-    assert all(candidate.needs_review for candidate in persisted.candidates)
+    assert all(not candidate.needs_review for candidate in persisted.candidates)
     assert {event.producer_kind for event in persisted.provenance} == {ProducerKind.SEARCH_ENGINE}
+    assert {
+        candidate.metadata["unsupported_source_filter"] for candidate in persisted.candidates
+    } == {"search_noise"}
+    assert {
+        candidate.metadata["unsupported_source_reason"] for candidate in persisted.candidates
+    } == {"app_store", "social_profile", "unsupported_search_domain"}
+    assert {
+        candidate.metadata["unsupported_source_domain"] for candidate in persisted.candidates
+    } == {
+        "x.com",
+        "play.google.com",
+        "apps.apple.com",
+        "morfix.co.il",
+        "context.reverso.net",
+        "wiktionary.org",
+        "linkedin.com",
+        "instagram.com",
+    }
     assert {
         candidate.metadata["latest_discovery_metadata"]["search_noise_filter_reason"]
         for candidate in persisted.candidates
-    } == {"unsupported_search_domain", "social_profile"}
+    } == {"app_store", "social_profile", "unsupported_search_domain"}
     assert {
         candidate.metadata["latest_discovery_metadata"]["search_noise_filter_domain"]
         for candidate in persisted.candidates
@@ -328,8 +349,11 @@ def test_persist_discovered_candidates_demotes_existing_unattempted_search_noise
     assert candidate.candidate_id == persisted_existing.candidate_id
     assert candidate.candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
     assert candidate.scrape_attempt_count == 0
+    assert candidate.metadata["unsupported_source_filter"] == "search_noise"
+    assert candidate.metadata["unsupported_source_reason"] == "social_profile"
+    assert candidate.metadata["unsupported_source_domain"] == "x.com"
     assert candidate.metadata["latest_discovery_metadata"]["search_noise_filter_reason"] == (
-        "unsupported_search_domain"
+        "social_profile"
     )
 
 
@@ -384,6 +408,7 @@ def test_persist_discovered_candidates_preserves_attempted_existing_noise_status
     assert candidate.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
     assert candidate.content_basis is ContentBasis.PARTIAL_PAGE
     assert candidate.scrape_attempt_count == 1
+    assert "unsupported_source_reason" not in candidate.metadata
 
 
 def test_persist_discovered_candidates_keeps_supported_news_articles_scrapeable(

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from pydantic import HttpUrl
 
 from denbust.data_models import RawArticle
-from denbust.discovery.models import DiscoveredCandidate, DiscoveryRun, ProducerKind
+from denbust.discovery.models import (
+    CandidateStatus,
+    ContentBasis,
+    DiscoveredCandidate,
+    DiscoveryRun,
+    ProducerKind,
+)
 from denbust.discovery.source_native import (
     _candidate_domain,
     _normalize_domain,
@@ -188,6 +194,38 @@ def test_persist_discovered_candidates_marks_social_domains_unsupported_without_
     assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
 
 
+def test_persist_discovered_candidates_marks_social_subdomains_unsupported(
+    tmp_path: Path,
+) -> None:
+    """Configured social subdomains should use the same non-scrapeable social handling."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    discovery = DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl("https://m.facebook.com/story.php?story_fbid=5&id=6"),
+        canonical_url=HttpUrl("https://m.facebook.com/story.php?story_fbid=5&id=6"),
+        title="פוסט פייסבוק רחב",
+        snippet="חשד לבית בושת",
+        discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        source_hint="m.facebook.com",
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-social-subdomain"),
+        discovered_candidates=[discovery],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    provenance = persisted.provenance[0]
+    assert candidate.candidate_status.value == "unsupported_source"
+    assert candidate.needs_review is True
+    assert provenance.producer_kind is ProducerKind.SOCIAL_SEARCH
+
+
 def test_persist_discovered_candidates_marks_search_noise_unsupported(
     tmp_path: Path,
 ) -> None:
@@ -233,6 +271,119 @@ def test_persist_discovered_candidates_marks_search_noise_unsupported(
         candidate.metadata["latest_discovery_metadata"]["search_noise_filter_reason"]
         for candidate in persisted.candidates
     } == {"unsupported_search_domain", "social_profile"}
+    assert {
+        candidate.metadata["latest_discovery_metadata"]["search_noise_filter_domain"]
+        for candidate in persisted.candidates
+    } == {
+        "x.com",
+        "play.google.com",
+        "apps.apple.com",
+        "morfix.co.il",
+        "context.reverso.net",
+        "wiktionary.org",
+        "linkedin.com",
+        "instagram.com",
+    }
+
+
+def test_persist_discovered_candidates_demotes_existing_unattempted_search_noise(
+    tmp_path: Path,
+) -> None:
+    """Existing scrapeable noise should be removed from scrape eligibility when rediscovered."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    existing = raw_article_to_discovered_candidate(
+        build_raw_article(
+            "https://x.com/example_profile",
+            source_name="brave",
+            title="profile",
+        )
+    )
+    persisted_existing = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-existing"),
+        discovered_candidates=[existing],
+        persistence=persistence,
+    ).candidates[0]
+    assert persisted_existing.candidate_status is CandidateStatus.NEW
+
+    rediscovered = DiscoveredCandidate(
+        producer_name="exa",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl("https://x.com/example_profile"),
+        canonical_url=HttpUrl("https://x.com/example_profile"),
+        title="profile",
+        snippet="metadata-poor result",
+        discovered_at=datetime(2026, 4, 11, 10, 0, tzinfo=UTC),
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-existing-noise"),
+        discovered_candidates=[rediscovered],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_id == persisted_existing.candidate_id
+    assert candidate.candidate_status is CandidateStatus.UNSUPPORTED_SOURCE
+    assert candidate.scrape_attempt_count == 0
+    assert candidate.metadata["latest_discovery_metadata"]["search_noise_filter_reason"] == (
+        "unsupported_search_domain"
+    )
+
+
+def test_persist_discovered_candidates_preserves_attempted_existing_noise_status(
+    tmp_path: Path,
+) -> None:
+    """Noise rediscovery should not rewrite candidates with scrape history."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    existing = raw_article_to_discovered_candidate(
+        build_raw_article(
+            "https://x.com/example_profile",
+            source_name="brave",
+            title="profile",
+        )
+    )
+    persisted_existing = (
+        persist_discovered_candidates(
+            run=DiscoveryRun(run_id="run-existing-attempted"),
+            discovered_candidates=[existing],
+            persistence=persistence,
+        )
+        .candidates[0]
+        .model_copy(
+            update={
+                "candidate_status": CandidateStatus.PARTIALLY_SCRAPED,
+                "content_basis": ContentBasis.PARTIAL_PAGE,
+                "scrape_attempt_count": 1,
+            }
+        )
+    )
+    persistence.upsert_candidates([persisted_existing])
+    rediscovered = DiscoveredCandidate(
+        producer_name="exa",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl("https://x.com/example_profile"),
+        canonical_url=HttpUrl("https://x.com/example_profile"),
+        title="profile",
+        snippet="metadata-poor result",
+        discovered_at=datetime(2026, 4, 11, 10, 0, tzinfo=UTC),
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-existing-attempted-noise"),
+        discovered_candidates=[rediscovered],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert candidate.content_basis is ContentBasis.PARTIAL_PAGE
+    assert candidate.scrape_attempt_count == 1
 
 
 def test_persist_discovered_candidates_keeps_supported_news_articles_scrapeable(


### PR DESCRIPTION
## Planning notation

- Notation: `DISC-PR-NOISE-FILTERS`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md` and `docs/january_2026_backfill_wet_test_plan.md`

## Summary

This PR adds a central discovery-layer noise filter for search-engine candidates. Obvious non-article search-result surfaces are retained in the durable candidate/provenance layer but marked `unsupported_source`, which keeps them out of scrape-drain budget selection.

Covered noisy surfaces include:

- profile-like `x.com` / `twitter.com` URLs, while post-like `/status/` URLs remain eligible
- Google Play / Apple app detail URLs, without blocking unrelated paths on those hosts
- social profile pages on Facebook, Instagram, LinkedIn, TikTok, and YouTube, while obvious post/video URLs remain eligible
- dictionary, translation, and reference utility domains including Morfix, Reverso, Wiktionary, and Pealim

## Self-review recommendations applied

After reviewing the PR from a skeptical maintainer stance, I applied the fixes directly:

1. Replaced broad host blocking with path-aware app-store and social-profile rules so the filter does not become a domain denylist.
2. Made social handling consistent across platforms: profile-like pages are filtered, while post-like URLs are left scrape-eligible unless they come from the existing explicit `social_targeted` query flow.
3. Added stable candidate-level metadata: `unsupported_source_filter=search_noise`, `unsupported_source_reason`, and `unsupported_source_domain`; provenance still receives the discovery-event filter reason.
4. Kept deterministic search noise out of the manual review backlog by not setting `needs_review=True` for machine-classified search noise. Existing social-targeted candidates preserve the previous review behavior.
5. Added boundary tests for allowed social posts, allowed non-app store paths, profile filtering, app-detail filtering, rediscovery demotion, attempted-candidate preservation, and diagnostics reason counting.

## Provenance and queue behavior

Provenance is preserved because candidate and `CandidateProvenance` rows are still written through the shared `persist_discovered_candidates()` path. The filter adds search-noise metadata to provenance and stable unsupported-source metadata to the candidate row so operators can explain why a candidate is retained but not scrapeable.

Queue fairness and prioritization are intentionally unchanged. `select_candidates_for_scrape()` and `select_backfill_candidates_for_scrape()` continue to rely on the existing scrapeable status set; this PR only classifies known low-value search-result surfaces as `unsupported_source` before they can enter that set.

## Docs and planning

- Updates discovery operations and the January wet-test plan to describe retained-but-not-scrapeable search-result noise, rediscovery demotion, path-aware social/app-store boundaries, and diagnostics reason counts.
- Updates `.agent-plan.md` in mainline semantics: `DISC-PR-NOISE-FILTERS` is done and `SCRAPE-PR-PARTIAL-DIAGNOSTICS` is the sole `[next]` item.
- Updates the README feature summary for the durable discovery layer.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q tests/unit/test_discovery_candidate_filters.py tests/unit/test_discovery_source_native.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_scrape_queue.py`
- `.venv/bin/pytest -q tests/unit/test_discovery*.py`
- `.venv/bin/mypy src/`

## Follow-up

`SCRAPE-PR-PARTIAL-DIAGNOSTICS` remains the next planned slice. It should improve partial-page interpretation without changing the queue fairness contract.