### PR TITLE
CLASSIFIER-PR-OUTPUT-ROBUSTNESS: characterize parser evidence

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,15 +6,15 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION` interpreted the first
-  post-warning-counter bounded Phase C January 1-7 scrape/backfill evidence pass. The run persisted
-  3,743 candidates, attempted 100 candidates, retained 30 provisional fallback rows, and recorded
-  warning counts of four parse failures, one invalid taxonomy pair, zero invalid legacy pairs, and
-  zero relevant-without-usable-taxonomy warnings across 100 fallback classifier inputs.
-- Next planned PR: characterize the observed fallback classifier parse-failure output shapes, add
-  fixture-backed regression coverage, and only then add bounded parser/output-shape robustness if
-  the observed shapes are safely recoverable without changing classifier prompts, taxonomy policy,
-  queue behavior, scraper behavior, scrape caps, or source-family support.
+- Last merged PR on main: `CLASSIFIER-PR-OUTPUT-ROBUSTNESS` inspected the 2026-05-14 bounded Phase
+  C fallback classifier warning evidence, found that the retained artifacts expose only a
+  brace-delimited non-JSON parse-error signature rather than raw malformed classifier responses, and
+  added fixture-backed rejection coverage without changing parser recovery behavior.
+- Next planned PR: persist sanitized classifier parse-failure shape evidence in run debug artifacts
+  so future robustness work can distinguish safely recoverable malformed responses from output
+  shapes that should remain rejected, without committing generated data artifacts or changing
+  classifier prompts, taxonomy policy, queue behavior, scraper behavior, scrape caps, or
+  source-family support.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -118,9 +118,14 @@
   `classifier_summary.warning_counts` from the next bounded Phase C scrape/backfill evidence pass to
   determine whether classifier-output hardening is justified, without changing prompts, taxonomy
   policy, queue behavior, scraper behavior, or source-family support in advance of that evidence.
-- [next] `CLASSIFIER-PR-OUTPUT-ROBUSTNESS`: characterize the observed 4% fallback parse-failure
+- [done] `CLASSIFIER-PR-OUTPUT-ROBUSTNESS`: characterize the observed 4% fallback parse-failure
   output shapes, add fixture-backed regression coverage, and only then add bounded
   parser/output-shape robustness if the observed shapes are safely recoverable without changing
+  classifier prompts, taxonomy validity policy, queue behavior, scraper behavior, scrape caps, or
+  source-family support.
+- [next] `CLASSIFIER-PR-PARSE-FAILURE-EVIDENCE-CAPTURE`: persist sanitized classifier
+  parse-failure shape evidence in run debug artifacts so the next robustness slice can evaluate
+  exact malformed response categories without committing generated data artifacts or changing
   classifier prompts, taxonomy validity policy, queue behavior, scraper behavior, scrape caps, or
   source-family support.
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -7,9 +7,9 @@
 ## Mainline Status
 
 - Last merged PR on main: `CLASSIFIER-PR-OUTPUT-ROBUSTNESS` inspected the 2026-05-14 bounded Phase
-  C fallback classifier warning evidence, found that the retained artifacts expose only a
-  brace-delimited non-JSON parse-error signature rather than raw malformed classifier responses, and
-  added fixture-backed rejection coverage without changing parser recovery behavior.
+  C fallback classifier warning evidence, found that the retained artifacts do not expose raw
+  malformed classifier responses, and added representative current-rejection coverage without
+  changing parser recovery behavior.
 - Next planned PR: persist sanitized classifier parse-failure shape evidence in run debug artifacts
   so future robustness work can distinguish safely recoverable malformed responses from output
   shapes that should remain rejected, without committing generated data artifacts or changing

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Planned future datasets:
   Brave+Exa/no-Google scrape/backfill run saw 4 parse failures and 1 invalid taxonomy pair across
   100 fallback classifier inputs, and compact summaries now retain `fallback_classifier_summary`
   for future fallback-only drains
+- Keeps classifier output robustness evidence-driven: the observed Phase C parse-failure artifacts
+  expose only a brace-delimited non-JSON decoder signature, so representative malformed fixtures are
+  rejected deterministically and parser recovery is deferred until raw malformed response shapes are
+  persisted safely
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Planned future datasets:
   Brave+Exa/no-Google scrape/backfill run saw 4 parse failures and 1 invalid taxonomy pair across
   100 fallback classifier inputs, and compact summaries now retain `fallback_classifier_summary`
   for future fallback-only drains
-- Keeps classifier output robustness evidence-driven: the observed Phase C parse-failure artifacts
-  expose only a brace-delimited non-JSON decoder signature, so representative malformed fixtures are
-  rejected deterministically and parser recovery is deferred until raw malformed response shapes are
-  persisted safely
+- Keeps classifier output robustness evidence-driven: the retained Phase C parse-failure artifacts
+  do not expose raw malformed response shapes, so representative non-JSON outputs are covered only
+  as current rejection-policy examples and parser recovery is deferred until sanitized shape
+  evidence is persisted safely
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking
@@ -437,8 +437,8 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   fallback classifier inputs produced 4 parse failures, 1 invalid taxonomy pair, no invalid legacy
   pairs, and no relevant-without-usable-taxonomy warnings. It also keeps
   `fallback_classifier_summary` in compact run summaries going forward and sets the next PR to
-  characterize observed parse-failure shapes before any bounded parser robustness change. It does
-  not recommend prompt, taxonomy-policy, queue, scraper, or source-family changes
+  inspect parse-failure shape evidence before any bounded parser robustness change. It does not
+  recommend prompt, taxonomy-policy, queue, scraper, or source-family changes
 - `DL-PR-12` adds explicit future self-heal hooks while preserving current behavior:
   `self_heal_eligible` is visible in queue diagnostics, failed scrape attempts are grouped by
   attempt kind/status/error/source/domain, source-adapter and generic-fetch failures carry stable

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -607,6 +607,22 @@ Classifier provider/API failures are fatal for `ingest`, `scrape_candidates`, an
 does not mark articles as seen. Live checks record the same condition as a per-case `error` rather
 than fabricating `actual=not_relevant`.
 
+Run-level classifier warning counters are diagnostic evidence, not a parser-policy override. The
+2026-05-14 Phase C bounded scrape/backfill evidence root
+`data/may_26_followup/20260514T182934Z/` persisted four fallback parse failures and one invalid
+taxonomy pair across 100 fallback classifier inputs. The root's full debug JSON and compact summary
+persisted only counts; its local `logs/`, `reports/`, and `summaries/` folders did not retain raw
+classifier response text. The only observable parse-failure output shape was therefore the JSON
+decoder signature `Expecting property name enclosed in double quotes: line 1 column 2`, which is
+consistent with brace-delimited non-JSON objects such as unquoted-key or single-quoted pseudo-JSON.
+
+Those shapes remain intentionally rejected unless a future artifact captures the exact malformed
+payload safely. Representative fixture strings now prove that brace-delimited non-JSON outputs
+return the low-confidence not-relevant fallback and increment `parse_failure_count`. Canonical JSON
+responses and invalid taxonomy-pair rejection remain unchanged. Do not broaden this into prompt
+changes, taxonomy-policy changes, queue behavior changes, scrape behavior changes, scrape-cap
+changes, or source-family expansion.
+
 ## One-Time 90-Day Re-Scan
 
 `C-8` does not add a dedicated workflow. The catch-up run uses the existing backfill jobs with the

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -335,11 +335,11 @@ fallback-specific input counts and warning counts while the compact `.summary.js
 `classifier_summary.warning_counts`; compact summaries now also retain
 `fallback_classifier_summary` for future fallback-only drains. The retained fallback rows still had
 valid persisted taxonomy pairs in `partial_page_diagnostics.classifier_warning_signals`, so the
