### PR TITLE
SRC-PR-KAN: Add low-confidence Kan diagnostic labeling

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-ISRAELHAYOM` added bounded generic-fetch source-family
-  recognition for main-domain Israel Hayom article URLs: search-discovered main-domain candidates
-  and fallback provenance group as `israelhayom`, while source-targeted discovery/backfill fanout,
-  subdomain matching, and browser/source-native scraper work remain out of scope because the
-  January evidence showed candidate-only backlog rather than attempted scrape or partial-page
+- Last merged PR on main: `SRC-PR-KAN` added bounded generic-fetch source-family recognition for
+  official main-domain Kan article URLs: search-discovered `kan.org.il` candidates and fallback
+  provenance group as `kan`, while source-targeted discovery/backfill fanout, unrelated Kan-named
+  domains, and browser/source-native scraper work remain out of scope because the January evidence
+  showed only a small candidate-only official Kan backlog and no attempted-scrape or partial-page
   behavior.
-- Next planned PR: `SRC-PR-KAN` adds or improves source-family support for Kan if bounded scrape
-  diagnostics show enough high-value unsupported or partial candidates.
+- Next planned PR: `SRC-PR-NEWS1` adds or improves source-family support for News1 if repeated
+  wet-test slices show relevant candidates and generic fetch/metadata extraction is insufficient.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -92,9 +92,10 @@
 - [done] `SRC-PR-ISRAELHAYOM`: add bounded generic-fetch source-family recognition for main-domain
   Israel Hayom article URLs without adding source-targeted query fanout or a browser/source-native
   scraper.
-- [next] `SRC-PR-KAN`: add or improve source-family support for Kan if the broader CSE/search
-  corpus keeps surfacing relevant candidates that current generic fetch cannot handle well.
-- [later] `SRC-PR-NEWS1`: add or improve source-family support for News1 if repeated wet-test
+- [done] `SRC-PR-KAN`: add bounded generic-fetch source-family recognition for official
+  main-domain Kan article URLs without adding source-targeted query fanout, unrelated Kan-named
+  domains, or a browser/source-native scraper.
+- [next] `SRC-PR-NEWS1`: add or improve source-family support for News1 if repeated wet-test
   slices show relevant candidates and generic fetch/metadata extraction is insufficient.
 
 ## Planning Workflow

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,12 +6,12 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-KAN` added bounded generic-fetch source-family recognition for
-  official main-domain Kan article URLs: search-discovered `kan.org.il` candidates and fallback
-  provenance group as `kan`, while source-targeted discovery/backfill fanout, unrelated Kan-named
-  domains, and browser/source-native scraper work remain out of scope because the January evidence
-  showed only a small candidate-only official Kan backlog and no attempted-scrape or partial-page
-  behavior.
+- Last merged PR on main: `SRC-PR-KAN` added low-confidence generic-fetch diagnostic labeling for
+  official Kan news article URLs under `kan.org.il/content/kan-news/`: future generic fallback
+  provenance can group those article-path candidates as `kan`, while source-targeted
+  discovery/backfill fanout, unrelated Kan-named domains, non-article Kan pages, and
+  browser/source-native scraper work remain out of scope because the January evidence showed only a
+  small candidate-only official Kan backlog and no attempted-scrape or partial-page behavior.
 - Next planned PR: `SRC-PR-NEWS1` adds or improves source-family support for News1 if repeated
   wet-test slices show relevant candidates and generic fetch/metadata extraction is insufficient.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
@@ -92,9 +92,9 @@
 - [done] `SRC-PR-ISRAELHAYOM`: add bounded generic-fetch source-family recognition for main-domain
   Israel Hayom article URLs without adding source-targeted query fanout or a browser/source-native
   scraper.
-- [done] `SRC-PR-KAN`: add bounded generic-fetch source-family recognition for official
-  main-domain Kan article URLs without adding source-targeted query fanout, unrelated Kan-named
-  domains, or a browser/source-native scraper.
+- [done] `SRC-PR-KAN`: add low-confidence generic-fetch diagnostic labeling for official
+  `kan.org.il/content/kan-news/` article URLs without adding source-targeted query fanout,
+  unrelated Kan-named domains, non-article Kan pages, or a browser/source-native scraper.
 - [next] `SRC-PR-NEWS1`: add or improve source-family support for News1 if repeated wet-test
   slices show relevant candidates and generic fetch/metadata extraction is insufficient.
 

