### PR TITLE
SRC-PR-NEWS1: Add bounded News1 source labeling

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -12,7 +12,7 @@
   fanout, non-archive News1 pages, generic metadata hardening, browser/source-native scraper work,
   and queue behavior changes remain out of scope because the January evidence showed only three
   Exa-discovered candidate-only News1 archive URLs and no attempted-scrape, partial-page, or
-  repeated source-suggestion pressure.
+  top source-suggestion pressure.
 - Next planned PR: run a fresh Phase C discovery/backfill evidence pass before planning further
   source-family expansion, scraper work, queue behavior changes, or generic metadata hardening.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-KAN` added low-confidence generic-fetch diagnostic labeling for
-  official Kan news article URLs under `kan.org.il/content/kan-news/`: future generic fallback
-  provenance can group those article-path candidates as `kan`, while source-targeted
-  discovery/backfill fanout, unrelated Kan-named domains, non-article Kan pages, and
-  browser/source-native scraper work remain out of scope because the January evidence showed only a
-  small candidate-only official Kan backlog and no attempted-scrape or partial-page behavior.
-- Next planned PR: `SRC-PR-NEWS1` adds or improves source-family support for News1 if repeated
-  wet-test slices show relevant candidates and generic fetch/metadata extraction is insufficient.
+- Last merged PR on main: `SRC-PR-NEWS1` added low-confidence generic-fetch diagnostic labeling for
+  main-domain News1 archive URLs under `news1.co.il/Archive/`: future generic fallback provenance
+  can group those archive-path candidates as `news1`, while source-targeted discovery/backfill
+  fanout, non-archive News1 pages, generic metadata hardening, browser/source-native scraper work,
+  and queue behavior changes remain out of scope because the January evidence showed only three
+  Exa-discovered candidate-only News1 archive URLs and no attempted-scrape, partial-page, or
+  repeated source-suggestion pressure.
+- Next planned PR: run a fresh Phase C discovery/backfill evidence pass before planning further
+  source-family expansion, scraper work, queue behavior changes, or generic metadata hardening.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -95,8 +96,11 @@
 - [done] `SRC-PR-KAN`: add low-confidence generic-fetch diagnostic labeling for official
   `kan.org.il/content/kan-news/` article URLs without adding source-targeted query fanout,
   unrelated Kan-named domains, non-article Kan pages, or a browser/source-native scraper.
-- [next] `SRC-PR-NEWS1`: add or improve source-family support for News1 if repeated wet-test
-  slices show relevant candidates and generic fetch/metadata extraction is insufficient.
+- [done] `SRC-PR-NEWS1`: add low-confidence generic-fetch diagnostic labeling for main-domain
+  News1 archive URLs without adding source-targeted query fanout, non-archive News1 pages, generic
+  metadata hardening, queue behavior changes, or a browser/source-native scraper.
+- [next] Run a fresh Phase C discovery/backfill evidence pass before planning further
+  source-family expansion, scraper work, queue behavior changes, or generic metadata hardening.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   paths under `kan.org.il/content/kan-news/`; this is not source-targeted fanout, a source-native
   adapter, a browser scraper, or broad support for non-article `kan.org.il` pages and unrelated
   Kan-named domains
+- `SRC-PR-NEWS1` adds low-confidence generic-fetch diagnostic labeling for main-domain News1
+  archive article paths under `news1.co.il/Archive/`; this is not source-targeted fanout, a
+  source-native adapter, a browser scraper, or broad support for non-archive News1 pages
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -352,15 +352,16 @@ After `SRC-PR-NEWS1`, search-discovered main-domain News1 archive article paths 
 low-confidence generic-fetch diagnostic labeling. Fresh candidate-state inspection over the January
 1-7 persisted state showed three `news1.co.il/Archive/` candidate-only URLs, all discovered by Exa,
 all still scrape-eligible after the bounded drain, and no News1 attempted-scrape or partial-page
-evidence. The checked-in post-scrape diagnostic did not show News1 as repeated source-suggestion
-pressure. This slice therefore does not justify recurring source-targeted query fanout, a
+evidence. The checked-in post-scrape diagnostic did not emit News1 among the top source suggestions.
+This slice therefore does not justify recurring source-targeted query fanout, a
 source-native adapter, a browser/CDP scraper, generic metadata hardening, or queue behavior changes.
 It:
 
 - recognizes main-domain News1 archive URLs under `news1.co.il/Archive/` as the `news1` source
   family for diagnostic/fallback-provenance labeling;
 - labels generic fallback provenance as `news1` when search engines found a matching News1 archive
-  URL and generic fetch later recovers usable metadata;
+  URL and generic fallback later records either partial page metadata or a retained
+  search-result-only fallback;
 - leaves non-archive News1 pages such as home and section pages ungrouped until separate evidence
   justifies them;
 - does not emit source-targeted discovery/backfill fanout for News1 until stronger repeated backlog

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -322,7 +322,7 @@ subdomain matching, a browser scraper, or a source-native adapter. It:
 Future work should inspect fresh `partial_page_diagnostics` and attempted Israel Hayom scrape
 evidence before adding Israel Hayom source-targeted query fanout, subdomain matching, or any
 browser/CDP scraper. This slice intentionally does not change queue fairness, prioritization,
-scrape caps, Mako/Haaretz browser behavior, Kan/News1 coverage, or broader Israeli source coverage.
+scrape caps, Mako/Haaretz browser behavior, Kan coverage, or broader Israeli source coverage.
 
 After `SRC-PR-KAN`, search-discovered official Kan news article paths have low-confidence
 generic-fetch diagnostic labeling. Fresh diagnostics and candidate-state inspection over the January
@@ -346,7 +346,32 @@ domains and social posts, so this slice does not broaden to those domains. It:
 Future work should inspect fresh `partial_page_diagnostics` and attempted Kan scrape evidence before
 adding Kan source-targeted query fanout, unrelated Kan-named domains, non-article Kan pages, or any
 browser/CDP scraper. This slice intentionally does not change queue fairness, prioritization, scrape
-caps, Mako/Haaretz browser behavior, News1 coverage, or broader Israeli source coverage.
+caps, Mako/Haaretz browser behavior, or broader Israeli source coverage.
+
+After `SRC-PR-NEWS1`, search-discovered main-domain News1 archive article paths have
+low-confidence generic-fetch diagnostic labeling. Fresh candidate-state inspection over the January
+1-7 persisted state showed three `news1.co.il/Archive/` candidate-only URLs, all discovered by Exa,
+all still scrape-eligible after the bounded drain, and no News1 attempted-scrape or partial-page
+evidence. The checked-in post-scrape diagnostic did not show News1 as repeated source-suggestion
+pressure. This slice therefore does not justify recurring source-targeted query fanout, a
+source-native adapter, a browser/CDP scraper, generic metadata hardening, or queue behavior changes.
+It:
+
+- recognizes main-domain News1 archive URLs under `news1.co.il/Archive/` as the `news1` source
+  family for diagnostic/fallback-provenance labeling;
+- labels generic fallback provenance as `news1` when search engines found a matching News1 archive
+  URL and generic fetch later recovers usable metadata;
+- leaves non-archive News1 pages such as home and section pages ungrouped until separate evidence
+  justifies them;
+- does not emit source-targeted discovery/backfill fanout for News1 until stronger repeated backlog
+  or extraction evidence justifies spending recurring query budget;
+- keeps News1 eligible for source-suggestion diagnostics when candidate-only or weak conversion
+  evidence still shows backlog pressure.
+
+Future work should inspect fresh `partial_page_diagnostics` and attempted News1 scrape evidence
+before adding News1 source-targeted query fanout, non-archive News1 pages, generic metadata
+hardening, or any browser/CDP scraper. This slice intentionally does not change queue fairness,
+prioritization, scrape caps, Mako/Haaretz browser behavior, or broader Israeli source coverage.
 
 ## GitHub Actions Run Path
 

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -145,8 +145,8 @@ the bounded drain, and no News1 attempted-scrape or partial-page evidence:
 | `candidate_72ea3953c62c179a8d85a6ae` | `https://www.news1.co.il/Archive/0026-D-175044-00.html` | `new` | `candidate_only` | `exa` | `exa` | 0 |
 | `candidate_824eaa3d83da7c421dbe46e2` | `https://www.news1.co.il/Archive/001-D-512714-00.html` | `new` | `candidate_only` | `exa` | `exa` | 0 |
 