-evidence supports a bounded classifier-output follow-up that first characterizes observed parse
-failure output shapes and adds fixture-backed regression coverage. It does not support changing
-classifier prompts, taxonomy policy, queue behavior, scrape candidate selection, generic fetch
-behavior, browser/CDP scraping, source-family support, scrape caps, or source-targeted query fanout
-in the interpretation slice.
+evidence supports a bounded classifier-output follow-up that first checks whether retained
+artifacts actually expose raw parse-failure output shapes. It does not support changing classifier
+prompts, taxonomy policy, queue behavior, scrape candidate selection, generic fetch behavior,
+browser/CDP scraping, source-family support, scrape caps, or source-targeted query fanout in the
+interpretation slice.
 
 After `SRC-PR-GLOBES-THEMARKER`, search-discovered Globes and TheMarker article pages have bounded
 generic-fetch source-family support. The January 1-7 evidence showed Globes as a repeated
@@ -612,16 +612,15 @@ Run-level classifier warning counters are diagnostic evidence, not a parser-poli
 `data/may_26_followup/20260514T182934Z/` persisted four fallback parse failures and one invalid
 taxonomy pair across 100 fallback classifier inputs. The root's full debug JSON and compact summary
 persisted only counts; its local `logs/`, `reports/`, and `summaries/` folders did not retain raw