--- a/README.md
+++ b/README.md
@@ -407,11 +407,10 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   `israelhayom`, while source-targeted discovery/backfill fanout, Israel Hayom subdomains, browser
   scrapers, source-native adapters, and queue-prioritization changes remain out of scope until
   stronger extraction evidence exists
-- `SRC-PR-KAN` adds bounded generic-fetch source-family recognition for official main-domain
-  `kan.org.il` article URLs: search-discovered official Kan article URLs can be grouped as `kan`,
-  while source-targeted discovery/backfill fanout, unrelated Kan-named domains such as
-  `kanisrael.co.il` or `kan-ashkelon.co.il`, browser scrapers, source-native adapters, and
-  queue-prioritization changes remain out of scope until stronger extraction evidence exists
+- `SRC-PR-KAN` adds low-confidence generic-fetch diagnostic labeling for official Kan news article
+  paths under `kan.org.il/content/kan-news/`; this is not source-targeted fanout, a source-native
+  adapter, a browser scraper, or broad support for non-article `kan.org.il` pages and unrelated
+  Kan-named domains
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/README.md
+++ b/README.md
@@ -407,6 +407,11 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   `israelhayom`, while source-targeted discovery/backfill fanout, Israel Hayom subdomains, browser
   scrapers, source-native adapters, and queue-prioritization changes remain out of scope until
   stronger extraction evidence exists
+- `SRC-PR-KAN` adds bounded generic-fetch source-family recognition for official main-domain
+  `kan.org.il` article URLs: search-discovered official Kan article URLs can be grouped as `kan`,
+  while source-targeted discovery/backfill fanout, unrelated Kan-named domains such as
+  `kanisrael.co.il` or `kan-ashkelon.co.il`, browser scrapers, source-native adapters, and
+  queue-prioritization changes remain out of scope until stronger extraction evidence exists
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -324,6 +324,28 @@ evidence before adding Israel Hayom source-targeted query fanout, subdomain matc
 browser/CDP scraper. This slice intentionally does not change queue fairness, prioritization,
 scrape caps, Mako/Haaretz browser behavior, Kan/News1 coverage, or broader Israeli source coverage.
 
+After `SRC-PR-KAN`, search-discovered official main-domain Kan article pages have bounded
+generic-fetch source-family recognition. Fresh diagnostics and candidate-state inspection over the
+January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs, one still
+scrape-eligible official Kan candidate after the bounded drain, and no official Kan attempted-scrape
+or partial-page evidence. The same evidence also showed unrelated Kan-named local domains and social
+posts, so this slice does not broaden to those domains. It:
+
+- recognizes main-domain `kan.org.il` URLs as the `kan` source family;
+- labels generic fallback provenance as `kan` when search engines found a main-domain official Kan
+  article URL;
+- leaves unrelated Kan-named domains such as `kanisrael.co.il`, `kan-ashkelon.co.il`, and Facebook
+  posts linking to those domains ungrouped until separate evidence justifies them;
+- does not emit source-targeted discovery/backfill fanout for Kan until stronger repeated backlog or
+  extraction evidence justifies spending recurring query budget;
+- keeps Kan eligible for source-suggestion diagnostics when candidate-only or weak conversion
+  evidence still shows backlog pressure.
+
+Future work should inspect fresh `partial_page_diagnostics` and attempted Kan scrape evidence before
+adding Kan source-targeted query fanout, unrelated Kan-named domains, or any browser/CDP scraper.
+This slice intentionally does not change queue fairness, prioritization, scrape caps, Mako/Haaretz
+browser behavior, News1 coverage, or broader Israeli source coverage.
+
 ## GitHub Actions Run Path
 
 The operational workflow split is:

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -324,27 +324,29 @@ evidence before adding Israel Hayom source-targeted query fanout, subdomain matc
 browser/CDP scraper. This slice intentionally does not change queue fairness, prioritization,
 scrape caps, Mako/Haaretz browser behavior, Kan/News1 coverage, or broader Israeli source coverage.
 
