### PR TITLE
SRC-PR-SPORT1-NOISE: Diagnose Sport1 candidate-only pressure

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,17 +6,16 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-GLOBES-THEMARKER-FOLLOWUP` split generic partial recoveries from
-  definite scrape failures in source-suggestion diagnostics after the fresh 2026-05-14 January 1-7
-  evidence pass showed `themarker.com` and `globes.co.il` still dominating source suggestions while
-  TheMarker also produced substantial generic partial-page metadata. The slice is diagnostics-only:
-  it does not change source-suggestion ranking, generic fetch extraction, source-targeted fanout,
-  queue fairness, prioritization, scrape caps, browser/CDP behavior, Mako/Haaretz behavior, or
-  source-family support.
-- Next planned PR: investigate the fresh Phase C evidence for the next bounded source-health or
-  classifier-output hardening slice, starting from `sport1.maariv.co.il` candidate-only pressure and
-  low-confidence candidate-fallback taxonomy/parser signals before proposing any queue behavior or
-  scraper change.
+- Last merged PR on main: `SRC-PR-SPORT1-NOISE` added diagnostic-only
+  `sports_vertical_candidate_only` source-suggestion labeling for `sport1.maariv.co.il` after the
+  fresh 2026-05-14 January 1-7 evidence pass showed 147 Sport1 candidates across two runs, all
+  candidate-only, with zero scrape attempts, partial recoveries, successes, or failures. The slice
+  keeps Sport1 and regular `www.maariv.co.il` news/law article URLs scrape-eligible and does not add
+  Maariv-family source support, source-targeted fanout, browser/CDP scraping, queue fairness or
+  scrape-cap changes, Mako/Haaretz behavior changes, or broader sports-domain policy.
+- Next planned PR: investigate the fresh Phase C classifier-output evidence from the same bounded
+  drain, focusing on low-confidence candidate-fallback rows and parse/taxonomy warning signals
+  before proposing any queue behavior, scraper change, or source-family expansion.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -105,10 +104,13 @@
   scrape failures in source-suggestion diagnostics without otherwise changing ranking, so
   TheMarker/Globes follow-up evidence can distinguish metadata-only generic progress from blocked
   or failed fetches.
-- [next] Investigate the fresh Phase C evidence for the next bounded source-health or
-  classifier-output hardening slice, starting from `sport1.maariv.co.il` candidate-only pressure and
-  low-confidence candidate-fallback taxonomy/parser signals before proposing any queue behavior or
-  scraper change.
+- [done] `SRC-PR-SPORT1-NOISE`: classify `sport1.maariv.co.il` candidate-only sports-vertical
+  pressure in source-suggestion diagnostics while keeping Sport1 and regular `www.maariv.co.il`
+  news/law article candidates scrape-eligible and avoiding Maariv-family support, source-targeted
+  fanout, scraper work, queue behavior changes, or broader sports-domain filtering.
+- [next] Investigate low-confidence candidate-fallback classifier output and parse/taxonomy warning
+  signals from the fresh 2026-05-14 Phase C bounded drain before proposing queue behavior, scraper,
+  or source-family changes.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Planned future datasets:
 - Reports self-heal-eligible candidate backlog and structured scrape-failure groups for future
   repair workflows, without running automatic AI repair or selector rewriting
 - Writes source-suggestion diagnostics artifacts for repeated unseen non-social domains
+- Flags candidate-only `sport1.maariv.co.il` pressure in source-suggestion diagnostics without
+  changing scrape eligibility or Maariv source-family support
 - Lints the tracked classifier validation CSV with `denbust validation-lint`
 - Shares validation taxonomy/category/index-relevance row-integrity rules between
   `denbust validation-lint` and reviewed-row finalize/import

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -325,6 +325,31 @@ This is a generic diagnostics interpretation fix triggered by Globes/TheMarker e
 not change generic fetch extraction, source targeted query fanout, queue fairness, source
 prioritization, scrape caps, browser/CDP behavior, or source-family support.
 
+After `SRC-PR-SPORT1-NOISE`, `sport1.maariv.co.il` candidate-only pressure is classified only in
+source-suggestion diagnostics. The fresh 2026-05-14 January 1-7 evidence showed
+`sport1.maariv.co.il` as a top source-suggestion domain with 147 candidates across two runs, all
+candidate-only, and no scrape attempts, partial recoveries, scrape successes, or scrape failures.
+Candidate-state inspection showed sports-vertical paths such as `israeli-soccer`, `world-soccer`,
+`square`, basketball, tennis, and related Sport1 sections, but the same sample still contained
+article-like pages and some legal/crime-adjacent wording. Candidate-only evidence is therefore not
+strong enough to suppress the domain before scrape/classifier evidence exists. The slice therefore:
+
+- adds `diagnostic_classification=sports_vertical_candidate_only` to matching
+  `source_suggestions.suggestions` entries when Sport1 pressure is entirely candidate-only and
+  unattempted;
+- renders that diagnostic classification in `denbust diagnose-discovery`;
+- keeps Sport1 search candidates scrape-eligible until attempted scrape, generic-fetch,
+  classifier, or retained-row evidence justifies a stronger action;
+- leaves regular `www.maariv.co.il` article URLs, including law/news article paths, scrape-eligible;
+- does not add Sport1 to generic-fetch source families or source-targeted discovery/backfill fanout;
+- does not change Maariv source-native scraping, queue fairness, prioritization, scrape caps,
+  browser/CDP behavior, Mako/Haaretz behavior, or broader sports-domain policy.
+
+If future evidence shows Sport1 candidates are consistently irrelevant after scrape/classifier
+processing, that should be handled as a separate evidence-backed filter decision. If future evidence
+shows retained TFHT rows or useful article extraction, that should be handled as a separate
+source-family decision.
+
 After `SRC-PR-ISRAELHAYOM`, search-discovered main-domain Israel Hayom article pages have bounded
 generic-fetch source-family recognition. The January 1-7 evidence showed `israelhayom.co.il` as a
 repeated source suggestion with 25 main-domain candidate-only URLs across two runs, plus local state

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -185,3 +185,28 @@ substantial metadata-only generic-fetch progress. Counting `partial` attempts as
 `scrape_failure_count` overstates failure pressure and obscures whether the next step should be
 metadata/classifier hardening, scraper work, or deferral pending more evidence. The correction does
 not otherwise change source-suggestion ranking.
+
+## Fresh Sport1 Candidate-Only Follow-Up Evidence
+
+The same 2026-05-14 fresh Phase C diagnostic showed `sport1.maariv.co.il` as a repeated
+candidate-only source suggestion:
+
+| Figure | Value |
+| --- | ---: |
+| Candidates | 147 |
+| Candidate-only candidates | 147 |
+| Runs | 2 |
+| Scrape attempts | 0 |
+| Partial recoveries | 0 |
+| Scrape successes | 0 |
+| Scrape failures | 0 |
+| Score | 185.75 |
+
+Candidate-state inspection showed Sport1 sports-vertical paths such as `israeli-soccer`,
+`world-soccer`, `square`, basketball, tennis, and related sections, but the candidates were still
+article-like URLs and some titles contained legal/crime-adjacent wording. That evidence supports a
+diagnostic-only `sports_vertical_candidate_only` source-suggestion classification. It does not
+support mapping Sport1 into Maariv-family article handling, suppressing Sport1 before
+scrape/classifier evidence exists, source-targeted query fanout, a browser/CDP scraper, queue
+fairness or scrape-cap changes, Mako/Haaretz behavior changes, or broader sports-domain filtering.
+Sport1 candidates and regular `www.maariv.co.il` news/law article URLs remain scrape-eligible.

--- a/docs/january_2026_backfill_wet_test_plan.md
+++ b/docs/january_2026_backfill_wet_test_plan.md
@@ -362,8 +362,8 @@ successful bounded wet test.
 ## Follow-Up PR Map
 
 Use stable planning IDs for the post-wet-test slices so they are not confused with GitHub pull
-request numbers. The current map is three simple cross-cutting PRs, four source-family PRs, and one
-evidence interpretation follow-up:
+request numbers. The current map is three simple cross-cutting PRs, four source-family PRs, and
+three evidence interpretation follow-ups:
 
 1. `WET-PR-EVIDENCE-CONFIG` - planning/config evidence only.
    Add a tracked Brave+Exa/no-Google local search config, document that local operators may bypass
@@ -434,6 +434,18 @@ evidence interpretation follow-up:
    metadata or a retained search-result-only fallback.
    Non-archive News1 pages, recurring source-targeted discovery/backfill queries, generic metadata
    hardening, and any browser/source-native scraper remain out of scope.
+9. `SRC-PR-SPORT1-NOISE` - evidence interpretation follow-up.
+   Implemented as diagnostic-only source-suggestion classification for `sport1.maariv.co.il`, not
+   as a search-noise filter or Maariv-family source support. The fresh 2026-05-14 January 1-7
+   diagnostic showed 147 Sport1 candidates across two runs, all candidate-only, with zero scrape
+   attempts, partial recoveries, successes, or failures. Candidate-state inspection showed
+   sports-vertical paths such as `israeli-soccer`, `world-soccer`, `square`, basketball, tennis, and
+   related sections, but the candidates were still article-like URLs and some titles contained
+   legal/crime-adjacent wording. Source suggestions now flag that shape as
+   `sports_vertical_candidate_only` while keeping Sport1 scrape-eligible until attempted
+   scrape/classifier evidence justifies stronger action. Source-family mapping, source-targeted
+   discovery/backfill fanout, browser/source-native scraper work, queue fairness/prioritization/
+   caps, Mako/Haaretz behavior changes, and broader sports-domain policy remain out of scope.
 
 Do not bundle the source-family work into one large scraper PR. Promote each source-family PR only
 after the latest diagnostics justify it.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -33,6 +33,12 @@ from denbust.taxonomy import default_taxonomy
 
 _SEARCH_ENGINE_NAMES: tuple[str, ...] = ("brave", "exa", "google_cse")
 _SOURCE_SUGGESTION_EXCLUDED_DOMAINS: frozenset[str] = frozenset({"facebook.com"})
+_SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS: dict[str, tuple[str, str]] = {
+    "sport1.maariv.co.il": (
+        "sports_vertical_candidate_only",
+        "candidate-only sports-vertical pressure; keep scrape-eligible until attempted evidence exists",
+    )
+}
 _RETRY_BACKLOG_STATUSES: tuple[CandidateStatus, ...] = (
     CandidateStatus.QUEUED,
     CandidateStatus.SCRAPE_PENDING,
@@ -254,6 +260,8 @@ class SourceSuggestion(BaseModel):
     scrape_failure_count: int = 0
     unsupported_count: int = 0
     score: float = 0.0
+    diagnostic_classification: str | None = None
+    diagnostic_note: str | None = None
 
 
 class SourceSuggestionReport(BaseModel):
@@ -647,13 +655,16 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
         lines.append("")
         lines.append("Source suggestions")
         for suggestion in report.source_suggestions.suggestions:
-            lines.append(
+            line = (
                 "  {domain} score={score:.2f} candidates={candidate_count} runs={run_count} "
                 "candidate_only={candidate_only_count} successes={scrape_success_count} "
                 "partials={scrape_partial_count} failures={scrape_failure_count}".format(
                     **suggestion.model_dump(mode="json")
                 )
             )
+            if suggestion.diagnostic_classification:
+                line += f" diagnostic={suggestion.diagnostic_classification}"
+            lines.append(line)
     if report.notes:
         lines.append("")
         lines.append("Notes")
@@ -1619,6 +1630,16 @@ def _build_source_suggestion_report(
             - failure_count * 0.25
             - unsupported_count * 0.5
         )
+        diagnostic_classification = None
+        diagnostic_note = None
+        if (
+            domain in _SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS
+            and candidate_only_count == len(domain_candidates)
+            and not domain_attempts
+        ):
+            diagnostic_classification, diagnostic_note = _SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS[
+                domain
+            ]
         suggestions.append(
             SourceSuggestion(
                 domain=domain,
@@ -1632,6 +1653,8 @@ def _build_source_suggestion_report(
                 scrape_failure_count=failure_count,
                 unsupported_count=unsupported_count,
                 score=score,
+                diagnostic_classification=diagnostic_classification,
+                diagnostic_note=diagnostic_note,
             )
         )
     suggestions.sort(key=lambda item: (-item.score, -item.candidate_count, item.domain))

--- a/tests/unit/test_discovery_candidate_filters.py
+++ b/tests/unit/test_discovery_candidate_filters.py
@@ -74,6 +74,8 @@ def test_classify_search_noise_marks_expected_noise_domains(
     "url",
     [
         "https://www.ynet.co.il/news/article/abc123",
+        "https://www.maariv.co.il/news/law/article-1270778",
+        "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
         "https://x.com/example/status/123456789",
         "https://mobile.twitter.com/example/status/123456789",
         "https://facebook.com/story.php?story_fbid=5&id=6",

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -1179,6 +1179,75 @@ def test_build_discovery_diagnostic_report_builds_source_suggestions(tmp_path: P
     assert "Source suggestions" in render_discovery_diagnostic_report(report)
 
 
+def test_source_suggestions_classify_sport1_candidate_only_pressure_without_demoting(
+    tmp_path: Path,
+) -> None:
+    """Sport1 candidate-only pressure should be diagnostic, not an eligibility filter."""
+    now = datetime.now(UTC)
+    config = Config(store={"state_root": tmp_path})
+    persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
+    persistence.upsert_candidates(
+        [
+            _candidate(
+                "candidate-sport1-a",
+                url="https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
+                discovered_via=["exa"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=2),
+                last_seen_at=now - timedelta(hours=2),
+            ),
+            _candidate(
+                "candidate-sport1-b",
+                url="https://sport1.maariv.co.il/world-soccer/article/1735653",
+                discovered_via=["brave"],
+                status=CandidateStatus.NEW,
+                first_seen_at=now - timedelta(days=1),
+                last_seen_at=now - timedelta(hours=1),
+            ),
+        ]
+    )
+    persistence.append_provenance(
+        [
+            CandidateProvenance(
+                run_id="run-1",
+                candidate_id="candidate-sport1-a",
+                producer_name="exa",
+                producer_kind=ProducerKind.SEARCH_ENGINE,
+                raw_url=HttpUrl(
+                    "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884"
+                ),
+                normalized_url=HttpUrl(
+                    "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884"
+                ),
+                discovered_at=now - timedelta(days=2),
+            ),
+            CandidateProvenance(
+                run_id="run-2",
+                candidate_id="candidate-sport1-b",
+                producer_name="brave",
+                producer_kind=ProducerKind.SEARCH_ENGINE,
+                raw_url=HttpUrl("https://sport1.maariv.co.il/world-soccer/article/1735653"),
+                normalized_url=HttpUrl("https://sport1.maariv.co.il/world-soccer/article/1735653"),
+                discovered_at=now - timedelta(days=1),
+            ),
+        ]
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+
+    suggestion = report.source_suggestions.suggestions[0]
+    assert suggestion.domain == "sport1.maariv.co.il"
+    assert suggestion.candidate_count == 2
+    assert suggestion.candidate_only_count == 2
+    assert suggestion.scrape_attempt_count == 0
+    assert suggestion.unsupported_count == 0
+    assert suggestion.run_count == 2
+    assert suggestion.score == 4.5
+    assert suggestion.diagnostic_classification == "sports_vertical_candidate_only"
+    assert "candidate-only sports-vertical pressure" in (suggestion.diagnostic_note or "")
+    assert "diagnostic=sports_vertical_candidate_only" in render_discovery_diagnostic_report(report)
+
+
 def test_build_discovery_diagnostic_report_ignores_candidates_without_domain(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -6,6 +6,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from pydantic import HttpUrl
 
 from denbust.data_models import RawArticle
@@ -305,6 +306,44 @@ def test_persist_discovered_candidates_marks_search_noise_unsupported(
         "linkedin.com",
         "instagram.com",
     }
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.maariv.co.il/news/law/article-1270778",
+        "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
+    ],
+)
+def test_persist_discovered_candidates_keeps_maariv_and_sport1_articles_scrapeable(
+    url: str,
+    tmp_path: Path,
+) -> None:
+    """Candidate-only Sport1 evidence should not demote article-like candidates."""
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    discovery = DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl(url),
+        canonical_url=HttpUrl(url),
+        title="חשד לבית בושת בבני ברק",
+        snippet="משטרה, בית בושת, בני ברק",
+        discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-maariv-news"),
+        discovered_candidates=[discovery],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_status.value == "new"
+    assert candidate.needs_review is False
+    assert "unsupported_source_filter" not in candidate.metadata
 
 
 def test_persist_discovered_candidates_demotes_existing_unattempted_search_noise(


### PR DESCRIPTION
## Planning notation

- Notation: `SRC-PR-SPORT1-NOISE`
- Parent milestone: `Phase C`
- Plan source: `.agent-plan.md`, `docs/january_2026_backfill_wet_test_plan.md`, and the fresh Phase C evidence under `data/may_26_followup/20260514T135635Z/`

## Summary

This PR implements the `sport1.maariv.co.il` evidence-investigation slice from the fresh Phase C discovery/backfill pass.

The outcome is diagnostic-only. Source suggestions now label fully candidate-only, unattempted `sport1.maariv.co.il` pressure as `sports_vertical_candidate_only`, while keeping Sport1 candidates scrape-eligible. This preserves the evidence signal without turning candidate-only pressure into a domain denylist.

Regular `www.maariv.co.il` news/law article URLs also remain scrape-eligible.

## Evidence and scope

The fresh generated evidence root is intentionally untracked: `data/may_26_followup/20260514T135635Z`.

The relevant post-scrape diagnostic showed `sport1.maariv.co.il` in source suggestions with:

- `candidate_count=147`
- `candidate_only_count=147`
- `run_count=2`
- `scrape_attempt_count=0`
- `scrape_success_count=0`
- `scrape_failure_count=0`
- `score=185.75`

Candidate-state inspection showed Sport1 sports-vertical paths such as `israeli-soccer`, `world-soccer`, `square`, basketball, tennis, and related sections. But the candidates are still article-like URLs, and some titles contain legal/crime-adjacent wording. That makes the evidence insufficient for suppression before scrape/classifier evidence exists.

## Changes

- Adds `diagnostic_classification` and `diagnostic_note` fields to source suggestions.
- Labels fully candidate-only, unattempted `sport1.maariv.co.il` suggestions as `sports_vertical_candidate_only`.
- Renders the diagnostic classification in `denbust diagnose-discovery` text output.
- Keeps Sport1 article-like search candidates scrape-eligible.
- Keeps regular `www.maariv.co.il/news/law/...` article URLs scrape-eligible.
- Extends tests for source-suggestion counts/scores, diagnostic output, and eligibility boundaries.
- Updates README/operator docs/wet-test evidence/planning docs with the exact deferral boundary.
- Updates `.agent-plan.md` in mainline semantics and sets the next Phase C slice to classifier-output hardening evidence.

## Out of scope

This PR intentionally does not:

- mark Sport1 candidates `unsupported_source`;
- add Sport1 to search-noise filtering;
- add Sport1 to Maariv-family generic-fetch handling;
- add source-targeted discovery or backfill fanout;
- add any browser/CDP or source-native scraper;
- change queue fairness, queue prioritization, or scrape caps;
- alter Mako/Haaretz browser-CDP behavior;
- broaden filtering to unrelated sports domains;
- commit generated `data/` artifacts.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_candidate_filters.py tests/unit/test_discovery_source_native.py tests/unit/test_discovery_diagnostics.py -k 'search_noise or source_suggestions or sport1 or maariv'`
- `.venv/bin/pytest -q tests/unit/test_discovery_candidate_filters.py tests/unit/test_discovery_source_native.py tests/unit/test_discovery_diagnostics.py tests/unit/test_discovery_source_families.py tests/unit/test_discovery_scrape_queue.py`
- `.venv/bin/pytest -q` (`1006 passed, 1 warning`)