-classifier response text. The only observable parse-failure output shape was therefore the JSON
-decoder signature `Expecting property name enclosed in double quotes: line 1 column 2`, which is
-consistent with brace-delimited non-JSON objects such as unquoted-key or single-quoted pseudo-JSON.
+classifier response text. That means the actual malformed response shapes are insufficiently
+observable from the retained artifacts.
 
-Those shapes remain intentionally rejected unless a future artifact captures the exact malformed
-payload safely. Representative fixture strings now prove that brace-delimited non-JSON outputs
-return the low-confidence not-relevant fallback and increment `parse_failure_count`. Canonical JSON
-responses and invalid taxonomy-pair rejection remain unchanged. Do not broaden this into prompt
-changes, taxonomy-policy changes, queue behavior changes, scrape behavior changes, scrape-cap
-changes, or source-family expansion.
+Parser recovery therefore remains intentionally deferred unless a future artifact captures exact
+malformed payload shape evidence safely. Representative non-JSON strings now prove only the current
+rejection policy: malformed object-like outputs return the low-confidence not-relevant fallback and
+increment `parse_failure_count`. Canonical JSON responses and invalid taxonomy-pair rejection remain
+unchanged. Do not broaden this into prompt changes, taxonomy-policy changes, queue behavior
+changes, scrape behavior changes, scrape-cap changes, or source-family expansion.
 
 ## One-Time 90-Day Re-Scan
 

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -323,3 +323,34 @@ before changing parser behavior. The evidence does not justify changing classifi
 taxonomy validity policy, legacy taxonomy policy, queue fairness, scrape candidate selection,
 generic fetch behavior, browser/CDP scraper behavior, scrape caps, source-family support, or
 source-targeted query fanout in this interpretation slice.
+
+## 2026-05-14 Addendum: Classifier Output Robustness Characterization
+
+`CLASSIFIER-PR-OUTPUT-ROBUSTNESS` inspected the generated evidence root
+`data/may_26_followup/20260514T182934Z/`, including the backfill-scrape debug payload
+`state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.json`, its compact
+`.summary.json`, the post-scrape discovery diagnostic, operational rows, run metadata, and the
+root-level `logs/`, `reports/`, and `summaries/` directories. The persisted artifacts confirmed the
+same four parse failures, one invalid taxonomy pair, 100 fallback classifier inputs, and 30 retained
+fallback operational rows, but they did not persist the raw malformed classifier responses. The
+root-level log/report/summary directories were empty.
+
+The only directly observable parse-failure shape was the parser error signature:
+`Expecting property name enclosed in double quotes: line 1 column 2`. That signature means the
+response reached the parser as a brace-delimited object-like string whose first property was not a
+valid JSON double-quoted key. It is consistent with shapes such as unquoted-key pseudo-JSON or
+single-quoted/Python-style dictionaries, but the exact raw outputs are insufficiently observable
+from the retained artifacts.
+
+No parser recovery was added because accepting guessed pseudo-JSON would change classifier output
+semantics without evidence that the observed raw responses were safely recoverable. Instead,
+fixture-backed regression coverage now proves representative brace-delimited non-JSON outputs are
+rejected deterministically as low-confidence not-relevant results and still increment
+`parse_failure_count`. Existing canonical JSON success behavior and invalid taxonomy-pair
+rejection/counting behavior remain unchanged.
+
+The next classifier-output follow-up should persist a sanitized parse-failure shape sample or
+structured parse-error evidence in run debug artifacts before considering any parser recovery. That
+future evidence-capture work should still avoid prompt changes, taxonomy-policy changes, queue
+behavior changes, scraper behavior changes, scrape-cap changes, source-family support, and raw
+generated data commits.

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -318,13 +318,13 @@ operational taxonomy.
 
 Interpretation: 5 warning events across 100 fallback classifier inputs, including four parse
 failures, is enough to justify a bounded classifier-output follow-up, but the next PR should first