-After `SRC-PR-KAN`, search-discovered official main-domain Kan article pages have bounded
-generic-fetch source-family recognition. Fresh diagnostics and candidate-state inspection over the
-January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs, one still
-scrape-eligible official Kan candidate after the bounded drain, and no official Kan attempted-scrape
-or partial-page evidence. The same evidence also showed unrelated Kan-named local domains and social
-posts, so this slice does not broaden to those domains. It:
+After `SRC-PR-KAN`, search-discovered official Kan news article paths have low-confidence
+generic-fetch diagnostic labeling. Fresh diagnostics and candidate-state inspection over the January
+1-7 persisted state showed two official `kan.org.il/content/kan-news/` candidate-only URLs, one
+still scrape-eligible official Kan candidate after the bounded drain, and no official Kan
+attempted-scrape or partial-page evidence. The same evidence also showed unrelated Kan-named local
+domains and social posts, so this slice does not broaden to those domains. It:
 
-- recognizes main-domain `kan.org.il` URLs as the `kan` source family;
-- labels generic fallback provenance as `kan` when search engines found a main-domain official Kan
-  article URL;
+- recognizes official Kan news article URLs under `kan.org.il/content/kan-news/` as the `kan`
+  source family for diagnostic/fallback-provenance labeling;
+- labels generic fallback provenance as `kan` when search engines found a matching official Kan news
+  article URL and generic fetch later recovers usable metadata;
 - leaves unrelated Kan-named domains such as `kanisrael.co.il`, `kan-ashkelon.co.il`, and Facebook
   posts linking to those domains ungrouped until separate evidence justifies them;
+- leaves non-article `kan.org.il` pages such as live, podcast, and homepage paths ungrouped;
 - does not emit source-targeted discovery/backfill fanout for Kan until stronger repeated backlog or
   extraction evidence justifies spending recurring query budget;
 - keeps Kan eligible for source-suggestion diagnostics when candidate-only or weak conversion
   evidence still shows backlog pressure.
 
 Future work should inspect fresh `partial_page_diagnostics` and attempted Kan scrape evidence before
-adding Kan source-targeted query fanout, unrelated Kan-named domains, or any browser/CDP scraper.
-This slice intentionally does not change queue fairness, prioritization, scrape caps, Mako/Haaretz
-browser behavior, News1 coverage, or broader Israeli source coverage.
+adding Kan source-targeted query fanout, unrelated Kan-named domains, non-article Kan pages, or any
+browser/CDP scraper. This slice intentionally does not change queue fairness, prioritization, scrape
+caps, Mako/Haaretz browser behavior, News1 coverage, or broader Israeli source coverage.
 
 ## GitHub Actions Run Path
 

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -119,10 +119,18 @@ discovery/backfill fanout, Israel Hayom subdomains, browser scraper work, queue 
 Mako/Haaretz Chrome-CDP behavior, and unrelated source families out of scope.
 
 For `SRC-PR-KAN`, fresh diagnostics and candidate-state inspection over the same persisted state
-showed two official `kan.org.il` candidate-only URLs, one still scrape-eligible official Kan
-candidate, and no official Kan attempted-scrape or partial-page evidence in the bounded drain. The
-same keyword searches also surfaced unrelated Kan-named domains such as `kanisrael.co.il`,
-`kan-ashkelon.co.il` Facebook posts, and other non-Kan hosts. That evidence supports bounded
-main-domain generic-fetch source-family recognition for official `kan.org.il` URLs only, while
-leaving source-targeted discovery/backfill fanout, unrelated Kan-named domains, browser scraper
-work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source families out of scope.
+showed two official `kan.org.il` candidate-only URLs and no official Kan attempted-scrape or
+partial-page evidence in the bounded drain:
+
+| Candidate ID | URL | Status | Content basis | Source hints | Discovered via | Scrape attempts |
+| --- | --- | --- | --- | --- | --- | ---: |
+| `candidate_c26f6055d9d8e0fb1ead6e4b` | `https://www.kan.org.il/content/kan-news/local/983197/` | `unsupported_source` | `candidate_only` | `www.facebook.com` | `brave` | 0 |
+| `candidate_d784dda040a57b3c2c7022ca` | `https://www.kan.org.il/content/kan-news/local/296141/` | `new` | `candidate_only` | `brave` | `brave` | 0 |
+
+The same keyword searches also surfaced unrelated Kan-named domains such as `kanisrael.co.il`,
+`kan-ashkelon.co.il` Facebook posts, and other non-Kan hosts. This weak evidence does not prove
+generic-fetch extraction quality for Kan. It only supports low-confidence diagnostic labeling for
+future official Kan news article-path candidates under `kan.org.il/content/kan-news/`, while leaving
+source-targeted discovery/backfill fanout, unrelated Kan-named domains, non-article Kan pages,
+browser scraper work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source
+families out of scope.

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -117,3 +117,12 @@ Israel Hayom attempted scrape or partial-page evidence in the bounded drain. Tha
 bounded main-domain generic-fetch source-family recognition, while leaving source-targeted
 discovery/backfill fanout, Israel Hayom subdomains, browser scraper work, queue fairness,
 Mako/Haaretz Chrome-CDP behavior, and unrelated source families out of scope.
