### PR TITLE
CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS: Add fallback diagnostic breakdowns

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,16 +6,16 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `SRC-PR-SPORT1-NOISE` added diagnostic-only
-  `sports_vertical_candidate_only` source-suggestion labeling for `sport1.maariv.co.il` after the
-  fresh 2026-05-14 January 1-7 evidence pass showed 147 Sport1 candidates across two runs, all
-  candidate-only, with zero scrape attempts, partial recoveries, successes, or failures. The slice
-  keeps Sport1 and regular `www.maariv.co.il` news/law article URLs scrape-eligible and does not add
-  Maariv-family source support, source-targeted fanout, browser/CDP scraping, queue fairness or
-  scrape-cap changes, Mako/Haaretz behavior changes, or broader sports-domain policy.
-- Next planned PR: investigate the fresh Phase C classifier-output evidence from the same bounded
-  drain, focusing on low-confidence candidate-fallback rows and parse/taxonomy warning signals
-  before proposing any queue behavior, scraper change, or source-family expansion.
+- Last merged PR on main: `CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS` added diagnostic-only
+  low-confidence candidate-fallback breakdowns after the fresh 2026-05-14 Phase C bounded drain
+  showed 30 retained candidate-fallback operational rows, all partial-page rows and all
+  low-confidence at the retained-record level. The slice reports fallback confidence distributions
+  and low-confidence fallback rows by source, domain, and taxonomy label, while leaving
+  run-log-only parse/taxonomy warning capture, classifier prompts, taxonomy policy, queue behavior,
+  scraper behavior, and source-family expansion unchanged.
+- Next planned PR: persist and report run-level classifier parse/taxonomy warning counts from
+  scrape/backfill runs, if the existing run/debug-summary surfaces can carry those signals without
+  changing classifier policy or prompts.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -108,9 +108,13 @@
   pressure in source-suggestion diagnostics while keeping Sport1 and regular `www.maariv.co.il`
   news/law article candidates scrape-eligible and avoiding Maariv-family support, source-targeted
   fanout, scraper work, queue behavior changes, or broader sports-domain filtering.
-- [next] Investigate low-confidence candidate-fallback classifier output and parse/taxonomy warning
-  signals from the fresh 2026-05-14 Phase C bounded drain before proposing queue behavior, scraper,
-  or source-family changes.
+- [done] `CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS`: add persisted diagnostic aggregation for
+  low-confidence candidate-fallback rows by source, domain, taxonomy label, and confidence field,
+  based on the fresh 2026-05-14 Phase C bounded drain, without changing classifier policy, queue
+  behavior, scraper behavior, or source-family support.
+- [next] `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS`: persist and report run-level classifier parse and
+  invalid-taxonomy warning counts in existing scrape/backfill run or debug-summary artifacts, if a
+  bounded implementation path exists without changing classifier prompts or policy.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Planned future datasets:
 - Breaks down partial-page diagnostics so operators can distinguish retained candidate-fallback
   operational rows, metadata-only partials, search-result-only generic fetch failures, source vs
   generic partial attempts, generic partials after source-adapter attempts, dominant partial
-  domains/sources, and visible current-candidate classifier/taxonomy risk signals
+  domains/sources, and visible current-candidate classifier/taxonomy risk signals, including
+  low-confidence fallback counts by source, domain, taxonomy label, and confidence field
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -278,12 +278,31 @@ many `partial_page` candidates:
   dominating partial outcomes.
 - `classifier_warning_signals` summarizes what discovery diagnostics can infer from persisted
   current-candidate fallback operational rows: fallback rows, partial fallback rows, low-confidence
-  fallback rows, missing taxonomy pairs, and invalid taxonomy pairs. Unrelated historical fallback
-  rows in the operational store are ignored. Run-level classifier parse warnings that are not
-  persisted in candidate or operational state still need the matching run log or debug summary.
+  fallback rows, missing taxonomy pairs, invalid taxonomy pairs, fallback confidence distributions,
+  and low-confidence fallback breakdowns by source, domain, and taxonomy label. Unrelated
+  historical fallback rows in the operational store are ignored. Run-level classifier parse warnings
+  that are not persisted in candidate or operational state still need the matching run log or debug
+  summary.
 
 This diagnostic slice is interpretation-only. It does not change queue fairness, source
 prioritization, scrape caps, generic fetch behavior, or source-family scraper support.