-characterize the observed parse-failure output shapes and add fixture-backed regression coverage
-before changing parser behavior. The evidence does not justify changing classifier prompts,
-taxonomy validity policy, legacy taxonomy policy, queue fairness, scrape candidate selection,
-generic fetch behavior, browser/CDP scraper behavior, scrape caps, source-family support, or
-source-targeted query fanout in this interpretation slice.
+check whether retained artifacts expose raw parse-failure output shapes before changing parser
+behavior. The evidence does not justify changing classifier prompts, taxonomy validity policy,
+legacy taxonomy policy, queue fairness, scrape candidate selection, generic fetch behavior,
+browser/CDP scraper behavior, scrape caps, source-family support, or source-targeted query fanout in
+this interpretation slice.
 
-## 2026-05-14 Addendum: Classifier Output Robustness Characterization
+## 2026-05-14 Addendum: Classifier Output Robustness Evidence Review
 
 `CLASSIFIER-PR-OUTPUT-ROBUSTNESS` inspected the generated evidence root
 `data/may_26_followup/20260514T182934Z/`, including the backfill-scrape debug payload
@@ -335,18 +335,16 @@ same four parse failures, one invalid taxonomy pair, 100 fallback classifier inp
 fallback operational rows, but they did not persist the raw malformed classifier responses. The
 root-level log/report/summary directories were empty.
 
-The only directly observable parse-failure shape was the parser error signature:
-`Expecting property name enclosed in double quotes: line 1 column 2`. That signature means the
-response reached the parser as a brace-delimited object-like string whose first property was not a
-valid JSON double-quoted key. It is consistent with shapes such as unquoted-key pseudo-JSON or
-single-quoted/Python-style dictionaries, but the exact raw outputs are insufficiently observable
-from the retained artifacts.
+The actual malformed response shapes are therefore insufficiently observable from the retained
+artifacts. Earlier local process logs from related runs showed JSON decoder messages consistent with
+object-like non-JSON text, but those messages are not retained in this evidence root and are not
+enough to characterize the four target parse failures as a specific recoverable output category.
 
 No parser recovery was added because accepting guessed pseudo-JSON would change classifier output
-semantics without evidence that the observed raw responses were safely recoverable. Instead,
-fixture-backed regression coverage now proves representative brace-delimited non-JSON outputs are
-rejected deterministically as low-confidence not-relevant results and still increment
-`parse_failure_count`. Existing canonical JSON success behavior and invalid taxonomy-pair
+semantics without evidence that the target raw responses were safely recoverable. Instead,
+representative current-policy regression coverage now proves plausible malformed object-like
+non-JSON outputs are rejected deterministically as low-confidence not-relevant results and still
+increment `parse_failure_count`. Existing canonical JSON success behavior and invalid taxonomy-pair
 rejection/counting behavior remain unchanged.
 
 The next classifier-output follow-up should persist a sanitized parse-failure shape sample or

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -128,11 +128,11 @@ class TestClassifierParsing:
             "'taxonomy_subcategory_id': 'keeping_brothel', 'confidence': 'high'}",
         ],
     )
