### PR TITLE
SCRAPE-PR-PARTIAL-DIAGNOSTICS: add partial-page conversion diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,17 +6,19 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `DISC-PR-NOISE-FILTERS` marked obvious non-article search-result
-  surfaces `unsupported_source` before they can consume scrape-drain budget.
-- Next planned PR: `SCRAPE-PR-PARTIAL-DIAGNOSTICS` hardens partial-page reporting so operators can
-  distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
-  classifier parse/taxonomy warnings.
+- Last merged PR on main: `SCRAPE-PR-PARTIAL-DIAGNOSTICS` added structured partial-page diagnostics
+  for retained candidate-fallback rows, metadata-only partials, generic/source-adapter partial
+  attempts, blocked generic fetches, dominant partial domains/sources, and persisted
+  classifier/taxonomy warning signals.
+- Next planned PR: `SRC-PR-GLOBES-THEMARKER` adds or improves source-family support for
+  Globes/TheMarker if the sharpened partial-page diagnostics keep showing high-value unsupported or
+  partial candidates there.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
   `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`; the first no-CDP scrape attempt was
-  aborted/reset and should not be interpreted as valid scrape evidence. Follow-up PRs should focus
-  on partial-page diagnostics and source-family expansion.
+  aborted/reset and should not be interpreted as valid scrape evidence. Follow-up PRs should use the
+  new partial-page diagnostics to justify source-family expansion.
 
 ## Task Ledger
 
@@ -80,10 +82,10 @@
 - [done] `DISC-PR-NOISE-FILTERS`: filter or deprioritize non-article search-result surfaces such
   as social profiles, app-store detail pages, dictionaries, and other obvious metadata-poor pages
   before they consume scrape-drain budget while leaving post-like social URLs scrape-eligible.
-- [next] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
+- [done] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
   distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
   classifier parse/taxonomy warnings.
-- [later] `SRC-PR-GLOBES-THEMARKER`: add or improve source-family support for Globes/TheMarker if
+- [next] `SRC-PR-GLOBES-THEMARKER`: add or improve source-family support for Globes/TheMarker if
   wet-test diagnostics keep showing high-value unsupported or partial candidates there.
 - [later] `SRC-PR-ISRAELHAYOM`: add or improve source-family support for Israel Hayom if bounded
   scrape diagnostics show enough high-value unsupported or partial candidates.

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -8,8 +8,8 @@
 
 - Last merged PR on main: `SCRAPE-PR-PARTIAL-DIAGNOSTICS` added structured partial-page diagnostics
   for retained candidate-fallback rows, metadata-only partials, generic/source-adapter partial
-  attempts, blocked generic fetches, dominant partial domains/sources, and persisted
-  classifier/taxonomy warning signals.
+  attempts, generic partials after source-adapter attempts, blocked generic fetches, dominant
+  partial domains/sources, and persisted current-candidate classifier/taxonomy warning signals.
 - Next planned PR: `SRC-PR-GLOBES-THEMARKER` adds or improves source-family support for
   Globes/TheMarker if the sharpened partial-page diagnostics keep showing high-value unsupported or
   partial candidates there.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Planned future datasets:
 - Reports queue-drain selection order, attempted and remaining eligible source mix, configured
   candidate cap, persisted scrape-attempt count, and inferred stop reason for bounded candidate
   scrape passes
+- Breaks down partial-page diagnostics so operators can distinguish retained candidate-fallback
+  operational rows, metadata-only partials, search-result-only generic fetch failures, source vs
+  generic partial attempts, dominant partial domains/sources, and visible classifier/taxonomy risk
+  signals
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Planned future datasets:
   scrape passes
 - Breaks down partial-page diagnostics so operators can distinguish retained candidate-fallback
   operational rows, metadata-only partials, search-result-only generic fetch failures, source vs
-  generic partial attempts, dominant partial domains/sources, and visible classifier/taxonomy risk
-  signals
+  generic partial attempts, generic partials after source-adapter attempts, dominant partial
+  domains/sources, and visible current-candidate classifier/taxonomy risk signals
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -253,24 +253,33 @@ many `partial_page` candidates:
 
 - `partial_candidate_count` is the candidate-layer partial count. It includes candidates with
   `content_basis=partial_page` or `candidate_status=partially_scraped`.
+- `operational_matching_enabled` and `operational_records_available` must be checked before
+  interpreting retained-row or metadata-only counts. If operational matching is skipped, retained
+  counts are zero and `metadata_only_partial_candidate_count` is intentionally zero because it was
+  not measured.
 - `retained_operational_record_candidate_count` and `retained_operational_record_count` show how
-  many partial candidates produced retained candidate-fallback operational rows.
+  many partial candidates produced retained `candidate_fallback` operational rows with
+  `content_basis=partial_page`; unrelated full-article rows with the same URL do not count as
+  partial fallback retention.
 - `metadata_only_partial_candidate_count` is the partial-candidate count that did not match a
-  retained operational row, so those pages are still metadata-only from the operator perspective.
+  retained fallback operational row when operational matching was enabled, so those pages are still
+  metadata-only from the operator perspective.
 - `search_result_only_candidate_count`, `blocked_generic_fetch_candidate_count`,
   `failed_generic_fetch_candidate_count`, and `timeout_generic_fetch_candidate_count` separate
   poor or blocked generic fetch outcomes from usable metadata extraction.
 - `generic_fetch_partial_candidate_count`, `source_adapter_partial_candidate_count`,
-  `partial_attempts_by_kind`, and `partial_attempts_by_source_adapter` show whether partials came
-  from generic fallback or a source adapter.
+  `partial_after_source_adapter_attempt_count`, `partial_without_source_adapter_attempt_count`,
+  `partial_attempts_by_kind`, and `partial_attempts_by_source_adapter` show whether usable partials
+  came directly from generic fallback, from a true source-adapter partial attempt, or from generic
+  fallback after a source-adapter attempt failed or missed the candidate.
 - `partial_candidates_by_domain`, `partial_candidates_by_source`, and
   `generic_fetch_error_code_counts` identify the domains, source hints, and generic fetch errors
   dominating partial outcomes.
 - `classifier_warning_signals` summarizes what discovery diagnostics can infer from persisted
-  candidate-fallback operational rows: fallback rows, partial fallback rows, low-confidence
-  fallback rows, missing taxonomy pairs, and invalid taxonomy pairs. Run-level classifier parse
-  warnings that are not persisted in candidate or operational state still need the matching run log
-  or debug summary.
+  current-candidate fallback operational rows: fallback rows, partial fallback rows, low-confidence
+  fallback rows, missing taxonomy pairs, and invalid taxonomy pairs. Unrelated historical fallback
+  rows in the operational store are ignored. Run-level classifier parse warnings that are not
+  persisted in candidate or operational state still need the matching run log or debug summary.
 
 This diagnostic slice is interpretation-only. It does not change queue fairness, source
 prioritization, scrape caps, generic fetch behavior, or source-family scraper support.

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -247,6 +247,34 @@ candidate metadata stores `unsupported_source_filter=search_noise`,
 reports `queue_health.search_noise_filter_reason_counts` so operators can distinguish app-store,
 social-profile, and unsupported utility-domain noise.
 
+After `SCRAPE-PR-PARTIAL-DIAGNOSTICS`, `denbust diagnose-discovery` adds a
+`partial_page_diagnostics` JSON object and a matching text section. Use it when a wet test reports
+many `partial_page` candidates:
+
+- `partial_candidate_count` is the candidate-layer partial count. It includes candidates with
+  `content_basis=partial_page` or `candidate_status=partially_scraped`.
+- `retained_operational_record_candidate_count` and `retained_operational_record_count` show how
+  many partial candidates produced retained candidate-fallback operational rows.
+- `metadata_only_partial_candidate_count` is the partial-candidate count that did not match a
+  retained operational row, so those pages are still metadata-only from the operator perspective.
+- `search_result_only_candidate_count`, `blocked_generic_fetch_candidate_count`,
+  `failed_generic_fetch_candidate_count`, and `timeout_generic_fetch_candidate_count` separate
+  poor or blocked generic fetch outcomes from usable metadata extraction.
+- `generic_fetch_partial_candidate_count`, `source_adapter_partial_candidate_count`,
+  `partial_attempts_by_kind`, and `partial_attempts_by_source_adapter` show whether partials came
+  from generic fallback or a source adapter.
+- `partial_candidates_by_domain`, `partial_candidates_by_source`, and
+  `generic_fetch_error_code_counts` identify the domains, source hints, and generic fetch errors
+  dominating partial outcomes.
+- `classifier_warning_signals` summarizes what discovery diagnostics can infer from persisted
+  candidate-fallback operational rows: fallback rows, partial fallback rows, low-confidence
+  fallback rows, missing taxonomy pairs, and invalid taxonomy pairs. Run-level classifier parse
+  warnings that are not persisted in candidate or operational state still need the matching run log
+  or debug summary.
+
+This diagnostic slice is interpretation-only. It does not change queue fairness, source
+prioritization, scrape caps, generic fetch behavior, or source-family scraper support.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -100,3 +100,11 @@ so the stop reason is explainable as a budget limit rather than a queue-contract
 also exposed candidate-quality noise, including social/profile/app-store/dictionary-like surfaces
 that can consume scrape budget. That follow-up belongs in `DISC-PR-NOISE-FILTERS`, not in this
 config-and-evidence slice.
