### PR TITLE
SRC-PR-GLOBES-THEMARKER: support generic source families

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -7,10 +7,10 @@
 ## Mainline Status
 
 - Last merged PR on main: `SRC-PR-GLOBES-THEMARKER` added bounded generic-fetch source-family
-  support for Globes/TheMarker: recognized `globes.co.il` and `themarker.com`, grouped
-  search-discovered candidates and fallback provenance as `globes`/`themarker`, preferred article
-  metadata/JSON-LD for generic partial extraction, and kept browser/source-native scraper work out
-  of scope.
+  support for Globes/TheMarker: source-targeted discovery/backfill queries cover
+  `www.globes.co.il` and `www.themarker.com`, search-discovered candidates and fallback provenance
+  group as `globes`/`themarker`, generic partial extraction prefers article metadata/JSON-LD, and
+  browser/source-native scraper work remains out of scope.
 - Next planned PR: `SRC-PR-ISRAELHAYOM` adds or improves source-family support for Israel Hayom if
   bounded scrape diagnostics show enough high-value unsupported or partial candidates.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
@@ -86,7 +86,8 @@
   distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
   classifier parse/taxonomy warnings.
 - [done] `SRC-PR-GLOBES-THEMARKER`: add bounded generic-fetch source-family support for
-  Globes/TheMarker without adding a browser/source-native scraper.
+  Globes/TheMarker, including source-targeted discovery/backfill queries, without adding a
+  browser/source-native scraper.
 - [next] `SRC-PR-ISRAELHAYOM`: add or improve source-family support for Israel Hayom if bounded
   scrape diagnostics show enough high-value unsupported or partial candidates.
 - [later] `SRC-PR-KAN`: add or improve source-family support for Kan if the broader CSE/search

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,13 +6,13 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SCRAPE-PR-PARTIAL-DIAGNOSTICS` added structured partial-page diagnostics
-  for retained candidate-fallback rows, metadata-only partials, generic/source-adapter partial
-  attempts, generic partials after source-adapter attempts, blocked generic fetches, dominant
-  partial domains/sources, and persisted current-candidate classifier/taxonomy warning signals.
-- Next planned PR: `SRC-PR-GLOBES-THEMARKER` adds or improves source-family support for
-  Globes/TheMarker if the sharpened partial-page diagnostics keep showing high-value unsupported or
-  partial candidates there.
+- Last merged PR on main: `SRC-PR-GLOBES-THEMARKER` added bounded generic-fetch source-family
+  support for Globes/TheMarker: recognized `globes.co.il` and `themarker.com`, grouped
+  search-discovered candidates and fallback provenance as `globes`/`themarker`, preferred article
+  metadata/JSON-LD for generic partial extraction, and kept browser/source-native scraper work out
+  of scope.
+- Next planned PR: `SRC-PR-ISRAELHAYOM` adds or improves source-family support for Israel Hayom if
+  bounded scrape diagnostics show enough high-value unsupported or partial candidates.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -85,9 +85,9 @@
 - [done] `SCRAPE-PR-PARTIAL-DIAGNOSTICS`: harden partial-page reporting so operators can
   distinguish retained provisional rows, metadata-only partial pages, blocked generic fetches, and
   classifier parse/taxonomy warnings.
-- [next] `SRC-PR-GLOBES-THEMARKER`: add or improve source-family support for Globes/TheMarker if
-  wet-test diagnostics keep showing high-value unsupported or partial candidates there.
-- [later] `SRC-PR-ISRAELHAYOM`: add or improve source-family support for Israel Hayom if bounded
+- [done] `SRC-PR-GLOBES-THEMARKER`: add bounded generic-fetch source-family support for
+  Globes/TheMarker without adding a browser/source-native scraper.
+- [next] `SRC-PR-ISRAELHAYOM`: add or improve source-family support for Israel Hayom if bounded
   scrape diagnostics show enough high-value unsupported or partial candidates.
 - [later] `SRC-PR-KAN`: add or improve source-family support for Kan if the broader CSE/search
   corpus keeps surfacing relevant candidates that current generic fetch cannot handle well.

--- a/README.md
+++ b/README.md
@@ -396,6 +396,11 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   for bounded candidate scrape passes, including persisted attempted order, actual-attempt source
   mix, remaining eligible order/source mix, configured candidate cap, persisted scrape-attempt
   count, and inferred stop reason, without changing queue prioritization or fairness behavior
+- `SRC-PR-GLOBES-THEMARKER` adds bounded generic-fetch source-family support for `globes.co.il` and
+  `themarker.com`: diagnostics and fallback provenance now group search-discovered article URLs as
+  `globes`/`themarker`, article metadata and JSON-LD are preferred over page titles for partial
+  metadata extraction, and those domains no longer appear as unsupported source-suggestion
+  expansion targets. This is intentionally not a browser scraper or source-native discovery adapter
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/README.md
+++ b/README.md
@@ -399,8 +399,9 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - `SRC-PR-GLOBES-THEMARKER` adds bounded generic-fetch source-family support for `globes.co.il` and
   `themarker.com`: diagnostics and fallback provenance now group search-discovered article URLs as
   `globes`/`themarker`, article metadata and JSON-LD are preferred over page titles for partial
-  metadata extraction, and those domains no longer appear as unsupported source-suggestion
-  expansion targets. This is intentionally not a browser scraper or source-native discovery adapter
+  metadata extraction, and source-targeted discovery/backfill queries now cover both domains while
+  source-suggestion diagnostics can still surface weak conversion or candidate-only backlog. This is
+  intentionally not a browser scraper or source-native discovery adapter
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -113,9 +113,10 @@ eligible for Google CSE-backed discovery. The current domain set is:
 - `shakuf.co.il/*`
 - `www.news1.co.il/*`
 
-The pipeline currently builds source-targeted Google CSE queries for configured source domains and
-Facebook social discovery. Future discovery expansion can and should use this same CSE to query the
-broader listed Israeli news domains through the API before adding new source-specific scrapers.
+The pipeline currently builds source-targeted Google CSE queries for configured source domains,
+supported generic-fetch source families, and Facebook social discovery. Future discovery expansion
+can and should use this same CSE to query the broader listed Israeli news domains through the API
+before adding new source-specific scrapers.
 
 Before model-backed validation, lint the tracked validation CSV without credentials:
 
@@ -291,11 +292,12 @@ pages returning HTTP 200 through the generic fetch path and being retained as pa
 implementation therefore does not add a browser scraper or source-native search adapter. It:
 
 - recognizes `globes.co.il` and `themarker.com` as supported generic-fetch source families;
+- emits source-targeted discovery/backfill queries for `www.globes.co.il` and `www.themarker.com`;
 - labels generic fallback provenance as `globes` or `themarker` when search engines found the URL;
 - uses article metadata and JSON-LD before the document title when generic fetch extracts partial
   page metadata;
-- removes those domains from source-suggestion expansion candidates because their current support
-  boundary is metadata-backed generic fetch, not source-native discovery.
+- keeps those domains eligible for source-suggestion diagnostics when candidate-only or weak
+  conversion evidence still shows backlog pressure.
 
 Future work should still inspect fresh `partial_page_diagnostics` before adding any Globes or
 TheMarker browser/CDP scraper. This slice intentionally does not change queue fairness,

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -284,6 +284,23 @@ many `partial_page` candidates:
 This diagnostic slice is interpretation-only. It does not change queue fairness, source
 prioritization, scrape caps, generic fetch behavior, or source-family scraper support.
 
+After `SRC-PR-GLOBES-THEMARKER`, search-discovered Globes and TheMarker article pages have bounded
+generic-fetch source-family support. The January 1-7 evidence showed Globes as a repeated
+unsupported source suggestion (`globes.co.il`, 25 candidates across two runs) and showed TheMarker
+pages returning HTTP 200 through the generic fetch path and being retained as partial pages. The
+implementation therefore does not add a browser scraper or source-native search adapter. It:
+
+- recognizes `globes.co.il` and `themarker.com` as supported generic-fetch source families;
+- labels generic fallback provenance as `globes` or `themarker` when search engines found the URL;
+- uses article metadata and JSON-LD before the document title when generic fetch extracts partial
+  page metadata;
+- removes those domains from source-suggestion expansion candidates because their current support
+  boundary is metadata-backed generic fetch, not source-native discovery.
+
+Future work should still inspect fresh `partial_page_diagnostics` before adding any Globes or
+TheMarker browser/CDP scraper. This slice intentionally does not change queue fairness,
+prioritization, scrape caps, Mako/Haaretz browser behavior, or broader Israeli source coverage.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -371,8 +371,13 @@ PRs, for seven planned follow-ups total:
    current-candidate classifier/taxonomy warning signals. Queue fairness, source prioritization,
    generic fetch behavior, and source-family scraper support are unchanged.
 4. `SRC-PR-GLOBES-THEMARKER` - source-family expansion.
-   Add or improve source support for the Globes/TheMarker family if repeated diagnostics keep
-   showing high-value unsupported or partial candidates.
+   Implemented as bounded generic-fetch source-family support, not as a browser scraper. The
+   checked-in January 1-7 evidence showed `globes.co.il` as a repeated source suggestion and
+   showed TheMarker pages returning HTTP 200 with usable partial metadata through generic fetch.
+   Globes/TheMarker URLs are now mapped to source-family labels for diagnostics/fallback
+   provenance, generic metadata extraction prefers article metadata/JSON-LD over page titles, and
+   those domains are excluded from future source-suggestion expansion reports unless fresh
+   diagnostics justify a stronger scraper.
 5. `SRC-PR-ISRAELHAYOM` - source-family expansion.
    Add or improve Israel Hayom support if bounded scrape diagnostics show enough high-value
    unsupported or partial candidates.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -375,9 +375,10 @@ PRs, for seven planned follow-ups total:
    checked-in January 1-7 evidence showed `globes.co.il` as a repeated source suggestion and
    showed TheMarker pages returning HTTP 200 with usable partial metadata through generic fetch.
    Globes/TheMarker URLs are now mapped to source-family labels for diagnostics/fallback
-   provenance, generic metadata extraction prefers article metadata/JSON-LD over page titles, and
-   those domains are excluded from future source-suggestion expansion reports unless fresh
-   diagnostics justify a stronger scraper.
+   provenance, source-targeted discovery/backfill queries now cover `www.globes.co.il` and
+   `www.themarker.com`, generic metadata extraction prefers article metadata/JSON-LD over page
+   titles, and source-suggestion diagnostics remain available when candidate-only or weak
+   conversion evidence still justifies stronger scraper work.
 5. `SRC-PR-ISRAELHAYOM` - source-family expansion.
    Add or improve Israel Hayom support if bounded scrape diagnostics show enough high-value
    unsupported or partial candidates.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -25,10 +25,7 @@ from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     order_scrape_eligible_candidates,
 )
-from denbust.discovery.source_families import (
-    GENERIC_FETCH_SOURCE_DOMAINS,
-    source_family_name_for_domain,
-)
+from denbust.discovery.source_families import source_family_name_for_domain
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
@@ -1048,10 +1045,9 @@ def _build_scrape_failure_diagnostics(
 
 
 def _candidate_source(candidate: PersistentCandidate) -> str:
-    if candidate.source_hints:
-        first_hint = candidate.source_hints[0]
-        if first_hint not in _SEARCH_ENGINE_NAMES:
-            return first_hint
+    for source_hint in candidate.source_hints:
+        if source_hint not in _SEARCH_ENGINE_NAMES:
+            return source_hint
     for producer in candidate.discovered_via:
         if producer not in _SEARCH_ENGINE_NAMES:
             return producer
@@ -1566,7 +1562,6 @@ def _build_source_suggestion_report(
         for _, domain in enabled_source_domains(config)
         if (normalized := _normalize_domain(domain)) is not None
     }
-    known_domains.update(GENERIC_FETCH_SOURCE_DOMAINS)
     attempts_by_candidate_id: dict[str, list[ScrapeAttempt]] = {}
     for attempt in attempts:
         attempts_by_candidate_id.setdefault(attempt.candidate_id, []).append(attempt)

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -25,6 +25,10 @@ from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     order_scrape_eligible_candidates,
 )
+from denbust.discovery.source_families import (
+    GENERIC_FETCH_SOURCE_DOMAINS,
+    source_family_name_for_domain,
+)
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
@@ -1045,10 +1049,15 @@ def _build_scrape_failure_diagnostics(
 
 def _candidate_source(candidate: PersistentCandidate) -> str:
     if candidate.source_hints:
-        return candidate.source_hints[0]
+        first_hint = candidate.source_hints[0]
+        if first_hint not in _SEARCH_ENGINE_NAMES:
+            return first_hint
     for producer in candidate.discovered_via:
         if producer not in _SEARCH_ENGINE_NAMES:
             return producer
+    family_name = source_family_name_for_domain(candidate.domain)
+    if family_name is not None:
+        return family_name
     return candidate.domain or "unknown"
 
 
@@ -1557,6 +1566,7 @@ def _build_source_suggestion_report(
         for _, domain in enabled_source_domains(config)
         if (normalized := _normalize_domain(domain)) is not None
     }
+    known_domains.update(GENERIC_FETCH_SOURCE_DOMAINS)
     attempts_by_candidate_id: dict[str, list[ScrapeAttempt]] = {}
     for attempt in attempts:
         attempts_by_candidate_id.setdefault(attempt.candidate_id, []).append(attempt)

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from denbust.config import Config
 from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
-from denbust.discovery.queries import SOCIAL_DISCOVERY_DOMAINS, enabled_source_domains
+from denbust.discovery.queries import SOCIAL_DISCOVERY_DOMAINS, enabled_discovery_domains
 
 BACKFILL_BATCH_ID_ENV = "DENBUST_BACKFILL_BATCH_ID"
 BACKFILL_DATE_FROM_ENV = "DENBUST_BACKFILL_DATE_FROM"
@@ -111,7 +111,7 @@ def build_backfill_queries(
 
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
-    source_domains = enabled_source_domains(config)
+    source_domains = enabled_discovery_domains(config)
     for keyword in keywords:
         if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
             broad_key = (DiscoveryQueryKind.BROAD, keyword, window.index)

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from denbust.config import Config, SourceConfig, SourceType
 from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
+from denbust.discovery.source_families import generic_fetch_source_domains
 from denbust.taxonomy import default_taxonomy
 
 _SCRAPER_SOURCE_DOMAINS: dict[str, str] = {
@@ -54,6 +55,19 @@ def enabled_source_domains(config: Config) -> list[tuple[str, str]]:
     return source_domains
 
 
+def enabled_discovery_domains(config: Config) -> list[tuple[str, str]]:
+    """Return configured source domains plus generic-fetch source-family domains."""
+    source_domains = enabled_source_domains(config)
+    seen = {(source_name, domain) for source_name, domain in source_domains}
+    for source_name, domain in generic_fetch_source_domains():
+        key = (source_name, domain)
+        if key in seen:
+            continue
+        source_domains.append(key)
+        seen.add(key)
+    return source_domains
+
+
 def _taxonomy_query_specs() -> list[tuple[str, list[str]]]:
     specs_by_term: dict[str, set[str]] = {}
     for category_id, subcategory_id, term in default_taxonomy().discovery_terms():
@@ -82,7 +96,7 @@ def build_discovery_queries(
     date_to = current_time
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
-    source_domains = enabled_source_domains(config)
+    source_domains = enabled_discovery_domains(config)
 
     for keyword in keywords:
         if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
@@ -21,6 +22,7 @@ from denbust.discovery.models import (
     ScrapeAttempt,
     ScrapeAttemptKind,
 )
+from denbust.discovery.source_families import source_family_name_for_url
 from denbust.discovery.storage import DiscoveryPersistence
 from denbust.news_items.normalize import canonicalize_news_url, deduplicate_strings
 from denbust.sources.base import Source
@@ -383,12 +385,16 @@ def _fallback_metadata(
     source_name: str | None,
     fetch_result: GenericFetchResult,
 ) -> dict[str, object]:
+    fallback_source_name = (
+        source_name
+        or source_family_name_for_url(str(candidate.canonical_url or candidate.current_url))
+        or next(iter(candidate.source_hints), None)
+        or next(iter(candidate.discovered_via), None)
+    )
     payload: dict[str, object] = {
         "fallback_title": title or next(iter(candidate.titles), None),
         "fallback_snippet": snippet or next(iter(candidate.snippets), None),
-        "fallback_source_name": source_name
-        or next(iter(candidate.source_hints), None)
-        or next(iter(candidate.discovered_via), None),
+        "fallback_source_name": fallback_source_name,
         "fallback_content_basis": content_basis.value,
     }
     if publication_datetime is not None:
@@ -649,15 +655,18 @@ async def _fetch_partial_page(
 
 def _extract_partial_page_metadata(html: str) -> dict[str, Any]:
     soup = BeautifulSoup(html, "html.parser")
+    structured = _extract_structured_article_metadata(soup)
     title = _first_non_empty(
-        soup.title.string if soup.title and soup.title.string else None,
         _meta_content(soup, property_name="og:title"),
         _meta_content(soup, name="twitter:title"),
+        structured.get("title"),
+        soup.title.string if soup.title and soup.title.string else None,
     )
     snippet = _first_non_empty(
         _meta_content(soup, name="description"),
         _meta_content(soup, property_name="og:description"),
         _meta_content(soup, name="twitter:description"),
+        structured.get("snippet"),
     )
     publication_datetime = _parse_publication_datetime(
         _first_non_empty(
@@ -666,6 +675,7 @@ def _extract_partial_page_metadata(html: str) -> dict[str, Any]:
             _meta_content(soup, name="pubdate"),
             _meta_content(soup, name="publish-date"),
             _meta_content(soup, name="date"),
+            structured.get("publication_datetime"),
         )
     )
     return {
@@ -673,6 +683,66 @@ def _extract_partial_page_metadata(html: str) -> dict[str, Any]:
         "snippet": snippet,
         "publication_datetime": publication_datetime,
     }
+
+
+def _extract_structured_article_metadata(soup: BeautifulSoup) -> dict[str, str | None]:
+    """Extract article metadata from JSON-LD blocks when present."""
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        if not isinstance(script, Tag):
+            continue
+        raw_payload = script.string or script.get_text()
+        if not raw_payload:
+            continue
+        try:
+            payload = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            continue
+        for node in _iter_json_ld_nodes(payload):
+            if not _is_article_json_ld_node(node):
+                continue
+            return {
+                "title": _structured_string(node.get("headline") or node.get("name")),
+                "snippet": _structured_string(node.get("description")),
+                "publication_datetime": _structured_string(
+                    node.get("datePublished") or node.get("dateCreated")
+                ),
+            }
+    return {"title": None, "snippet": None, "publication_datetime": None}
+
+
+def _iter_json_ld_nodes(payload: object) -> list[dict[str, object]]:
+    if isinstance(payload, list):
+        nodes: list[dict[str, object]] = []
+        for item in payload:
+            nodes.extend(_iter_json_ld_nodes(item))
+        return nodes
+    if not isinstance(payload, dict):
+        return []
+    nodes = [payload]
+    graph = payload.get("@graph")
+    if isinstance(graph, list):
+        for item in graph:
+            nodes.extend(_iter_json_ld_nodes(item))
+    return nodes
+
+
+def _is_article_json_ld_node(node: dict[str, object]) -> bool:
+    value = node.get("@type")
+    if isinstance(value, str):
+        return value in {"Article", "NewsArticle", "ReportageNewsArticle"}
+    if isinstance(value, list):
+        return any(
+            isinstance(item, str) and item in {"Article", "NewsArticle", "ReportageNewsArticle"}
+            for item in value
+        )
+    return False
+
+
+def _structured_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = " ".join(value.split()).strip()
+    return normalized or None
 
 
 def _meta_content(

--- a/src/denbust/discovery/source_families.py
+++ b/src/denbust/discovery/source_families.py
@@ -1,0 +1,43 @@
+"""Known source-family helpers for search-discovered article candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from denbust.discovery.candidate_filters import match_domain, normalize_domain
+
+
+@dataclass(frozen=True)
+class SourceFamily:
+    """A search-discovered source family supported without source-native discovery."""
+
+    name: str
+    domains: frozenset[str]
+
+
+GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
+    SourceFamily(name="globes", domains=frozenset({"globes.co.il"})),
+    SourceFamily(name="themarker", domains=frozenset({"themarker.com"})),
+)
+
+_GENERIC_FETCH_DOMAIN_TO_SOURCE: dict[str, str] = {
+    domain: family.name for family in GENERIC_FETCH_SOURCE_FAMILIES for domain in family.domains
+}
+GENERIC_FETCH_SOURCE_DOMAINS: frozenset[str] = frozenset(_GENERIC_FETCH_DOMAIN_TO_SOURCE)
+
+
+def source_family_name_for_domain(domain: str | None) -> str | None:
+    """Return the known generic-fetch source family for a domain."""
+    normalized = normalize_domain(domain)
+    matched = match_domain(normalized, GENERIC_FETCH_SOURCE_DOMAINS)
+    if matched is None:
+        return None
+    return _GENERIC_FETCH_DOMAIN_TO_SOURCE[matched]
+
+
+def source_family_name_for_url(url: str | None) -> str | None:
+    """Return the known generic-fetch source family for a URL."""
+    if not url:
+        return None
+    return source_family_name_for_domain(urlparse(url).netloc)

--- a/src/denbust/discovery/source_families.py
+++ b/src/denbust/discovery/source_families.py
@@ -14,11 +14,20 @@ class SourceFamily:
 
     name: str
     domains: frozenset[str]
+    discovery_domain: str
 
 
 GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
-    SourceFamily(name="globes", domains=frozenset({"globes.co.il"})),
-    SourceFamily(name="themarker", domains=frozenset({"themarker.com"})),
+    SourceFamily(
+        name="globes",
+        domains=frozenset({"globes.co.il"}),
+        discovery_domain="www.globes.co.il",
+    ),
+    SourceFamily(
+        name="themarker",
+        domains=frozenset({"themarker.com"}),
+        discovery_domain="www.themarker.com",
+    ),
 )
 
 _GENERIC_FETCH_DOMAIN_TO_SOURCE: dict[str, str] = {
@@ -41,3 +50,8 @@ def source_family_name_for_url(url: str | None) -> str | None:
     if not url:
         return None
     return source_family_name_for_domain(urlparse(url).netloc)
+
+
+def generic_fetch_source_domains() -> list[tuple[str, str]]:
+    """Return source-targeted discovery domains for generic-fetch families."""
+    return [(family.name, family.discovery_domain) for family in GENERIC_FETCH_SOURCE_FAMILIES]

--- a/tests/fixtures/html/globes_article.html
+++ b/tests/fixtures/html/globes_article.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <title>גלובס - כותרת אתר כללית</title>
+    <meta property="og:title" content="כותרת כתבת גלובס על סחר בבני אדם" />
+    <meta property="og:description" content="תקציר כתבת גלובס מתוך מטא דאטה של עמוד כתבה." />
+    <meta property="article:published_time" content="2026-01-05T10:30:00+02:00" />
+  </head>
+  <body>
+    <article>
+      <h1>כותרת כתבת גלובס על סחר בבני אדם</h1>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/html/themarker_article.html
+++ b/tests/fixtures/html/themarker_article.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+  <head>
+    <title>TheMarker - כותרת אתר כללית</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": ["NewsArticle", "Article"],
+        "headline": "כותרת כתבת דה מרקר על אכיפה",
+        "description": "תקציר כתבת דה מרקר מתוך JSON-LD של עמוד כתבה.",
+        "datePublished": "2026-01-04T19:15:00+02:00"
+      }
+    </script>
+  </head>
+  <body>
+    <article>
+      <h1>כותרת כתבת דה מרקר על אכיפה</h1>
+    </article>
+  </body>
+</html>

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -203,14 +203,24 @@ def test_build_backfill_queries_normalizes_keywords_and_emits_source_targeted() 
     assert [query.query_text for query in broad_queries] == ["בית בושת", "סחר"]
     keyword_source_queries = [query for query in source_queries if "taxonomy" not in query.tags]
     taxonomy_source_queries = [query for query in source_queries if "taxonomy" in query.tags]
-    assert len(keyword_source_queries) == 4
-    assert len(taxonomy_source_queries) == len(taxonomy_queries) * 2
+    assert len(keyword_source_queries) == 8
+    assert (
+        len(taxonomy_source_queries)
+        == config.backfill.max_source_targeted_taxonomy_queries_per_window
+    )
     assert taxonomy_queries
     assert len(social_queries) == 2
-    assert {query.source_hint for query in keyword_source_queries} == {"ynet", "walla"}
+    assert {query.source_hint for query in keyword_source_queries} == {
+        "ynet",
+        "walla",
+        "globes",
+        "themarker",
+    }
     assert all(query.preferred_domains for query in keyword_source_queries)
     assert all(not query.preferred_domains for query in taxonomy_queries)
-    assert {query.source_hint for query in taxonomy_source_queries} == {"ynet", "walla"}
+    assert {"globes", "themarker"}.issubset(
+        {query.source_hint for query in taxonomy_source_queries}
+    )
     assert all("backfill" in query.tags and "window:0" in query.tags for query in source_queries)
     assert any(
         query.query_text == "צו הגבלת שימוש"
@@ -282,13 +292,20 @@ def test_build_backfill_queries_emits_source_targeted_taxonomy_terms(
         if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
         and query.query_text == "דירה דיסקרטית"
     ]
-    assert len(taxonomy_source_queries) == 1
-    assert taxonomy_source_queries[0].preferred_domains == ["www.mako.co.il"]
-    assert taxonomy_source_queries[0].source_hint == "mako"
-    assert taxonomy_source_queries[0].date_from == window.date_from
-    assert taxonomy_source_queries[0].date_to == window.date_to
-    assert {"backfill", "mako", "taxonomy", "category:brothels", "window:0"}.issubset(
-        set(taxonomy_source_queries[0].tags)
+    assert {
+        (query.source_hint, tuple(query.preferred_domains)) for query in taxonomy_source_queries
+    } == {
+        ("mako", ("www.mako.co.il",)),
+        ("globes", ("www.globes.co.il",)),
+        ("themarker", ("www.themarker.com",)),
+    }
+    assert all(
+        query.date_from == window.date_from and query.date_to == window.date_to
+        for query in taxonomy_source_queries
+    )
+    assert all(
+        {"backfill", "taxonomy", "category:brothels", "window:0"}.issubset(set(query.tags))
+        for query in taxonomy_source_queries
     )
 
 
@@ -359,8 +376,15 @@ def test_build_backfill_queries_keeps_taxonomy_source_provenance_for_keyword_ove
         for query in queries
         if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and query.query_text == "זנות"
     ]
-    assert len(source_queries) == 2
-    assert sorted("taxonomy" in query.tags for query in source_queries) == [False, True]
+    assert len(source_queries) == 6
+    assert sorted("taxonomy" in query.tags for query in source_queries) == [
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+    ]
 
 
 def test_build_backfill_queries_does_not_load_taxonomy_when_disabled(

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -819,6 +819,21 @@ def test_candidate_source_maps_supported_generic_source_family_domains() -> None
     assert _candidate_source(themarker) == "themarker"
 
 
+def test_candidate_source_scans_all_source_hints_before_domain_fallback() -> None:
+    """Search-engine hints should not hide later concrete source hints."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    candidate = _candidate(
+        "multi-hint",
+        url="https://www.mako.co.il/news/article/multi-hint",
+        discovered_via=["brave"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": ["exa", "mako"]})
+
+    assert _candidate_source(candidate) == "mako"
+
+
 def test_render_discovery_diagnostic_report_caps_queue_order_text(tmp_path: Path) -> None:
     """Text diagnostics should summarize long orders without dumping the whole queue."""
     now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
@@ -1214,10 +1229,10 @@ def test_build_discovery_diagnostic_report_normalizes_source_domains(tmp_path: P
     assert report.source_suggestions.suggestions == []
 
 
-def test_build_discovery_diagnostic_report_excludes_supported_generic_source_families(
+def test_build_discovery_diagnostic_report_keeps_generic_source_families_suggested(
     tmp_path: Path,
 ) -> None:
-    """Generic-fetch-supported source families should not remain expansion suggestions."""
+    """Generic-fetch labels alone should not hide unsupported source-family backlog."""
     now = datetime.now(UTC)
     config = Config(store={"state_root": tmp_path})
     persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
@@ -1253,8 +1268,8 @@ def test_build_discovery_diagnostic_report_excludes_supported_generic_source_fam
     report = build_discovery_diagnostic_report(config=config)
 
     suggestion_domains = {suggestion.domain for suggestion in report.source_suggestions.suggestions}
-    assert "globes.co.il" not in suggestion_domains
-    assert "themarker.com" not in suggestion_domains
+    assert "globes.co.il" in suggestion_domains
+    assert "themarker.com" in suggestion_domains
     assert "example.com" in suggestion_domains
 
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -795,6 +795,30 @@ def test_candidate_source_falls_back_to_non_search_producer_then_domain() -> Non
     assert _candidate_source(domain_only) == "example.com"
 
 
+def test_candidate_source_maps_supported_generic_source_family_domains() -> None:
+    """Search-only Globes/TheMarker candidates should be grouped by source family."""
+    now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
+    globes = _candidate(
+        "globes",
+        url="https://www.globes.co.il/news/article.aspx?did=1001531007",
+        discovered_via=["exa"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": ["exa"]})
+    themarker = _candidate(
+        "themarker",
+        url="https://www.themarker.com/news/2026-01-04/ty-article/abc",
+        discovered_via=["brave"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
+
+    assert _candidate_source(globes) == "globes"
+    assert _candidate_source(themarker) == "themarker"
+
+
 def test_render_discovery_diagnostic_report_caps_queue_order_text(tmp_path: Path) -> None:
     """Text diagnostics should summarize long orders without dumping the whole queue."""
     now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
@@ -1188,6 +1212,50 @@ def test_build_discovery_diagnostic_report_normalizes_source_domains(tmp_path: P
     report = build_discovery_diagnostic_report(config=config)
 
     assert report.source_suggestions.suggestions == []
+
+
+def test_build_discovery_diagnostic_report_excludes_supported_generic_source_families(
+    tmp_path: Path,
+) -> None:
+    """Generic-fetch-supported source families should not remain expansion suggestions."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    persistence.upsert_candidates(
+        [
+            _candidate(
+                "candidate-globes",
+                url="https://www.globes.co.il/news/article.aspx?did=1001531007",
+                discovered_via=["exa"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=2),
+                last_seen_at=now - timedelta(hours=2),
+            ),
+            _candidate(
+                "candidate-themarker",
+                url="https://www.themarker.com/news/2026-01-04/ty-article/abc",
+                discovered_via=["brave"],
+                status=CandidateStatus.PARTIALLY_SCRAPED,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(hours=1),
+            ),
+            _candidate(
+                "candidate-example",
+                url="https://example.com/news/article",
+                discovered_via=["brave"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(minutes=30),
+            ),
+        ]
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+
+    suggestion_domains = {suggestion.domain for suggestion in report.source_suggestions.suggestions}
+    assert "globes.co.il" not in suggestion_domains
+    assert "themarker.com" not in suggestion_domains
+    assert "example.com" in suggestion_domains
 
 
 def test_build_discovery_diagnostic_report_ignores_blank_provenance_domains(tmp_path: Path) -> None:

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -6,7 +6,11 @@ from datetime import UTC, datetime
 
 from denbust.config import Config, SourceConfig, SourceType
 from denbust.discovery.models import DiscoveryQueryKind
-from denbust.discovery.queries import build_discovery_queries, enabled_source_domains
+from denbust.discovery.queries import (
+    build_discovery_queries,
+    enabled_discovery_domains,
+    enabled_source_domains,
+)
 from denbust.taxonomy import default_taxonomy
 
 
@@ -47,8 +51,8 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     taxonomy_targeted_source_queries = [
         query for query in targeted_queries if "taxonomy" in query.tags
     ]
-    assert len(keyword_targeted_queries) == 4
-    assert len(taxonomy_targeted_source_queries) == len(taxonomy_queries) * 2
+    assert len(keyword_targeted_queries) == 8
+    assert len(taxonomy_targeted_source_queries) == len(taxonomy_queries) * 4
     assert len(taxonomy_queries) == len(
         {term for _, _, term in default_taxonomy().discovery_terms()}
     )
@@ -56,12 +60,22 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     assert {query.query_text for query in broad_queries} == {"בית בושת", "זנות"}
     assert {
         (query.source_hint, tuple(query.preferred_domains)) for query in keyword_targeted_queries
-    } == {("ynet", ("www.ynet.co.il",)), ("mako", ("www.mako.co.il",))}
+    } == {
+        ("ynet", ("www.ynet.co.il",)),
+        ("mako", ("www.mako.co.il",)),
+        ("globes", ("www.globes.co.il",)),
+        ("themarker", ("www.themarker.com",)),
+    }
     assert all(not query.preferred_domains for query in taxonomy_queries)
     assert {
         (query.source_hint, tuple(query.preferred_domains))
         for query in taxonomy_targeted_source_queries
-    } == {("ynet", ("www.ynet.co.il",)), ("mako", ("www.mako.co.il",))}
+    } == {
+        ("ynet", ("www.ynet.co.il",)),
+        ("mako", ("www.mako.co.il",)),
+        ("globes", ("www.globes.co.il",)),
+        ("themarker", ("www.themarker.com",)),
+    }
     assert any(
         query.query_text == "נישואין בכפייה"
         and {
@@ -95,9 +109,8 @@ def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
 
     queries = build_discovery_queries(config, days=3)
 
-    assert len(queries) == 1
-    assert queries[0].query_kind is DiscoveryQueryKind.SOURCE_TARGETED
-    assert queries[0].source_hint == "mako"
+    assert [query.source_hint for query in queries] == ["mako", "globes", "themarker"]
+    assert all(query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED for query in queries)
 
 
 def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
@@ -126,12 +139,22 @@ def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
         if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
         and query.query_text == "דירה דיסקרטית"
     ]
-    assert len(taxonomy_source_queries) == 1
-    assert taxonomy_source_queries[0].preferred_domains == ["www.mako.co.il"]
-    assert taxonomy_source_queries[0].source_hint == "mako"
-    assert taxonomy_source_queries[0].date_from == datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
-    assert taxonomy_source_queries[0].date_to == datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
-    assert {"mako", "taxonomy", "category:brothels"}.issubset(set(taxonomy_source_queries[0].tags))
+    assert {
+        (query.source_hint, tuple(query.preferred_domains)) for query in taxonomy_source_queries
+    } == {
+        ("mako", ("www.mako.co.il",)),
+        ("globes", ("www.globes.co.il",)),
+        ("themarker", ("www.themarker.com",)),
+    }
+    assert all(
+        query.date_from == datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+        and query.date_to == datetime(2026, 4, 16, 12, 0, tzinfo=UTC)
+        for query in taxonomy_source_queries
+    )
+    assert all(
+        {"taxonomy", "category:brothels"}.issubset(set(query.tags))
+        for query in taxonomy_source_queries
+    )
 
 
 def test_build_discovery_queries_keeps_taxonomy_source_provenance_for_keyword_overlap(
@@ -155,8 +178,15 @@ def test_build_discovery_queries_keeps_taxonomy_source_provenance_for_keyword_ov
         for query in queries
         if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and query.query_text == "זנות"
     ]
-    assert len(source_queries) == 2
-    assert sorted("taxonomy" in query.tags for query in source_queries) == [False, True]
+    assert len(source_queries) == 6
+    assert sorted("taxonomy" in query.tags for query in source_queries) == [
+        False,
+        False,
+        False,
+        True,
+        True,
+        True,
+    ]
 
 
 def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() -> None:
@@ -181,9 +211,13 @@ def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() 
     keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
 
     assert len(broad_queries) == 1
-    assert len(keyword_targeted_queries) == 1
+    assert len(keyword_targeted_queries) == 3
     assert broad_queries[0].query_text == "זנות"
-    assert keyword_targeted_queries[0].source_hint == "mako"
+    assert {query.source_hint for query in keyword_targeted_queries} == {
+        "mako",
+        "globes",
+        "themarker",
+    }
 
 
 def test_build_discovery_queries_returns_taxonomy_queries_for_empty_keyword_set() -> None:
@@ -225,8 +259,13 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
     ]
     keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
 
-    assert len(keyword_targeted_queries) == 1
-    assert keyword_targeted_queries[0].preferred_domains == ["www.ynet.co.il"]
+    assert {
+        (query.source_hint, tuple(query.preferred_domains)) for query in keyword_targeted_queries
+    } == {
+        ("ynet", ("www.ynet.co.il",)),
+        ("globes", ("www.globes.co.il",)),
+        ("themarker", ("www.themarker.com",)),
+    }
 
 
 def test_build_discovery_queries_can_disable_social_targeted_generation() -> None:
@@ -354,7 +393,7 @@ def test_build_discovery_queries_does_not_load_taxonomy_when_disabled(monkeypatc
 
 
 def test_enabled_source_domains_returns_only_enabled_resolved_domains() -> None:
-    """Public source-domain resolution should expose reusable enabled discovery domains."""
+    """Configured source-domain resolution should not include generic source families."""
     config = Config(
         sources=[
             SourceConfig(name="disabled", type=SourceType.SCRAPER, enabled=False),
@@ -367,4 +406,19 @@ def test_enabled_source_domains_returns_only_enabled_resolved_domains() -> None:
     assert enabled_source_domains(config) == [
         ("ynet", "www.ynet.co.il"),
         ("mako", "www.mako.co.il"),
+    ]
+
+
+def test_enabled_discovery_domains_adds_generic_fetch_source_families() -> None:
+    """Discovery-domain resolution should include bounded generic source families."""
+    config = Config(
+        sources=[
+            SourceConfig(name="ynet", type=SourceType.RSS, url="https://www.ynet.co.il/feed.xml"),
+        ]
+    )
+
+    assert enabled_discovery_domains(config) == [
+        ("ynet", "www.ynet.co.il"),
+        ("globes", "www.globes.co.il"),
+        ("themarker", "www.themarker.com"),
     ]

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -22,6 +22,7 @@ from denbust.discovery.models import (
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     GenericFetchResult,
+    _extract_partial_page_metadata,
     _metadata_datetime,
     scrape_candidates,
     select_backfill_candidates_for_scrape,
@@ -74,6 +75,52 @@ def build_raw_article(
         date=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
         source_name=source_name,
     )
+
+
+def test_extract_partial_page_metadata_prefers_article_metadata_for_globes_fixture() -> None:
+    """Globes-like article metadata should produce clean partial-page fields."""
+    html = """
+    <html>
+      <head>
+        <title>Generic site title</title>
+        <meta property="og:title" content="Globes article headline" />
+        <meta property="og:description" content="Globes article summary" />
+        <meta property="article:published_time" content="2026-01-05T10:30:00+02:00" />
+      </head>
+    </html>
+    """
+
+    parsed = _extract_partial_page_metadata(html)
+
+    assert parsed["title"] == "Globes article headline"
+    assert parsed["snippet"] == "Globes article summary"
+    assert parsed["publication_datetime"] == datetime(2026, 1, 5, 8, 30, tzinfo=UTC)
+
+
+def test_extract_partial_page_metadata_uses_themarker_json_ld_fixture() -> None:
+    """TheMarker-like JSON-LD should fill metadata when meta tags are absent."""
+    html = """
+    <html>
+      <head>
+        <title>TheMarker site title</title>
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": ["NewsArticle", "Article"],
+            "headline": "TheMarker article headline",
+            "description": "TheMarker article summary",
+            "datePublished": "2026-01-04T19:15:00+02:00"
+          }
+        </script>
+      </head>
+    </html>
+    """
+
+    parsed = _extract_partial_page_metadata(html)
+
+    assert parsed["title"] == "TheMarker article headline"
+    assert parsed["snippet"] == "TheMarker article summary"
+    assert parsed["publication_datetime"] == datetime(2026, 1, 4, 17, 15, tzinfo=UTC)
 
 
 class FakeSource:
@@ -658,6 +705,50 @@ async def test_scrape_candidates_retains_partial_fallback_after_adapter_exceptio
         FetchStatus.FAILED,
         FetchStatus.PARTIAL,
     ]
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_labels_globes_generic_partial_from_candidate_domain(
+    tmp_path: Path,
+) -> None:
+    """Generic partial fallback metadata should use supported source-family domains."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-globes",
+        status=CandidateStatus.NEW,
+        source_hint="exa",
+        current_url="https://www.globes.co.il/news/article.aspx?did=1001531007",
+        canonical_url="https://globes.co.il/news/article.aspx?did=1001531007",
+    ).model_copy(update={"discovered_via": ["exa"]})
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת גלובס",
+            snippet="תקציר גלובס",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-globes")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.metadata["fallback_source_name"] == "globes"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -33,6 +33,13 @@ from denbust.discovery.state_paths import resolve_discovery_state_paths
 from denbust.discovery.storage import StateRepoDiscoveryPersistence
 from denbust.models.common import DatasetName
 
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def load_fixture(path: str) -> str:
+    """Load a tracked fixture file."""
+    return (FIXTURES_DIR / path).read_text(encoding="utf-8")
+
 
 def build_candidate(
     candidate_id: str,
@@ -78,48 +85,20 @@ def build_raw_article(
 
 
 def test_extract_partial_page_metadata_prefers_article_metadata_for_globes_fixture() -> None:
-    """Globes-like article metadata should produce clean partial-page fields."""
-    html = """
-    <html>
-      <head>
-        <title>Generic site title</title>
-        <meta property="og:title" content="Globes article headline" />
-        <meta property="og:description" content="Globes article summary" />
-        <meta property="article:published_time" content="2026-01-05T10:30:00+02:00" />
-      </head>
-    </html>
-    """
+    """Globes article metadata should produce clean partial-page fields."""
+    parsed = _extract_partial_page_metadata(load_fixture("html/globes_article.html"))
 
-    parsed = _extract_partial_page_metadata(html)
-
-    assert parsed["title"] == "Globes article headline"
-    assert parsed["snippet"] == "Globes article summary"
+    assert parsed["title"] == "כותרת כתבת גלובס על סחר בבני אדם"
+    assert parsed["snippet"] == "תקציר כתבת גלובס מתוך מטא דאטה של עמוד כתבה."
     assert parsed["publication_datetime"] == datetime(2026, 1, 5, 8, 30, tzinfo=UTC)
 
 
 def test_extract_partial_page_metadata_uses_themarker_json_ld_fixture() -> None:
-    """TheMarker-like JSON-LD should fill metadata when meta tags are absent."""
-    html = """
-    <html>
-      <head>
-        <title>TheMarker site title</title>
-        <script type="application/ld+json">
-          {
-            "@context": "https://schema.org",
-            "@type": ["NewsArticle", "Article"],
-            "headline": "TheMarker article headline",
-            "description": "TheMarker article summary",
-            "datePublished": "2026-01-04T19:15:00+02:00"
-          }
-        </script>
-      </head>
-    </html>
-    """
+    """TheMarker JSON-LD should fill metadata when meta tags are absent."""
+    parsed = _extract_partial_page_metadata(load_fixture("html/themarker_article.html"))
 
-    parsed = _extract_partial_page_metadata(html)
-
-    assert parsed["title"] == "TheMarker article headline"
-    assert parsed["snippet"] == "TheMarker article summary"
+    assert parsed["title"] == "כותרת כתבת דה מרקר על אכיפה"
+    assert parsed["snippet"] == "תקציר כתבת דה מרקר מתוך JSON-LD של עמוד כתבה."
     assert parsed["publication_datetime"] == datetime(2026, 1, 4, 17, 15, tzinfo=UTC)
 
 


### PR DESCRIPTION
## Summary

Implements planning slice `SRC-PR-GLOBES-THEMARKER` as bounded generic-fetch source-family support for Globes and TheMarker.

The January 1-7 Chrome-CDP wet-test evidence justified a narrow scope rather than a browser/source-native scraper:

- `globes.co.il` appeared as a repeated high-value source suggestion with 25 candidates across two runs in the checked-in post-scrape diagnostic artifact.
- TheMarker candidates in the retry scrape log returned HTTP 200 through generic fetch and were retained as partial pages, so the clear gap was source-family labeling and metadata quality rather than a new browser path.
- The existing Mako/Haaretz browser-CDP behavior remains untouched, and queue fairness/prioritization is unchanged.

## Changes

- Added a small generic source-family registry for `globes.co.il` and `themarker.com`.
- Updated generic fallback metadata so search-discovered Globes/TheMarker pages are attributed as `globes` / `themarker` instead of `brave` / `exa` when no source adapter is involved.
- Updated discovery diagnostics so search-only Globes/TheMarker candidates group by source family and no longer remain source-suggestion expansion targets after this bounded support exists.
- Improved generic partial-page metadata extraction by preferring article metadata / JSON-LD before document titles.
- Added fixture-backed unit coverage for Globes/TheMarker metadata extraction, source-family mapping, fallback provenance, and source-suggestion behavior.
- Updated `.agent-plan.md`, `README.md`, `docs/discovery_operations.md`, and the January wet-test plan to document the support boundary and set `SRC-PR-ISRAELHAYOM` as the single next planned slice.

## Out of Scope

- No Globes or TheMarker browser/CDP scraper.
- No source-native search adapter.
- No queue fairness, prioritization, or scrape-budget changes.
- No live-network-dependent tests or committed generated `data/` artifacts.
- No broader Israeli source-family expansion beyond Globes/TheMarker.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_scrape_queue.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_queries.py`
- `.venv/bin/pytest -q`

Pre-commit/pre-push hooks also passed during commit and push.


## Review Follow-up

Addressed the self-review findings before handoff:

- Globes/TheMarker are now included in source-targeted discovery and backfill query generation, not just post-hoc broad-search labeling.
- Source-suggestion diagnostics still surface `globes.co.il` / `themarker.com` when candidate-only or weak conversion evidence remains, so the generic-fetch registry does not hide future scraper pressure.
- Candidate source inference now scans all `source_hints` before falling back to producer/domain inference, avoiding distorted source-mix diagnostics when search-engine hints precede concrete source hints.
- Globes/TheMarker metadata extraction coverage now uses tracked static HTML fixtures instead of inline invented snippets.