+
+After `CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS`, the fresh 2026-05-14 Phase C bounded drain
+showed 30 retained candidate-fallback operational rows, all partial-page rows and all
+low-confidence at the record level, while the scrape log also contained classifier parse and invalid
+taxonomy-pair warnings. The durable diagnostic gap was that `denbust diagnose-discovery` flattened
+those 30 low-confidence fallback rows into a single count, obscuring whether the pressure was tied
+to specific source labels, domains, taxonomy labels, or confidence fields. The slice therefore:
+
+- adds fallback `record_confidence` and `classification_confidence` count distributions;
+- reports low-confidence fallback rows by source label, source domain, and taxonomy pair;
+- keeps the counts scoped to operational rows matched to the current candidate state;
+- leaves run-log-only parse and invalid taxonomy warnings as a separate persistence/reporting
+  follow-up because those warnings are not attached to candidate or operational records today.
+
+This is still diagnostic-only. It does not change classifier prompts, taxonomy policy, queue
+fairness, source prioritization, scrape candidate selection, generic fetch behavior,
+browser/CDP scraping, or source-family support.
 
 After `SRC-PR-GLOBES-THEMARKER`, search-discovered Globes and TheMarker article pages have bounded
 generic-fetch source-family support. The January 1-7 evidence showed Globes as a repeated

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -1,6 +1,6 @@
 # January 1-7, 2026 Backfill Wet-Test Evidence
 
-Date summarized: 2026-05-13
+Date summarized: 2026-05-13, with 2026-05-14 Phase C diagnostic addenda appended.
 
 This is the checked-in evidence summary for the bounded January 1-7 Chrome-CDP wet test. The
 generated logs and JSON artifacts remain local under `data/may_26_followup/20260503T214851Z/` and
@@ -210,3 +210,27 @@ support mapping Sport1 into Maariv-family article handling, suppressing Sport1 b
 scrape/classifier evidence exists, source-targeted query fanout, a browser/CDP scraper, queue
 fairness or scrape-cap changes, Mako/Haaretz behavior changes, or broader sports-domain filtering.
 Sport1 candidates and regular `www.maariv.co.il` news/law article URLs remain scrape-eligible.
+
+## 2026-05-14 Addendum: Fresh Classifier Candidate-Fallback Diagnostic Evidence
+
+The same 2026-05-14 fresh Phase C diagnostic reported 30 retained candidate-fallback operational
+rows. All 30 were partial-page fallback rows and all 30 were low-confidence at the retained-record
+level, while none had missing or invalid taxonomy pairs in the persisted operational state. Direct
+inspection of the local operational rows showed the low-confidence fallback rows were spread across
+Haaretz, Walla, Mako, Ynet, TheMarker, Brave-only, and Globes source labels and across valid TFHT
+taxonomy pairs such as `brothels/keeping_brothel`,
+`human_trafficking/trafficking_slavery_conditions`, and
+`pimping_prostitution/phenomenon_coverage`.
+
+The scrape log also contained run-level classifier warnings: invalid taxonomy pairs
+`pimping_prostitution / advertising_prostitution` and
+`human_trafficking / phenomenon_coverage`, plus several JSON parse failures. Those warnings were
+visible only in the run log, not in candidate state or the retained operational records. This
+supports improving persisted diagnostic aggregation for matched candidate-fallback rows, while
+leaving run-log warning capture as a separate diagnostic persistence follow-up.
+
+`CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS` therefore adds source/domain/taxonomy/confidence
+breakdowns for low-confidence fallback rows in `partial_page_diagnostics.classifier_warning_signals`.
+It does not change classifier prompts or policy, taxonomy validity, queue fairness, scrape
+candidate selection, generic fetch behavior, browser/CDP scraping, source-family support, or source
+targeted query fanout.

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -217,6 +217,11 @@ class ClassifierWarningSignals(BaseModel):
     partial_page_fallback_without_taxonomy_count: int = 0
     low_confidence_fallback_record_count: int = 0
     invalid_taxonomy_pair_record_count: int = 0
