### PR TITLE
CLASSIFIER-PR-RUN-WARNING-ARTIFACTS: Persist classifier warning counts

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,16 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS` added diagnostic-only
-  low-confidence candidate-fallback breakdowns after the fresh 2026-05-14 Phase C bounded drain
-  showed 30 retained candidate-fallback operational rows, all partial-page rows and all
-  low-confidence at the retained-record level. The slice reports fallback confidence distributions
-  and low-confidence fallback rows by source, domain, and taxonomy label, while leaving
-  run-log-only parse/taxonomy warning capture, classifier prompts, taxonomy policy, queue behavior,
-  scraper behavior, and source-family expansion unchanged.
-- Next planned PR: persist and report run-level classifier parse/taxonomy warning counts from
-  scrape/backfill runs, if the existing run/debug-summary surfaces can carry those signals without
-  changing classifier policy or prompts.
+- Last merged PR on main: `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS` added diagnostic-only run-level
+  classifier parser warning counters after the fresh 2026-05-14 Phase C bounded drain showed
+  parse and invalid-taxonomy warnings only in logs. Run debug summaries now persist
+  `classifier_summary.warning_counts`, and fallback-only scrape/backfill drains emit compact scrape
+  debug summaries so provisional candidate-fallback runs have machine-readable warning counts.
+- Next planned PR: use persisted run-level classifier warning counts from the next bounded Phase C
+  scrape/backfill evidence pass to decide whether classifier-output hardening is warranted, while
+  keeping any prompt or taxonomy-policy change out of scope until artifact-backed warning rates
+  justify it.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -112,9 +111,13 @@
   low-confidence candidate-fallback rows by source, domain, taxonomy label, and confidence field,
   based on the fresh 2026-05-14 Phase C bounded drain, without changing classifier policy, queue
   behavior, scraper behavior, or source-family support.
-- [next] `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS`: persist and report run-level classifier parse and
+- [done] `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS`: persist and report run-level classifier parse and
   invalid-taxonomy warning counts in existing scrape/backfill run or debug-summary artifacts, if a
   bounded implementation path exists without changing classifier prompts or policy.
+- [next] `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`: use persisted
+  `classifier_summary.warning_counts` from the next bounded Phase C scrape/backfill evidence pass to
+  determine whether classifier-output hardening is justified, without changing prompts, taxonomy
+  policy, queue behavior, scraper behavior, or source-family support in advance of that evidence.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Planned future datasets:
   generic partial attempts, generic partials after source-adapter attempts, dominant partial
   domains/sources, and visible current-candidate classifier/taxonomy risk signals, including
   low-confidence fallback counts by source, domain, taxonomy label, and confidence field
+- Persists run-level classifier parser warning counts in run debug summaries under
+  `classifier_summary.warning_counts`, including JSON parse failures and invalid taxonomy pairs,
+  and exposes fallback-only scrape/backfill context under `fallback_classifier_summary`, without
+  changing classifier prompts, taxonomy policy, or scrape selection behavior
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -280,9 +280,9 @@ many `partial_page` candidates:
   current-candidate fallback operational rows: fallback rows, partial fallback rows, low-confidence
   fallback rows, missing taxonomy pairs, invalid taxonomy pairs, fallback confidence distributions,
   and low-confidence fallback breakdowns by source, domain, and taxonomy label. Unrelated
-  historical fallback rows in the operational store are ignored. Run-level classifier parse warnings
-  that are not persisted in candidate or operational state still need the matching run log or debug
-  summary.
+  historical fallback rows in the operational store are ignored. Run-level classifier parser
+  warnings are tracked separately in the run debug summary because they are emitted before any
+  candidate or operational record identity exists.
 
 This diagnostic slice is interpretation-only. It does not change queue fairness, source
 prioritization, scrape caps, generic fetch behavior, or source-family scraper support.
@@ -303,6 +303,18 @@ to specific source labels, domains, taxonomy labels, or confidence fields. The s
 This is still diagnostic-only. It does not change classifier prompts, taxonomy policy, queue
 fairness, source prioritization, scrape candidate selection, generic fetch behavior,
 browser/CDP scraping, or source-family support.
+
+After `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS`, scrape/backfill/ingest run debug summaries include
+`classifier_summary.warning_counts` with stable counters for classifier JSON parse failures, invalid
+taxonomy pairs, invalid legacy category/sub-category pairs, and relevant responses without a usable
+taxonomy or legacy category. Fallback-only `scrape_candidates` and `backfill_scrape` drains now emit
+a compact scrape debug payload, so a run that only retains provisional candidate-fallback rows still
+has a `.summary.json` artifact carrying those warning counts. Those fallback-only payloads also
+include `fallback_classifier_summary` with fallback classifier input counts, retained fallback
+operational-record counts, and the same warning counters so operators do not have to interpret
+fallback classification through zero full-article counts. These fields are diagnostic-only: they do
+not alter classifier prompts, taxonomy validity rules, candidate selection, queue fairness, generic
+fetch behavior, browser/CDP scraping, or source-family support.
 
 After `SRC-PR-GLOBES-THEMARKER`, search-discovered Globes and TheMarker article pages have bounded
 generic-fetch source-family support. The January 1-7 evidence showed Globes as a repeated

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -234,3 +234,26 @@ breakdowns for low-confidence fallback rows in `partial_page_diagnostics.classif
 It does not change classifier prompts or policy, taxonomy validity, queue fairness, scrape
 candidate selection, generic fetch behavior, browser/CDP scraping, source-family support, or source
 targeted query fanout.
