### PR TITLE
SRC-PR-GLOBES-THEMARKER-FOLLOWUP: split partial source suggestions

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,17 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-NEWS1` added low-confidence generic-fetch diagnostic labeling for
-  main-domain News1 archive URLs under `news1.co.il/Archive/`: future generic fallback provenance
-  can group those archive-path candidates as `news1`, while source-targeted discovery/backfill
-  fanout, non-archive News1 pages, generic metadata hardening, browser/source-native scraper work,
-  and queue behavior changes remain out of scope because the January evidence showed only three
-  Exa-discovered candidate-only News1 archive URLs and no attempted-scrape, partial-page, or
-  top source-suggestion pressure.
-- Next planned PR: run a fresh Phase C discovery/backfill evidence pass before planning further
-  source-family expansion, scraper work, queue behavior changes, or generic metadata hardening.
+- Last merged PR on main: `SRC-PR-GLOBES-THEMARKER-FOLLOWUP` split generic partial recoveries from
+  definite scrape failures in source-suggestion diagnostics after the fresh 2026-05-14 January 1-7
+  evidence pass showed `themarker.com` and `globes.co.il` still dominating source suggestions while
+  TheMarker also produced substantial generic partial-page metadata. The slice is diagnostics-only:
+  it does not change source-suggestion ranking, generic fetch extraction, source-targeted fanout,
+  queue fairness, prioritization, scrape caps, browser/CDP behavior, Mako/Haaretz behavior, or
+  source-family support.
+- Next planned PR: investigate the fresh Phase C evidence for the next bounded source-health or
+  classifier-output hardening slice, starting from `sport1.maariv.co.il` candidate-only pressure and
+  low-confidence candidate-fallback taxonomy/parser signals before proposing any queue behavior or
+  scraper change.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -99,8 +101,14 @@
 - [done] `SRC-PR-NEWS1`: add low-confidence generic-fetch diagnostic labeling for main-domain
   News1 archive URLs without adding source-targeted query fanout, non-archive News1 pages, generic
   metadata hardening, queue behavior changes, or a browser/source-native scraper.
-- [next] Run a fresh Phase C discovery/backfill evidence pass before planning further
-  source-family expansion, scraper work, queue behavior changes, or generic metadata hardening.
+- [done] `SRC-PR-GLOBES-THEMARKER-FOLLOWUP`: split generic partial recoveries from definite
+  scrape failures in source-suggestion diagnostics without otherwise changing ranking, so
+  TheMarker/Globes follow-up evidence can distinguish metadata-only generic progress from blocked
+  or failed fetches.
+- [next] Investigate the fresh Phase C evidence for the next bounded source-health or
+  classifier-output hardening slice, starting from `sport1.maariv.co.il` candidate-only pressure and
+  low-confidence candidate-fallback taxonomy/parser signals before proposing any queue behavior or
+  scraper change.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Planned future datasets:
   operational rows, metadata-only partials, search-result-only generic fetch failures, source vs
   generic partial attempts, generic partials after source-adapter attempts, dominant partial
   domains/sources, and visible current-candidate classifier/taxonomy risk signals
+- Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
+  recoveries separately from definite scrape failures, without otherwise changing source-suggestion
+  ranking
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -303,6 +303,28 @@ Future work should still inspect fresh `partial_page_diagnostics` before adding 
 TheMarker browser/CDP scraper. This slice intentionally does not change queue fairness,
 prioritization, scrape caps, Mako/Haaretz browser behavior, or broader Israeli source coverage.
 
+After `SRC-PR-GLOBES-THEMARKER-FOLLOWUP`, the generic source-suggestion diagnostics contract
+distinguishes partial recoveries from definite scrape failures. The fresh 2026-05-14 January 1-7
+evidence pass persisted 3,745 candidates, attempted 100 candidates, retained 30 provisional
+operational rows, stopped at `budget_cap_reached`, and reported 97 partial pages. TheMarker
+dominated the partial-page pressure (`themarker.com=32`) and both TheMarker and Globes still
+appeared as top source suggestions (`themarker.com`: 298 candidates, 34 attempts; `globes.co.il`:
+216 candidates, 1 attempt). Because those TheMarker attempts were generic metadata recoveries
+rather than full article successes, counting `partial` attempts as failures made the
+source-suggestion line overstate failure pressure and understate usable generic-fetch progress. The
+follow-up therefore:
+
+- adds `scrape_partial_count` to `source_suggestions.suggestions`;
+- renders `partials=...` beside successes and failures in `denbust diagnose-discovery`;
+- counts only non-success, non-partial attempts as `scrape_failure_count`;
+- leaves source-suggestion ranking otherwise unchanged, so partials are not failures but also do
+  not receive an unsupported positive score bump;
+- keeps Globes/TheMarker source-family scope unchanged.
+
+This is a generic diagnostics interpretation fix triggered by Globes/TheMarker evidence. It does
+not change generic fetch extraction, source targeted query fanout, queue fairness, source
+prioritization, scrape caps, browser/CDP behavior, or source-family support.
+
 After `SRC-PR-ISRAELHAYOM`, search-discovered main-domain Israel Hayom article pages have bounded
 generic-fetch source-family recognition. The January 1-7 evidence showed `israelhayom.co.il` as a
 repeated source suggestion with 25 main-domain candidate-only URLs across two runs, plus local state

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -151,3 +151,37 @@ main-domain News1 archive-path candidates under `news1.co.il/Archive/`, while le
 source-targeted discovery/backfill fanout, non-archive News1 pages, generic metadata hardening,
 browser scraper work, queue fairness, Mako/Haaretz Chrome-CDP behavior, and unrelated source
 families out of scope.
+
+## Fresh Globes/TheMarker Follow-Up Evidence
+
+The 2026-05-14 fresh Phase C January 1-7 discovery/backfill evidence pass used the same
+Brave+Exa/no-Google local search mode and Chrome-CDP scrape shape under the generated local root
+`data/may_26_followup/20260514T135635Z/`. The generated artifacts are intentionally untracked.
+
+The run reported:
+
+| Figure | Value |
+| --- | ---: |
+| Persisted candidates | 3,745 |
+| Attempted candidates | 100 |
+| Persisted scrape attempts | 159 |
+| Provisional operational rows retained | 30 |
+| Partial pages | 97 |
+| Scrape failures | 3 |
+| Remaining eligible candidates | 3,143 |
+| Inferred stop reason | `budget_cap_reached` |
+
+The partial-page diagnostics showed all 97 partials came from generic fetch, with top partial
+domains led by `themarker.com=32`, `haaretz.co.il=27`, `mako.co.il=13`, `news.walla.co.il=10`, and
+`ynet.co.il=9`. Source suggestions still showed Globes and TheMarker pressure after the prior
+source-family slice: `themarker.com` had 298 candidates, 266 candidate-only candidates, and 34
+attempts; `globes.co.il` had 216 candidates, 215 candidate-only candidates, and one attempt.
+
+This evidence does not justify a browser/CDP scraper, new source-family fanout, queue fairness
+change, scrape-cap change, Mako/Haaretz behavior change, or unrelated source-family work. It does
+justify a generic source-suggestion diagnostics correction that separates partial recoveries from
+definite scrape failures: TheMarker can simultaneously be a top backlog source and a source with
+substantial metadata-only generic-fetch progress. Counting `partial` attempts as
+`scrape_failure_count` overstates failure pressure and obscures whether the next step should be
+metadata/classifier hardening, scraper work, or deferral pending more evidence. The correction does
+not otherwise change source-suggestion ranking.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -362,8 +362,8 @@ successful bounded wet test.
 ## Follow-Up PR Map
 
 Use stable planning IDs for the post-wet-test slices so they are not confused with GitHub pull
-request numbers. The current map is three simple cross-cutting PRs followed by four source-family
-PRs, for seven planned follow-ups total:
+request numbers. The current map is three simple cross-cutting PRs, four source-family PRs, and one
+evidence interpretation follow-up:
 
 1. `WET-PR-EVIDENCE-CONFIG` - planning/config evidence only.
    Add a tracked Brave+Exa/no-Google local search config, document that local operators may bypass
@@ -395,6 +395,15 @@ PRs, for seven planned follow-ups total:
    `www.themarker.com`, generic metadata extraction prefers article metadata/JSON-LD over page
    titles, and source-suggestion diagnostics remain available when candidate-only or weak
    conversion evidence still justifies stronger scraper work.
+4.1. `SRC-PR-GLOBES-THEMARKER-FOLLOWUP` - evidence interpretation follow-up.
+   Implemented as a generic source-suggestion diagnostics correction after the fresh 2026-05-14
+   January 1-7 pass showed TheMarker and Globes still dominating suggestions while TheMarker also
+   dominated generic partial-page recoveries. Source suggestions now report `scrape_partial_count`,
+   render `partials=...` in text output, and no longer count `partial` generic fetch attempts as
+   `scrape_failure_count`. This keeps generic metadata progress separate from blocked or failed
+   fetches without giving partials a positive ranking bonus. It does not add a scraper, change
+   generic fetch extraction, expand source-targeted fanout, change queue fairness/prioritization/
+   caps, or alter Mako/Haaretz browser behavior.
 5. `SRC-PR-ISRAELHAYOM` - source-family expansion.
    Implemented as bounded main-domain generic-fetch source-family recognition, not as a browser
    scraper or source-targeted query expansion. Fresh diagnostics over the January 1-7 persisted

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -395,7 +395,7 @@ evidence interpretation follow-up:
    `www.themarker.com`, generic metadata extraction prefers article metadata/JSON-LD over page
    titles, and source-suggestion diagnostics remain available when candidate-only or weak
    conversion evidence still justifies stronger scraper work.
-4.1. `SRC-PR-GLOBES-THEMARKER-FOLLOWUP` - evidence interpretation follow-up.
+5. `SRC-PR-GLOBES-THEMARKER-FOLLOWUP` - evidence interpretation follow-up.
    Implemented as a generic source-suggestion diagnostics correction after the fresh 2026-05-14
    January 1-7 pass showed TheMarker and Globes still dominating suggestions while TheMarker also
    dominated generic partial-page recoveries. Source suggestions now report `scrape_partial_count`,
@@ -404,7 +404,7 @@ evidence interpretation follow-up:
    fetches without giving partials a positive ranking bonus. It does not add a scraper, change
    generic fetch extraction, expand source-targeted fanout, change queue fairness/prioritization/
    caps, or alter Mako/Haaretz browser behavior.
-5. `SRC-PR-ISRAELHAYOM` - source-family expansion.
+6. `SRC-PR-ISRAELHAYOM` - source-family expansion.
    Implemented as bounded main-domain generic-fetch source-family recognition, not as a browser
    scraper or source-targeted query expansion. Fresh diagnostics over the January 1-7 persisted
    state showed `israelhayom.co.il` as a repeated source suggestion with 25 candidate-only
@@ -413,7 +413,7 @@ evidence interpretation follow-up:
    mapped to a source-family label for diagnostics/fallback provenance; subdomains and recurring
    source-targeted discovery/backfill queries remain out of scope until stronger extraction
    evidence exists.
-6. `SRC-PR-KAN` - source-family expansion.
+7. `SRC-PR-KAN` - source-family expansion.
    Implemented as low-confidence generic-fetch diagnostic labeling, not as a browser scraper or
    source-targeted query expansion. Fresh diagnostics and candidate-state inspection over the
    January 1-7 persisted state showed two official `kan.org.il` candidate-only URLs under
@@ -423,7 +423,7 @@ evidence interpretation follow-up:
    `kan-ashkelon.co.il`, Facebook posts linking to those domains, and non-article `kan.org.il`
    pages remain out of scope, as do recurring source-targeted discovery/backfill queries and any
    browser/source-native scraper.
-7. `SRC-PR-NEWS1` - source-family expansion.
+8. `SRC-PR-NEWS1` - source-family expansion.
    Implemented as low-confidence generic-fetch diagnostic labeling, not as a browser scraper,
    source-targeted query expansion, or generic metadata hardening. Candidate-state inspection over
    the January 1-7 persisted state showed three main-domain News1 archive candidate-only URLs under

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -250,6 +250,7 @@ class SourceSuggestion(BaseModel):
     search_result_only_count: int = 0
     scrape_attempt_count: int = 0
     scrape_success_count: int = 0
+    scrape_partial_count: int = 0
     scrape_failure_count: int = 0
     unsupported_count: int = 0
     score: float = 0.0
@@ -649,7 +650,9 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
             lines.append(
                 "  {domain} score={score:.2f} candidates={candidate_count} runs={run_count} "
                 "candidate_only={candidate_only_count} successes={scrape_success_count} "
-                "failures={scrape_failure_count}".format(**suggestion.model_dump(mode="json"))
+                "partials={scrape_partial_count} failures={scrape_failure_count}".format(
+                    **suggestion.model_dump(mode="json")
+                )
             )
     if report.notes:
         lines.append("")
@@ -1584,8 +1587,13 @@ def _build_source_suggestion_report(
         success_count = sum(
             1 for attempt in domain_attempts if attempt.fetch_status is FetchStatus.SUCCESS
         )
+        partial_count = sum(
+            1 for attempt in domain_attempts if attempt.fetch_status is FetchStatus.PARTIAL
+        )
         failure_count = sum(
-            1 for attempt in domain_attempts if attempt.fetch_status is not FetchStatus.SUCCESS
+            1
+            for attempt in domain_attempts
+            if attempt.fetch_status not in {FetchStatus.SUCCESS, FetchStatus.PARTIAL}
         )
         candidate_only_count = sum(
             1
@@ -1620,6 +1628,7 @@ def _build_source_suggestion_report(
                 search_result_only_count=search_result_only_count,
                 scrape_attempt_count=len(domain_attempts),
                 scrape_success_count=success_count,
+                scrape_partial_count=partial_count,
                 scrape_failure_count=failure_count,
                 unsupported_count=unsupported_count,
                 score=score,

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -1309,6 +1309,86 @@ def test_build_discovery_diagnostic_report_keeps_generic_source_families_suggest
     assert "example.com" in suggestion_domains
 
 
+def test_source_suggestions_separate_generic_partials_from_failures(tmp_path: Path) -> None:
+    """Generic partial recoveries should not inflate failure counts or ranking score."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    persistence.upsert_candidates(
+        [
+            _candidate(
+                "candidate-themarker-partial",
+                url="https://www.themarker.com/news/2026-01-04/ty-article/abc",
+                discovered_via=["brave"],
+                status=CandidateStatus.PARTIALLY_SCRAPED,
+                first_seen_at=now - timedelta(days=2),
+                last_seen_at=now - timedelta(hours=2),
+                content_basis=ContentBasis.PARTIAL_PAGE,
+            ),
+            _candidate(
+                "candidate-themarker-blocked",
+                url="https://www.themarker.com/news/2026-01-05/ty-article/def",
+                discovered_via=["exa"],
+                status=CandidateStatus.SCRAPE_FAILED,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(hours=1),
+                content_basis=ContentBasis.SEARCH_RESULT_ONLY,
+            ),
+            _candidate(
+                "candidate-example-a",
+                url="https://example.com/news/a",
+                discovered_via=["brave"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(minutes=45),
+            ),
+            _candidate(
+                "candidate-example-b",
+                url="https://example.com/news/b",
+                discovered_via=["exa"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(minutes=30),
+            ),
+        ]
+    )
+    persistence.append_attempts(
+        [
+            ScrapeAttempt(
+                candidate_id="candidate-themarker-partial",
+                started_at=now - timedelta(hours=2),
+                finished_at=now - timedelta(hours=2),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.PARTIAL,
+            ),
+            ScrapeAttempt(
+                candidate_id="candidate-themarker-blocked",
+                started_at=now - timedelta(hours=1),
+                finished_at=now - timedelta(hours=1),
+                attempt_kind=ScrapeAttemptKind.GENERIC_FETCH,
+                fetch_status=FetchStatus.BLOCKED,
+                error_code="generic_fetch_http_403",
+            ),
+        ]
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+
+    suggestion_by_domain = {
+        suggestion.domain: suggestion for suggestion in report.source_suggestions.suggestions
+    }
+    suggestion = next(
+        item for item in report.source_suggestions.suggestions if item.domain == "themarker.com"
+    )
+    assert suggestion.scrape_attempt_count == 2
+    assert suggestion.scrape_partial_count == 1
+    assert suggestion.scrape_failure_count == 1
+    assert suggestion.score == 1.75
+    assert suggestion_by_domain["example.com"].score == 2.5
+    assert report.source_suggestions.suggestions[0].domain == "example.com"
+    assert "partials=1 failures=1" in render_discovery_diagnostic_report(report)
+
+
 def test_build_discovery_diagnostic_report_ignores_blank_provenance_domains(tmp_path: Path) -> None:
     """Blank provenance domains should not contribute to source-suggestion run counts."""
     now = datetime.now(UTC)


### PR DESCRIPTION
## Planning notation

- Notation: `SRC-PR-GLOBES-THEMARKER-FOLLOWUP`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`, `docs/january_2026_backfill_wet_test_plan.md`, and the fresh Phase C evidence pass under local generated root `data/may_26_followup/20260514T135635Z/`

