### PR TITLE
CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE: Capture parse-failure structure diagnostics

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,18 +6,17 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-PARSE-FAILURE-EVIDENCE-INTERPRETATION` ran a bounded
-  Phase C fallback classifier evidence pass and interpreted the sanitized parse-failure shape
-  diagnostics: all five parse failures were `object_like_non_json` with one-line, no-code-fence,
-  `missing_property_name` samples at line 1 column 2, which is suggestive but not enough to justify
-  parser recovery.
-- Next planned PR: `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE` should slightly broaden
-  sanitized parse-failure structure capture, such as tail shape and wrapper/balance indicators, so a
-  later fixture-backed parser recovery decision can distinguish safely recoverable double-wrapped
-  objects from ambiguous object-like non-JSON without storing raw classifier responses. This next
-  slice is capture-only: it should not change parser behavior unless a later evidence interpretation
-  proves that the observed structure is balanced, consistently double-wrapped JSON with a valid
-  recoverable inner object.
+- Last merged PR on main: `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE` broadened sanitized
+  parse-failure structure capture with tail shape, quote-aware brace-balance, double-wrapper,
+  inner-object, and valid-inner-JSON indicators while preserving existing parse-failure counts,
+  category counts, sample caps, sanitization boundaries, and parser recovery behavior.
+- Next planned PR: `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-INTERPRETATION` should run a bounded
+  Phase C evidence pass using the new sanitized structure fields and interpret whether repeated
+  parse failures are balanced, consistently double-wrapped object candidates with
+  `inner_json_object_candidate=true`. Parser recovery should remain deferred unless the evidence
+  supports a later fixture-backed recovery PR that proves a valid recoverable inner object;
+  unbalanced wrappers, pseudo-JSON, mixed categories, or absent repeat failures should keep recovery
+  deferred.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -137,7 +136,7 @@
   parser recovery remains deferred without changing classifier prompts, taxonomy validity policy,
   legacy taxonomy policy, queue behavior, scraper behavior, scrape caps, source-family support, or
   committing generated data artifacts.
-- [next] `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE`: slightly broaden sanitized
+- [done] `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE`: slightly broaden sanitized
   parse-failure structure capture with tail shape and wrapper/balance indicators, without raw
   response text, prompt changes, parser recovery behavior changes, taxonomy-policy changes, queue
   behavior changes, scraper behavior changes, scrape-cap changes, source-family support, or
@@ -145,6 +144,12 @@
   balanced double-wrapped JSON with a valid inner object can justify a later fixture-backed recovery
   PR; unbalanced wrappers, pseudo-JSON, mixed categories, or absent repeat failures should keep
   recovery deferred.
+- [next] `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-INTERPRETATION`: run a bounded Phase C
+  fallback-classifier evidence pass using the new sanitized tail shape, quote-aware brace-balance,
+  double-wrapper, inner-object, and valid-inner-JSON fields, then decide whether parser recovery
+  remains deferred or a later fixture-backed recovery PR is justified without changing prompts,
+  parser behavior, taxonomy policy, queue behavior, scraper behavior, scrape caps, source-family
+  support, or committing generated data artifacts.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Planned future datasets:
 - Interprets the first post-capture bounded Phase C parse-failure evidence pass: five fallback
   parse failures across 100 fallback classifier inputs were all `object_like_non_json`, with
   one-line, no-code-fence samples and `missing_property_name` at line 1 column 2, so parser recovery
-  remains deferred until a capture-only follow-up records slightly richer sanitized structure such
-  as tail shape or wrapper/balance evidence and a later interpretation proves recovery is safe
+  remains deferred until a follow-up evidence pass uses the newly captured sanitized tail shape,
+  quote-aware brace balance, wrapper/inner-object indicators, and valid-inner-JSON signal to prove
+  recovery is safe
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -628,10 +628,19 @@ parse-failure shape diagnostics beside the existing warning counters under
 `sample_shape_max_length=80`. Samples store only structural metadata such as response length,
 normalized length, line count, a sanitized allowlisted JSON error kind, JSON error position,
 code-fence flags, and a character-class `shape_signature`; they do not store raw classifier
-response text, article text, secrets, provider headers, prompts, or candidate payloads. The sample
-selection prefers category coverage within the cap, so a rare later category can replace an earlier
-duplicate sample. Compact `.summary.json` files retain the same summary fields so operators can
-review parse-failure shape pressure without opening generated full debug logs.
+response text, article text, secrets, provider headers, prompts, or candidate payloads. After
+`CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE`, samples also include the same bounded
+character-class `tail_shape_signature`, `leading_brace_count`, `trailing_brace_count`,
+`brace_balance`, `starts_with_double_open_object`, `ends_with_double_close_object`,
+`outer_wrapper_candidate`, `inner_object_candidate`, `contains_balanced_inner_object`, and
+`inner_json_object_candidate`. Brace balance is computed outside JSON double-quoted strings so a
+literal brace inside a string does not distort the structural signal. The wrapper and balanced
+inner-object fields are structure-only indicators; only `inner_json_object_candidate` says that
+trimming one outer wrapper would expose a parseable JSON object. None of these fields parse or
+recover the malformed response for production classification. The sample selection prefers category
+coverage within the cap, so a rare later category can replace an earlier duplicate sample. Compact
+`.summary.json` files retain the same summary fields so operators can review parse-failure shape
+pressure without opening generated full debug logs.
 
 The stable parse-failure categories are `empty_response`, `json_decode_error`,
 `non_object_json_array`, `non_object_json_scalar`, `object_like_non_json`,
@@ -683,16 +692,16 @@ signature, brace-balance signal, or enough wrapper metadata to prove that simply
 would always recover a valid classifier object without accepting ambiguous pseudo-JSON.
 
 Parser recovery therefore remains deferred. The observed category is not safely recoverable from
-the current artifact shape alone; it is also not evidence for prompt changes, taxonomy validity
+the previous artifact shape alone; it is also not evidence for prompt changes, taxonomy validity
 changes, legacy taxonomy changes, queue behavior changes, scrape candidate selection changes,
 generic fetch changes, browser/CDP scraper changes, scrape-cap changes, source-family support, or
-source-targeted query fanout. The next bounded PR should slightly broaden sanitized shape capture,
-for example with tail character-class signature and object-wrapper/balance indicators, before any
-fixture-backed parser recovery decision. That next PR should remain capture-only. A later
-interpretation can recommend parser recovery only if the added sanitized fields prove a balanced,
-consistently double-wrapped JSON object with a valid recoverable inner object; pseudo-JSON,
-unbalanced wrappers, mixed parse-failure categories, or no repeated parse failures should keep
-recovery deferred.
+source-targeted query fanout. The next bounded evidence interpretation should use the added tail
+character-class signature and object-wrapper/balance indicators without committing generated
+artifacts. A later interpretation can recommend parser recovery only if the added sanitized fields
+show repeat failures that are balanced, consistently double-wrapped object candidates with
+`inner_json_object_candidate=true`; pseudo-JSON, balanced-but-not-JSON inner objects, unbalanced
+wrappers, mixed parse-failure categories, or no repeated parse failures should keep recovery
+deferred.
 
 ## One-Time 90-Day Re-Scan
 

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -376,6 +376,35 @@ prompts, parser recovery behavior, taxonomy validity policy, legacy taxonomy pol
 fairness, scrape candidate selection, generic fetch behavior, browser/CDP scraping, scrape caps,
 source-family support, or source-targeted query fanout.
 
+## 2026-05-14 Addendum: Parse-Failure Structure Evidence Capture
+
+`CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE` broadens the sanitized sample metadata for future
+runs without changing parser recovery. In addition to the existing leading `shape_signature`,
+parse-failure samples now carry a bounded `tail_shape_signature`, `leading_brace_count`,
+`trailing_brace_count`, `brace_balance`, `starts_with_double_open_object`,
+`ends_with_double_close_object`, `outer_wrapper_candidate`, `inner_object_candidate`, and
+`contains_balanced_inner_object`, plus `inner_json_object_candidate` to distinguish a structurally
+balanced inner object from a parseable JSON object. These fields are retained in both full debug
+payloads and compact `.summary.json` payloads through
+`classifier_summary.parse_failure_diagnostics` and
+`fallback_classifier_summary.parse_failure_diagnostics`.
+
+The fields are deliberately structural: signatures are character classes capped by
+`sample_shape_max_length=80`, quote-aware brace counts and balance are numeric, and
+wrapper/inner-object indicators are booleans. They do not store raw classifier response text, full
+article text, prompts, provider metadata, candidate payloads, secrets, or generated evidence
+artifact content.
+
+The decision gate for the next interpretation remains narrow. Repeat failures that are balanced,
+consistently double-wrapped object candidates can justify a later fixture-backed parser recovery PR
+only when `inner_json_object_candidate=true` repeats consistently and that later PR proves the
+recoverable inner object is valid in fixture-backed tests. Unbalanced wrappers, pseudo-JSON,
+balanced-but-not-JSON inner objects, mixed parse-failure categories, or absent repeat failures
+should keep recovery deferred. This capture-only slice does not change classifier prompts, parser
+recovery behavior, taxonomy validity policy, legacy taxonomy policy, queue behavior, scrape
+candidate selection, generic fetch behavior, browser/CDP scraper behavior, scrape caps,
+source-family support, or source-targeted query fanout.
+
 ## 2026-05-14 Addendum: Parse-Failure Evidence Interpretation
 
 `CLASSIFIER-PR-PARSE-FAILURE-EVIDENCE-INTERPRETATION` found no existing post-PR #131 generated

--- a/src/denbust/classifier/relevance.py
+++ b/src/denbust/classifier/relevance.py
@@ -56,6 +56,16 @@ PARSE_FAILURE_SAMPLE_KEYS = (
     "normalized_length",
     "line_count",
     "shape_signature",
+    "tail_shape_signature",
+    "leading_brace_count",
+    "trailing_brace_count",
+    "brace_balance",
+    "starts_with_double_open_object",
+    "ends_with_double_close_object",
+    "outer_wrapper_candidate",
+    "inner_object_candidate",
+    "contains_balanced_inner_object",
+    "inner_json_object_candidate",
     "json_error_kind",
     "json_error_position",
     "json_error_line",
@@ -181,6 +191,16 @@ class ClassifierParseFailureSample:
     normalized_length: int
     line_count: int
     shape_signature: str
+    tail_shape_signature: str
+    leading_brace_count: int
+    trailing_brace_count: int
+    brace_balance: int
+    starts_with_double_open_object: bool
+    ends_with_double_close_object: bool
+    outer_wrapper_candidate: bool
+    inner_object_candidate: bool
+    contains_balanced_inner_object: bool
+    inner_json_object_candidate: bool
     json_error_kind: str | None = None
     json_error_position: int | None = None
     json_error_line: int | None = None
@@ -196,6 +216,16 @@ class ClassifierParseFailureSample:
             "normalized_length": self.normalized_length,
             "line_count": self.line_count,
             "shape_signature": self.shape_signature,
+            "tail_shape_signature": self.tail_shape_signature,
+            "leading_brace_count": self.leading_brace_count,
+            "trailing_brace_count": self.trailing_brace_count,
+            "brace_balance": self.brace_balance,
+            "starts_with_double_open_object": self.starts_with_double_open_object,
+            "ends_with_double_close_object": self.ends_with_double_close_object,
+            "outer_wrapper_candidate": self.outer_wrapper_candidate,
+            "inner_object_candidate": self.inner_object_candidate,
+            "contains_balanced_inner_object": self.contains_balanced_inner_object,
+            "inner_json_object_candidate": self.inner_json_object_candidate,
             "json_error_kind": self.json_error_kind,
             "json_error_position": self.json_error_position,
             "json_error_line": self.json_error_line,
@@ -231,6 +261,7 @@ class ClassifierParseFailureDiagnostics:
         stable_category = (
             category if category in PARSE_FAILURE_CATEGORY_KEYS else "other_parse_failure"
         )
+        structure = _parse_failure_structure_metadata(normalized_text)
         self.category_counts[stable_category] += 1
         sample = ClassifierParseFailureSample(
             category=stable_category,
@@ -241,6 +272,19 @@ class ClassifierParseFailureDiagnostics:
                 normalized_text,
                 max_length=self.sample_shape_max_length,
             ),
+            tail_shape_signature=_tail_shape_signature(
+                normalized_text,
+                max_length=self.sample_shape_max_length,
+            ),
+            leading_brace_count=structure.leading_brace_count,
+            trailing_brace_count=structure.trailing_brace_count,
+            brace_balance=structure.brace_balance,
+            starts_with_double_open_object=structure.starts_with_double_open_object,
+            ends_with_double_close_object=structure.ends_with_double_close_object,
+            outer_wrapper_candidate=structure.outer_wrapper_candidate,
+            inner_object_candidate=structure.inner_object_candidate,
+            contains_balanced_inner_object=structure.contains_balanced_inner_object,
+            inner_json_object_candidate=structure.inner_json_object_candidate,
             json_error_kind=(
                 _json_decode_error_kind(json_error) if json_error is not None else None
             ),
@@ -284,6 +328,21 @@ class ClassifierParseFailureDiagnostics:
         }
 
 
+@dataclass(frozen=True)
+class ParseFailureStructureMetadata:
+    """Structural parse-failure indicators that do not retain response content."""
+
+    leading_brace_count: int
+    trailing_brace_count: int
+    brace_balance: int
+    starts_with_double_open_object: bool
+    ends_with_double_close_object: bool
+    outer_wrapper_candidate: bool
+    inner_object_candidate: bool
+    contains_balanced_inner_object: bool
+    inner_json_object_candidate: bool
+
+
 def _shape_signature(text: str, *, max_length: int) -> str:
     """Return bounded structural character classes instead of raw response text."""
     signature: list[str] = []
@@ -299,6 +358,95 @@ def _shape_signature(text: str, *, max_length: int) -> str:
         else:
             signature.append("?")
     return "".join(signature)
+
+
+def _tail_shape_signature(text: str, *, max_length: int) -> str:
+    """Return bounded structural character classes for the response tail."""
+    if max_length <= 0:
+        return ""
+    return _shape_signature(text[-max_length:], max_length=max_length)
+
+
+def _leading_char_count(text: str, char: str) -> int:
+    """Count repeated leading structural characters after surrounding whitespace."""
+    stripped = text.strip()
+    count = 0
+    for candidate in stripped:
+        if candidate != char:
+            break
+        count += 1
+    return count
+
+
+def _trailing_char_count(text: str, char: str) -> int:
+    """Count repeated trailing structural characters after surrounding whitespace."""
+    stripped = text.strip()
+    count = 0
+    for candidate in reversed(stripped):
+        if candidate != char:
+            break
+        count += 1
+    return count
+
+
+def _structural_brace_balance(text: str) -> int:
+    """Count brace balance outside JSON double-quoted strings."""
+    balance = 0
+    in_string = False
+    escaped = False
+    for char in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            balance += 1
+        elif char == "}":
+            balance -= 1
+    return balance
+
+
+def _is_json_object(text: str) -> bool:
+    """Return whether text parses as a JSON object without retaining parsed content."""
+    with contextlib.suppress(json.JSONDecodeError):
+        return isinstance(json.loads(text), dict)
+    return False
+
+
+def _parse_failure_structure_metadata(text: str) -> ParseFailureStructureMetadata:
+    """Return bounded structure-only indicators for malformed object-like responses."""
+    stripped = text.strip()
+    leading_brace_count = _leading_char_count(stripped, "{")
+    trailing_brace_count = _trailing_char_count(stripped, "}")
+    brace_balance = _structural_brace_balance(stripped)
+    starts_with_double_open_object = stripped.startswith("{{")
+    ends_with_double_close_object = stripped.endswith("}}")
+    outer_wrapper_candidate = (
+        starts_with_double_open_object and ends_with_double_close_object and brace_balance == 0
+    )
+    inner_text = stripped[1:-1].strip() if outer_wrapper_candidate else ""
+    inner_object_candidate = inner_text.startswith("{") and inner_text.endswith("}")
+    contains_balanced_inner_object = (
+        inner_object_candidate and _structural_brace_balance(inner_text) == 0
+    )
+    inner_json_object_candidate = contains_balanced_inner_object and _is_json_object(inner_text)
+    return ParseFailureStructureMetadata(
+        leading_brace_count=leading_brace_count,
+        trailing_brace_count=trailing_brace_count,
+        brace_balance=brace_balance,
+        starts_with_double_open_object=starts_with_double_open_object,
+        ends_with_double_close_object=ends_with_double_close_object,
+        outer_wrapper_candidate=outer_wrapper_candidate,
+        inner_object_candidate=inner_object_candidate,
+        contains_balanced_inner_object=contains_balanced_inner_object,
+        inner_json_object_candidate=inner_json_object_candidate,
+    )
 
 
 def _strip_markdown_fence(text: str) -> tuple[str, bool]:

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -142,6 +142,33 @@ _CLASSIFIER_WARNING_COUNT_KEYS = (
     "invalid_legacy_pair_count",
     "relevant_without_usable_taxonomy_count",
 )
+_PARSE_FAILURE_SAMPLE_STRING_KEYS = {
+    "shape_signature",
+    "tail_shape_signature",
+}
+_PARSE_FAILURE_SAMPLE_INT_KEYS = {
+    "response_length",
+    "normalized_length",
+    "line_count",
+    "leading_brace_count",
+    "trailing_brace_count",
+    "brace_balance",
+}
+_PARSE_FAILURE_SAMPLE_OPTIONAL_INT_KEYS = {
+    "json_error_position",
+    "json_error_line",
+    "json_error_column",
+}
+_PARSE_FAILURE_SAMPLE_BOOL_KEYS = {
+    "starts_with_code_fence",
+    "ends_with_code_fence",
+    "starts_with_double_open_object",
+    "ends_with_double_close_object",
+    "outer_wrapper_candidate",
+    "inner_object_candidate",
+    "contains_balanced_inner_object",
+    "inner_json_object_candidate",
+}
 
 
 def _sanitize_classifier_provider_error(error: ClassifierProviderError) -> str:
@@ -1459,6 +1486,23 @@ def _normalize_classifier_warning_counts(
     return normalized
 
 
+def _is_safe_parse_failure_sample_value(key: str, value: object) -> bool:
+    """Return whether a parse-failure sample value is safe to copy to artifacts."""
+    if key == "category":
+        return isinstance(value, str) and value in PARSE_FAILURE_CATEGORY_KEYS
+    if key in _PARSE_FAILURE_SAMPLE_INT_KEYS:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if key in _PARSE_FAILURE_SAMPLE_OPTIONAL_INT_KEYS:
+        return value is None or (isinstance(value, int) and not isinstance(value, bool))
+    if key in _PARSE_FAILURE_SAMPLE_BOOL_KEYS:
+        return isinstance(value, bool)
+    return (
+        key == "json_error_kind"
+        and isinstance(value, str)
+        and value in PARSE_FAILURE_JSON_ERROR_KIND_KEYS
+    )
+
+
 def _normalize_classifier_parse_failure_diagnostics(
     diagnostics: Mapping[str, object] | None,
 ) -> dict[str, object]:
@@ -1498,23 +1542,9 @@ def _normalize_classifier_parse_failure_diagnostics(
                 if key not in raw_sample:
                     continue
                 value = raw_sample[key]
-                if key == "shape_signature" and isinstance(value, str):
+                if key in _PARSE_FAILURE_SAMPLE_STRING_KEYS and isinstance(value, str):
                     sample[key] = value[:sample_shape_max_length]
-                elif key in {
-                    "category",
-                    "response_length",
-                    "normalized_length",
-                    "line_count",
-                    "json_error_position",
-                    "json_error_line",
-                    "json_error_column",
-                    "starts_with_code_fence",
-                    "ends_with_code_fence",
-                } or (
-                    key == "json_error_kind"
-                    and isinstance(value, str)
-                    and value in PARSE_FAILURE_JSON_ERROR_KIND_KEYS
-                ):
+                elif _is_safe_parse_failure_sample_value(key, value):
                     sample[key] = value
             samples.append(sample)
 

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -163,6 +163,104 @@ class TestClassifierParsing:
         }
         assert classifier.parse_failure_diagnostics["category_counts"]["object_like_non_json"] == 1
 
+    def test_double_open_object_like_failure_records_wrapper_structure(self) -> None:
+        """Double-wrapped object-like failures should expose structure without recovery."""
+        classifier = Classifier(api_key="test-key")
+        response = (
+            '{{"relevant": true, "enforcement_related": true, '
+            '"taxonomy_category_id": "brothels", '
+            '"taxonomy_subcategory_id": "administrative_closure", '
+            '"confidence": "high"}}'
+        )
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.enforcement_related is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.confidence == "low"
+        assert classifier.warning_counts["parse_failure_count"] == 1
+        diagnostics = classifier.parse_failure_diagnostics
+        sample = diagnostics["samples"][0]
+        assert diagnostics["category_counts"]["object_like_non_json"] == 1
+        assert sample["leading_brace_count"] == 2
+        assert sample["trailing_brace_count"] == 2
+        assert sample["brace_balance"] == 0
+        assert sample["starts_with_double_open_object"] is True
+        assert sample["ends_with_double_close_object"] is True
+        assert sample["outer_wrapper_candidate"] is True
+        assert sample["inner_object_candidate"] is True
+        assert sample["contains_balanced_inner_object"] is True
+        assert sample["inner_json_object_candidate"] is True
+        assert set(sample) == set(PARSE_FAILURE_SAMPLE_KEYS)
+        assert response not in str(diagnostics)
+
+    def test_pseudo_json_double_wrapper_is_not_inner_json_candidate(self) -> None:
+        """Balanced pseudo-JSON should not masquerade as a valid inner object."""
+        classifier = Classifier(api_key="test-key")
+
+        classifier._parse_response("{{relevant: true}}")
+
+        sample = classifier.parse_failure_diagnostics["samples"][0]
+        assert sample["leading_brace_count"] == 2
+        assert sample["trailing_brace_count"] == 2
+        assert sample["brace_balance"] == 0
+        assert sample["outer_wrapper_candidate"] is True
+        assert sample["inner_object_candidate"] is True
+        assert sample["contains_balanced_inner_object"] is True
+        assert sample["inner_json_object_candidate"] is False
+
+    def test_structural_balance_ignores_braces_inside_json_strings(self) -> None:
+        """Brace balance should not be thrown off by literal braces inside strings."""
+        classifier = Classifier(api_key="test-key")
+        response = '{{"relevant": true, "reason": "literal } brace and escaped \\" quote"}}'
+
+        classifier._parse_response(response)
+
+        sample = classifier.parse_failure_diagnostics["samples"][0]
+        assert sample["brace_balance"] == 0
+        assert sample["outer_wrapper_candidate"] is True
+        assert sample["inner_object_candidate"] is True
+        assert sample["contains_balanced_inner_object"] is True
+        assert sample["inner_json_object_candidate"] is True
+
+    def test_unbalanced_object_like_failure_records_non_recoverable_structure(self) -> None:
+        """Unbalanced wrappers should remain rejected and report non-candidate structure."""
+        classifier = Classifier(api_key="test-key")
+        response = '{{"relevant": true, "secret": "sk-ant-secret"}'
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        diagnostics = classifier.parse_failure_diagnostics
+        sample = diagnostics["samples"][0]
+        assert diagnostics["category_counts"]["object_like_non_json"] == 1
+        assert sample["leading_brace_count"] == 2
+        assert sample["trailing_brace_count"] == 1
+        assert sample["brace_balance"] == 1
+        assert sample["starts_with_double_open_object"] is True
+        assert sample["ends_with_double_close_object"] is False
+        assert sample["outer_wrapper_candidate"] is False
+        assert sample["inner_object_candidate"] is False
+        assert sample["contains_balanced_inner_object"] is False
+        assert sample["inner_json_object_candidate"] is False
+        assert "sk-ant-secret" not in str(diagnostics)
+        assert '"secret"' not in str(diagnostics)
+
+    def test_parse_failure_tail_shape_is_bounded_and_sanitized(self) -> None:
+        """Tail signatures should expose only bounded structure classes."""
+        classifier = Classifier(api_key="test-key")
+        response = "{" + ("alpha: " * 40) + 'token: "sk-ant-secret"}'
+
+        classifier._parse_response(response)
+
+        diagnostics = classifier.parse_failure_diagnostics
+        sample = diagnostics["samples"][0]
+        assert len(sample["tail_shape_signature"]) <= PARSE_FAILURE_SAMPLE_SHAPE_MAX_LENGTH
+        assert "alpha" not in str(diagnostics)
+        assert "sk-ant-secret" not in str(diagnostics)
+        assert "token" not in str(diagnostics)
+
     def test_parse_unknown_category(self) -> None:
         """Test parsing unknown category defaults to not_relevant."""
         classifier = Classifier(api_key="test-key")

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -364,6 +364,16 @@ class TestFetchAndClassifyHelpers:
                         "normalized_length": 44,
                         "line_count": 1,
                         "shape_signature": "{AAAAAAAA: AAAA",
+                        "tail_shape_signature": "{AAAAAAAA: AAAA",
+                        "leading_brace_count": 1,
+                        "trailing_brace_count": 0,
+                        "brace_balance": 1,
+                        "starts_with_double_open_object": False,
+                        "ends_with_double_close_object": False,
+                        "outer_wrapper_candidate": False,
+                        "inner_object_candidate": False,
+                        "contains_balanced_inner_object": False,
+                        "inner_json_object_candidate": False,
                         "json_error_kind": "missing_property_name",
                         "json_error_position": 1,
                         "json_error_line": 1,
@@ -401,6 +411,16 @@ class TestFetchAndClassifyHelpers:
                     "normalized_length": 44,
                     "line_count": 1,
                     "shape_signature": "{AAAAAAAA: AAAA",
+                    "tail_shape_signature": "{AAAAAAAA: AAAA",
+                    "leading_brace_count": 1,
+                    "trailing_brace_count": 0,
+                    "brace_balance": 1,
+                    "starts_with_double_open_object": False,
+                    "ends_with_double_close_object": False,
+                    "outer_wrapper_candidate": False,
+                    "inner_object_candidate": False,
+                    "contains_balanced_inner_object": False,
+                    "inner_json_object_candidate": False,
                     "json_error_kind": "missing_property_name",
                     "json_error_position": 1,
                     "json_error_line": 1,
@@ -418,6 +438,37 @@ class TestFetchAndClassifyHelpers:
             for sample in classifier_summary["parse_failure_diagnostics"]["samples"]
         )
         assert "sk-ant-secret" not in str(classifier_summary["parse_failure_diagnostics"])
+
+    def test_classifier_summary_drops_mistyped_parse_failure_sample_values(self) -> None:
+        """Sample normalization should not pass through mistyped artifact fields."""
+        classifier_summary = _build_classifier_summary(
+            unseen_articles=[],
+            classified_articles=[],
+            classifier_parse_failure_diagnostics={
+                "category_counts": {"object_like_non_json": 1},
+                "samples": [
+                    {
+                        "category": "object_like_non_json",
+                        "shape_signature": "{{AAAA}}",
+                        "leading_brace_count": "sk-ant-secret",
+                        "trailing_brace_count": True,
+                        "starts_with_double_open_object": "true",
+                        "json_error_position": "bearer token-value",
+                        "inner_json_object_candidate": "yes",
+                    }
+                ],
+            },
+        )
+
+        diagnostics = classifier_summary["parse_failure_diagnostics"]
+        assert diagnostics["samples"] == [
+            {
+                "category": "object_like_non_json",
+                "shape_signature": "{{AAAA}}",
+            }
+        ]
+        assert "sk-ant-secret" not in str(diagnostics)
+        assert "bearer token-value" not in str(diagnostics)
 
     def test_mark_seen_collects_all_source_urls(self, tmp_path: Path) -> None:
         """mark_seen should persist every source URL from unified items."""
@@ -1877,6 +1928,16 @@ class TestRunPipelineAsync:
                     "normalized_length": 38,
                     "line_count": 1,
                     "shape_signature": "{AAAAAAAA: AAAA",
+                    "tail_shape_signature": "{AAAAAAAA: AAAA",
+                    "leading_brace_count": 1,
+                    "trailing_brace_count": 0,
+                    "brace_balance": 1,
+                    "starts_with_double_open_object": False,
+                    "ends_with_double_close_object": False,
+                    "outer_wrapper_candidate": False,
+                    "inner_object_candidate": False,
+                    "contains_balanced_inner_object": False,
+                    "inner_json_object_candidate": False,
                     "json_error_kind": "missing_property_name",
                     "json_error_position": 1,
                     "json_error_line": 1,
@@ -1967,6 +2028,16 @@ class TestRunPipelineAsync:
                         "normalized_length": 38,
                         "line_count": 1,
                         "shape_signature": "{AAAAAAAA: AAAA",
+                        "tail_shape_signature": "{AAAAAAAA: AAAA",
+                        "leading_brace_count": 1,
+                        "trailing_brace_count": 0,
+                        "brace_balance": 1,
+                        "starts_with_double_open_object": False,
+                        "ends_with_double_close_object": False,
+                        "outer_wrapper_candidate": False,
+                        "inner_object_candidate": False,
+                        "contains_balanced_inner_object": False,
+                        "inner_json_object_candidate": False,
                         "json_error_kind": "missing_property_name",
                         "json_error_position": 1,
                         "json_error_line": 1,

--- a/tests/unit/test_run_snapshots.py
+++ b/tests/unit/test_run_snapshots.py
@@ -121,7 +121,21 @@ class TestRunSnapshots:
                     "rejected_article_count": 2,
                     "parse_failure_diagnostics": {
                         "category_counts": {"object_like_non_json": 1},
-                        "samples": [{"category": "object_like_non_json"}],
+                        "samples": [
+                            {
+                                "category": "object_like_non_json",
+                                "tail_shape_signature": 'AAAA": "AAAA"}}',
+                                "leading_brace_count": 2,
+                                "trailing_brace_count": 2,
+                                "brace_balance": 0,
+                                "starts_with_double_open_object": True,
+                                "ends_with_double_close_object": True,
+                                "outer_wrapper_candidate": True,
+                                "inner_object_candidate": True,
+                                "contains_balanced_inner_object": True,
+                                "inner_json_object_candidate": True,
+                            }
+                        ],
                         "sample_count": 1,
                         "sample_max_count": 8,
                         "sample_shape_max_length": 80,
@@ -138,7 +152,21 @@ class TestRunSnapshots:
                     },
                     "parse_failure_diagnostics": {
                         "category_counts": {"object_like_non_json": 1},
-                        "samples": [{"category": "object_like_non_json"}],
+                        "samples": [
+                            {
+                                "category": "object_like_non_json",
+                                "tail_shape_signature": 'AAAA": "AAAA"}}',
+                                "leading_brace_count": 2,
+                                "trailing_brace_count": 2,
+                                "brace_balance": 0,
+                                "starts_with_double_open_object": True,
+                                "ends_with_double_close_object": True,
+                                "outer_wrapper_candidate": True,
+                                "inner_object_candidate": True,
+                                "contains_balanced_inner_object": True,
+                                "inner_json_object_candidate": True,
+                            }
+                        ],
                         "sample_count": 1,
                         "sample_max_count": 8,
                         "sample_shape_max_length": 80,
@@ -159,7 +187,21 @@ class TestRunSnapshots:
         payload = json.loads(content)
         assert payload["classifier_summary"]["parse_failure_diagnostics"] == {
             "category_counts": {"object_like_non_json": 1},
-            "samples": [{"category": "object_like_non_json"}],
+            "samples": [
+                {
+                    "category": "object_like_non_json",
+                    "tail_shape_signature": 'AAAA": "AAAA"}}',
+                    "leading_brace_count": 2,
+                    "trailing_brace_count": 2,
+                    "brace_balance": 0,
+                    "starts_with_double_open_object": True,
+                    "ends_with_double_close_object": True,
+                    "outer_wrapper_candidate": True,
+                    "inner_object_candidate": True,
+                    "contains_balanced_inner_object": True,
+                    "inner_json_object_candidate": True,
+                }
+            ],
             "sample_count": 1,
             "sample_max_count": 8,
             "sample_shape_max_length": 80,
@@ -175,7 +217,21 @@ class TestRunSnapshots:
             },
             "parse_failure_diagnostics": {
                 "category_counts": {"object_like_non_json": 1},
-                "samples": [{"category": "object_like_non_json"}],
+                "samples": [
+                    {
+                        "category": "object_like_non_json",
+                        "tail_shape_signature": 'AAAA": "AAAA"}}',
+                        "leading_brace_count": 2,
+                        "trailing_brace_count": 2,
+                        "brace_balance": 0,
+                        "starts_with_double_open_object": True,
+                        "ends_with_double_close_object": True,
+                        "outer_wrapper_candidate": True,
+                        "inner_object_candidate": True,
+                        "contains_balanced_inner_object": True,
+                        "inner_json_object_candidate": True,
+                    }
+                ],
                 "sample_count": 1,
                 "sample_max_count": 8,
                 "sample_shape_max_length": 80,


### PR DESCRIPTION
## Planning notation

`CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE` under the Phase C planning track in `.agent-plan.md`.

## Summary

This PR broadens sanitized classifier parse-failure diagnostics so a later evidence interpretation pass can distinguish likely double-wrapped JSON from ambiguous object-like non-JSON without storing raw model output.

New `parse_failure_diagnostics.samples[]` fields:

- `tail_shape_signature`
- `leading_brace_count`
- `trailing_brace_count`
- `brace_balance`
- `starts_with_double_open_object`
- `ends_with_double_close_object`
- `outer_wrapper_candidate`
- `inner_object_candidate`
- `contains_balanced_inner_object`
- `inner_json_object_candidate`

The existing `parse_failure_count`, category counts, sample cap, and `sample_shape_max_length=80` behavior are preserved. The compact `.summary.json` path retains these fields through the existing classifier and fallback classifier summary objects.

## Self-review hardening

After an outsider-style self-review, this PR now tightens the original implementation in three ways:

- Brace balance is quote-aware, so braces inside JSON double-quoted strings do not create false imbalance.
- Balanced wrapper shape is separated from valid inner JSON: `contains_balanced_inner_object` remains structural, while `inner_json_object_candidate=true` is required before a later interpretation can treat the sample as a parseable wrapped object candidate.
- Summary normalization now type-checks sample fields at the artifact boundary, dropping mistyped numeric/boolean fields instead of copying arbitrary values into debug summaries.

## Sanitization boundary

The new fields are structure-only metadata: bounded character-class signatures, numeric brace counts, and boolean wrapper indicators. They do not store raw classifier response text, full article text, prompts, provider metadata, candidate payloads, generated artifact contents, or secrets.

## Decision gate

This PR is capture-only. Parser recovery remains out of scope.

The next interpretation pass can use these fields to decide whether repeated parse failures are balanced, consistently double-wrapped object candidates with `inner_json_object_candidate=true`. A later fixture-backed recovery PR is justified only if that evidence can prove a valid recoverable inner object. Pseudo-JSON, balanced-but-not-JSON inner objects, unbalanced wrappers, mixed categories, or absent repeat failures should keep recovery deferred.

## Behavior intentionally unchanged

- No classifier prompt changes
- No parser recovery changes
- No taxonomy validity or legacy taxonomy policy changes
- No queue fairness or prioritization changes
- No scrape candidate selection changes
- No generic fetch, browser/CDP scraper, or scrape-cap changes
- No source-family support changes
- No generated `data/` artifact commits

## Docs and planning

- Updates `docs/discovery_operations.md` and the January 2026 wet-test evidence addendum with the new sanitized structure fields and decision gate.
- Updates `README.md` operator-facing summary.
- Marks `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-EVIDENCE` done in `.agent-plan.md` and sets exactly one next slice: `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-INTERPRETATION`.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_classifier.py tests/unit/test_pipeline_core.py tests/unit/test_run_snapshots.py`
- `git diff --check`
- pre-commit hooks during amend: merge-conflict check, EOF fix, trailing whitespace, YAML check, Ruff, Ruff format, mypy, smoke tests
- pre-push hooks during force-with-lease push: merge-conflict check, EOF fix, trailing whitespace, YAML check, Ruff, Ruff format, unit tests, integration tests