+
+## 2026-05-14 Addendum: Run-Level Classifier Warning Artifacts
+
+`CLASSIFIER-PR-RUN-WARNING-ARTIFACTS` addresses the separate run-log-only warning gap from the same
+fresh Phase C bounded drain. The bounded implementation path is the existing run debug summary
+artifact, not discovery diagnostics: parse failures and invalid taxonomy pairs occur inside the
+classifier parser before there is necessarily a durable candidate or operational-record identity to
+attach to.
+
+Run debug summaries now persist `classifier_summary.warning_counts` with counts for:
+
+- `parse_failure_count`
+- `invalid_taxonomy_pair_count`
+- `invalid_legacy_pair_count`
+- `relevant_without_usable_taxonomy_count`
+
+Fallback-only `scrape_candidates` and `backfill_scrape` runs also emit a compact scrape debug
+payload so retained provisional candidate-fallback rows do not leave classifier parser warnings
+visible only in process logs. The compact payload includes a dedicated `fallback_classifier_summary`
+for fallback classifier input counts, retained fallback operational-record counts, and warning
+counts. This is diagnostic persistence only. It does not change classifier prompts, taxonomy
+validity, classifier policy, queue fairness, scrape candidate selection, generic fetch behavior,
+browser/CDP scraping, source-family support, or source-targeted query fanout.

--- a/src/denbust/classifier/relevance.py
+++ b/src/denbust/classifier/relevance.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import logging
 import re
+from dataclasses import dataclass
 
 import anthropic
 from anthropic.types import TextBlock
@@ -116,6 +117,25 @@ class ClassifierProviderError(RuntimeError):
     """Raised when the configured classifier provider fails before returning usable text."""
 
 
+@dataclass
+class ClassifierWarningCounts:
+    """Run-local classifier parser warning counters."""
+
+    parse_failure_count: int = 0
+    invalid_taxonomy_pair_count: int = 0
+    invalid_legacy_pair_count: int = 0
+    relevant_without_usable_taxonomy_count: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        """Return stable artifact fields for run/debug summaries."""
+        return {
+            "parse_failure_count": self.parse_failure_count,
+            "invalid_taxonomy_pair_count": self.invalid_taxonomy_pair_count,
+            "invalid_legacy_pair_count": self.invalid_legacy_pair_count,
+            "relevant_without_usable_taxonomy_count": self.relevant_without_usable_taxonomy_count,
+        }
+
+
 def sanitize_provider_error_message(error: BaseException | str) -> str:
     """Return compact provider error text safe for logs and artifacts."""
     raw_message = str(error) or type(error).__name__
@@ -159,6 +179,16 @@ class Classifier:
         self._system_prompt = system_prompt
         self._user_prompt_template = user_prompt_template or CLASSIFICATION_PROMPT
         self._taxonomy = default_taxonomy()