## Summary

This is the bounded Globes/TheMarker follow-up after the fresh 2026-05-14 Phase C January 1-7 discovery/backfill evidence pass.

The code change is diagnostics-only: source suggestions now separate generic partial recoveries from definite scrape failures. `source_suggestions.suggestions` includes `scrape_partial_count`, text diagnostics render `partials=...`, and `scrape_failure_count` no longer treats `FetchStatus.PARTIAL` as a failure. Source-suggestion ranking is otherwise unchanged.

## Evidence and scope decision

The fresh evidence pass reported:

- 3,745 persisted candidates after discovery.
- 100 attempted candidates, stopping at `budget_cap_reached`.
- 30 retained provisional operational rows.
- 97 partial pages, all generic-fetch partials.
- Top partial domains included `themarker.com=32` and no Globes partial pressure.
- Source suggestions still ranked `themarker.com` and `globes.co.il` highly:
  - `themarker.com`: 298 candidates, 266 candidate-only, 34 attempts, 34 reported failures, score 357.0.
  - `globes.co.il`: 216 candidates, 215 candidate-only, 1 attempt, 1 reported failure, score 269.5.

That combination showed a concrete interpretation issue: TheMarker could be both a high-pressure backlog source and a source with substantial generic metadata recovery, but the suggestion report was counting partial generic-fetch attempts as failures. The evidence supports a generic diagnostic correction triggered by Globes/TheMarker evidence, not scraper work and not a ranking-policy change.

## What changed

- Added `scrape_partial_count` to `SourceSuggestion` diagnostics.
- Rendered partial counts in `denbust diagnose-discovery` source suggestion text output.
- Counted only non-success, non-partial attempts as `scrape_failure_count`.
- Kept source-suggestion scoring/ranking otherwise unchanged; partials are not failures, but they do not get a positive ranking bonus.
- Added unit coverage proving generic partial attempts do not inflate failure counts or source-suggestion score/ranking.
- Updated README, discovery operations docs, wet-test evidence docs, wet-test plan, and `.agent-plan.md` with the exact support boundary.

## Intentionally out of scope

This PR does not:

- add a Globes or TheMarker browser/CDP scraper;
- change generic metadata extraction behavior;
- change source-targeted discovery/backfill fanout;
- change source-suggestion ranking beyond removing the failure penalty for partial attempts;
- change queue fairness, prioritization, or scrape caps;
- alter Mako or Haaretz browser-CDP behavior;
- broaden source-family support;
- commit generated `data/` artifacts.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py` (`31 passed`)
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery*.py` (`182 passed`)
- Commit hooks passed, including mypy and smoke tests.