+
+For `SRC-PR-KAN`, fresh diagnostics and candidate-state inspection over the same persisted state
+showed two official `kan.org.il` candidate-only URLs, one still scrape-eligible official Kan
+candidate, and no official Kan attempted-scrape or partial-page evidence in the bounded drain. The
+same keyword searches also surfaced unrelated Kan-named domains such as `kanisrael.co.il`,
+`kan-ashkelon.co.il` Facebook posts, and other non-Kan hosts. That evidence supports bounded
+main-domain generic-fetch source-family recognition for official `kan.org.il` URLs only, while
+leaving source-targeted discovery/backfill fanout, unrelated Kan-named domains, browser scraper
+work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source families out of scope.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -405,14 +405,15 @@ PRs, for seven planned follow-ups total:
    source-targeted discovery/backfill queries remain out of scope until stronger extraction
    evidence exists.
 6. `SRC-PR-KAN` - source-family expansion.
-   Implemented as bounded main-domain generic-fetch source-family recognition, not as a browser
-   scraper or source-targeted query expansion. Fresh diagnostics and candidate-state inspection over
-   the January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs, including
-   one still scrape-eligible candidate and no attempted-scrape or partial-page evidence. Official
-   main-domain Kan URLs are now mapped to a source-family label for diagnostics/fallback
-   provenance. Unrelated Kan-named domains such as `kanisrael.co.il`, `kan-ashkelon.co.il`, and
-   Facebook posts linking to those domains remain out of scope, as do recurring source-targeted
-   discovery/backfill queries and any browser/source-native scraper.
+   Implemented as low-confidence generic-fetch diagnostic labeling, not as a browser scraper or
+   source-targeted query expansion. Fresh diagnostics and candidate-state inspection over the
+   January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs under
+   `/content/kan-news/` and no attempted-scrape or partial-page evidence. Official Kan news article
+   paths can now be mapped to a source-family label for diagnostics/fallback provenance when future
+   generic fetches recover metadata. Unrelated Kan-named domains such as `kanisrael.co.il`,
+   `kan-ashkelon.co.il`, Facebook posts linking to those domains, and non-article `kan.org.il`
+   pages remain out of scope, as do recurring source-targeted discovery/backfill queries and any
+   browser/source-native scraper.
 7. `SRC-PR-NEWS1` - source-family expansion.
    Add or improve News1 support if repeated wet-test slices show relevant candidates and generic
    fetch/metadata extraction is insufficient.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -405,8 +405,14 @@ PRs, for seven planned follow-ups total:
    source-targeted discovery/backfill queries remain out of scope until stronger extraction
    evidence exists.
 6. `SRC-PR-KAN` - source-family expansion.
-   Add or improve Kan support if the broader search corpus keeps surfacing relevant candidates that
-   current generic fetch cannot handle well.
+   Implemented as bounded main-domain generic-fetch source-family recognition, not as a browser
+   scraper or source-targeted query expansion. Fresh diagnostics and candidate-state inspection over
+   the January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs, including
+   one still scrape-eligible candidate and no attempted-scrape or partial-page evidence. Official
+   main-domain Kan URLs are now mapped to a source-family label for diagnostics/fallback
+   provenance. Unrelated Kan-named domains such as `kanisrael.co.il`, `kan-ashkelon.co.il`, and
+   Facebook posts linking to those domains remain out of scope, as do recurring source-targeted
+   discovery/backfill queries and any browser/source-native scraper.
 7. `SRC-PR-NEWS1` - source-family expansion.
    Add or improve News1 support if repeated wet-test slices show relevant candidates and generic
    fetch/metadata extraction is insufficient.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -25,7 +25,7 @@ from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     order_scrape_eligible_candidates,
 )