-The same post-scrape diagnostic did not show `news1.co.il` as repeated source-suggestion pressure.
-This weak but concrete evidence supports low-confidence diagnostic labeling for future
+The same post-scrape diagnostic did not emit `news1.co.il` among the top source suggestions. This
+weak but concrete evidence supports low-confidence diagnostic labeling for future
 main-domain News1 archive-path candidates under `news1.co.il/Archive/`, while leaving
 source-targeted discovery/backfill fanout, non-archive News1 pages, generic metadata hardening,
 browser scraper work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -134,3 +134,20 @@ future official Kan news article-path candidates under `kan.org.il/content/kan-n
 source-targeted discovery/backfill fanout, unrelated Kan-named domains, non-article Kan pages,
 browser scraper work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source
 families out of scope.
+
+For `SRC-PR-NEWS1`, candidate-state inspection over the same persisted state showed three
+main-domain News1 archive candidate-only URLs, all Exa-discovered, all still scrape-eligible after
+the bounded drain, and no News1 attempted-scrape or partial-page evidence:
+
+| Candidate ID | URL | Status | Content basis | Source hints | Discovered via | Scrape attempts |
+| --- | --- | --- | --- | --- | --- | ---: |
+| `candidate_f3635f618524800b7e7fefce` | `https://www.news1.co.il/Archive/001-D-512703-00.html` | `new` | `candidate_only` | `exa` | `exa` | 0 |
+| `candidate_72ea3953c62c179a8d85a6ae` | `https://www.news1.co.il/Archive/0026-D-175044-00.html` | `new` | `candidate_only` | `exa` | `exa` | 0 |
+| `candidate_824eaa3d83da7c421dbe46e2` | `https://www.news1.co.il/Archive/001-D-512714-00.html` | `new` | `candidate_only` | `exa` | `exa` | 0 |
+
+The same post-scrape diagnostic did not show `news1.co.il` as repeated source-suggestion pressure.
+This weak but concrete evidence supports low-confidence diagnostic labeling for future
+main-domain News1 archive-path candidates under `news1.co.il/Archive/`, while leaving
+source-targeted discovery/backfill fanout, non-archive News1 pages, generic metadata hardening,
+browser scraper work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source
+families out of scope.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -419,9 +419,10 @@ PRs, for seven planned follow-ups total:
    source-targeted query expansion, or generic metadata hardening. Candidate-state inspection over
    the January 1-7 persisted state showed three main-domain News1 archive candidate-only URLs under
    `/Archive/`, all discovered by Exa, all still scrape-eligible after the bounded drain, and no