+    fallback_record_confidence_counts: list[FailureSummary] = Field(default_factory=list)
+    fallback_classification_confidence_counts: list[FailureSummary] = Field(default_factory=list)
+    low_confidence_fallback_records_by_source: list[FailureSummary] = Field(default_factory=list)
+    low_confidence_fallback_records_by_domain: list[FailureSummary] = Field(default_factory=list)
+    low_confidence_fallback_records_by_taxonomy: list[FailureSummary] = Field(default_factory=list)
 
 
 class PartialPageDiagnostics(BaseModel):
@@ -651,6 +656,46 @@ def render_discovery_diagnostic_report(report: DiscoveryDiagnosticReport) -> str
                 **classifier.model_dump(mode="json")
             )
         )
+        if classifier.fallback_record_confidence_counts:
+            lines.append(
+                "  fallback_record_confidence: "
+                + ", ".join(
+                    f"{item.name}={item.count}"
+                    for item in classifier.fallback_record_confidence_counts
+                )
+            )
+        if classifier.fallback_classification_confidence_counts:
+            lines.append(
+                "  fallback_classification_confidence: "
+                + ", ".join(
+                    f"{item.name}={item.count}"
+                    for item in classifier.fallback_classification_confidence_counts
+                )
+            )
+        if classifier.low_confidence_fallback_records_by_source:
+            lines.append(
+                "  low_confidence_fallback_sources: "
+                + ", ".join(
+                    f"{item.name}={item.count}"
+                    for item in classifier.low_confidence_fallback_records_by_source
+                )
+            )
+        if classifier.low_confidence_fallback_records_by_domain:
+            lines.append(
+                "  low_confidence_fallback_domains: "
+                + ", ".join(
+                    f"{item.name}={item.count}"
+                    for item in classifier.low_confidence_fallback_records_by_domain
+                )
+            )
+        if classifier.low_confidence_fallback_records_by_taxonomy:
+            lines.append(
+                "  low_confidence_fallback_taxonomy: "
+                + ", ".join(
+                    f"{item.name}={item.count}"
+                    for item in classifier.low_confidence_fallback_records_by_taxonomy
+                )
+            )
     if report.source_suggestions.suggestions:
         lines.append("")
         lines.append("Source suggestions")
