### PR TITLE
CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION: Interpret warning-count evidence

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS` added diagnostic-only run-level
-  classifier parser warning counters after the fresh 2026-05-14 Phase C bounded drain showed
-  parse and invalid-taxonomy warnings only in logs. Run debug summaries now persist
-  `classifier_summary.warning_counts`, and fallback-only scrape/backfill drains emit compact scrape
-  debug summaries so provisional candidate-fallback runs have machine-readable warning counts.
-- Next planned PR: use persisted run-level classifier warning counts from the next bounded Phase C
-  scrape/backfill evidence pass to decide whether classifier-output hardening is warranted, while
-  keeping any prompt or taxonomy-policy change out of scope until artifact-backed warning rates
-  justify it.
+- Last merged PR on main: `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION` interpreted the first
+  post-warning-counter bounded Phase C January 1-7 scrape/backfill evidence pass. The run persisted
+  3,743 candidates, attempted 100 candidates, retained 30 provisional fallback rows, and recorded
+  warning counts of four parse failures, one invalid taxonomy pair, zero invalid legacy pairs, and
+  zero relevant-without-usable-taxonomy warnings across 100 fallback classifier inputs.
+- Next planned PR: characterize the observed fallback classifier parse-failure output shapes, add
+  fixture-backed regression coverage, and only then add bounded parser/output-shape robustness if
+  the observed shapes are safely recoverable without changing classifier prompts, taxonomy policy,
+  queue behavior, scraper behavior, scrape caps, or source-family support.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -114,10 +114,15 @@
 - [done] `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS`: persist and report run-level classifier parse and
   invalid-taxonomy warning counts in existing scrape/backfill run or debug-summary artifacts, if a
   bounded implementation path exists without changing classifier prompts or policy.
-- [next] `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`: use persisted
+- [done] `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`: use persisted
   `classifier_summary.warning_counts` from the next bounded Phase C scrape/backfill evidence pass to
   determine whether classifier-output hardening is justified, without changing prompts, taxonomy
   policy, queue behavior, scraper behavior, or source-family support in advance of that evidence.
+- [next] `CLASSIFIER-PR-OUTPUT-ROBUSTNESS`: characterize the observed 4% fallback parse-failure
+  output shapes, add fixture-backed regression coverage, and only then add bounded
+  parser/output-shape robustness if the observed shapes are safely recoverable without changing
+  classifier prompts, taxonomy validity policy, queue behavior, scraper behavior, scrape caps, or
+  source-family support.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Planned future datasets:
   `classifier_summary.warning_counts`, including JSON parse failures and invalid taxonomy pairs,
   and exposes fallback-only scrape/backfill context under `fallback_classifier_summary`, without
   changing classifier prompts, taxonomy policy, or scrape selection behavior
+- Documents the first post-persistence warning-count interpretation pass: the bounded January 1-7
+  Brave+Exa/no-Google scrape/backfill run saw 4 parse failures and 1 invalid taxonomy pair across
+  100 fallback classifier inputs, and compact summaries now retain `fallback_classifier_summary`
+  for future fallback-only drains
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking
@@ -424,6 +428,13 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
 - `SRC-PR-NEWS1` adds low-confidence generic-fetch diagnostic labeling for main-domain News1
   archive article paths under `news1.co.il/Archive/`; this is not source-targeted fanout, a
   source-native adapter, a browser scraper, or broad support for non-archive News1 pages
+- `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION` records the first post-warning-counter Phase C
+  interpretation pass under generated local root `data/may_26_followup/20260514T182934Z/`: 100
+  fallback classifier inputs produced 4 parse failures, 1 invalid taxonomy pair, no invalid legacy
+  pairs, and no relevant-without-usable-taxonomy warnings. It also keeps
+  `fallback_classifier_summary` in compact run summaries going forward and sets the next PR to
+  characterize observed parse-failure shapes before any bounded parser robustness change. It does
+  not recommend prompt, taxonomy-policy, queue, scraper, or source-family changes
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -316,6 +316,31 @@ fallback classification through zero full-article counts. These fields are diagn
 not alter classifier prompts, taxonomy validity rules, candidate selection, queue fairness, generic
 fetch behavior, browser/CDP scraping, or source-family support.
 
+After `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`, the first post-persistence bounded Phase C
+January 1-7 scrape/backfill evidence pass under `data/may_26_followup/20260514T182934Z/` used the
+same Brave+Exa/no-Google local config and the same Chrome-CDP scrape shape. It persisted 3,743
+candidates, attempted 100 candidates, recorded 159 scrape attempts, retained 30 provisional
+fallback operational rows, left 3,148 eligible candidates, and stopped at `budget_cap_reached`.
+The post-scrape run payload recorded 100 fallback classifier inputs and these warning counts in both
+`classifier_summary.warning_counts` and `fallback_classifier_summary.warning_counts`:
+
+- `parse_failure_count=4`
+- `invalid_taxonomy_pair_count=1`
+- `invalid_legacy_pair_count=0`
+- `relevant_without_usable_taxonomy_count=0`
+
+That is a 4% parse-failure rate, a 1% invalid-taxonomy-output rate, and a combined 5% warning rate
+over fallback classifier inputs. During the evidence pass, the full debug JSON carried the
+fallback-specific input counts and warning counts while the compact `.summary.json` carried only
+`classifier_summary.warning_counts`; compact summaries now also retain
+`fallback_classifier_summary` for future fallback-only drains. The retained fallback rows still had
+valid persisted taxonomy pairs in `partial_page_diagnostics.classifier_warning_signals`, so the
+evidence supports a bounded classifier-output follow-up that first characterizes observed parse
+failure output shapes and adds fixture-backed regression coverage. It does not support changing
+classifier prompts, taxonomy policy, queue behavior, scrape candidate selection, generic fetch
+behavior, browser/CDP scraping, source-family support, scrape caps, or source-targeted query fanout
+in the interpretation slice.
+
 After `SRC-PR-GLOBES-THEMARKER`, search-discovered Globes and TheMarker article pages have bounded
 generic-fetch source-family support. The January 1-7 evidence showed Globes as a repeated
 unsupported source suggestion (`globes.co.il`, 25 candidates across two runs) and showed TheMarker

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -257,3 +257,69 @@ for fallback classifier input counts, retained fallback operational-record count
 counts. This is diagnostic persistence only. It does not change classifier prompts, taxonomy
 validity, classifier policy, queue fairness, scrape candidate selection, generic fetch behavior,
 browser/CDP scraping, source-family support, or source-targeted query fanout.
+
+## 2026-05-14 Addendum: Warning-Count Evidence Interpretation
+
+`CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION` ran the next bounded Phase C January 1-7 evidence
+pass after run-level classifier warning counts were persisted. The generated local evidence root is
+`data/may_26_followup/20260514T182934Z/`; generated artifacts remain untracked.
+
+The run reused the established local Brave+Exa/no-Google configuration,
+`agents/news/local_search_brave_exa.yaml`, because the local Google CSE path is still treated as an
+operator-dependent API-access risk. The scrape drain used a temporary Chrome-CDP endpoint at
+`http://127.0.0.1:9222` and did not broaden the window, source list, search-engine set, queue
+policy, scrape cap, scraper behavior, or source-family support.
+
+Operator notes: the first discovery attempt failed before this shell loaded the repo-local
+`direnv` environment, so the successful run used `direnv exec .` to load `.env.local` without
+printing secret values. The initial Chrome-CDP preflight also failed because no browser was
+listening on port 9222; the successful scrape used a temporary Chrome profile with remote debugging
+enabled for this evidence pass.
+
+The run reported:
+
+| Figure | Value |
+| --- | ---: |
+| Persisted candidates | 3,743 |
+| Attempted candidates | 100 |
+| Persisted scrape attempts | 159 |
+| Provisional operational rows retained | 30 |
+| Partial pages | 97 |
+| Scrape failures | 3 |
+| Remaining eligible candidates | 3,148 |
+| Inferred stop reason | `budget_cap_reached` |
+
+The full post-scrape run payload
+`data/may_26_followup/20260514T182934Z/state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.json`
+persisted these warning counters:
+
+| Counter | Count | Rate |
+| --- | ---: | ---: |
+| `classifier_summary.warning_counts.parse_failure_count` | 4 | 4% of 100 fallback classifier inputs |
+| `classifier_summary.warning_counts.invalid_taxonomy_pair_count` | 1 | 1% of 100 fallback classifier inputs |
+| `classifier_summary.warning_counts.invalid_legacy_pair_count` | 0 | 0% |
+| `classifier_summary.warning_counts.relevant_without_usable_taxonomy_count` | 0 | 0% |
+| `fallback_classifier_summary.warning_counts.parse_failure_count` | 4 | 4% of 100 fallback classifier inputs |
+| `fallback_classifier_summary.warning_counts.invalid_taxonomy_pair_count` | 1 | 1% of 100 fallback classifier inputs |
+| `fallback_classifier_summary.warning_counts.invalid_legacy_pair_count` | 0 | 0% |
+| `fallback_classifier_summary.warning_counts.relevant_without_usable_taxonomy_count` | 0 | 0% |
+
+The same payload recorded `fallback_classifier_input_count=100` and
+`fallback_operational_record_count=30`. During this interpretation pass, the matching compact
+`.summary.json` retained `classifier_summary.warning_counts` but did not yet include
+`fallback_classifier_summary`; this PR closes that compact-summary artifact gap for future runs so
+operators do not need the full debug JSON to see fallback classifier input counts and warning
+counts.
+
+The post-scrape discovery diagnostic still showed that all 30 retained fallback rows had valid
+persisted taxonomy pairs and that `invalid_taxonomy_pair_record_count` was zero. That means the
+observed warning pressure is real classifier-output loss before retention, not corrupted persisted
+operational taxonomy.
+
+Interpretation: 5 warning events across 100 fallback classifier inputs, including four parse
+failures, is enough to justify a bounded classifier-output follow-up, but the next PR should first
+characterize the observed parse-failure output shapes and add fixture-backed regression coverage
+before changing parser behavior. The evidence does not justify changing classifier prompts,
+taxonomy validity policy, legacy taxonomy policy, queue fairness, scrape candidate selection,
+generic fetch behavior, browser/CDP scraper behavior, scrape caps, source-family support, or
+source-targeted query fanout in this interpretation slice.