-   News1 attempted-scrape or partial-page evidence. The post-scrape diagnostic did not show News1 as
-   repeated source-suggestion pressure. News1 archive paths can now be mapped to a source-family
-   label for diagnostics/fallback provenance when future generic fetches recover metadata.
+   News1 attempted-scrape or partial-page evidence. The post-scrape diagnostic did not emit News1
+   among the top source suggestions. News1 archive paths can now be mapped to a source-family label
+   for diagnostics/fallback provenance when future generic fallback records either partial page
+   metadata or a retained search-result-only fallback.
    Non-archive News1 pages, recurring source-targeted discovery/backfill queries, generic metadata
    hardening, and any browser/source-native scraper remain out of scope.
 

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -415,8 +415,15 @@ PRs, for seven planned follow-ups total:
    pages remain out of scope, as do recurring source-targeted discovery/backfill queries and any
    browser/source-native scraper.
 7. `SRC-PR-NEWS1` - source-family expansion.
-   Add or improve News1 support if repeated wet-test slices show relevant candidates and generic
-   fetch/metadata extraction is insufficient.
+   Implemented as low-confidence generic-fetch diagnostic labeling, not as a browser scraper,
+   source-targeted query expansion, or generic metadata hardening. Candidate-state inspection over
+   the January 1-7 persisted state showed three main-domain News1 archive candidate-only URLs under
+   `/Archive/`, all discovered by Exa, all still scrape-eligible after the bounded drain, and no
+   News1 attempted-scrape or partial-page evidence. The post-scrape diagnostic did not show News1 as
+   repeated source-suggestion pressure. News1 archive paths can now be mapped to a source-family
+   label for diagnostics/fallback provenance when future generic fetches recover metadata.
+   Non-archive News1 pages, recurring source-targeted discovery/backfill queries, generic metadata
+   hardening, and any browser/source-native scraper remain out of scope.
 
 Do not bundle the source-family work into one large scraper PR. Promote each source-family PR only
 after the latest diagnostics justify it.