-    def test_parse_brace_delimited_non_json_fixtures_remain_rejected(
+    def test_parse_representative_object_like_non_json_remains_rejected(
         self,
         response: str,
     ) -> None:
-        """Observed parse-failure logs only expose the decoder shape, so do not recover guesses."""
+        """Do not recover plausible malformed object-like outputs without retained raw evidence."""
         classifier = Classifier(api_key="test-key")
 
         result = classifier._parse_response(response)

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -117,6 +117,38 @@ class TestClassifierParsing:
         assert result.category == Category.NOT_RELEVANT
         assert result.confidence == "low"
 
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "{relevant: true, enforcement_related: true, "
+            "taxonomy_category_id: 'brothels', "
+            "taxonomy_subcategory_id: 'keeping_brothel', confidence: 'high'}",
+            "{'relevant': True, 'enforcement_related': True, "
+            "'taxonomy_category_id': 'brothels', "
+            "'taxonomy_subcategory_id': 'keeping_brothel', 'confidence': 'high'}",
+        ],
+    )
+    def test_parse_brace_delimited_non_json_fixtures_remain_rejected(
+        self,
+        response: str,
+    ) -> None:
+        """Observed parse-failure logs only expose the decoder shape, so do not recover guesses."""
+        classifier = Classifier(api_key="test-key")
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.enforcement_related is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.sub_category is None
+        assert result.confidence == "low"
+        assert classifier.warning_counts == {
+            "parse_failure_count": 1,
+            "invalid_taxonomy_pair_count": 0,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+        }
+
     def test_parse_unknown_category(self) -> None:
         """Test parsing unknown category defaults to not_relevant."""
         classifier = Classifier(api_key="test-key")


### PR DESCRIPTION
## Planning notation

CLASSIFIER-PR-OUTPUT-ROBUSTNESS, under the Phase C classifier diagnostics track in `.agent-plan.md`.

## Summary

This PR implements the bounded classifier-output robustness slice after `CLASSIFIER-PR-WARNING-EVIDENCE-INTERPRETATION`.

It inspects the post-PR #128/#129 Phase C evidence root:

- `data/may_26_followup/20260514T182934Z/`
- `state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.json`
- `state/news_items/backfill_scrape/logs/2026-05-14T18-38-54-795669Z.summary.json`
- `artifacts/diagnose_discovery_after_scrape.json`
- `state/news_items/operational/news_items.json`
- `state/news_items/operational/run_metadata.jsonl`
- root-level `logs/`, `reports/`, and `summaries/` directories

The evidence confirmed the existing warning counts: 100 fallback classifier inputs, 4 parse failures, 1 invalid taxonomy pair, 0 invalid legacy pairs, 0 relevant-without-usable-taxonomy warnings, and 30 retained fallback operational rows with valid persisted taxonomy pairs.

## Parse-failure evidence review

The retained artifacts did not persist raw malformed classifier responses. The root-level `logs/`, `reports/`, and `summaries/` directories were empty, and the full debug JSON retained counts but not response text.

That means the four target parse-failure output shapes are insufficiently observable from the retained evidence. Earlier local process logs from related runs showed JSON decoder messages consistent with object-like non-JSON text, but those messages are not retained in this evidence root and are not enough to characterize the four target parse failures as a specific recoverable output category.

## Behavior

No parser recovery was added. Recovering guessed pseudo-JSON would change classifier output semantics without evidence that the target raw responses are safely recoverable.

Instead, this PR adds representative current-policy regression coverage for plausible malformed object-like non-JSON outputs. Those outputs are rejected deterministically as low-confidence not-relevant fallback results and still increment `parse_failure_count`.

Existing behavior remains unchanged for:

- canonical successful JSON classifier responses
- invalid taxonomy-pair rejection and `invalid_taxonomy_pair_count`
- classifier prompts
- taxonomy validity policy
- legacy taxonomy policy
- queue behavior
- scrape candidate selection
- generic fetch behavior
- browser/CDP scraper behavior
- scrape caps
- source-family support

## Docs and planning

- `README.md` now records that output robustness remains evidence-driven and parser recovery is deferred until sanitized malformed response shape evidence is safely persisted.
- `docs/discovery_operations.md` documents that retained artifacts are insufficient to characterize raw parse-failure shapes and that current rejection behavior remains intentional.
- `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md` adds the output-robustness evidence-review addendum.
- `.agent-plan.md` marks `CLASSIFIER-PR-OUTPUT-ROBUSTNESS` done and sets exactly one next item: `CLASSIFIER-PR-PARSE-FAILURE-EVIDENCE-CAPTURE`.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/pytest -q tests/unit/test_classifier.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- commit hook smoke tests
- push hook unit and integration tests

## Generated data

No generated `data/` artifacts are committed.