--- a/src/denbust/store/run_snapshots.py
+++ b/src/denbust/store/run_snapshots.py
@@ -54,6 +54,7 @@ def write_run_debug_summary(
         "workflow": payload.get("workflow", {}),
         "source_summaries": payload.get("source_summaries", []),
         "classifier_summary": payload.get("classifier_summary", {}),
+        "fallback_classifier_summary": payload.get("fallback_classifier_summary"),
         "problems": payload.get("problems", {}),
         "suspicions": payload.get("suspicions", []),
         "warnings": payload.get("warnings", []),

--- a/tests/unit/test_run_snapshots.py
+++ b/tests/unit/test_run_snapshots.py
@@ -1,5 +1,6 @@
 """Unit tests for run snapshot persistence."""
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -117,6 +118,16 @@ class TestRunSnapshots:
                 "workflow": {"run_id": "123"},
                 "source_summaries": [{"source_name": "mako", "raw_article_count": 0}],
                 "classifier_summary": {"rejected_article_count": 2},
+                "fallback_classifier_summary": {
+                    "fallback_classifier_input_count": 3,
+                    "fallback_operational_record_count": 1,
+                    "warning_counts": {
+                        "parse_failure_count": 1,
+                        "invalid_taxonomy_pair_count": 0,
+                        "invalid_legacy_pair_count": 0,
+                        "relevant_without_usable_taxonomy_count": 0,
+                    },
+                },
                 "problems": {"all_unseen_rejected": True},
                 "suspicions": ["all_unseen_rejected"],
                 "warnings": [],
@@ -129,4 +140,15 @@ class TestRunSnapshots:
         content = path.read_text(encoding="utf-8")
         assert '"schema_version": "news_items.ingest.debug.v1"' in content
         assert '"suspicions": [' in content
+        payload = json.loads(content)
+        assert payload["fallback_classifier_summary"] == {
+            "fallback_classifier_input_count": 3,
+            "fallback_operational_record_count": 1,
+            "warning_counts": {
+                "parse_failure_count": 1,
+                "invalid_taxonomy_pair_count": 0,
+                "invalid_legacy_pair_count": 0,
+                "relevant_without_usable_taxonomy_count": 0,
+            },
+        }
         assert '"rejected_articles"' not in content


### PR DESCRIPTION
## Planning notation

CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION

Parent milestone: Phase C
Plan source: `.agent-plan.md` current `[next]` item from main after PR #128.

## Summary

This PR records the first bounded Phase C warning-count interpretation pass after `CLASSIFIER-PR-RUN-WARNING-ARTIFACTS` / PR #128 persisted run-level classifier warning counters. It also fixes the compact run-summary artifact contract so future fallback-only scrape/backfill summaries retain `fallback_classifier_summary` instead of requiring the full debug JSON for fallback classifier input counts.

## Evidence used

Generated local evidence root: `data/may_26_followup/20260514T182934Z/`

Inspected artifacts:

- `data/may_26_followup/20260514T182934Z/artifacts/diagnose_discovery_after_discover.json`
- `data/may_26_followup/20260514T182934Z/artifacts/diagnose_discovery_after_scrape.json`
- `data/may_26_followup/20260514T182934Z/state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.json`
- `data/may_26_followup/20260514T182934Z/state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.summary.json`

The evidence was newly generated because no existing post-PR #128 `data/may_26_followup/` root contained `classifier_summary.warning_counts`. Generated `data/` artifacts are intentionally untracked and are not committed.

Operator notes: the successful live run used `direnv exec .` to load repo-local credentials without printing secret values, and a temporary Chrome profile with remote debugging enabled on `127.0.0.1:9222` for the CDP-backed scrape drain.

## Observed warning counts and rates

The bounded January 1-7 Brave+Exa/no-Google run persisted 3,743 candidates, attempted 100 candidates, recorded 159 scrape attempts, retained 30 provisional fallback rows, left 3,148 eligible candidates, and stopped at `budget_cap_reached`.

The full scrape payload recorded 100 fallback classifier inputs and these warning counts in both `classifier_summary.warning_counts` and `fallback_classifier_summary.warning_counts`:

- `parse_failure_count=4` (4% of fallback classifier inputs)
- `invalid_taxonomy_pair_count=1` (1% of fallback classifier inputs)
- `invalid_legacy_pair_count=0`
- `relevant_without_usable_taxonomy_count=0`

Combined parser/taxonomy warning rate: 5 warning events across 100 fallback classifier inputs. The matching compact `.summary.json` had `classifier_summary.warning_counts` but was missing `fallback_classifier_summary`; this PR fixes that gap for future summaries and adds unit coverage.

## Interpretation

Classifier-output hardening is not implemented here. The evidence supports a bounded follow-up that first characterizes the observed parse-failure output shapes and adds fixture-backed regression coverage, then adds parser/output-shape robustness only when the observed shapes are safely recoverable. The evidence does not show corrupted persisted operational taxonomy: post-scrape diagnostics still report valid taxonomy pairs for retained fallback rows and `invalid_taxonomy_pair_record_count=0`.

The next planned PR in `.agent-plan.md` is now `CLASSIFIER-PR-OUTPUT-ROBUSTNESS`, scoped to characterization and fixture-backed robustness rather than prompt, taxonomy-policy, queue, scraper, or source-family changes.

## Intentionally out of scope

This PR does not change classifier prompts, classifier taxonomy policy, legacy taxonomy policy, queue fairness, scrape candidate selection, generic fetch behavior, browser/CDP scraper behavior, scrape caps, source-family support, or source-targeted query fanout.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_run_snapshots.py`
- pre-commit on amend: merge-conflict check, EOF/whitespace hooks, ruff, ruff format, mypy, smoke tests
- pre-push on push: merge-conflict check, EOF/whitespace hooks, ruff, ruff format, unit tests, integration tests