+        self._warning_counts = ClassifierWarningCounts()
+
+    @property
+    def warning_counts(self) -> dict[str, int]:
+        """Return run-local parser warning counters for diagnostic artifacts."""
+        return self._warning_counts.as_dict()
+
+    def reset_warning_counts(self) -> None:
+        """Reset parser warning counters at a pipeline run boundary."""
+        self._warning_counts = ClassifierWarningCounts()
 
     async def classify(self, article: RawArticle) -> ClassificationResult:
         """Classify a single article."""
@@ -207,6 +237,19 @@ class Classifier:
                 normalized_text = "\n".join(lines[1:-1] if lines[-1] == "```" else lines[1:])
 
             data = json.loads(normalized_text)
+            if not isinstance(data, dict):
+                self._warning_counts.parse_failure_count += 1
+                logger.warning(
+                    "Failed to parse classification response: expected JSON object, got %s",
+                    type(data).__name__,
+                )
+                return ClassificationResult(
+                    relevant=False,
+                    enforcement_related=False,
+                    category=Category.NOT_RELEVANT,
+                    sub_category=None,
+                    confidence="low",
+                )
             relevant = bool(data.get("relevant", False))
             enforcement_related = bool(data.get("enforcement_related", False))
 
@@ -229,6 +272,7 @@ class Classifier:
                         taxonomy_subcategory_id,
                     )
                 else:
+                    self._warning_counts.invalid_taxonomy_pair_count += 1
                     logger.warning(
                         "Invalid taxonomy pair from classifier: %s / %s",
                         taxonomy_category_id,
@@ -254,6 +298,7 @@ class Classifier:
                 if sub_category is not None:
                     allowed_subcategories = ALLOWED_SUBCATEGORIES.get(category, set())
                     if sub_category not in allowed_subcategories:
+                        self._warning_counts.invalid_legacy_pair_count += 1
                         logger.warning(
                             "Invalid category/sub_category pair from classifier: %s / %s",
                             category,
@@ -261,6 +306,7 @@ class Classifier:
                         )
                         sub_category = None
                 if relevant and category == Category.NOT_RELEVANT:
+                    self._warning_counts.relevant_without_usable_taxonomy_count += 1
                     logger.warning(
                         "Classifier returned relevant=true without a usable taxonomy leaf or legacy category"
                     )
@@ -284,6 +330,7 @@ class Classifier:
             )
 
         except (json.JSONDecodeError, KeyError) as error:
+            self._warning_counts.parse_failure_count += 1
             logger.warning("Failed to parse classification response: %s", error)
             return ClassificationResult(
                 relevant=False,

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 from collections import defaultdict
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -132,6 +133,12 @@ _OPERATIONAL_STORE_JOBS = {
     JobName.RELEASE,
     JobName.BACKUP,
 }
+_CLASSIFIER_WARNING_COUNT_KEYS = (
+    "parse_failure_count",
+    "invalid_taxonomy_pair_count",
+    "invalid_legacy_pair_count",
+    "relevant_without_usable_taxonomy_count",
+)
 
 
 def _sanitize_classifier_provider_error(error: ClassifierProviderError) -> str:
@@ -148,6 +155,27 @@ def _mark_classifier_provider_error(
     result.fatal = True
     result.errors.append(f"classifier_provider_error={sanitized}")
     return sanitized
+
+
+def _classifier_warning_counts(classifier: object) -> dict[str, int]:
+    """Read passive classifier parser warning counters when the classifier exposes them."""
+    raw_counts = getattr(classifier, "warning_counts", None)
+    if callable(raw_counts):
+        raw_counts = raw_counts()
+    if not isinstance(raw_counts, Mapping):
+        return dict.fromkeys(_CLASSIFIER_WARNING_COUNT_KEYS, 0)
+    counts: dict[str, int] = {}
+    for key in _CLASSIFIER_WARNING_COUNT_KEYS:
+        value = raw_counts.get(key, 0)
+        counts[key] = value if isinstance(value, int) and not isinstance(value, bool) else 0
+    return counts
+
+
+def _reset_classifier_warning_counts(classifier: object) -> None:
+    """Reset classifier parser warning counters when the classifier exposes a reset hook."""
+    reset = getattr(classifier, "reset_warning_counts", None)
+    if callable(reset):
+        reset()
 
 
 def release_publication_dir(config: Config) -> Path:
@@ -1107,6 +1135,7 @@ async def _process_ingest_articles(
                 unseen_articles=unseen_articles,
                 classified_articles=classified_articles,
                 unified_items=unified_items,
+                classifier_warning_counts=_classifier_warning_counts(classifier),
             )
         )
         return result
@@ -1126,6 +1155,7 @@ async def _process_ingest_articles(
                 unseen_articles=unseen_articles,
                 classified_articles=classified_articles,
                 unified_items=unified_items,
+                classifier_warning_counts=_classifier_warning_counts(classifier),
             )
         )
         return result