+
+After `SCRAPE-PR-PARTIAL-DIAGNOSTICS`, future `denbust diagnose-discovery` artifacts include
+`partial_page_diagnostics` for this exact interpretation gap. The original checked-in artifact still
+records only the older `queue_health.partial_page_candidates=88` figure, but fresh diagnostics over
+the same persisted state can now report how many partial candidates produced candidate-fallback
+operational rows, how many stayed metadata-only, whether partial extraction came from generic fetch
+or a source adapter, which domains/source hints dominate partials, and which persisted
+classifier/taxonomy warning signals affect conversion interpretation.

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -105,6 +105,7 @@ After `SCRAPE-PR-PARTIAL-DIAGNOSTICS`, future `denbust diagnose-discovery` artif
 `partial_page_diagnostics` for this exact interpretation gap. The original checked-in artifact still
 records only the older `queue_health.partial_page_candidates=88` figure, but fresh diagnostics over
 the same persisted state can now report how many partial candidates produced candidate-fallback
-operational rows, how many stayed metadata-only, whether partial extraction came from generic fetch
-or a source adapter, which domains/source hints dominate partials, and which persisted
-classifier/taxonomy warning signals affect conversion interpretation.
+operational rows, how many stayed metadata-only when operational matching is enabled, whether
+partial extraction came from generic fetch, a source adapter, or generic fallback after a
+source-adapter attempt, which domains/source hints dominate partials, and which persisted
+current-candidate classifier/taxonomy warning signals affect conversion interpretation.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -366,9 +366,10 @@ PRs, for seven planned follow-ups total:
    Implemented as a diagnostics-only `partial_page_diagnostics` section in
    `denbust diagnose-discovery`. Operators can now separate retained candidate-fallback
    operational rows from metadata-only partials, blocked/failed/time-out generic fetches from
-   usable generic metadata extraction, source-adapter partials from generic partials, dominant
-   partial domains/source hints, and persisted classifier/taxonomy warning signals. Queue fairness,
-   source prioritization, generic fetch behavior, and source-family scraper support are unchanged.
+   usable generic metadata extraction, true source-adapter partial attempts from generic partials
+   after a source-adapter miss/failure, dominant partial domains/source hints, and persisted
+   current-candidate classifier/taxonomy warning signals. Queue fairness, source prioritization,
+   generic fetch behavior, and source-family scraper support are unchanged.
 4. `SRC-PR-GLOBES-THEMARKER` - source-family expansion.
    Add or improve source support for the Globes/TheMarker family if repeated diagnostics keep
    showing high-value unsupported or partial candidates.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -363,8 +363,12 @@ PRs, for seven planned follow-ups total:
    URLs and non-app store paths remain scrape-eligible. Diagnostics expose durable reason counts,
    and queue fairness/prioritization intentionally remain unchanged.
 3. `SCRAPE-PR-PARTIAL-DIAGNOSTICS` - scrape interpretation.
-   Make partial-page diagnostics sharper so operators can distinguish retained provisional rows,
-   metadata-only partial pages, blocked generic fetches, and classifier parse/taxonomy warnings.
+   Implemented as a diagnostics-only `partial_page_diagnostics` section in
+   `denbust diagnose-discovery`. Operators can now separate retained candidate-fallback
+   operational rows from metadata-only partials, blocked/failed/time-out generic fetches from
+   usable generic metadata extraction, source-adapter partials from generic partials, dominant
+   partial domains/source hints, and persisted classifier/taxonomy warning signals. Queue fairness,
+   source prioritization, generic fetch behavior, and source-family scraper support are unchanged.
 4. `SRC-PR-GLOBES-THEMARKER` - source-family expansion.
    Add or improve source support for the Globes/TheMarker family if repeated diagnostics keep
    showing high-value unsupported or partial candidates.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -205,6 +205,8 @@ class ClassifierWarningSignals(BaseModel):
 class PartialPageDiagnostics(BaseModel):
     """Detailed partial-page interpretation for candidate conversion diagnostics."""
 
+    operational_matching_enabled: bool = False
+    operational_records_available: bool = False
     partial_candidate_count: int = 0
     retained_operational_record_candidate_count: int = 0
     retained_operational_record_count: int = 0
@@ -212,6 +214,8 @@ class PartialPageDiagnostics(BaseModel):
     search_result_only_candidate_count: int = 0
     generic_fetch_partial_candidate_count: int = 0
     source_adapter_partial_candidate_count: int = 0
+    partial_after_source_adapter_attempt_count: int = 0
+    partial_without_source_adapter_attempt_count: int = 0
     blocked_generic_fetch_candidate_count: int = 0
     failed_generic_fetch_candidate_count: int = 0
     timeout_generic_fetch_candidate_count: int = 0