-from denbust.discovery.source_families import source_family_name_for_domain
+from denbust.discovery.source_families import source_family_name_for_url
 from denbust.discovery.state_paths import write_metrics_snapshot
 from denbust.news_items.normalize import canonicalize_news_url
 from denbust.ops.factory import create_operational_store
@@ -1051,7 +1051,7 @@ def _candidate_source(candidate: PersistentCandidate) -> str:
     for producer in candidate.discovered_via:
         if producer not in _SEARCH_ENGINE_NAMES:
             return producer
-    family_name = source_family_name_for_domain(candidate.domain)
+    family_name = source_family_name_for_url(str(candidate.current_url))
     if family_name is not None:
         return family_name
     return candidate.domain or "unknown"

--- a/src/denbust/discovery/source_families.py
+++ b/src/denbust/discovery/source_families.py
@@ -37,6 +37,13 @@ GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
         include_subdomains=False,
         source_targeted_discovery=False,
     ),
+    SourceFamily(
+        name="kan",
+        domains=frozenset({"kan.org.il"}),
+        discovery_domain="www.kan.org.il",
+        include_subdomains=False,
+        source_targeted_discovery=False,
+    ),
 )
 
 

--- a/src/denbust/discovery/source_families.py
+++ b/src/denbust/discovery/source_families.py
@@ -17,6 +17,7 @@ class SourceFamily:
     discovery_domain: str
     include_subdomains: bool = True
     source_targeted_discovery: bool = True
+    article_path_prefixes: tuple[str, ...] = ()
 
 
 GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
@@ -43,21 +44,29 @@ GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
         discovery_domain="www.kan.org.il",
         include_subdomains=False,
         source_targeted_discovery=False,
+        article_path_prefixes=("/content/kan-news/",),
     ),
 )
 
 
-def source_family_name_for_domain(domain: str | None) -> str | None:
-    """Return the known generic-fetch source family for a domain."""
+def _family_matches_domain(family: SourceFamily, domain: str | None) -> bool:
     normalized = normalize_domain(domain)
     if normalized is None:
-        return None
+        return False
+    return any(
+        normalized == family_domain
+        or (family.include_subdomains and normalized.endswith(f".{family_domain}"))
+        for family_domain in family.domains
+    )
+
+
+def source_family_name_for_domain(domain: str | None) -> str | None:
+    """Return the known generic-fetch source family for an unrestricted domain."""
     for family in GENERIC_FETCH_SOURCE_FAMILIES:
-        for family_domain in family.domains:
-            if normalized == family_domain or (
-                family.include_subdomains and normalized.endswith(f".{family_domain}")
-            ):
-                return family.name
+        if family.article_path_prefixes:
+            continue
+        if _family_matches_domain(family, domain):
+            return family.name
     return None
 
 
@@ -65,7 +74,16 @@ def source_family_name_for_url(url: str | None) -> str | None:
     """Return the known generic-fetch source family for a URL."""
     if not url:
         return None
-    return source_family_name_for_domain(urlparse(url).netloc)
+    parsed = urlparse(url)
+    for family in GENERIC_FETCH_SOURCE_FAMILIES:
+        if not _family_matches_domain(family, parsed.netloc):
+            continue
+        if family.article_path_prefixes and not any(
+            parsed.path.startswith(prefix) for prefix in family.article_path_prefixes
+        ):
+            continue
+        return family.name
+    return None
 
 
 def generic_fetch_source_domains() -> list[tuple[str, str]]:

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -822,10 +822,19 @@ def test_candidate_source_maps_supported_generic_source_family_domains() -> None
         first_seen_at=now,
         last_seen_at=now,
     ).model_copy(update={"source_hints": []})