@@ -1156,6 +1186,7 @@ async def _process_ingest_articles(
                 classified_articles=classified_articles,
                 unified_items=unified_items,
                 classifier_error=sanitized_error,
+                classifier_warning_counts=_classifier_warning_counts(classifier),
             )
         )
         return result
@@ -1175,6 +1206,7 @@ async def _process_ingest_articles(
                 unseen_articles=unseen_articles,
                 classified_articles=classified_articles,
                 unified_items=unified_items,
+                classifier_warning_counts=_classifier_warning_counts(classifier),
             )
         )
         return result
@@ -1213,6 +1245,7 @@ async def _process_ingest_articles(
             unseen_articles=unseen_articles,
             classified_articles=classified_articles,
             unified_items=unified_items,
+            classifier_warning_counts=_classifier_warning_counts(classifier),
         )
     )
     return result
@@ -1356,6 +1389,7 @@ def _build_classifier_summary(
     unseen_articles: list[RawArticle],
     classified_articles: list[ClassifiedArticle],
     classifier_error: str | None = None,
+    classifier_warning_counts: Mapping[str, int] | None = None,
 ) -> dict[str, object]:
     """Summarize classifier outputs and anomalies."""
     rejected_by_category: dict[str, int] = {}
@@ -1375,10 +1409,24 @@ def _build_classifier_summary(
         "relevant_article_count": relevant_count,
         "rejected_article_count": rejected_count,
         "rejected_by_category": rejected_by_category,
+        "warning_counts": _normalize_classifier_warning_counts(classifier_warning_counts),
         "classification_output_anomaly": len(classified_articles) != len(unseen_articles),
         "classification_failed": classifier_error is not None,
         "classifier_error": classifier_error,
     }
+
+
+def _normalize_classifier_warning_counts(
+    counts: Mapping[str, int] | None,
+) -> dict[str, int]:
+    """Normalize classifier warning counters into stable summary keys."""
+    if counts is None:
+        return dict.fromkeys(_CLASSIFIER_WARNING_COUNT_KEYS, 0)
+    normalized: dict[str, int] = {}
+    for key in _CLASSIFIER_WARNING_COUNT_KEYS:
+        value = counts.get(key, 0)
+        normalized[key] = value if isinstance(value, int) and not isinstance(value, bool) else 0
+    return normalized
 
 
 def _summary_int(payload: dict[str, object], key: str) -> int:
@@ -1500,6 +1548,7 @@ def _build_ingest_debug_payload(
     classified_articles: list[ClassifiedArticle],
     unified_items: list[UnifiedItem],
     classifier_error: str | None = None,
+    classifier_warning_counts: Mapping[str, int] | None = None,
 ) -> dict[str, object]:
     """Build a detailed ingest diagnostic log for state-repo inspection."""
     relevant_articles = [
@@ -1526,6 +1575,7 @@ def _build_ingest_debug_payload(
         unseen_articles=unseen_articles,
         classified_articles=classified_articles,
         classifier_error=classifier_error,
+        classifier_warning_counts=classifier_warning_counts,
     )
     problems = _build_problem_summary(
         source_summaries=source_summaries,
@@ -1577,6 +1627,62 @@ def _build_ingest_debug_payload(
     }
 
 
+def _build_scrape_candidate_debug_payload(
+    *,
+    result: RunSnapshot,
+    classifier: Classifier,
+    scrape_batch: CandidateScrapeBatch,
+    fallback_record_count: int,
+    batch_id: str | None = None,
+) -> dict[str, object]:
+    """Build a compact scrape/backfill diagnostic payload for fallback-only drains."""
+    fallback_input_count = sum(
+        1 for candidate in scrape_batch.fallback_candidates if _fallback_input_article(candidate)
+    )
+    classifier_summary = _build_classifier_summary(
+        unseen_articles=[],
+        classified_articles=[],
+        classifier_warning_counts=_classifier_warning_counts(classifier),
+    )
+    fallback_classifier_summary = {
+        "fallback_classifier_input_count": fallback_input_count,
+        "fallback_operational_record_count": fallback_record_count,
+        "warning_counts": _classifier_warning_counts(classifier),
+    }
+    return {
+        "schema_version": "news_items.scrape_candidates.debug.v1",
+        "run_timestamp": result.run_timestamp.isoformat(),
+        "dataset_name": result.dataset_name.value,
+        "job_name": result.job_name.value,
+        "config_name": result.config_name,
+        "config_path": result.config_path,
+        "days_searched": result.days_searched,
+        "result_summary": result.result_summary,
+        "workflow": _workflow_metadata(),
+        "counts": {
+            "source_count": result.source_count,
+            "raw_article_count": result.raw_article_count,
+            "selected_candidate_count": len(scrape_batch.selected_candidates),
+            "fallback_candidate_count": len(scrape_batch.fallback_candidates),
+            "fallback_operational_record_count": fallback_record_count,
+            "scrape_attempt_count": len(scrape_batch.attempts),
+            "unified_item_count": result.unified_item_count,
+            "seen_count_before": result.seen_count_before,
+            "seen_count_after": result.seen_count_after,
+        },
+        "batch_id": batch_id,
+        "classifier_summary": classifier_summary,
+        "fallback_classifier_summary": fallback_classifier_summary,
+        "problems": {
+            "classification_failed": False,
+            "classification_output_anomaly": False,
+        },
+        "suspicions": [],
+        "warnings": result.warnings,
+        "errors": result.errors,
+    }
+
+
 async def run_news_ingest_job(
     config: Config,
     config_path: Path | None = None,
@@ -1609,6 +1715,7 @@ async def run_news_ingest_job(
         system_prompt=config.classifier.system_prompt,
         user_prompt_template=config.classifier.user_prompt_template,
     )
+    _reset_classifier_warning_counts(classifier)
     deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
     seen_store = create_seen_store(config.state_paths.seen_path)
     result.seen_count_before = seen_store.count
@@ -1899,6 +2006,7 @@ async def run_news_scrape_candidates_job(
         system_prompt=config.classifier.system_prompt,
         user_prompt_template=config.classifier.user_prompt_template,
     )
+    _reset_classifier_warning_counts(classifier)
     deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
     seen_store = create_seen_store(config.state_paths.seen_path)
     result.seen_count_before = seen_store.count
@@ -1945,10 +2053,20 @@ async def run_news_scrape_candidates_job(
         if not scrape_batch.raw_articles:
             result.unified_item_count = len(fallback_records)
             if fallback_records:
-                return result.finish(
+                result.finish(
                     f"fallback retention completed with {len(fallback_records)} provisional row(s)"
                 )
-            return result.finish("candidate scrape completed with no materializable rows")
+            else:
+                result.finish("candidate scrape completed with no materializable rows")
+            result.set_debug_payload(
+                _build_scrape_candidate_debug_payload(
+                    result=result,
+                    classifier=classifier,
+                    scrape_batch=scrape_batch,
+                    fallback_record_count=len(fallback_records),
+                )
+            )
+            return result
 
         processed = await _process_ingest_articles(
             config=config,
@@ -2188,6 +2306,7 @@ async def run_news_backfill_scrape_job(
         system_prompt=config.classifier.system_prompt,
         user_prompt_template=config.classifier.user_prompt_template,
     )
+    _reset_classifier_warning_counts(classifier)
     deduplicator = create_deduplicator(threshold=config.dedup.similarity_threshold)
     seen_store = create_seen_store(config.state_paths.seen_path)
     result.seen_count_before = seen_store.count
@@ -2235,10 +2354,20 @@ async def run_news_backfill_scrape_job(
 
         if not scrape_batch.raw_articles:
             result.unified_item_count = len(fallback_records)
-            return result.finish(
+            result.finish(
                 "fallback retention completed with "
                 f"{len(fallback_records)} provisional row(s) for backfill batch {batch_id}"
             )
+            result.set_debug_payload(
+                _build_scrape_candidate_debug_payload(
+                    result=result,
+                    classifier=classifier,
+                    scrape_batch=scrape_batch,
+                    fallback_record_count=len(fallback_records),
+                    batch_id=batch_id,
+                )
+            )
+            return result
 
         processed = await _process_ingest_articles(
             config=config,

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -1180,8 +1180,13 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
     """Backfill scrape should support fallback-only and ingest-processing paths with final batch updates."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     sources = [FakeSource("ynet")]
+    classifier = MagicMock()
+    classifier.warning_counts = {
+        "parse_failure_count": 3,
+        "invalid_taxonomy_pair_count": 2,
+    }
     monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: sources)
-    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
     monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
     monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
 
@@ -1218,6 +1223,25 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
         "fallback retention completed with 1 provisional row(s) for backfill batch batch-1"
     )
     assert "fallback_operational_records=1" in fallback.warnings
+    assert fallback.debug_payload is not None
+    assert fallback.debug_payload["schema_version"] == "news_items.scrape_candidates.debug.v1"
+    assert fallback.debug_payload["batch_id"] == "batch-1"
+    assert fallback.debug_payload["classifier_summary"]["warning_counts"] == {
+        "parse_failure_count": 3,
+        "invalid_taxonomy_pair_count": 2,
+        "invalid_legacy_pair_count": 0,
+        "relevant_without_usable_taxonomy_count": 0,
+    }
+    assert fallback.debug_payload["fallback_classifier_summary"] == {
+        "fallback_classifier_input_count": 1,
+        "fallback_operational_record_count": 1,
+        "warning_counts": {
+            "parse_failure_count": 3,
+            "invalid_taxonomy_pair_count": 2,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        },
+    }
     assert fallback_store.get_backfill_batch("batch-1") is not None
 
     processed_store = build_store(tmp_path / "processed")

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -219,6 +219,12 @@ class TestClassifierParsing:
         assert result.category == Category.BROTHEL
         assert result.sub_category == SubCategory.CLOSURE
         assert result.index_relevant is True
+        assert classifier.warning_counts == {
+            "parse_failure_count": 0,
+            "invalid_taxonomy_pair_count": 0,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        }
 
     def test_parse_invalid_taxonomy_pair_falls_back_to_not_relevant(self) -> None:
         """Taxonomy pairs outside the packaged taxonomy should be rejected."""
@@ -239,6 +245,49 @@ class TestClassifierParsing:
         assert result.taxonomy_subcategory_id is None
         assert result.category == Category.NOT_RELEVANT
         assert result.sub_category is None
+        assert classifier.warning_counts["invalid_taxonomy_pair_count"] == 1
+
+    def test_parse_warning_counts_accumulate_parse_and_invalid_taxonomy_warnings(self) -> None:
+        """Parser warnings should be counted without changing returned classifications."""
+        classifier = Classifier(api_key="test-key")
+
+        parse_failure = classifier._parse_response("not-json")
+        invalid_taxonomy = classifier._parse_response(
+            '{"relevant": true, "enforcement_related": true, '
+            '"taxonomy_category_id": "human_trafficking", '
+            '"taxonomy_subcategory_id": "phenomenon_coverage", '
+            '"confidence": "high"}'
+        )
+
+        assert parse_failure.relevant is False
+        assert invalid_taxonomy.relevant is False
+        assert classifier.warning_counts["parse_failure_count"] == 1
+        assert classifier.warning_counts["invalid_taxonomy_pair_count"] == 1
+
+    def test_parse_non_object_json_counts_as_parse_failure(self) -> None:
+        """Valid JSON with the wrong top-level shape should not crash the run."""
+        classifier = Classifier(api_key="test-key")
+
+        result = classifier._parse_response("[]")
+
+        assert result.relevant is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.confidence == "low"
+        assert classifier.warning_counts["parse_failure_count"] == 1
+
+    def test_reset_warning_counts_clears_run_local_counters(self) -> None:
+        """Pipeline run boundaries can explicitly clear accumulated counters."""
+        classifier = Classifier(api_key="test-key")
+        classifier._parse_response("[]")
+
+        classifier.reset_warning_counts()
+
+        assert classifier.warning_counts == {
+            "parse_failure_count": 0,
+            "invalid_taxonomy_pair_count": 0,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        }
 
     def test_parse_taxonomy_pair_derives_index_relevant_even_when_payload_disagrees(self) -> None:
         """index_relevant should be computed from the packaged taxonomy rather than the model payload."""

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -343,6 +343,24 @@ class TestFetchAndClassifyHelpers:
         assert "source_error_rate_high" in suspicions
         assert "sources_returned_zero_results" in suspicions
 
+    def test_classifier_summary_persists_warning_counts(self) -> None:
+        """Run debug summaries should carry classifier parser warning counters."""
+        classifier_summary = _build_classifier_summary(
+            unseen_articles=[build_raw_article("https://example.com/u1")],
+            classified_articles=[],
+            classifier_warning_counts={
+                "parse_failure_count": 2,
+                "invalid_taxonomy_pair_count": 1,
+            },
+        )
+
+        assert classifier_summary["warning_counts"] == {
+            "parse_failure_count": 2,
+            "invalid_taxonomy_pair_count": 1,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        }
+
     def test_mark_seen_collects_all_source_urls(self, tmp_path: Path) -> None:
         """mark_seen should persist every source URL from unified items."""
         from denbust.store.seen import SeenStore
@@ -1785,6 +1803,10 @@ class TestRunPipelineAsync:
                 build_classified_article("https://example.com/fallback", relevant=True),
             ]
         )
+        classifier.warning_counts = {
+            "parse_failure_count": 2,
+            "invalid_taxonomy_pair_count": 1,
+        }
         monkeypatch.setattr(
             "denbust.pipeline.create_sources", lambda _config: [FakeSource("test", [])]
         )
@@ -1823,6 +1845,24 @@ class TestRunPipelineAsync:
         assert rows[0]["content_basis"] == ContentBasis.SEARCH_RESULT_ONLY.value
         assert rows[0]["record_confidence"] == "low"
         assert rows[0]["event_candidate_ids"] == ["candidate-fallback"]
+        assert result.debug_payload is not None
+        assert result.debug_payload["schema_version"] == "news_items.scrape_candidates.debug.v1"
+        assert result.debug_payload["classifier_summary"]["warning_counts"] == {
+            "parse_failure_count": 2,
+            "invalid_taxonomy_pair_count": 1,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        }
+        assert result.debug_payload["fallback_classifier_summary"] == {
+            "fallback_classifier_input_count": 1,
+            "fallback_operational_record_count": 1,
+            "warning_counts": {
+                "parse_failure_count": 2,
+                "invalid_taxonomy_pair_count": 1,
+                "invalid_legacy_pair_count": 0,
+                "relevant_without_usable_taxonomy_count": 0,
+            },
+        }
 
     @pytest.mark.asyncio
     async def test_run_news_scrape_candidates_job_marks_provider_error_fatal_without_seen(
@@ -3304,7 +3344,13 @@ class TestRunPipeline:
                 "counts": {"unseen_article_count": 1},
                 "workflow": {},
                 "source_summaries": [],
-                "classifier_summary": {"rejected_article_count": 1},
+                "classifier_summary": {
+                    "rejected_article_count": 1,
+                    "warning_counts": {
+                        "parse_failure_count": 2,
+                        "invalid_taxonomy_pair_count": 1,
+                    },
+                },
                 "problems": {"all_unseen_rejected": True},
                 "suspicions": ["all_unseen_rejected"],
                 "warnings": [],
@@ -3333,6 +3379,11 @@ class TestRunPipeline:
         assert '"rejected_articles": [' in content
         summary_content = summary_path.read_text(encoding="utf-8")
         assert '"suspicions": [' in summary_content
+        summary_payload = json.loads(summary_content)
+        assert summary_payload["classifier_summary"]["warning_counts"] == {
+            "parse_failure_count": 2,
+            "invalid_taxonomy_pair_count": 1,
+        }
 
     def test_run_job_from_config_best_effort_debug_write_still_persists_snapshot(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Planning notation

CLASSIFIER-PR-RUN-WARNING-ARTIFACTS

Parent milestone: Phase C

Plan source: `.agent-plan.md` next item after `CLASSIFIER-PR-CANDIDATE-FALLBACK-DIAGNOSTICS`.

## Summary

- Adds passive run-local classifier parser warning counters for JSON parse failures, invalid taxonomy pairs, invalid legacy category/sub-category pairs, and relevant responses without a usable taxonomy or legacy category.
- Treats valid JSON with the wrong top-level shape, such as arrays or strings, as counted parse failures rather than letting the run crash.
- Persists warning counters in existing run/debug-summary artifacts under `classifier_summary.warning_counts`.
- Adds compact scrape debug payloads for fallback-only `scrape_candidates` and `backfill_scrape` drains so provisional candidate-fallback runs have `.summary.json` artifacts even when no full article rows are materialized.
- Adds `fallback_classifier_summary` for fallback classifier input counts, retained fallback operational-record counts, and warning counts so fallback-only runs are not interpreted through zero full-article classifier counts.
- Adds an explicit classifier warning-counter reset hook and calls it at pipeline run boundaries.
- Updates README, discovery operations, January 2026 wet-test evidence, and `.agent-plan.md` to document the diagnostic boundary and next evidence interpretation slice.

## Evidence and scope

The fresh 2026-05-14 Phase C bounded drain retained 30 candidate-fallback operational rows and showed classifier parse/taxonomy warnings only in process logs. Discovery diagnostics can summarize persisted candidate/operational-row signals, but parser warnings occur inside the classifier before there is necessarily a durable candidate or operational-row identity to attach to. The bounded persistence point is therefore the run debug summary artifact, not discovery diagnostics or classifier policy.

This keeps the slice diagnostic-only: it does not change classifier prompts, classifier policy, taxonomy validity, queue fairness, scrape candidate selection, browser/CDP scraper behavior, generic fetch behavior, source-family support, or source-targeted query fanout.

## Review-driven hardening

After a hostile self-review, this branch also fixes the weak spots in the first implementation:

- Non-object JSON model responses are now counted as parse failures instead of raising `AttributeError`.
- The classifier exposes `reset_warning_counts()` and the pipeline calls it explicitly at run boundaries.
- Fallback-only payloads now include a dedicated `fallback_classifier_summary` rather than mixing fallback counts into normal zero-row classifier totals.
- Regression tests now prove nonzero warning counts flow through fallback-only scrape/backfill payloads and through the debug-summary writer.

## Artifact fields

Run debug summaries now include:

- `classifier_summary.warning_counts.parse_failure_count`
- `classifier_summary.warning_counts.invalid_taxonomy_pair_count`
- `classifier_summary.warning_counts.invalid_legacy_pair_count`
- `classifier_summary.warning_counts.relevant_without_usable_taxonomy_count`

Fallback-only scrape/backfill debug payloads also include:

- `fallback_classifier_summary.fallback_classifier_input_count`
- `fallback_classifier_summary.fallback_operational_record_count`
- `fallback_classifier_summary.warning_counts.*`

## Tests and validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_classifier.py tests/unit/test_pipeline_core.py tests/unit/test_backfill_pipeline.py tests/unit/test_run_snapshots.py`
- `.venv/bin/pytest -q`

Full test suite result after review fixes: 1011 passed, 1 existing Typer/runpy warning.

## Follow-up

The next planned slice is `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`: use persisted warning counts from the next bounded Phase C scrape/backfill evidence pass to decide whether classifier-output hardening is justified. Prompt or taxonomy-policy changes remain out of scope until artifact-backed warning rates justify them.