@@ -363,6 +367,7 @@ def build_discovery_diagnostic_report(
             attempts=attempts,
             operational_rows=operational_rows,
             operational_urls=operational_urls,
+            operational_matching_enabled=include_operational_matches,
         ),
         source_suggestions=_build_source_suggestion_report(
             config=config,
@@ -558,6 +563,12 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
     lines.append("")
     lines.append("Partial pages")
     lines.append(
+        "  operational_matching={matching} operational_records_available={available}".format(
+            matching="enabled" if partials.operational_matching_enabled else "skipped",
+            available=str(partials.operational_records_available).lower(),
+        )
+    )
+    lines.append(
         "  partial_candidates={partial_candidate_count} "
         "retained_operational_candidate_matches={retained_operational_record_candidate_count} "
         "retained_operational_records={retained_operational_record_count} "
@@ -569,6 +580,8 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
     lines.append(
         "  generic_partial_candidates={generic_fetch_partial_candidate_count} "
         "source_adapter_partial_candidates={source_adapter_partial_candidate_count} "
+        "partial_after_source_adapter_attempts={partial_after_source_adapter_attempt_count} "
+        "partial_without_source_adapter_attempts={partial_without_source_adapter_attempt_count} "
         "blocked_generic_fetch_candidates={blocked_generic_fetch_candidate_count} "
         "failed_generic_fetch_candidates={failed_generic_fetch_candidate_count} "
         "timeout_generic_fetch_candidates={timeout_generic_fetch_candidate_count}".format(
@@ -1150,11 +1163,20 @@ def _candidate_operational_record_matches(
     candidate: PersistentCandidate,
     operational_rows: list[dict[str, Any]],
     operational_urls: set[str],
+    require_candidate_fallback: bool = False,
+    require_content_basis: ContentBasis | None = None,
 ) -> list[dict[str, Any]]:
     candidate_urls = _candidate_identity_urls(candidate)
     url_matched = bool(operational_urls and candidate_urls & operational_urls)
     matched_rows: list[dict[str, Any]] = []
     for row in operational_rows:
+        if require_candidate_fallback and not _record_is_candidate_fallback(row):
+            continue
+        if (
+            require_content_basis is not None
+            and _record_content_basis(row) != require_content_basis.value
+        ):
+            continue
         event_candidate_ids = row.get("event_candidate_ids")
         if isinstance(event_candidate_ids, list) and candidate.candidate_id in event_candidate_ids:
             matched_rows.append(row)
@@ -1232,6 +1254,24 @@ def _record_has_valid_taxonomy_pair(row: dict[str, Any]) -> bool:
     return default_taxonomy().has_pair(category, subcategory)
 
 
+def _candidate_scoped_operational_rows(
+    *,
+    candidates: list[PersistentCandidate],
+    operational_rows: list[dict[str, Any]],
+    operational_urls: set[str],
+) -> list[dict[str, Any]]:
+    scoped_rows_by_id_or_index: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        for row in _candidate_operational_record_matches(
+            candidate=candidate,
+            operational_rows=operational_rows,
+            operational_urls=operational_urls,
+        ):
+            key = str(row.get("id") or f"row-{len(scoped_rows_by_id_or_index)}")
+            scoped_rows_by_id_or_index[key] = row
+    return list(scoped_rows_by_id_or_index.values())
+
+
 def _build_classifier_warning_signals(
     operational_rows: list[dict[str, Any]],
 ) -> ClassifierWarningSignals:
@@ -1276,6 +1316,7 @@ def _build_partial_page_diagnostics(
     attempts: list[ScrapeAttempt],
     operational_rows: list[dict[str, Any]],
     operational_urls: set[str],
+    operational_matching_enabled: bool,
 ) -> PartialPageDiagnostics:
     attempts_by_candidate_id = _candidate_attempts_by_id(attempts)
     partial_candidates = [
@@ -1291,15 +1332,27 @@ def _build_partial_page_diagnostics(
     ]
     matched_partial_candidate_ids: set[str] = set()
     retained_record_count = 0
-    for candidate in partial_candidates:
-        matched_rows = _candidate_operational_record_matches(
-            candidate=candidate,
+    scoped_operational_rows = (
+        _candidate_scoped_operational_rows(
+            candidates=candidates,
             operational_rows=operational_rows,
             operational_urls=operational_urls,
         )
-        if matched_rows:
-            matched_partial_candidate_ids.add(candidate.candidate_id)
-            retained_record_count += len(matched_rows)
+        if operational_matching_enabled
+        else []
+    )
+    if operational_matching_enabled:
+        for candidate in partial_candidates:
+            matched_rows = _candidate_operational_record_matches(
+                candidate=candidate,
+                operational_rows=operational_rows,
+                operational_urls=operational_urls,
+                require_candidate_fallback=True,
+                require_content_basis=ContentBasis.PARTIAL_PAGE,
+            )
+            if matched_rows:
+                matched_partial_candidate_ids.add(candidate.candidate_id)
+                retained_record_count += len(matched_rows)
 
     partial_attempts = [
         attempt for attempt in attempts if attempt.fetch_status is FetchStatus.PARTIAL
@@ -1311,11 +1364,16 @@ def _build_partial_page_diagnostics(
         and attempt.fetch_status in {FetchStatus.BLOCKED, FetchStatus.FAILED, FetchStatus.TIMEOUT}
     )
     return PartialPageDiagnostics(
+        operational_matching_enabled=operational_matching_enabled,
+        operational_records_available=bool(operational_rows),
         partial_candidate_count=len(partial_candidates),
         retained_operational_record_candidate_count=len(matched_partial_candidate_ids),
         retained_operational_record_count=retained_record_count,
-        metadata_only_partial_candidate_count=len(partial_candidates)
-        - len(matched_partial_candidate_ids),
+        metadata_only_partial_candidate_count=(
+            len(partial_candidates) - len(matched_partial_candidate_ids)
+            if operational_matching_enabled
+            else 0
+        ),
         search_result_only_candidate_count=len(search_result_only_candidates),
         generic_fetch_partial_candidate_count=sum(
             1
@@ -1332,6 +1390,32 @@ def _build_partial_page_diagnostics(
             if _candidate_has_attempt(
                 attempts_by_candidate_id.get(candidate.candidate_id, []),
                 attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.PARTIAL,
+            )
+        ),
+        partial_after_source_adapter_attempt_count=sum(
+            1
+            for candidate in partial_candidates
+            if _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            )
+            and _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.PARTIAL,
+            )
+        ),
+        partial_without_source_adapter_attempt_count=sum(
+            1
+            for candidate in partial_candidates
+            if not _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+            )
+            and _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
                 fetch_status=FetchStatus.PARTIAL,
             )
         ),
@@ -1374,7 +1458,7 @@ def _build_partial_page_diagnostics(
         generic_fetch_error_code_counts=_failure_summaries_from_counter(
             generic_fetch_error_code_counts
         ),
-        classifier_warning_signals=_build_classifier_warning_signals(operational_rows),
+        classifier_warning_signals=_build_classifier_warning_signals(scoped_operational_rows),
     )
 
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -17,6 +17,7 @@ from denbust.discovery.models import (
     FetchStatus,
     PersistentCandidate,
     ScrapeAttempt,
+    ScrapeAttemptKind,
 )
 from denbust.discovery.queries import enabled_source_domains
 from denbust.discovery.scrape_queue import (
@@ -26,6 +27,7 @@ from denbust.discovery.scrape_queue import (
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
+from denbust.taxonomy import default_taxonomy
 
 _SEARCH_ENGINE_NAMES: tuple[str, ...] = ("brave", "exa", "google_cse")
 _SOURCE_SUGGESTION_EXCLUDED_DOMAINS: frozenset[str] = frozenset({"facebook.com"})
@@ -188,6 +190,41 @@ class QueueDrainDiagnostics(BaseModel):
     remaining_eligible_source_mix: list[SourceMixEntry] = Field(default_factory=list)
 
 
+class ClassifierWarningSignals(BaseModel):
+    """Classifier-related conversion signals visible from persisted operational rows."""
+
+    candidate_fallback_record_count: int = 0
+    partial_page_fallback_record_count: int = 0
+    search_result_only_fallback_record_count: int = 0
+    fallback_record_without_taxonomy_count: int = 0
+    partial_page_fallback_without_taxonomy_count: int = 0
+    low_confidence_fallback_record_count: int = 0
+    invalid_taxonomy_pair_record_count: int = 0
+
+
+class PartialPageDiagnostics(BaseModel):
+    """Detailed partial-page interpretation for candidate conversion diagnostics."""
+
+    partial_candidate_count: int = 0
+    retained_operational_record_candidate_count: int = 0
+    retained_operational_record_count: int = 0
+    metadata_only_partial_candidate_count: int = 0
+    search_result_only_candidate_count: int = 0
+    generic_fetch_partial_candidate_count: int = 0
+    source_adapter_partial_candidate_count: int = 0
+    blocked_generic_fetch_candidate_count: int = 0
+    failed_generic_fetch_candidate_count: int = 0
+    timeout_generic_fetch_candidate_count: int = 0
+    partial_candidates_by_domain: list[FailureSummary] = Field(default_factory=list)
+    partial_candidates_by_source: list[FailureSummary] = Field(default_factory=list)
+    partial_attempts_by_kind: list[FailureSummary] = Field(default_factory=list)
+    partial_attempts_by_source_adapter: list[FailureSummary] = Field(default_factory=list)
+    generic_fetch_error_code_counts: list[FailureSummary] = Field(default_factory=list)
+    classifier_warning_signals: ClassifierWarningSignals = Field(
+        default_factory=ClassifierWarningSignals
+    )
+
+
 class SourceSuggestion(BaseModel):
     """Advisory suggestion for a candidate-heavy unseen domain."""
 
@@ -236,6 +273,7 @@ class DiscoveryDiagnosticReport(BaseModel):
     queue_drain: QueueDrainDiagnostics = Field(
         default_factory=lambda: QueueDrainDiagnostics(max_candidate_budget=0)
     )
+    partial_page_diagnostics: PartialPageDiagnostics = Field(default_factory=PartialPageDiagnostics)
     source_suggestions: SourceSuggestionReport = Field(default_factory=SourceSuggestionReport)
 
 
@@ -283,9 +321,11 @@ def build_discovery_diagnostic_report(
     provenance = _read_jsonl(paths.candidate_provenance_path, CandidateProvenance)
     now = datetime.now(UTC)
     operational_urls: set[str] = set()
+    operational_rows: list[dict[str, Any]] = []
     operational_notes: list[str] = []
     if include_operational_matches:
-        operational_urls, operational_notes = _load_operational_record_urls(config)
+        operational_rows, operational_notes = _load_operational_records(config)
+        operational_urls = _operational_record_urls(operational_rows)
     elif config.operational.provider is not OperationalProvider.NONE:
         operational_notes.append(
             "Operational record matching was skipped for this diagnostics artifact."
@@ -317,6 +357,12 @@ def build_discovery_diagnostic_report(
             candidates=candidates,
             attempts=attempts,
             now=now,
+        ),
+        partial_page_diagnostics=_build_partial_page_diagnostics(
+            candidates=candidates,
+            attempts=attempts,
+            operational_rows=operational_rows,
+            operational_urls=operational_urls,
         ),
         source_suggestions=_build_source_suggestion_report(
             config=config,
@@ -507,6 +553,60 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
             label="remaining_eligible_order",
             candidates=drain.remaining_eligible_candidate_order,
             total_count=drain.remaining_eligible_candidate_count,
+        )
+    partials = report.partial_page_diagnostics
+    lines.append("")
+    lines.append("Partial pages")
+    lines.append(
+        "  partial_candidates={partial_candidate_count} "
+        "retained_operational_candidate_matches={retained_operational_record_candidate_count} "
+        "retained_operational_records={retained_operational_record_count} "
+        "metadata_only_partial_candidates={metadata_only_partial_candidate_count} "
+        "search_result_only_candidates={search_result_only_candidate_count}".format(
+            **partials.model_dump(mode="json")
+        )
+    )
+    lines.append(
+        "  generic_partial_candidates={generic_fetch_partial_candidate_count} "
+        "source_adapter_partial_candidates={source_adapter_partial_candidate_count} "
+        "blocked_generic_fetch_candidates={blocked_generic_fetch_candidate_count} "
+        "failed_generic_fetch_candidates={failed_generic_fetch_candidate_count} "
+        "timeout_generic_fetch_candidates={timeout_generic_fetch_candidate_count}".format(
+            **partials.model_dump(mode="json")
+        )
+    )
+    if partials.partial_candidates_by_domain:
+        lines.append(
+            "  partial_domains: "
+            + ", ".join(
+                f"{item.name}={item.count}" for item in partials.partial_candidates_by_domain
+            )
+        )
+    if partials.partial_candidates_by_source:
+        lines.append(
+            "  partial_sources: "
+            + ", ".join(
+                f"{item.name}={item.count}" for item in partials.partial_candidates_by_source
+            )
+        )
+    if partials.generic_fetch_error_code_counts:
+        lines.append(
+            "  generic_fetch_errors: "
+            + ", ".join(
+                f"{item.name}={item.count}" for item in partials.generic_fetch_error_code_counts
+            )
+        )
+    classifier = partials.classifier_warning_signals
+    if classifier.candidate_fallback_record_count:
+        lines.append(
+            "  classifier_signals candidate_fallback_records={candidate_fallback_record_count} "
+            "partial_fallback_records={partial_page_fallback_record_count} "
+            "fallback_without_taxonomy={fallback_record_without_taxonomy_count} "
+            "partial_without_taxonomy={partial_page_fallback_without_taxonomy_count} "
+            "low_confidence_fallback={low_confidence_fallback_record_count} "
+            "invalid_taxonomy_pairs={invalid_taxonomy_pair_record_count}".format(
+                **classifier.model_dump(mode="json")
+            )
         )
     if report.source_suggestions.suggestions:
         lines.append("")
@@ -714,24 +814,32 @@ def _candidate_identity_urls(candidate: PersistentCandidate) -> set[str]:
 
 
 def _load_operational_record_urls(config: Config) -> tuple[set[str], list[str]]:
+    rows, notes = _load_operational_records(config)
+    return _operational_record_urls(rows), notes
+
+
+def _load_operational_records(config: Config) -> tuple[list[dict[str, Any]], list[str]]:
     notes: list[str] = []
     try:
         store = create_operational_store(config)
     except Exception as exc:
-        return set(), [f"Operational store unavailable: {type(exc).__name__}: {exc}"]
+        return [], [f"Operational store unavailable: {type(exc).__name__}: {exc}"]
 
     try:
         rows = store.fetch_records(config.dataset_name.value)
     except Exception as exc:
         notes.append(f"Operational record fetch failed: {type(exc).__name__}: {exc}")
-        return set(), notes
+        return [], notes
     finally:
         store.close()
+    return [dict(row) for row in rows], notes
 
+
+def _operational_record_urls(rows: list[dict[str, Any]]) -> set[str]:
     urls = {
         canonicalize_news_url(str(row["canonical_url"])) for row in rows if row.get("canonical_url")
     }
-    return urls, notes
+    return urls
 
 
 def _build_candidate_conversion_metrics(
@@ -1034,6 +1142,239 @@ def _build_queue_drain_diagnostics(
         ],
         attempted_source_mix=_attempted_source_mix(candidates, attempts),
         remaining_eligible_source_mix=_source_mix(remaining_eligible),
+    )
+
+
+def _candidate_operational_record_matches(
+    *,
+    candidate: PersistentCandidate,
+    operational_rows: list[dict[str, Any]],
+    operational_urls: set[str],
+) -> list[dict[str, Any]]:
+    candidate_urls = _candidate_identity_urls(candidate)
+    url_matched = bool(operational_urls and candidate_urls & operational_urls)
+    matched_rows: list[dict[str, Any]] = []
+    for row in operational_rows:
+        event_candidate_ids = row.get("event_candidate_ids")
+        if isinstance(event_candidate_ids, list) and candidate.candidate_id in event_candidate_ids:
+            matched_rows.append(row)
+            continue
+        canonical_url = row.get("canonical_url")
+        if (
+            url_matched
+            and isinstance(canonical_url, str)
+            and canonicalize_news_url(canonical_url) in candidate_urls
+        ):
+            matched_rows.append(row)
+    return matched_rows
+
+
+def _candidate_attempts_by_id(
+    attempts: list[ScrapeAttempt],
+) -> dict[str, list[ScrapeAttempt]]:
+    attempts_by_candidate_id: dict[str, list[ScrapeAttempt]] = {}
+    for attempt in attempts:
+        attempts_by_candidate_id.setdefault(attempt.candidate_id, []).append(attempt)
+    return attempts_by_candidate_id
+
+
+def _candidate_has_attempt(
+    attempts: list[ScrapeAttempt],
+    *,
+    attempt_kind: ScrapeAttemptKind | None = None,
+    fetch_status: FetchStatus | None = None,
+) -> bool:
+    return any(
+        (attempt_kind is None or attempt.attempt_kind is attempt_kind)
+        and (fetch_status is None or attempt.fetch_status is fetch_status)
+        for attempt in attempts
+    )
+
+
+def _candidate_has_generic_fetch_status(
+    attempts: list[ScrapeAttempt],
+    statuses: set[FetchStatus],
+) -> bool:
+    return any(
+        attempt.attempt_kind is ScrapeAttemptKind.GENERIC_FETCH and attempt.fetch_status in statuses
+        for attempt in attempts
+    )
+
+
+def _failure_summaries_from_counter(
+    counts: Counter[str], *, limit: int = 5
+) -> list[FailureSummary]:
+    return [FailureSummary(name=name, count=count) for name, count in counts.most_common(limit)]
+
+
+def _record_content_basis(row: dict[str, Any]) -> str:
+    value = row.get("content_basis")
+    if isinstance(value, ContentBasis):
+        return value.value
+    if isinstance(value, str) and value:
+        return value
+    return ""
+
+
+def _record_is_candidate_fallback(row: dict[str, Any]) -> bool:
+    return row.get("annotation_source") == "candidate_fallback"
+
+
+def _record_has_taxonomy_pair(row: dict[str, Any]) -> bool:
+    return bool(row.get("taxonomy_category_id") and row.get("taxonomy_subcategory_id"))
+
+
+def _record_has_valid_taxonomy_pair(row: dict[str, Any]) -> bool:
+    category = row.get("taxonomy_category_id")
+    subcategory = row.get("taxonomy_subcategory_id")
+    if not isinstance(category, str) or not isinstance(subcategory, str):
+        return False
+    return default_taxonomy().has_pair(category, subcategory)
+
+
+def _build_classifier_warning_signals(
+    operational_rows: list[dict[str, Any]],
+) -> ClassifierWarningSignals:
+    fallback_rows = [row for row in operational_rows if _record_is_candidate_fallback(row)]
+    partial_rows = [
+        row
+        for row in fallback_rows
+        if _record_content_basis(row) == ContentBasis.PARTIAL_PAGE.value
+    ]
+    search_result_only_rows = [
+        row
+        for row in fallback_rows
+        if _record_content_basis(row) == ContentBasis.SEARCH_RESULT_ONLY.value
+    ]
+    fallback_without_taxonomy = [row for row in fallback_rows if not _record_has_taxonomy_pair(row)]
+    invalid_taxonomy_pairs = [
+        row
+        for row in fallback_rows
+        if _record_has_taxonomy_pair(row) and not _record_has_valid_taxonomy_pair(row)
+    ]
+    low_confidence_rows = [
+        row
+        for row in fallback_rows
+        if row.get("record_confidence") == "low" or row.get("classification_confidence") == "low"
+    ]
+    return ClassifierWarningSignals(
+        candidate_fallback_record_count=len(fallback_rows),
+        partial_page_fallback_record_count=len(partial_rows),
+        search_result_only_fallback_record_count=len(search_result_only_rows),
+        fallback_record_without_taxonomy_count=len(fallback_without_taxonomy),
+        partial_page_fallback_without_taxonomy_count=sum(
+            1 for row in partial_rows if not _record_has_taxonomy_pair(row)
+        ),
+        low_confidence_fallback_record_count=len(low_confidence_rows),
+        invalid_taxonomy_pair_record_count=len(invalid_taxonomy_pairs),
+    )
+
+
+def _build_partial_page_diagnostics(
+    *,
+    candidates: list[PersistentCandidate],
+    attempts: list[ScrapeAttempt],
+    operational_rows: list[dict[str, Any]],
+    operational_urls: set[str],
+) -> PartialPageDiagnostics:
+    attempts_by_candidate_id = _candidate_attempts_by_id(attempts)
+    partial_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.content_basis is ContentBasis.PARTIAL_PAGE
+        or candidate.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    ]
+    search_result_only_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.content_basis is ContentBasis.SEARCH_RESULT_ONLY
+    ]
+    matched_partial_candidate_ids: set[str] = set()
+    retained_record_count = 0
+    for candidate in partial_candidates:
+        matched_rows = _candidate_operational_record_matches(
+            candidate=candidate,
+            operational_rows=operational_rows,
+            operational_urls=operational_urls,
+        )
+        if matched_rows:
+            matched_partial_candidate_ids.add(candidate.candidate_id)
+            retained_record_count += len(matched_rows)
+
+    partial_attempts = [
+        attempt for attempt in attempts if attempt.fetch_status is FetchStatus.PARTIAL
+    ]
+    generic_fetch_error_code_counts = Counter(
+        attempt.error_code or "unknown"
+        for attempt in attempts
+        if attempt.attempt_kind is ScrapeAttemptKind.GENERIC_FETCH
+        and attempt.fetch_status in {FetchStatus.BLOCKED, FetchStatus.FAILED, FetchStatus.TIMEOUT}
+    )
+    return PartialPageDiagnostics(
+        partial_candidate_count=len(partial_candidates),
+        retained_operational_record_candidate_count=len(matched_partial_candidate_ids),
+        retained_operational_record_count=retained_record_count,
+        metadata_only_partial_candidate_count=len(partial_candidates)
+        - len(matched_partial_candidate_ids),
+        search_result_only_candidate_count=len(search_result_only_candidates),
+        generic_fetch_partial_candidate_count=sum(
+            1
+            for candidate in partial_candidates
+            if _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.PARTIAL,
+            )
+        ),
+        source_adapter_partial_candidate_count=sum(
+            1
+            for candidate in partial_candidates
+            if _candidate_has_attempt(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.PARTIAL,
+            )
+        ),
+        blocked_generic_fetch_candidate_count=sum(
+            1
+            for candidate in candidates
+            if _candidate_has_generic_fetch_status(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                {FetchStatus.BLOCKED},
+            )
+        ),
+        failed_generic_fetch_candidate_count=sum(
+            1
+            for candidate in candidates
+            if _candidate_has_generic_fetch_status(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                {FetchStatus.FAILED},
+            )
+        ),
+        timeout_generic_fetch_candidate_count=sum(
+            1
+            for candidate in candidates
+            if _candidate_has_generic_fetch_status(
+                attempts_by_candidate_id.get(candidate.candidate_id, []),
+                {FetchStatus.TIMEOUT},
+            )
+        ),
+        partial_candidates_by_domain=_failure_summaries_from_counter(
+            Counter(candidate.domain or "unknown" for candidate in partial_candidates)
+        ),
+        partial_candidates_by_source=_failure_summaries_from_counter(
+            Counter(_candidate_source(candidate) for candidate in partial_candidates)
+        ),
+        partial_attempts_by_kind=_failure_summaries_from_counter(
+            Counter(attempt.attempt_kind.value for attempt in partial_attempts)
+        ),
+        partial_attempts_by_source_adapter=_failure_summaries_from_counter(
+            Counter(attempt.source_adapter_name or "generic_fetch" for attempt in partial_attempts)
+        ),
+        generic_fetch_error_code_counts=_failure_summaries_from_counter(
+            generic_fetch_error_code_counts
+        ),
+        classifier_warning_signals=_build_classifier_warning_signals(operational_rows),
     )
 
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -48,6 +49,15 @@ _STALE_CANDIDATE_STATUSES: tuple[CandidateStatus, ...] = (
     CandidateStatus.UNSUPPORTED_SOURCE,
 )
 _QUEUE_DRAIN_TEXT_ORDER_LIMIT = 10
+
+
+@dataclass(frozen=True)
+class OperationalRecordIndex:
+    """Lookup tables for candidate-related operational records."""
+
+    rows: list[dict[str, Any]]
+    rows_by_candidate_id: dict[str, list[dict[str, Any]]]
+    rows_by_canonical_url: dict[str, list[dict[str, Any]]]
 
 
 class EngineOverlapMetrics(BaseModel):
@@ -341,7 +351,7 @@ def build_discovery_diagnostic_report(
         latest_candidates_path=str(paths.latest_candidates_path),
         scrape_attempts_path=str(paths.scrape_attempts_path),
         candidate_provenance_path=str(paths.candidate_provenance_path),
-        operational_records_available=bool(operational_urls),
+        operational_records_available=bool(operational_rows),
         notes=operational_notes,
         engine_overlap=_build_engine_overlap_metrics(overlap_candidates),
         source_search_coverage=_build_source_search_coverage(candidates),
@@ -366,7 +376,6 @@ def build_discovery_diagnostic_report(
             candidates=candidates,
             attempts=attempts,
             operational_rows=operational_rows,
-            operational_urls=operational_urls,
             operational_matching_enabled=include_operational_matches,
         ),
         source_suggestions=_build_source_suggestion_report(
@@ -382,7 +391,7 @@ def build_discovery_diagnostic_report(
         report.notes.append("No persisted scrape attempts were found.")
     if (
         include_operational_matches
-        and not operational_urls
+        and not operational_rows
         and config.operational.provider is not OperationalProvider.NONE
     ):
         report.notes.append(
@@ -600,6 +609,18 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
             "  partial_sources: "
             + ", ".join(
                 f"{item.name}={item.count}" for item in partials.partial_candidates_by_source
+            )
+        )
+    if partials.partial_attempts_by_kind:
+        lines.append(
+            "  partial_attempt_kinds: "
+            + ", ".join(f"{item.name}={item.count}" for item in partials.partial_attempts_by_kind)
+        )
+    if partials.partial_attempts_by_source_adapter:
+        lines.append(
+            "  partial_attempt_sources: "
+            + ", ".join(
+                f"{item.name}={item.count}" for item in partials.partial_attempts_by_source_adapter
             )
         )
     if partials.generic_fetch_error_code_counts:
@@ -1158,36 +1179,69 @@ def _build_queue_drain_diagnostics(
     )
 
 
+def _operational_row_key(row: dict[str, Any]) -> str:
+    raw_key = row.get("id") or row.get("canonical_url")
+    return str(raw_key) if raw_key else str(id(row))
+
+
+def _build_operational_record_index(rows: list[dict[str, Any]]) -> OperationalRecordIndex:
+    rows_by_candidate_id: dict[str, list[dict[str, Any]]] = {}
+    rows_by_canonical_url: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        event_candidate_ids = row.get("event_candidate_ids")
+        if isinstance(event_candidate_ids, list):
+            for candidate_id in event_candidate_ids:
+                if isinstance(candidate_id, str) and candidate_id:
+                    rows_by_candidate_id.setdefault(candidate_id, []).append(row)
+        canonical_url = row.get("canonical_url")
+        if isinstance(canonical_url, str) and canonical_url:
+            normalized_url = canonicalize_news_url(canonical_url)
+            rows_by_canonical_url.setdefault(normalized_url, []).append(row)
+    return OperationalRecordIndex(
+        rows=rows,
+        rows_by_candidate_id=rows_by_candidate_id,
+        rows_by_canonical_url=rows_by_canonical_url,
+    )
+
+
+def _operational_record_matches_filter(
+    row: dict[str, Any],
+    *,
+    require_candidate_fallback: bool,
+    require_content_basis: ContentBasis | None,
+) -> bool:
+    if require_candidate_fallback and not _record_is_candidate_fallback(row):
+        return False
+    return not (
+        require_content_basis is not None
+        and _record_content_basis(row) != require_content_basis.value
+    )
+
+
 def _candidate_operational_record_matches(
     *,
     candidate: PersistentCandidate,
-    operational_rows: list[dict[str, Any]],
-    operational_urls: set[str],
+    operational_index: OperationalRecordIndex,
     require_candidate_fallback: bool = False,
     require_content_basis: ContentBasis | None = None,
 ) -> list[dict[str, Any]]:
-    candidate_urls = _candidate_identity_urls(candidate)
-    url_matched = bool(operational_urls and candidate_urls & operational_urls)
-    matched_rows: list[dict[str, Any]] = []
-    for row in operational_rows:
-        if require_candidate_fallback and not _record_is_candidate_fallback(row):
-            continue
-        if (
-            require_content_basis is not None
-            and _record_content_basis(row) != require_content_basis.value
+    matched_by_key: dict[str, dict[str, Any]] = {}
+    for row in operational_index.rows_by_candidate_id.get(candidate.candidate_id, []):
+        if _operational_record_matches_filter(
+            row,
+            require_candidate_fallback=require_candidate_fallback,
+            require_content_basis=require_content_basis,
         ):
-            continue
-        event_candidate_ids = row.get("event_candidate_ids")
-        if isinstance(event_candidate_ids, list) and candidate.candidate_id in event_candidate_ids:
-            matched_rows.append(row)
-            continue
-        canonical_url = row.get("canonical_url")
-        if (
-            url_matched
-            and isinstance(canonical_url, str)
-            and canonicalize_news_url(canonical_url) in candidate_urls
-        ):
-            matched_rows.append(row)
+            matched_by_key[_operational_row_key(row)] = row
+    for candidate_url in _candidate_identity_urls(candidate):
+        for row in operational_index.rows_by_canonical_url.get(candidate_url, []):
+            if _operational_record_matches_filter(
+                row,
+                require_candidate_fallback=require_candidate_fallback,
+                require_content_basis=require_content_basis,
+            ):
+                matched_by_key[_operational_row_key(row)] = row
+    matched_rows = list(matched_by_key.values())
     return matched_rows
 
 
@@ -1257,18 +1311,15 @@ def _record_has_valid_taxonomy_pair(row: dict[str, Any]) -> bool:
 def _candidate_scoped_operational_rows(
     *,
     candidates: list[PersistentCandidate],
-    operational_rows: list[dict[str, Any]],
-    operational_urls: set[str],
+    operational_index: OperationalRecordIndex,
 ) -> list[dict[str, Any]]:
     scoped_rows_by_id_or_index: dict[str, dict[str, Any]] = {}
     for candidate in candidates:
         for row in _candidate_operational_record_matches(
             candidate=candidate,
-            operational_rows=operational_rows,
-            operational_urls=operational_urls,
+            operational_index=operational_index,
         ):
-            key = str(row.get("id") or f"row-{len(scoped_rows_by_id_or_index)}")
-            scoped_rows_by_id_or_index[key] = row
+            scoped_rows_by_id_or_index[_operational_row_key(row)] = row
     return list(scoped_rows_by_id_or_index.values())
 
 
@@ -1315,10 +1366,10 @@ def _build_partial_page_diagnostics(
     candidates: list[PersistentCandidate],
     attempts: list[ScrapeAttempt],
     operational_rows: list[dict[str, Any]],
-    operational_urls: set[str],
     operational_matching_enabled: bool,
 ) -> PartialPageDiagnostics:
     attempts_by_candidate_id = _candidate_attempts_by_id(attempts)
+    operational_index = _build_operational_record_index(operational_rows)
     partial_candidates = [
         candidate
         for candidate in candidates
@@ -1335,8 +1386,7 @@ def _build_partial_page_diagnostics(
     scoped_operational_rows = (
         _candidate_scoped_operational_rows(
             candidates=candidates,
-            operational_rows=operational_rows,
-            operational_urls=operational_urls,
+            operational_index=operational_index,
         )
         if operational_matching_enabled
         else []
@@ -1345,8 +1395,7 @@ def _build_partial_page_diagnostics(
         for candidate in partial_candidates:
             matched_rows = _candidate_operational_record_matches(
                 candidate=candidate,
-                operational_rows=operational_rows,
-                operational_urls=operational_urls,
+                operational_index=operational_index,
                 require_candidate_fallback=True,
                 require_content_basis=ContentBasis.PARTIAL_PAGE,
             )

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -374,7 +374,7 @@ def build_discovery_diagnostic_report(
         partial_page_diagnostics=_build_partial_page_diagnostics(
             candidates=candidates,
             attempts=attempts,
-            operational_rows=operational_rows,
+            operational_index=operational_index,
             operational_matching_enabled=include_operational_matches,
         ),
         source_suggestions=_build_source_suggestion_report(
@@ -884,7 +884,7 @@ def _build_candidate_conversion_metrics(
     matched_candidate_ids = {
         candidate.candidate_id
         for candidate in candidates
-        if _candidate_operational_record_matches(
+        if _candidate_has_operational_record_match(
             candidate=candidate,
             operational_index=operational_index,
         )
@@ -1247,6 +1247,31 @@ def _candidate_operational_record_matches(
     return matched_rows
 
 
+def _candidate_has_operational_record_match(
+    *,
+    candidate: PersistentCandidate,
+    operational_index: OperationalRecordIndex,
+    require_candidate_fallback: bool = False,
+    require_content_basis: ContentBasis | None = None,
+) -> bool:
+    for row in operational_index.rows_by_candidate_id.get(candidate.candidate_id, []):
+        if _operational_record_matches_filter(
+            row,
+            require_candidate_fallback=require_candidate_fallback,
+            require_content_basis=require_content_basis,
+        ):
+            return True
+    for candidate_url in _candidate_identity_urls(candidate):
+        for row in operational_index.rows_by_canonical_url.get(candidate_url, []):
+            if _operational_record_matches_filter(
+                row,
+                require_candidate_fallback=require_candidate_fallback,
+                require_content_basis=require_content_basis,
+            ):
+                return True
+    return False
+
+
 def _candidate_attempts_by_id(
     attempts: list[ScrapeAttempt],
 ) -> dict[str, list[ScrapeAttempt]]:
@@ -1375,11 +1400,10 @@ def _build_partial_page_diagnostics(
     *,
     candidates: list[PersistentCandidate],
     attempts: list[ScrapeAttempt],
-    operational_rows: list[dict[str, Any]],
+    operational_index: OperationalRecordIndex,
     operational_matching_enabled: bool,
 ) -> PartialPageDiagnostics:
     attempts_by_candidate_id = _candidate_attempts_by_id(attempts)
-    operational_index = _build_operational_record_index(operational_rows)
     partial_candidates = [
         candidate
         for candidate in candidates
@@ -1424,7 +1448,7 @@ def _build_partial_page_diagnostics(
     )
     return PartialPageDiagnostics(
         operational_matching_enabled=operational_matching_enabled,
-        operational_records_available=bool(operational_rows),
+        operational_records_available=bool(operational_index.rows),
         partial_candidate_count=len(partial_candidates),
         retained_operational_record_candidate_count=len(matched_partial_candidate_ids),
         retained_operational_record_count=retained_record_count,

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -334,16 +334,15 @@ def build_discovery_diagnostic_report(
     )
     provenance = _read_jsonl(paths.candidate_provenance_path, CandidateProvenance)
     now = datetime.now(UTC)
-    operational_urls: set[str] = set()
     operational_rows: list[dict[str, Any]] = []
     operational_notes: list[str] = []
     if include_operational_matches:
         operational_rows, operational_notes = _load_operational_records(config)
-        operational_urls = _operational_record_urls(operational_rows)
     elif config.operational.provider is not OperationalProvider.NONE:
         operational_notes.append(
             "Operational record matching was skipped for this diagnostics artifact."
         )
+    operational_index = _build_operational_record_index(operational_rows)
     report = DiscoveryDiagnosticReport(
         config_path=str(config_path) if config_path is not None else "<in-memory-config>",
         dataset_name=config.dataset_name.value,
@@ -360,7 +359,7 @@ def build_discovery_diagnostic_report(
         ),
         candidate_conversion=_build_candidate_conversion_metrics(
             candidates,
-            operational_urls=operational_urls,
+            operational_index=operational_index,
         ),
         top_failure_sources=_build_failure_summaries(candidates, attempts, key="source"),
         top_failure_domains=_build_failure_summaries(candidates, attempts, key="domain"),
@@ -879,13 +878,16 @@ def _operational_record_urls(rows: list[dict[str, Any]]) -> set[str]:
 def _build_candidate_conversion_metrics(
     candidates: list[PersistentCandidate],
     *,
-    operational_urls: set[str],
+    operational_index: OperationalRecordIndex,
 ) -> CandidateConversionMetrics:
     total = len(candidates)
     matched_candidate_ids = {
         candidate.candidate_id
         for candidate in candidates
-        if operational_urls and _candidate_identity_urls(candidate) & operational_urls
+        if _candidate_operational_record_matches(
+            candidate=candidate,
+            operational_index=operational_index,
+        )
     }
     status_counts = Counter(candidate.candidate_status for candidate in candidates)
     basis_counts = Counter(candidate.content_basis for candidate in candidates)
@@ -1308,6 +1310,14 @@ def _record_has_valid_taxonomy_pair(row: dict[str, Any]) -> bool:
     return default_taxonomy().has_pair(category, subcategory)
 
 
+def _partial_attempt_source_label(attempt: ScrapeAttempt) -> str:
+    if attempt.source_adapter_name:
+        return attempt.source_adapter_name
+    if attempt.attempt_kind is ScrapeAttemptKind.SOURCE_ADAPTER:
+        return "unknown_source_adapter"
+    return "generic_fetch"
+
+
 def _candidate_scoped_operational_rows(
     *,
     candidates: list[PersistentCandidate],
@@ -1502,7 +1512,7 @@ def _build_partial_page_diagnostics(
             Counter(attempt.attempt_kind.value for attempt in partial_attempts)
         ),
         partial_attempts_by_source_adapter=_failure_summaries_from_counter(
-            Counter(attempt.source_adapter_name or "generic_fetch" for attempt in partial_attempts)
+            Counter(_partial_attempt_source_label(attempt) for attempt in partial_attempts)
         ),
         generic_fetch_error_code_counts=_failure_summaries_from_counter(
             generic_fetch_error_code_counts

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -353,7 +353,41 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 "content_basis": "partial_page",
                 "record_confidence": "low",
                 "classification_confidence": "low",
-            }
+            },
+            {
+                "id": "full-row-same-url",
+                "source_name": "themarker",
+                "source_domain": "themarker.com",
+                "url": "https://www.themarker.com/news/article-metadata-only",
+                "canonical_url": "https://www.themarker.com/news/article-metadata-only",
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "title": "full row should not count as fallback retention",
+                "category": "not_relevant",
+                "sub_category": None,
+                "summary_one_sentence": "full row",
+                "annotation_source": None,
+                "event_candidate_ids": [],
+                "content_basis": "full_article_page",
+                "record_confidence": "high",
+            },
+            {
+                "id": "unrelated-fallback",
+                "source_name": "globes",
+                "source_domain": "globes.co.il",
+                "url": "https://www.globes.co.il/news/unrelated",
+                "canonical_url": "https://www.globes.co.il/news/unrelated",
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "title": "unrelated fallback should not pollute current diagnostics",
+                "category": "not_relevant",
+                "sub_category": None,
+                "summary_one_sentence": "unrelated",
+                "annotation_source": "candidate_fallback",
+                "event_candidate_ids": ["unrelated-candidate"],
+                "content_basis": "partial_page",
+                "record_confidence": "low",
+            },
         ],
     )
 
@@ -361,12 +395,16 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     partials = report.partial_page_diagnostics
 
     assert partials.partial_candidate_count == 2
+    assert partials.operational_matching_enabled is True
+    assert partials.operational_records_available is True
     assert partials.retained_operational_record_candidate_count == 1
     assert partials.retained_operational_record_count == 1
     assert partials.metadata_only_partial_candidate_count == 1
     assert partials.search_result_only_candidate_count == 1
     assert partials.generic_fetch_partial_candidate_count == 2
     assert partials.source_adapter_partial_candidate_count == 0
+    assert partials.partial_after_source_adapter_attempt_count == 1
+    assert partials.partial_without_source_adapter_attempt_count == 1
     assert partials.blocked_generic_fetch_candidate_count == 1
     assert partials.generic_fetch_error_code_counts[0].model_dump(mode="json") == {
         "name": "generic_fetch_http_403",
@@ -377,8 +415,41 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     assert partials.classifier_warning_signals.partial_page_fallback_without_taxonomy_count == 1
     rendered = render_discovery_diagnostic_report(report)
     assert "Partial pages" in rendered
+    assert "operational_matching=enabled" in rendered
     assert "metadata_only_partial_candidates=1" in rendered
+    assert "partial_after_source_adapter_attempts=1" in rendered
     assert "classifier_signals candidate_fallback_records=1" in rendered
+
+
+def test_partial_page_diagnostics_mark_operational_counts_as_unmeasured_when_skipped(
+    tmp_path: Path,
+) -> None:
+    """Skipped operational matching should not masquerade as metadata-only evidence."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    candidate = _candidate(
+        "partial-skipped",
+        url="https://www.globes.co.il/news/article-skipped",
+        discovered_via=["brave"],
+        status=CandidateStatus.PARTIALLY_SCRAPED,
+        first_seen_at=now - timedelta(days=1),
+        last_seen_at=now,
+        content_basis=ContentBasis.PARTIAL_PAGE,
+    )
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        candidates_override=[candidate],
+        attempts_override=[],
+        include_operational_matches=False,
+    )
+    partials = report.partial_page_diagnostics
+
+    assert partials.operational_matching_enabled is False
+    assert partials.retained_operational_record_candidate_count == 0
+    assert partials.retained_operational_record_count == 0
+    assert partials.metadata_only_partial_candidate_count == 0
+    assert "operational_matching=skipped" in render_discovery_diagnostic_report(report)
 
 
 def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -17,6 +17,7 @@ from denbust.diagnostics.discovery import (
     _candidate_source,
     _load_operational_record_urls,
     _normalize_domain,
+    _partial_attempt_source_label,
     _read_jsonl,
     _record_content_basis,
     _record_has_valid_taxonomy_pair,
@@ -552,6 +553,8 @@ def test_discovery_diagnostic_report_treats_event_id_only_operational_rows_as_av
 
 def test_record_helpers_handle_enum_blank_and_missing_taxonomy_values() -> None:
     """Operational helper predicates should handle typed and incomplete rows."""
+    now = datetime.now(UTC)
+
     assert _record_content_basis({"content_basis": ContentBasis.PARTIAL_PAGE}) == "partial_page"
     assert _record_content_basis({"content_basis": ""}) == ""
     assert _record_content_basis({}) == ""
@@ -560,6 +563,19 @@ def test_record_helpers_handle_enum_blank_and_missing_taxonomy_values() -> None:
             {"taxonomy_category_id": None, "taxonomy_subcategory_id": "missing"}
         )
         is False
+    )
+    assert (
+        _partial_attempt_source_label(
+            ScrapeAttempt(
+                candidate_id="source-named",
+                started_at=now,
+                finished_at=now,
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.PARTIAL,
+                source_adapter_name="mako",
+            )
+        )
+        == "mako"
     )
 
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -372,6 +372,21 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 "record_confidence": "high",
             },
             {
+                "id": "wrong-basis-fallback",
+                "source_name": "themarker",
+                "source_domain": "themarker.com",
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "title": "wrong-basis fallback should not count as partial retention",
+                "category": "not_relevant",
+                "sub_category": None,
+                "summary_one_sentence": "wrong basis",
+                "annotation_source": "candidate_fallback",
+                "event_candidate_ids": ["partial-metadata-only"],
+                "content_basis": "search_result_only",
+                "record_confidence": "high",
+            },
+            {
                 "id": "unrelated-fallback",
                 "source_name": "globes",
                 "source_domain": "globes.co.il",
@@ -387,6 +402,25 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 "event_candidate_ids": ["unrelated-candidate"],
                 "content_basis": "partial_page",
                 "record_confidence": "low",
+            },
+            {
+                "id": "search-result-fallback",
+                "source_name": "globes",
+                "source_domain": "globes.co.il",
+                "url": "https://www.globes.co.il/news/article-blocked",
+                "canonical_url": "https://www.globes.co.il/news/article-blocked",
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "title": "search-result fallback should count classifier warning signals",
+                "category": "not_relevant",
+                "sub_category": None,
+                "summary_one_sentence": "search-result fallback",
+                "annotation_source": "candidate_fallback",
+                "event_candidate_ids": ["blocked-search-result-only"],
+                "content_basis": "search_result_only",
+                "record_confidence": "low",
+                "taxonomy_category_id": "invalid_category",
+                "taxonomy_subcategory_id": "invalid_subcategory",
             },
         ],
     )
@@ -410,15 +444,20 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
         "name": "generic_fetch_http_403",
         "count": 1,
     }
-    assert partials.classifier_warning_signals.candidate_fallback_record_count == 1
+    assert partials.classifier_warning_signals.candidate_fallback_record_count == 3
     assert partials.classifier_warning_signals.partial_page_fallback_record_count == 1
+    assert partials.classifier_warning_signals.search_result_only_fallback_record_count == 2
+    assert partials.classifier_warning_signals.low_confidence_fallback_record_count == 2
+    assert partials.classifier_warning_signals.invalid_taxonomy_pair_record_count == 1
     assert partials.classifier_warning_signals.partial_page_fallback_without_taxonomy_count == 1
     rendered = render_discovery_diagnostic_report(report)
     assert "Partial pages" in rendered
     assert "operational_matching=enabled" in rendered
     assert "metadata_only_partial_candidates=1" in rendered
     assert "partial_after_source_adapter_attempts=1" in rendered
-    assert "classifier_signals candidate_fallback_records=1" in rendered
+    assert "partial_attempt_kinds: generic_fetch=2" in rendered
+    assert "partial_attempt_sources: generic_fetch=2" in rendered
+    assert "classifier_signals candidate_fallback_records=3" in rendered
 
 
 def test_partial_page_diagnostics_mark_operational_counts_as_unmeasured_when_skipped(
@@ -450,6 +489,55 @@ def test_partial_page_diagnostics_mark_operational_counts_as_unmeasured_when_ski
     assert partials.retained_operational_record_count == 0
     assert partials.metadata_only_partial_candidate_count == 0
     assert "operational_matching=skipped" in render_discovery_diagnostic_report(report)
+
+
+def test_discovery_diagnostic_report_treats_event_id_only_operational_rows_as_available(
+    tmp_path: Path,
+) -> None:
+    """Operational availability should not depend on canonical_url presence."""
+    now = datetime.now(UTC)
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+    candidate = _candidate(
+        "event-id-only",
+        url="https://www.globes.co.il/news/event-id-only",
+        discovered_via=["brave"],
+        status=CandidateStatus.PARTIALLY_SCRAPED,
+        first_seen_at=now - timedelta(days=1),
+        last_seen_at=now,
+        content_basis=ContentBasis.PARTIAL_PAGE,
+    )
+    LocalJsonOperationalStore(tmp_path / "operational").upsert_records(
+        DatasetName.NEWS_ITEMS.value,
+        [
+            {
+                "id": "event-id-only-row",
+                "publication_datetime": now.isoformat(),
+                "event_candidate_ids": ["event-id-only"],
+                "annotation_source": "candidate_fallback",
+                "content_basis": "partial_page",
+            }
+        ],
+    )
+
+    report = build_discovery_diagnostic_report(
+        config=config,
+        candidates_override=[candidate],
+        attempts_override=[],
+    )
+
+    assert report.operational_records_available is True
+    assert report.partial_page_diagnostics.operational_records_available is True
+    assert report.partial_page_diagnostics.retained_operational_record_candidate_count == 1
+    assert (
+        "No operational records were available for candidate-to-news-item matching."
+        not in report.notes
+    )
 
 
 def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -256,6 +256,131 @@ def test_build_discovery_diagnostic_report_counts_search_noise_reasons(tmp_path:
     assert "search_noise_filters social_profile=2" in rendered
 
 
+def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
+    tmp_path: Path,
+) -> None:
+    """Partial-page diagnostics should distinguish retained rows from metadata-only partials."""
+    now = datetime.now(UTC)
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    retained = _candidate(
+        "partial-retained",
+        url="https://www.globes.co.il/news/article-retained",
+        discovered_via=["brave"],
+        status=CandidateStatus.PARTIALLY_SCRAPED,
+        first_seen_at=now - timedelta(days=1),
+        last_seen_at=now,
+        content_basis=ContentBasis.PARTIAL_PAGE,
+    )
+    metadata_only = _candidate(
+        "partial-metadata-only",
+        url="https://www.themarker.com/news/article-metadata-only",
+        discovered_via=["exa"],
+        status=CandidateStatus.PARTIALLY_SCRAPED,
+        first_seen_at=now - timedelta(days=1),
+        last_seen_at=now,
+        content_basis=ContentBasis.PARTIAL_PAGE,
+    )
+    blocked = _candidate(
+        "blocked-search-result-only",
+        url="https://www.globes.co.il/news/article-blocked",
+        discovered_via=["brave"],
+        status=CandidateStatus.SCRAPE_FAILED,
+        first_seen_at=now - timedelta(days=1),
+        last_seen_at=now,
+        content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+    )
+    persistence.upsert_candidates([retained, metadata_only, blocked])
+    persistence.append_attempts(
+        [
+            ScrapeAttempt(
+                candidate_id="partial-retained",
+                started_at=now,
+                finished_at=now,
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.FAILED,
+                source_adapter_name="globes",
+                error_code="candidate_not_found",
+            ),
+            ScrapeAttempt(
+                candidate_id="partial-retained",
+                started_at=now + timedelta(seconds=1),
+                finished_at=now + timedelta(seconds=1),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.PARTIAL,
+            ),
+            ScrapeAttempt(
+                candidate_id="partial-metadata-only",
+                started_at=now + timedelta(seconds=2),
+                finished_at=now + timedelta(seconds=2),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.PARTIAL,
+            ),
+            ScrapeAttempt(
+                candidate_id="blocked-search-result-only",
+                started_at=now + timedelta(seconds=3),
+                finished_at=now + timedelta(seconds=3),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.BLOCKED,
+                error_code="generic_fetch_http_403",
+            ),
+        ]
+    )
+    store = LocalJsonOperationalStore(tmp_path / "operational")
+    store.upsert_records(
+        DatasetName.NEWS_ITEMS.value,
+        [
+            {
+                "id": "fallback-retained",
+                "source_name": "globes",
+                "source_domain": "globes.co.il",
+                "url": "https://www.globes.co.il/news/article-retained",
+                "canonical_url": "https://www.globes.co.il/news/article-retained",
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "title": "retained",
+                "category": "not_relevant",
+                "sub_category": None,
+                "summary_one_sentence": "retained",
+                "annotation_source": "candidate_fallback",
+                "event_candidate_ids": ["partial-retained"],
+                "content_basis": "partial_page",
+                "record_confidence": "low",
+                "classification_confidence": "low",
+            }
+        ],
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+    partials = report.partial_page_diagnostics
+
+    assert partials.partial_candidate_count == 2
+    assert partials.retained_operational_record_candidate_count == 1
+    assert partials.retained_operational_record_count == 1
+    assert partials.metadata_only_partial_candidate_count == 1
+    assert partials.search_result_only_candidate_count == 1
+    assert partials.generic_fetch_partial_candidate_count == 2
+    assert partials.source_adapter_partial_candidate_count == 0
+    assert partials.blocked_generic_fetch_candidate_count == 1
+    assert partials.generic_fetch_error_code_counts[0].model_dump(mode="json") == {
+        "name": "generic_fetch_http_403",
+        "count": 1,
+    }
+    assert partials.classifier_warning_signals.candidate_fallback_record_count == 1
+    assert partials.classifier_warning_signals.partial_page_fallback_record_count == 1
+    assert partials.classifier_warning_signals.partial_page_fallback_without_taxonomy_count == 1
+    rendered = render_discovery_diagnostic_report(report)
+    assert "Partial pages" in rendered
+    assert "metadata_only_partial_candidates=1" in rendered
+    assert "classifier_signals candidate_fallback_records=1" in rendered
+
+
 def test_build_discovery_diagnostic_report_explains_queue_drain_budget_cap(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -18,6 +18,8 @@ from denbust.diagnostics.discovery import (
     _load_operational_record_urls,
     _normalize_domain,
     _read_jsonl,
+    _record_content_basis,
+    _record_has_valid_taxonomy_pair,
     build_discovery_diagnostic_report,
     persist_discovery_diagnostic_artifacts,
     render_discovery_diagnostic_report,
@@ -316,16 +318,23 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 fetch_status=FetchStatus.PARTIAL,
             ),
             ScrapeAttempt(
-                candidate_id="partial-metadata-only",
+                candidate_id="partial-retained",
                 started_at=now + timedelta(seconds=2),
                 finished_at=now + timedelta(seconds=2),
+                attempt_kind=ScrapeAttemptKind.SOURCE_ADAPTER,
+                fetch_status=FetchStatus.PARTIAL,
+            ),
+            ScrapeAttempt(
+                candidate_id="partial-metadata-only",
+                started_at=now + timedelta(seconds=3),
+                finished_at=now + timedelta(seconds=3),
                 attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
                 fetch_status=FetchStatus.PARTIAL,
             ),
             ScrapeAttempt(
                 candidate_id="blocked-search-result-only",
-                started_at=now + timedelta(seconds=3),
-                finished_at=now + timedelta(seconds=3),
+                started_at=now + timedelta(seconds=4),
+                finished_at=now + timedelta(seconds=4),
                 attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
                 fetch_status=FetchStatus.BLOCKED,
                 error_code="generic_fetch_http_403",
@@ -436,7 +445,7 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     assert partials.metadata_only_partial_candidate_count == 1
     assert partials.search_result_only_candidate_count == 1
     assert partials.generic_fetch_partial_candidate_count == 2
-    assert partials.source_adapter_partial_candidate_count == 0
+    assert partials.source_adapter_partial_candidate_count == 1
     assert partials.partial_after_source_adapter_attempt_count == 1
     assert partials.partial_without_source_adapter_attempt_count == 1
     assert partials.blocked_generic_fetch_candidate_count == 1
@@ -455,8 +464,8 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     assert "operational_matching=enabled" in rendered
     assert "metadata_only_partial_candidates=1" in rendered
     assert "partial_after_source_adapter_attempts=1" in rendered
-    assert "partial_attempt_kinds: generic_fetch=2" in rendered
-    assert "partial_attempt_sources: generic_fetch=2" in rendered
+    assert "partial_attempt_kinds: generic_fetch=2, source_adapter=1" in rendered
+    assert "partial_attempt_sources: generic_fetch=2, unknown_source_adapter=1" in rendered
     assert "classifier_signals candidate_fallback_records=3" in rendered
 
 
@@ -532,11 +541,25 @@ def test_discovery_diagnostic_report_treats_event_id_only_operational_rows_as_av
     )
 
     assert report.operational_records_available is True
+    assert report.candidate_conversion.operational_record_matches == 1
     assert report.partial_page_diagnostics.operational_records_available is True
     assert report.partial_page_diagnostics.retained_operational_record_candidate_count == 1
     assert (
         "No operational records were available for candidate-to-news-item matching."
         not in report.notes
+    )
+
+
+def test_record_helpers_handle_enum_blank_and_missing_taxonomy_values() -> None:
+    """Operational helper predicates should handle typed and incomplete rows."""
+    assert _record_content_basis({"content_basis": ContentBasis.PARTIAL_PAGE}) == "partial_page"
+    assert _record_content_basis({"content_basis": ""}) == ""
+    assert _record_content_basis({}) == ""
+    assert (
+        _record_has_valid_taxonomy_pair(
+            {"taxonomy_category_id": None, "taxonomy_subcategory_id": "missing"}
+        )
+        is False
     )
 
 


### PR DESCRIPTION
## Planning notation

- Notation: `SCRAPE-PR-PARTIAL-DIAGNOSTICS`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md` and `docs/january_2026_backfill_wet_test_plan.md`

## Summary

This PR adds structured scrape-interpretation diagnostics for the January 1-7 wet-test gap where `partially_scraped` was too coarse to explain conversion.

New `denbust diagnose-discovery` JSON field: `partial_page_diagnostics`.

It reports:

- partial candidate counts, including candidates with `content_basis=partial_page` or `candidate_status=partially_scraped`
- explicit `operational_matching_enabled` and `operational_records_available` flags so retained-row and metadata-only counts are not misread when operational matching is skipped
- retained candidate-fallback operational row matches vs metadata-only partial candidates, scoped to current candidates and requiring `annotation_source=candidate_fallback` plus `content_basis=partial_page`
- search-result-only candidates and blocked/failed/time-out generic fetch outcomes
- generic-fetch partial candidates vs true source-adapter partial candidates
- generic partials after a source-adapter attempt vs generic partials with no source-adapter attempt
- partial candidates by domain and source hint
- partial attempts by kind and source adapter
- generic fetch error-code counts
- persisted current-candidate classifier/taxonomy warning signals from candidate-fallback operational rows, including low-confidence rows, rows without taxonomy pairs, and invalid taxonomy pairs

The text renderer now includes a compact `Partial pages` section with the same operator-facing breakdown.

## Operator interpretation

After this PR, operators should not treat `queue_health.partial_page_candidates` alone as evidence that partials are useful. Use `partial_page_diagnostics` to separate:

- partial candidates that produced retained provisional operational rows
- partial candidates that remain metadata-only, only when operational matching was enabled
- usable generic metadata extraction from blocked or poor generic fetches
- true source-adapter partials from generic fallback partials
- generic fallback partials that happened after a source-adapter miss/failure
- domain/source clusters that justify later source-family work
- persisted current-candidate fallback classifier/taxonomy signals that can affect conversion interpretation

Run-level classifier parse warnings that are not persisted in candidate or operational state still need the matching run log or debug summary.

## Intentionally unchanged

- Queue fairness and prioritization are unchanged.
- Scrape caps and queue-drain selection are unchanged.
- Generic fetch behavior is unchanged.
- No source-family scraper support is added in this slice.
- No live January wet test was rerun.

## Docs and planning

Updated:

- `.agent-plan.md`: marks `SCRAPE-PR-PARTIAL-DIAGNOSTICS` done in mainline semantics and sets `SRC-PR-GLOBES-THEMARKER` as the single `[next]` item.
- `README.md`: mentions the new partial-page diagnostic breakdown.
- `docs/discovery_operations.md`: documents each new field and interpretation boundary.
- `docs/january_2026_backfill_wet_test_plan.md`: marks the slice implemented and keeps source-family work separate.
- `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`: notes that old checked-in evidence has only the older partial count, while fresh diagnostics can now produce the richer breakdown.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py`

Pre-commit/pre-push hooks also passed during commit/push, including the repo smoke/unit/integration hook suite.