@@ -996,7 +1041,7 @@ def _build_failure_summaries(
         else:
             raise ValueError(f"Unsupported failure summary key: {key}")
         counts[value] += 1
-    return [FailureSummary(name=name, count=count) for name, count in counts.most_common(5)]
+    return _failure_summaries_from_counter(counts)
 
 
 def _build_scrape_failure_diagnostics(
@@ -1324,9 +1369,12 @@ def _candidate_has_generic_fetch_status(
 
 
 def _failure_summaries_from_counter(
-    counts: Counter[str], *, limit: int = 5
+    counts: Counter[str], *, limit: int | None = 5
 ) -> list[FailureSummary]:
-    return [FailureSummary(name=name, count=count) for name, count in counts.most_common(limit)]
+    ordered_counts = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    if limit is not None:
+        ordered_counts = ordered_counts[:limit]
+    return [FailureSummary(name=name, count=count) for name, count in ordered_counts]
 
 
 def _record_content_basis(row: dict[str, Any]) -> str:
@@ -1352,6 +1400,26 @@ def _record_has_valid_taxonomy_pair(row: dict[str, Any]) -> bool:
     if not isinstance(category, str) or not isinstance(subcategory, str):
         return False
     return default_taxonomy().has_pair(category, subcategory)
+
+
+def _record_label(row: dict[str, Any], field_name: str, *, default: str = "unknown") -> str:
+    value = row.get(field_name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
+
+
+def _record_confidence_label(row: dict[str, Any], field_name: str) -> str:
+    return _record_label(row, field_name).casefold()
+
+
+def _record_taxonomy_label(row: dict[str, Any]) -> str:
+    if not _record_has_taxonomy_pair(row):
+        return "missing"
+    return "{category}/{subcategory}".format(
+        category=row["taxonomy_category_id"],
+        subcategory=row["taxonomy_subcategory_id"],
+    )
 
 
 def _partial_attempt_source_label(attempt: ScrapeAttempt) -> str:
@@ -1400,8 +1468,15 @@ def _build_classifier_warning_signals(
     low_confidence_rows = [
         row
         for row in fallback_rows
-        if row.get("record_confidence") == "low" or row.get("classification_confidence") == "low"
+        if _record_confidence_label(row, "record_confidence") == "low"
+        or _record_confidence_label(row, "classification_confidence") == "low"
     ]
+    record_confidence_counts = Counter(
+        _record_confidence_label(row, "record_confidence") for row in fallback_rows
+    )
+    classification_confidence_counts = Counter(
+        _record_confidence_label(row, "classification_confidence") for row in fallback_rows
+    )
     return ClassifierWarningSignals(
         candidate_fallback_record_count=len(fallback_rows),
         partial_page_fallback_record_count=len(partial_rows),
@@ -1412,6 +1487,26 @@ def _build_classifier_warning_signals(
         ),
         low_confidence_fallback_record_count=len(low_confidence_rows),
         invalid_taxonomy_pair_record_count=len(invalid_taxonomy_pairs),
+        fallback_record_confidence_counts=_failure_summaries_from_counter(
+            record_confidence_counts,
+            limit=None,
+        ),
+        fallback_classification_confidence_counts=_failure_summaries_from_counter(
+            classification_confidence_counts,
+            limit=None,
+        ),
+        low_confidence_fallback_records_by_source=_failure_summaries_from_counter(
+            Counter(_record_label(row, "source_name") for row in low_confidence_rows),
+            limit=None,
+        ),
+        low_confidence_fallback_records_by_domain=_failure_summaries_from_counter(
+            Counter(_record_label(row, "source_domain") for row in low_confidence_rows),
+            limit=None,
+        ),
+        low_confidence_fallback_records_by_taxonomy=_failure_summaries_from_counter(
+            Counter(_record_taxonomy_label(row) for row in low_confidence_rows),
+            limit=None,
+        ),
     )
 
 

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -363,6 +363,8 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 "content_basis": "partial_page",
                 "record_confidence": "low",
                 "classification_confidence": "low",
+                "taxonomy_category_id": "brothels",
+                "taxonomy_subcategory_id": "keeping_brothel",
             },
             {
                 "id": "full-row-same-url",
@@ -395,6 +397,9 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
                 "event_candidate_ids": ["partial-metadata-only"],
                 "content_basis": "search_result_only",
                 "record_confidence": "high",
+                "classification_confidence": "high",
+                "taxonomy_category_id": "pimping_prostitution",
+                "taxonomy_subcategory_id": "phenomenon_coverage",
             },
             {
                 "id": "unrelated-fallback",
@@ -459,7 +464,34 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     assert partials.classifier_warning_signals.search_result_only_fallback_record_count == 2
     assert partials.classifier_warning_signals.low_confidence_fallback_record_count == 2
     assert partials.classifier_warning_signals.invalid_taxonomy_pair_record_count == 1
-    assert partials.classifier_warning_signals.partial_page_fallback_without_taxonomy_count == 1
+    assert partials.classifier_warning_signals.partial_page_fallback_without_taxonomy_count == 0
+    assert [
+        item.model_dump(mode="json")
+        for item in partials.classifier_warning_signals.fallback_record_confidence_counts
+    ] == [{"name": "low", "count": 2}, {"name": "high", "count": 1}]
+    assert [
+        item.model_dump(mode="json")
+        for item in partials.classifier_warning_signals.fallback_classification_confidence_counts
+    ] == [
+        {"name": "high", "count": 1},
+        {"name": "low", "count": 1},
+        {"name": "unknown", "count": 1},
+    ]
+    assert [
+        item.model_dump(mode="json")
+        for item in partials.classifier_warning_signals.low_confidence_fallback_records_by_source
+    ] == [{"name": "globes", "count": 2}]
+    assert [
+        item.model_dump(mode="json")
+        for item in partials.classifier_warning_signals.low_confidence_fallback_records_by_domain
+    ] == [{"name": "globes.co.il", "count": 2}]
+    assert [
+        item.model_dump(mode="json")
+        for item in partials.classifier_warning_signals.low_confidence_fallback_records_by_taxonomy
+    ] == [
+        {"name": "brothels/keeping_brothel", "count": 1},
+        {"name": "invalid_category/invalid_subcategory", "count": 1},
+    ]
     rendered = render_discovery_diagnostic_report(report)
     assert "Partial pages" in rendered
     assert "operational_matching=enabled" in rendered
@@ -468,6 +500,9 @@ def test_build_discovery_diagnostic_report_breaks_down_partial_pages(
     assert "partial_attempt_kinds: generic_fetch=2, source_adapter=1" in rendered
     assert "partial_attempt_sources: generic_fetch=2, unknown_source_adapter=1" in rendered
     assert "classifier_signals candidate_fallback_records=3" in rendered
+    assert "fallback_record_confidence: low=2, high=1" in rendered
+    assert "low_confidence_fallback_sources: globes=2" in rendered
+    assert "low_confidence_fallback_taxonomy: brothels/keeping_brothel=1" in rendered
 
 
 def test_partial_page_diagnostics_mark_operational_counts_as_unmeasured_when_skipped(
@@ -499,6 +534,101 @@ def test_partial_page_diagnostics_mark_operational_counts_as_unmeasured_when_ski
     assert partials.retained_operational_record_count == 0
     assert partials.metadata_only_partial_candidate_count == 0
     assert "operational_matching=skipped" in render_discovery_diagnostic_report(report)
+
+
+def test_classifier_warning_signals_report_all_low_confidence_fallback_groups(
+    tmp_path: Path,
+) -> None:
+    """Classifier fallback breakdowns should not hide low-confidence tail groups."""
+    now = datetime.now(UTC)
+    config = Config(
+        store={"state_root": tmp_path},
+        operational={
+            "provider": OperationalProvider.LOCAL_JSON,
+            "root_dir": tmp_path / "operational",
+        },
+    )
+    taxonomy_pairs = [
+        ("brothels", "administrative_closure"),
+        ("brothels", "keeping_brothel"),
+        ("human_trafficking", "trafficking_slavery_conditions"),
+        ("human_trafficking", "trafficking_sexual_exploitation"),
+        ("human_trafficking", "trafficking_women"),
+        ("pimping_prostitution", "phenomenon_coverage"),
+        (None, None),
+    ]
+    sources = ["walla", "haaretz", "mako", "ynet", "brave", "globes", "maariv"]
+    domains = [
+        "news.walla.co.il",
+        "haaretz.co.il",
+        "mako.co.il",
+        "ynet.co.il",
+        "law.acri.org.il",
+        "globes.co.il",
+        "maariv.co.il",
+    ]
+    candidates = [
+        _candidate(
+            f"fallback-tail-{index}",
+            url=f"https://example-{index}.co.il/article",
+            discovered_via=["brave"],
+            status=CandidateStatus.PARTIALLY_SCRAPED,
+            first_seen_at=now - timedelta(days=1),
+            last_seen_at=now,
+            content_basis=ContentBasis.PARTIAL_PAGE,
+        )
+        for index in range(len(sources))
+    ]
+    StateRepoDiscoveryPersistence(config.discovery_state_paths).upsert_candidates(candidates)
+    LocalJsonOperationalStore(tmp_path / "operational").upsert_records(
+        DatasetName.NEWS_ITEMS.value,
+        [
+            {
+                "id": f"fallback-tail-row-{index}",
+                "source_name": source,
+                "source_domain": domains[index],
+                "publication_datetime": now.isoformat(),
+                "retrieval_datetime": now.isoformat(),
+                "annotation_source": "candidate_fallback",
+                "event_candidate_ids": [candidate.candidate_id],
+                "content_basis": "partial_page",
+                "record_confidence": " Low " if index == 0 else "LOW" if index == 1 else "low",
+                "classification_confidence": " Medium ",
+                **(
+                    {
+                        "taxonomy_category_id": taxonomy_pairs[index][0],
+                        "taxonomy_subcategory_id": taxonomy_pairs[index][1],
+                    }
+                    if taxonomy_pairs[index] != (None, None)
+                    else {}
+                ),
+            }
+            for index, (candidate, source) in enumerate(zip(candidates, sources, strict=True))
+        ],
+    )
+
+    report = build_discovery_diagnostic_report(config=config)
+    signals = report.partial_page_diagnostics.classifier_warning_signals
+
+    assert signals.low_confidence_fallback_record_count == 7
+    assert [item.model_dump(mode="json") for item in signals.fallback_record_confidence_counts] == [
+        {"name": "low", "count": 7}
+    ]
+    assert [
+        item.model_dump(mode="json") for item in signals.fallback_classification_confidence_counts
+    ] == [{"name": "medium", "count": 7}]
+    assert [item.name for item in signals.low_confidence_fallback_records_by_source] == sorted(
+        sources
+    )
+    assert [item.name for item in signals.low_confidence_fallback_records_by_domain] == sorted(
+        domains
+    )
+    assert all(item.count == 1 for item in signals.low_confidence_fallback_records_by_source)
+    assert all(item.count == 1 for item in signals.low_confidence_fallback_records_by_domain)
+    assert [item.name for item in signals.low_confidence_fallback_records_by_taxonomy] == sorted(
+        {f"{category}/{subcategory}" for category, subcategory in taxonomy_pairs} - {"None/None"}
+        | {"missing"}
+    )
 
 
 def test_discovery_diagnostic_report_treats_event_id_only_operational_rows_as_available(


### PR DESCRIPTION
## Planning notation

CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS under the Phase C plan, tracked from `.agent-plan.md`.

## Summary

- Add persisted diagnostic breakdowns under `partial_page_diagnostics.classifier_warning_signals` for candidate-fallback confidence distributions and low-confidence fallback rows by source, domain, and taxonomy pair.
- Render those breakdowns in `denbust diagnose-discovery` text output while preserving the existing aggregate counts.
- Update README, discovery operations docs, January wet-test evidence, and `.agent-plan.md` to describe the diagnostic boundary and next follow-up.

## Evidence and scope

The fresh 2026-05-14 Phase C bounded drain under `data/may_26_followup/20260514T135635Z/` reported 30 retained candidate-fallback operational rows. All 30 were partial-page fallback rows and all 30 were low-confidence at the retained-record level. The previous diagnostic artifact flattened that signal into one count, hiding whether the rows clustered by source label, source domain, taxonomy pair, or confidence field.

Regenerating diagnostics over the same local state now exposes the expected breakdowns: record confidence `low=30`, classification confidence `high=21, medium=9`, top low-confidence source labels `walla=8`, `haaretz=8`, `mako=5`, `ynet=4`, `brave=2`, and top taxonomy labels led by `brothels/keeping_brothel=7`, `pimping_prostitution/phenomenon_coverage=6`, and `human_trafficking/trafficking_slavery_conditions=6`.

The scrape log also showed classifier parse failures and invalid taxonomy-pair warnings, but those warnings are not attached to candidate or operational rows today. This PR documents that as the next bounded diagnostic persistence follow-up instead of changing classifier policy in this slice.

## Intentionally out of scope

- No queue fairness, prioritization, scrape-cap, or scrape candidate-selection changes.
- No source-family support, source-targeted fanout, browser/CDP scraper, or generic fetch behavior changes.
- No classifier prompt, classifier policy, or taxonomy validity changes.
- No generated `data/` artifacts committed.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py -k "partial_page or classifier_warning"`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py tests/unit/test_classifier.py tests/unit/test_cli.py -k "diagnose_discovery or partial_page or classifier_warning or parse"`
- `.venv/bin/pytest -q tests/unit/test_discovery_diagnostics.py`
- `DENBUST_STATE_ROOT=data/may_26_followup/20260514T135635Z/state .venv/bin/denbust diagnose-discovery --config agents/news/local_search_brave_exa.yaml --format json --output /tmp/classifier_candidate_fallback_diagnostics_check.json`

Pre-commit/pre-push hooks also ran successfully during commit and push.