+    kan_non_article = _candidate(
+        "kan-non-article",
+        url="https://www.kan.org.il/live/",
+        discovered_via=["brave"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
 
     assert _candidate_source(globes) == "globes"
     assert _candidate_source(themarker) == "themarker"
     assert _candidate_source(kan) == "kan"
+    assert _candidate_source(kan_non_article) == "www.kan.org.il"
 
 
 def test_candidate_source_scans_all_source_hints_before_domain_fallback() -> None:

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -796,7 +796,7 @@ def test_candidate_source_falls_back_to_non_search_producer_then_domain() -> Non
 
 
 def test_candidate_source_maps_supported_generic_source_family_domains() -> None:
-    """Search-only Globes/TheMarker candidates should be grouped by source family."""
+    """Search-only generic-fetch candidates should be grouped by source family."""
     now = datetime(2026, 5, 3, 15, 31, tzinfo=UTC)
     globes = _candidate(
         "globes",
@@ -814,9 +814,18 @@ def test_candidate_source_maps_supported_generic_source_family_domains() -> None
         first_seen_at=now,
         last_seen_at=now,
     ).model_copy(update={"source_hints": []})
+    kan = _candidate(
+        "kan",
+        url="https://www.kan.org.il/content/kan-news/local/296141/",
+        discovered_via=["brave"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
 
     assert _candidate_source(globes) == "globes"
     assert _candidate_source(themarker) == "themarker"
+    assert _candidate_source(kan) == "kan"
 
 
 def test_candidate_source_scans_all_source_hints_before_domain_fallback() -> None:

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -775,6 +775,50 @@ async def test_scrape_candidates_labels_israelhayom_generic_partial_from_candida
 
 
 @pytest.mark.asyncio
+async def test_scrape_candidates_labels_kan_generic_partial_from_candidate_domain(
+    tmp_path: Path,
+) -> None:
+    """Generic partial fallback metadata should label official Kan source-family URLs."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-kan",
+        status=CandidateStatus.NEW,
+        source_hint="brave",
+        current_url="https://www.kan.org.il/content/kan-news/local/296141/",
+        canonical_url="https://www.kan.org.il/content/kan-news/local/296141/",
+    ).model_copy(update={"discovered_via": ["brave"]})
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת כאן",
+            snippet="תקציר כאן",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-kan")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.metadata["fallback_source_name"] == "kan"
+
+
+@pytest.mark.asyncio
 async def test_scrape_candidates_records_fallback_metadata_for_final_url_and_diagnostics(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_discovery_source_families.py
+++ b/tests/unit/test_discovery_source_families.py
@@ -14,7 +14,6 @@ def test_source_family_name_for_domain_matches_known_article_domains() -> None:
     assert source_family_name_for_domain("www.globes.co.il") == "globes"
     assert source_family_name_for_domain("www.themarker.com") == "themarker"
     assert source_family_name_for_domain("www.israelhayom.co.il") == "israelhayom"
-    assert source_family_name_for_domain("www.kan.org.il") == "kan"
     assert (
         source_family_name_for_url("https://www.israelhayom.co.il/news/law/article/19616169")
         == "israelhayom"
@@ -33,9 +32,12 @@ def test_israelhayom_family_matching_is_exact_to_main_domain() -> None:
 
 def test_kan_family_matching_is_exact_to_main_domain() -> None:
     """Kan support is bounded to the official main domain until stronger evidence exists."""
+    assert source_family_name_for_domain("www.kan.org.il") is None
     assert source_family_name_for_domain("kanisrael.co.il") is None
     assert source_family_name_for_domain("kan-ashkelon.co.il") is None
     assert source_family_name_for_domain("news.kan.org.il") is None
+    assert source_family_name_for_url("https://www.kan.org.il/live/") is None
+    assert source_family_name_for_url("https://www.kan.org.il/content/podcast/123/") is None
 
 
 def test_source_targeted_discovery_domains_excludes_candidate_only_families() -> None:

--- a/tests/unit/test_discovery_source_families.py
+++ b/tests/unit/test_discovery_source_families.py
@@ -14,9 +14,13 @@ def test_source_family_name_for_domain_matches_known_article_domains() -> None:
     assert source_family_name_for_domain("www.globes.co.il") == "globes"
     assert source_family_name_for_domain("www.themarker.com") == "themarker"
     assert source_family_name_for_domain("www.israelhayom.co.il") == "israelhayom"
+    assert source_family_name_for_domain("www.kan.org.il") == "kan"
     assert (
         source_family_name_for_url("https://www.israelhayom.co.il/news/law/article/19616169")
         == "israelhayom"
+    )
+    assert (
+        source_family_name_for_url("https://www.kan.org.il/content/kan-news/local/296141/") == "kan"
     )
 
 
@@ -27,7 +31,14 @@ def test_israelhayom_family_matching_is_exact_to_main_domain() -> None:
     assert source_family_name_for_domain("coalition.israelhayom.co.il") is None
 
 
-def test_source_targeted_discovery_domains_excludes_israelhayom_until_extraction_evidence() -> None:
+def test_kan_family_matching_is_exact_to_main_domain() -> None:
+    """Kan support is bounded to the official main domain until stronger evidence exists."""
+    assert source_family_name_for_domain("kanisrael.co.il") is None
+    assert source_family_name_for_domain("kan-ashkelon.co.il") is None
+    assert source_family_name_for_domain("news.kan.org.il") is None
+
+
+def test_source_targeted_discovery_domains_excludes_candidate_only_families() -> None:
     """Candidate-only evidence should not automatically spend recurring source-query budget."""
     assert generic_fetch_source_domains() == [
         ("globes", "www.globes.co.il"),


### PR DESCRIPTION
## Planning notation

- Notation: `SRC-PR-KAN`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md` and `docs/january_2026_backfill_wet_test_plan.md`

## What changed

- Added low-confidence generic-fetch diagnostic labeling for official Kan news article URLs under `kan.org.il/content/kan-news/` as `kan`.
- Kept Kan out of source-targeted discovery/backfill fanout by leaving `source_targeted_discovery=false`.
- Added path-aware source-family matching so non-article `kan.org.il` pages and unrelated Kan-named domains are not grouped as `kan`.
- Added unit coverage for canonical mapping, exact path/domain boundaries, diagnostics source grouping, no fanout, and generic fallback provenance labeling.
- Updated `docs/discovery_operations.md`, the January wet-test plan/evidence docs, `README.md`, and `.agent-plan.md` with the downgraded Kan support boundary and `SRC-PR-NEWS1` as the next planned slice.

## Evidence and scope decision

Fresh diagnostics and candidate-state inspection over `data/may_26_followup/20260503T214851Z/` showed weak official Kan evidence only: two official `kan.org.il/content/kan-news/` candidate-only URLs, one still scrape-eligible official Kan candidate after the bounded drain, and no official Kan attempted-scrape or partial-page evidence. `kan.org.il` did not appear in the top source suggestions, and `partial_page_diagnostics` had no Kan partial-domain evidence.

The evidence docs now include the exact candidate IDs, URLs, statuses, content basis, source hints, producers, and scrape-attempt counts used for this decision.

The same corpus also surfaced unrelated Kan-named/non-official surfaces, including `kanisrael.co.il`, Facebook posts linking to `kan-ashkelon.co.il`, and other non-Kan hosts. Those are intentionally not grouped as `kan`.

That evidence supports low-confidence article-path diagnostic labeling only. It does not prove Kan generic-fetch extraction quality and does not justify Kan source-targeted discovery/backfill fanout, broad domain recognition, focused metadata/extraction hardening, a browser/CDP scraper, queue fairness/prioritization changes, scrape-cap changes, or changes to Mako/Haaretz browser-CDP behavior.

## Out of scope

- No News1 or other source-family changes.
- No source-targeted Kan query fanout.
- No `kanisrael.co.il`, `kan-ashkelon.co.il`, Facebook post, or other Kan-named domain grouping.
- No non-article `kan.org.il` page grouping.
- No source-native adapter or browser/CDP scraper.
- No queue fairness, prioritization, scrape cap, Mako, or Haaretz behavior changes.
- No generated `data/` artifacts committed.

## Review-driven hardening

The self-review found that the first version overstated support, classified all `kan.org.il` paths, and lacked auditable candidate rows in the evidence doc. The follow-up commit tightens matching to `/content/kan-news/`, downgrades public language to low-confidence diagnostic labeling, removes broad-support wording, and adds the exact evidence table.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_source_families.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_queries.py`
- `.venv/bin/pytest -q tests/unit/test_discovery_*.py tests/unit/test_source_*.py tests/unit/test_scraper_browser.py`

## Operational impact

Search-discovered official Kan news article-path candidates can now be grouped and labeled consistently in diagnostics and generic fallback provenance if generic fetch later recovers partial metadata. Recurring source-targeted search budget remains unchanged until stronger repeated evidence justifies it.