--- a/src/denbust/discovery/source_families.py
+++ b/src/denbust/discovery/source_families.py
@@ -46,6 +46,14 @@ GENERIC_FETCH_SOURCE_FAMILIES: tuple[SourceFamily, ...] = (
         source_targeted_discovery=False,
         article_path_prefixes=("/content/kan-news/",),
     ),
+    SourceFamily(
+        name="news1",
+        domains=frozenset({"news1.co.il"}),
+        discovery_domain="www.news1.co.il",
+        include_subdomains=False,
+        source_targeted_discovery=False,
+        article_path_prefixes=("/Archive/",),
+    ),
 )
 
 

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -238,6 +238,32 @@ def test_build_backfill_queries_normalizes_keywords_and_emits_source_targeted() 
     }
 
 
+def test_build_backfill_queries_excludes_news1_source_targeted_fanout() -> None:
+    """Candidate-only News1 evidence should not spend recurring backfill query budget."""
+    config = Config(
+        keywords=["בית בושת"],
+        sources=[
+            {
+                "name": "walla",
+                "type": "rss",
+                "enabled": True,
+                "url": "https://news.walla.co.il/feed",
+            },
+        ],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 7, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    assert all(query.source_hint != "news1" for query in queries)
+    assert all(tuple(query.preferred_domains) != ("www.news1.co.il",) for query in queries)
+
+
 def test_build_backfill_queries_returns_empty_when_keywords_normalize_away() -> None:
     """Backfill query generation should short-circuit when no usable keyword-driven queries remain."""
     config = Config(keywords=["", "   "], discovery={"default_query_kinds": ["source_targeted"]})

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -822,6 +822,22 @@ def test_candidate_source_maps_supported_generic_source_family_domains() -> None
         first_seen_at=now,
         last_seen_at=now,
     ).model_copy(update={"source_hints": []})
+    news1 = _candidate(
+        "news1",
+        url="https://www.news1.co.il/Archive/001-D-512703-00.html",
+        discovered_via=["exa"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
+    news1_non_archive = _candidate(
+        "news1-non-archive",
+        url="https://www.news1.co.il/Home/",
+        discovered_via=["exa"],
+        status=CandidateStatus.NEW,
+        first_seen_at=now,
+        last_seen_at=now,
+    ).model_copy(update={"source_hints": []})
     kan_non_article = _candidate(
         "kan-non-article",
         url="https://www.kan.org.il/live/",
@@ -834,6 +850,8 @@ def test_candidate_source_maps_supported_generic_source_family_domains() -> None
     assert _candidate_source(globes) == "globes"
     assert _candidate_source(themarker) == "themarker"
     assert _candidate_source(kan) == "kan"
+    assert _candidate_source(news1) == "news1"
+    assert _candidate_source(news1_non_archive) == "www.news1.co.il"
     assert _candidate_source(kan_non_article) == "www.kan.org.il"
 
 

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -113,6 +113,20 @@ def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
     assert all(query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED for query in queries)
 
 
+def test_build_discovery_queries_excludes_news1_source_targeted_fanout() -> None:
+    """Candidate-only News1 evidence should not add recurring source-targeted fanout."""
+    config = Config(
+        keywords=["בית בושת"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    assert all(query.source_hint != "news1" for query in queries)
+    assert all(tuple(query.preferred_domains) != ("www.news1.co.il",) for query in queries)
+
+
 def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
     monkeypatch,
 ) -> None:

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -863,6 +863,95 @@ async def test_scrape_candidates_labels_news1_generic_partial_from_archive_path(
 
 
 @pytest.mark.asyncio
+async def test_scrape_candidates_labels_news1_search_result_only_fallback(
+    tmp_path: Path,
+) -> None:
+    """Failed generic fetches should still label News1 archive fallback provenance."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-news1-failed",
+        status=CandidateStatus.NEW,
+        source_hint="exa",
+        current_url="https://www.news1.co.il/Archive/001-D-512703-00.html",
+        canonical_url="https://www.news1.co.il/Archive/001-D-512703-00.html",
+    ).model_copy(update={"discovered_via": ["exa"]})
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.FAILED,
+            error_code="generic_fetch_error",
+            error_message="Generic fetch failed",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-news1-failed")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.SCRAPE_FAILED
+    assert stored.content_basis is ContentBasis.SEARCH_RESULT_ONLY
+    assert stored.metadata["fallback_source_name"] == "news1"
+
+
+@pytest.mark.asyncio
+async def test_scrape_candidates_does_not_label_news1_non_archive_fallback(
+    tmp_path: Path,
+) -> None:
+    """Non-archive News1 fallback metadata should keep the search-engine source hint."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-news1-home",
+        status=CandidateStatus.NEW,
+        source_hint="exa",
+        current_url="https://www.news1.co.il/Home/",
+        canonical_url="https://www.news1.co.il/Home/",
+    ).model_copy(update={"discovered_via": ["exa"]})
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת ניוז1",
+            snippet="תקציר ניוז1",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-news1-home")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.metadata["fallback_source_name"] == "exa"
+
+
+@pytest.mark.asyncio
 async def test_scrape_candidates_records_fallback_metadata_for_final_url_and_diagnostics(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -819,6 +819,50 @@ async def test_scrape_candidates_labels_kan_generic_partial_from_candidate_domai
 
 
 @pytest.mark.asyncio
+async def test_scrape_candidates_labels_news1_generic_partial_from_archive_path(
+    tmp_path: Path,
+) -> None:
+    """Generic partial fallback metadata should label News1 archive URLs only."""
+    store = build_store(tmp_path)
+    candidate = build_candidate(
+        "candidate-news1",
+        status=CandidateStatus.NEW,
+        source_hint="exa",
+        current_url="https://www.news1.co.il/Archive/001-D-512703-00.html",
+        canonical_url="https://www.news1.co.il/Archive/001-D-512703-00.html",
+    ).model_copy(update={"discovered_via": ["exa"]})
+    store.upsert_candidates([candidate])
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="כותרת ניוז1",
+            snippet="תקציר ניוז1",
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[],
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    stored = store.get_candidate("candidate-news1")
+    assert stored is not None
+    assert stored.candidate_status is CandidateStatus.PARTIALLY_SCRAPED
+    assert stored.metadata["fallback_source_name"] == "news1"
+
+
+@pytest.mark.asyncio
 async def test_scrape_candidates_records_fallback_metadata_for_final_url_and_diagnostics(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_discovery_source_families.py
+++ b/tests/unit/test_discovery_source_families.py
@@ -21,6 +21,10 @@ def test_source_family_name_for_domain_matches_known_article_domains() -> None:
     assert (
         source_family_name_for_url("https://www.kan.org.il/content/kan-news/local/296141/") == "kan"
     )
+    assert (
+        source_family_name_for_url("https://www.news1.co.il/Archive/001-D-512703-00.html")
+        == "news1"
+    )
 
 
 def test_israelhayom_family_matching_is_exact_to_main_domain() -> None:
@@ -38,6 +42,21 @@ def test_kan_family_matching_is_exact_to_main_domain() -> None:
     assert source_family_name_for_domain("news.kan.org.il") is None
     assert source_family_name_for_url("https://www.kan.org.il/live/") is None
     assert source_family_name_for_url("https://www.kan.org.il/content/podcast/123/") is None
+
+
+def test_news1_family_matching_is_exact_to_main_archive_paths() -> None:
+    """News1 support is bounded to main-domain archive URLs until stronger evidence exists."""
+    assert source_family_name_for_domain("www.news1.co.il") is None
+    assert source_family_name_for_domain("news1.co.il") is None
+    assert source_family_name_for_domain("archive.news1.co.il") is None
+    assert source_family_name_for_url("https://www.news1.co.il/Archive/001-D-512703-00.html") == (
+        "news1"
+    )
+    assert source_family_name_for_url("https://www.news1.co.il/Archive/0026-D-175044-00.html") == (
+        "news1"
+    )
+    assert source_family_name_for_url("https://www.news1.co.il/") is None
+    assert source_family_name_for_url("https://www.news1.co.il/Home/") is None
 
 
 def test_source_targeted_discovery_domains_excludes_candidate_only_families() -> None:


### PR DESCRIPTION
## Planning notation

- Notation: `SRC-PR-NEWS1`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md` and `docs/january_2026_backfill_wet_test_plan.md`

## Summary

This PR implements the News1 source-family planning slice with the narrowest evidence-backed boundary. It adds low-confidence generic-fetch diagnostic/fallback-provenance labeling for main-domain News1 archive article URLs under `news1.co.il/Archive/`.

## Evidence and scope decision

The saved January 1-7 Brave+Exa Chrome-CDP evidence showed three News1 candidates in persisted state:

- `candidate_f3635f618524800b7e7fefce` -> `https://www.news1.co.il/Archive/001-D-512703-00.html`
- `candidate_72ea3953c62c179a8d85a6ae` -> `https://www.news1.co.il/Archive/0026-D-175044-00.html`
- `candidate_824eaa3d83da7c421dbe46e2` -> `https://www.news1.co.il/Archive/001-D-512714-00.html`

All three were Exa-discovered, remained `candidate_only`, had zero scrape attempts, and had no partial-page evidence. The post-scrape diagnostic did not emit News1 among the top source suggestions.

That evidence supports path/domain-limited low-confidence labeling only. It does not justify source-targeted discovery/backfill fanout, a source-native adapter, a browser/CDP scraper, queue behavior changes, scrape cap changes, or generic metadata hardening.

## Changes

- Adds `news1` to generic-fetch source-family recognition for `news1.co.il/Archive/` URLs only.
- Keeps News1 out of `generic_fetch_source_domains()`, so source-targeted discovery/backfill query fanout is unchanged.
- Makes the fallback-provenance contract explicit: matching News1 archive URLs can be labeled on partial-page fallback and on retained search-result-only fallback after a failed generic fetch.
- Adds unit coverage for source-family URL matching, diagnostics grouping, generic fallback provenance labeling, search-result-only fallback labeling, non-archive News1 exclusion, and explicit discovery/backfill no-fanout behavior.
- Updates README, discovery operations docs, January wet-test plan/evidence docs, and `.agent-plan.md` in mainline semantics.

## Out of scope

- Non-archive News1 pages.
- News1 source-targeted discovery/backfill queries.
- Browser/CDP or source-native scraping.
- Generic metadata/extraction hardening.
- Queue fairness, prioritization, and scrape caps.
- Mako/Haaretz browser behavior.
- Other source families.

## Review hardening applied

A self-review found that the first version under-described search-result-only fallback labeling, overclaimed what top-5 source suggestions prove, and left no-fanout behavior too implicit. This revision fixes the docs and adds direct tests for those contracts.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_queries.py::test_build_discovery_queries_excludes_news1_source_targeted_fanout tests/unit/test_discovery_backfill.py::test_build_backfill_queries_excludes_news1_source_targeted_fanout tests/unit/test_discovery_scrape_queue.py::test_scrape_candidates_labels_news1_generic_partial_from_archive_path tests/unit/test_discovery_scrape_queue.py::test_scrape_candidates_labels_news1_search_result_only_fallback tests/unit/test_discovery_scrape_queue.py::test_scrape_candidates_does_not_label_news1_non_archive_fallback`
- `.venv/bin/pytest -q tests/unit/test_discovery_*.py`
- `.venv/bin/pytest -q`

Full pytest result after review hardening: 1000 passed, 1 existing CLI `runpy` warning.