### PR TITLE
CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY: Recover proven classifier double-wrapper JSON

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,20 +6,19 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-INTERPRETATION` ran a bounded
-  Phase C evidence pass using the sanitized tail-shape, quote-aware brace-balance, double-wrapper,
-  inner-object, and valid-inner-JSON fields. All five repeat parse failures were balanced
-  double-wrapped object candidates with `inner_json_object_candidate=true`, so a later narrowly
-  fixture-backed recovery PR is justified; this interpretation did not change prompts, parser
-  behavior, taxonomy policy, queue behavior, scraper behavior, scrape caps, source-family support,
-  or commit generated data artifacts.
-- Next planned PR: `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY` should add bounded parser
-  recovery for the proven double-wrapped valid-inner-JSON classifier-output shape only, with
-  fixture-backed coverage for the observed structure and explicit negative fixtures for pseudo-JSON,
-  unbalanced wrappers, mixed categories, non-object JSON, code-fenced malformed JSON, and invalid
-  taxonomy output. It must preserve classifier prompts, taxonomy validity policy, legacy taxonomy
-  policy, queue behavior, scraper behavior, scrape caps, source-family support, and generated-data
-  boundaries.
+- Last merged PR on main: `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY` adds bounded parser
+  recovery for the proven balanced double-wrapped classifier-output shape only: exactly two leading
+  object braces, exactly two trailing object braces, quote-aware balanced braces, a balanced inner
+  object candidate after trimming one outer wrapper, and a valid parseable inner JSON object. The
+  recovered object flows through the same taxonomy validation and legacy handling as ordinary JSON,
+  and `double_wrapper_recovery_count` keeps the path observable in run summaries. Invalid taxonomy
+  pairs remain rejected and counted without prompt, taxonomy-policy, queue, scraper, scrape-cap,
+  source-family, source-targeted fanout, or generated-data changes.
+- Next planned PR: `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK` should run or interpret the next
+  bounded Phase C fallback classifier evidence pass after double-wrapper recovery lands, verify
+  whether parse-failure counts drop without invalid-taxonomy leakage or retained-row taxonomy
+  corruption, and keep any further classifier-output, queue, scraper, or source-family changes
+  deferred until fresh evidence justifies them.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -155,12 +154,17 @@
   only as a later fixture-backed, shape-specific PR without changing prompts, parser behavior in
   this slice, taxonomy policy, queue behavior, scraper behavior, scrape caps, source-family support,
   or committing generated data artifacts.
-- [next] `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY`: add bounded recovery for classifier
+- [done] `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY`: add bounded recovery for classifier
   outputs that have exactly the proven balanced double-wrapper shape and a valid parseable inner
   object, while rejecting pseudo-JSON, unbalanced wrappers, non-object JSON, code-fenced malformed
   JSON, invalid taxonomy pairs, and unrelated parse-failure categories. Keep prompts, taxonomy
   validity policy, legacy taxonomy policy, queue behavior, scraper behavior, scrape caps,
   source-family support, and generated-data boundaries unchanged.
+- [next] `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK`: run or interpret a bounded Phase C fallback
+  classifier evidence pass after double-wrapper recovery is on main, confirm whether recovered
+  outputs reduce parse-failure counts without introducing invalid taxonomy retention, and defer any
+  broader parser, prompt, taxonomy-policy, queue, scraper, scrape-cap, source-family, or
+  source-targeted fanout work until that evidence exists.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Planned future datasets:
   consistently balanced double-wrapped valid-inner-JSON classifier output, so the next parser slice
   can add fixture-backed recovery for that exact shape while keeping prompts, taxonomy policy, queue
   behavior, scraper behavior, source support, and generated-data boundaries unchanged
+- Recovers only the proven classifier double-wrapper shape where the normalized response starts
+  with exactly two opening object braces, ends with exactly two closing object braces, has balanced
+  braces outside strings, and trimming one outer wrapper exposes a valid JSON object; recovered
+  objects still use the normal taxonomy validation path and increment
+  `double_wrapper_recovery_count`, while pseudo-JSON, unbalanced wrappers, non-object JSON,
+  code-fenced malformed JSON, and invalid taxonomy pairs remain rejected
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -732,13 +732,18 @@ double object braces, had `brace_balance=0`, and set `outer_wrapper_candidate=tr
 `inner_json_object_candidate=true`.
 
 That structure crosses the recovery decision gate established by the capture slice. Parser recovery
-is now justified only as a later fixture-backed, shape-specific PR for balanced double-wrapped
-classifier JSON where trimming exactly one outer wrapper exposes a valid inner JSON object. Recovery
-must remain rejected for pseudo-JSON, balanced-but-not-JSON inner text, unbalanced wrappers, mixed
-parse-failure categories, non-object JSON, code-fenced malformed JSON, and invalid taxonomy output.
-The interpretation does not itself change classifier prompts, parser behavior, taxonomy validity
-policy, legacy taxonomy policy, queue behavior, scrape candidate selection, generic fetch behavior,
-browser/CDP scraper behavior, scrape caps, source-family support, source-targeted query fanout, or
+is implemented only as a fixture-backed, shape-specific path for balanced double-wrapped classifier
+JSON where trimming exactly one outer wrapper exposes a valid inner JSON object. Recovered objects
+then pass through the same classifier validation and taxonomy handling as ordinary parsed objects,
+and each recovery increments `double_wrapper_recovery_count` in the existing classifier summary
+counters so future evidence passes can distinguish recovered outputs from ordinary valid JSON.
+Invalid taxonomy pairs inside recovered objects still increment the invalid-taxonomy warning
+counter and are rejected. Recovery remains rejected for pseudo-JSON, balanced-but-not-JSON inner
+text, unbalanced wrappers, mixed parse-failure categories, non-object JSON, code-fenced malformed
+JSON, and invalid taxonomy output. The implementation does not change classifier prompts, taxonomy
+validity policy, legacy taxonomy policy, queue behavior, scrape candidate selection, generic fetch
+behavior, browser/CDP scraper behavior, scrape caps, source-family support, source-targeted
+query fanout, or
 generated-data artifact tracking.
 
 ## One-Time 90-Day Re-Scan

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -615,3 +615,22 @@ categories, non-object JSON, code-fenced malformed JSON, and invalid taxonomy ou
 interpretation does not change classifier prompts, parser behavior, taxonomy validity policy,
 legacy taxonomy policy, queue behavior, scrape candidate selection, generic fetch behavior,
 browser/CDP scraper behavior, scrape caps, source-family support, or source-targeted query fanout.
+
+## 2026-05-15 Addendum: Double-Wrapper Parser Recovery
+
+`CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY` implements the later recovery slice justified by
+the structure interpretation above. The parser now recovers only when the normalized classifier
+response has exactly the proven shape: two leading object braces, two trailing object braces,
+quote-aware balanced braces, a balanced inner object candidate after trimming one outer wrapper, and
+an inner substring that parses as a JSON object. That recovered object is then handled by the same
+existing classifier validation code as ordinary JSON, while `double_wrapper_recovery_count` records
+how many responses used this recovery path.
+
+This is an implementation addendum, not a new wet-test claim. It does not add evidence artifacts or
+change the January 1-7 run figures. The negative boundary remains explicit: pseudo-JSON,
+balanced-but-not-valid-JSON inner text, unbalanced wrappers, non-object JSON, code-fenced malformed
+JSON, and recovered JSON with invalid taxonomy pairs remain rejected or counted by the same warning
+paths as before. The slice does not change classifier prompts, taxonomy validity policy, legacy
+taxonomy policy, queue behavior, scrape candidate selection, generic fetch behavior, browser/CDP
+scraper behavior, scrape caps, source-family support, source-targeted query fanout, or generated
+data tracking.

--- a/src/denbust/classifier/relevance.py
+++ b/src/denbust/classifier/relevance.py
@@ -165,12 +165,13 @@ class ClassifierProviderError(RuntimeError):
 
 @dataclass
 class ClassifierWarningCounts:
-    """Run-local classifier parser warning counters."""
+    """Run-local classifier parser warning and recovery counters."""
 
     parse_failure_count: int = 0
     invalid_taxonomy_pair_count: int = 0
     invalid_legacy_pair_count: int = 0
     relevant_without_usable_taxonomy_count: int = 0
+    double_wrapper_recovery_count: int = 0
 
     def as_dict(self) -> dict[str, int]:
         """Return stable artifact fields for run/debug summaries."""
@@ -179,6 +180,7 @@ class ClassifierWarningCounts:
             "invalid_taxonomy_pair_count": self.invalid_taxonomy_pair_count,
             "invalid_legacy_pair_count": self.invalid_legacy_pair_count,
             "relevant_without_usable_taxonomy_count": self.relevant_without_usable_taxonomy_count,
+            "double_wrapper_recovery_count": self.double_wrapper_recovery_count,
         }
 
 
@@ -449,6 +451,36 @@ def _parse_failure_structure_metadata(text: str) -> ParseFailureStructureMetadat
     )
 
 
+def _is_recoverable_double_wrapper_structure(
+    structure: ParseFailureStructureMetadata,
+) -> bool:
+    """Return whether structure matches the proven recovery gate."""
+    return (
+        structure.leading_brace_count == 2
+        and structure.trailing_brace_count == 2
+        and structure.outer_wrapper_candidate
+        and structure.inner_object_candidate
+        and structure.contains_balanced_inner_object
+        and structure.inner_json_object_candidate
+    )
+
+
+def _recover_double_wrapped_json_object(text: str) -> dict[str, Any] | None:
+    """Recover the proven ``{{ ... }}`` classifier output shape only."""
+    stripped = text.strip()
+    structure = _parse_failure_structure_metadata(stripped)
+    if not _is_recoverable_double_wrapper_structure(structure):
+        return None
+    inner_text = stripped[1:-1].strip()
+    try:
+        recovered = json.loads(inner_text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(recovered, dict):
+        return None
+    return recovered
+
+
 def _strip_markdown_fence(text: str) -> tuple[str, bool]:
     """Strip a leading Markdown code fence using the existing parser behavior."""
     normalized_text = text.strip()
@@ -551,7 +583,7 @@ class Classifier:
 
     @property
     def warning_counts(self) -> dict[str, int]:
-        """Return run-local parser warning counters for diagnostic artifacts."""
+        """Return run-local parser warning and recovery counters for artifacts."""
         return self._warning_counts.as_dict()
 
     @property
@@ -560,7 +592,7 @@ class Classifier:
         return self._parse_failure_diagnostics.as_dict()
 
     def reset_warning_counts(self) -> None:
-        """Reset parser warning counters at a pipeline run boundary."""
+        """Reset parser warning and recovery counters at a pipeline run boundary."""
         self._warning_counts = ClassifierWarningCounts()
         self._parse_failure_diagnostics = ClassifierParseFailureDiagnostics.empty()
 
@@ -605,9 +637,20 @@ class Classifier:
     def _parse_response(self, text: str) -> ClassificationResult:
         """Parse LLM response into ClassificationResult."""
         try:
-            normalized_text, _ = _strip_markdown_fence(text)
+            normalized_text, stripped_markdown_fence = _strip_markdown_fence(text)
 
-            data = json.loads(normalized_text)
+            try:
+                data = json.loads(normalized_text)
+            except json.JSONDecodeError as error:
+                recovered_data = (
+                    None
+                    if stripped_markdown_fence
+                    else _recover_double_wrapped_json_object(normalized_text)
+                )
+                if recovered_data is None:
+                    raise error
+                self._warning_counts.double_wrapper_recovery_count += 1
+                data = recovered_data
             if not isinstance(data, dict):
                 self._warning_counts.parse_failure_count += 1
                 self._parse_failure_diagnostics.record(

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -141,6 +141,7 @@ _CLASSIFIER_WARNING_COUNT_KEYS = (
     "invalid_taxonomy_pair_count",
     "invalid_legacy_pair_count",
     "relevant_without_usable_taxonomy_count",
+    "double_wrapper_recovery_count",
 )
 _PARSE_FAILURE_SAMPLE_STRING_KEYS = {
     "shape_signature",
@@ -188,7 +189,7 @@ def _mark_classifier_provider_error(
 
 
 def _classifier_warning_counts(classifier: object) -> dict[str, int]:
-    """Read passive classifier parser warning counters when the classifier exposes them."""
+    """Read passive classifier parser warning/recovery counters when exposed."""
     raw_counts = getattr(classifier, "warning_counts", None)
     if callable(raw_counts):
         raw_counts = raw_counts()
@@ -1476,7 +1477,7 @@ def _build_classifier_summary(
 def _normalize_classifier_warning_counts(
     counts: Mapping[str, int] | None,
 ) -> dict[str, int]:
-    """Normalize classifier warning counters into stable summary keys."""
+    """Normalize classifier warning/recovery counters into stable summary keys."""
     if counts is None:
         return dict.fromkeys(_CLASSIFIER_WARNING_COUNT_KEYS, 0)
     normalized: dict[str, int] = {}

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -1184,6 +1184,7 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
     classifier.warning_counts = {
         "parse_failure_count": 3,
         "invalid_taxonomy_pair_count": 2,
+        "double_wrapper_recovery_count": 4,
     }
     monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: sources)
     monkeypatch.setattr("denbust.pipeline.create_classifier", lambda **_kwargs: classifier)
@@ -1231,6 +1232,7 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
         "invalid_taxonomy_pair_count": 2,
         "invalid_legacy_pair_count": 0,
         "relevant_without_usable_taxonomy_count": 0,
+        "double_wrapper_recovery_count": 4,
     }
     assert fallback.debug_payload["fallback_classifier_summary"] == {
         "fallback_classifier_input_count": 1,
@@ -1240,6 +1242,7 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
             "invalid_taxonomy_pair_count": 2,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 4,
         },
         "parse_failure_diagnostics": {
             "category_counts": {

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -160,11 +160,12 @@ class TestClassifierParsing:
             "invalid_taxonomy_pair_count": 0,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 0,
         }
         assert classifier.parse_failure_diagnostics["category_counts"]["object_like_non_json"] == 1
 
-    def test_double_open_object_like_failure_records_wrapper_structure(self) -> None:
-        """Double-wrapped object-like failures should expose structure without recovery."""
+    def test_double_wrapped_valid_taxonomy_json_is_recovered(self) -> None:
+        """The proven balanced double-wrapper shape should classify through normal validation."""
         classifier = Classifier(api_key="test-key")
         response = (
             '{{"relevant": true, "enforcement_related": true, '
@@ -175,32 +176,32 @@ class TestClassifierParsing:
 
         result = classifier._parse_response(response)
 
-        assert result.relevant is False
-        assert result.enforcement_related is False
-        assert result.category == Category.NOT_RELEVANT
-        assert result.confidence == "low"
-        assert classifier.warning_counts["parse_failure_count"] == 1
-        diagnostics = classifier.parse_failure_diagnostics
-        sample = diagnostics["samples"][0]
-        assert diagnostics["category_counts"]["object_like_non_json"] == 1
-        assert sample["leading_brace_count"] == 2
-        assert sample["trailing_brace_count"] == 2
-        assert sample["brace_balance"] == 0
-        assert sample["starts_with_double_open_object"] is True
-        assert sample["ends_with_double_close_object"] is True
-        assert sample["outer_wrapper_candidate"] is True
-        assert sample["inner_object_candidate"] is True
-        assert sample["contains_balanced_inner_object"] is True
-        assert sample["inner_json_object_candidate"] is True
-        assert set(sample) == set(PARSE_FAILURE_SAMPLE_KEYS)
-        assert response not in str(diagnostics)
+        assert result.relevant is True
+        assert result.enforcement_related is True
+        assert result.taxonomy_version == "1"
+        assert result.taxonomy_category_id == "brothels"
+        assert result.taxonomy_subcategory_id == "administrative_closure"
+        assert result.category == Category.BROTHEL
+        assert result.sub_category == SubCategory.CLOSURE
+        assert result.index_relevant is True
+        assert result.confidence == "high"
+        assert classifier.warning_counts == {
+            "parse_failure_count": 0,
+            "invalid_taxonomy_pair_count": 0,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 1,
+        }
+        assert classifier.parse_failure_diagnostics["sample_count"] == 0
 
     def test_pseudo_json_double_wrapper_is_not_inner_json_candidate(self) -> None:
         """Balanced pseudo-JSON should not masquerade as a valid inner object."""
         classifier = Classifier(api_key="test-key")
 
-        classifier._parse_response("{{relevant: true}}")
+        result = classifier._parse_response("{{relevant: true}}")
 
+        assert result.relevant is False
+        assert classifier.warning_counts["parse_failure_count"] == 1
         sample = classifier.parse_failure_diagnostics["samples"][0]
         assert sample["leading_brace_count"] == 2
         assert sample["trailing_brace_count"] == 2
@@ -211,9 +212,9 @@ class TestClassifierParsing:
         assert sample["inner_json_object_candidate"] is False
 
     def test_structural_balance_ignores_braces_inside_json_strings(self) -> None:
-        """Brace balance should not be thrown off by literal braces inside strings."""
+        """Malformed inner JSON should still record quote-aware balanced structure."""
         classifier = Classifier(api_key="test-key")
-        response = '{{"relevant": true, "reason": "literal } brace and escaped \\" quote"}}'
+        response = '{{"relevant": true, "reason": "literal } brace and escaped \\" quote",}}'
 
         classifier._parse_response(response)
 
@@ -222,7 +223,32 @@ class TestClassifierParsing:
         assert sample["outer_wrapper_candidate"] is True
         assert sample["inner_object_candidate"] is True
         assert sample["contains_balanced_inner_object"] is True
-        assert sample["inner_json_object_candidate"] is True
+        assert sample["inner_json_object_candidate"] is False
+
+    def test_double_wrapped_valid_json_with_string_braces_is_recovered(self) -> None:
+        """Quote-aware brace balance should allow proven-shape recovery."""
+        classifier = Classifier(api_key="test-key")
+        response = (
+            '{{"relevant": false, "enforcement_related": false, '
+            '"taxonomy_category_id": null, "taxonomy_subcategory_id": null, '
+            '"reason": "literal } brace and escaped \\" quote", '
+            '"confidence": "high"}}'
+        )
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.enforcement_related is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.confidence == "high"
+        assert classifier.warning_counts == {
+            "parse_failure_count": 0,
+            "invalid_taxonomy_pair_count": 0,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 1,
+        }
+        assert classifier.parse_failure_diagnostics["sample_count"] == 0
 
     def test_unbalanced_object_like_failure_records_non_recoverable_structure(self) -> None:
         """Unbalanced wrappers should remain rejected and report non-candidate structure."""
@@ -246,6 +272,52 @@ class TestClassifierParsing:
         assert sample["inner_json_object_candidate"] is False
         assert "sk-ant-secret" not in str(diagnostics)
         assert '"secret"' not in str(diagnostics)
+
+    def test_code_fenced_recoverable_double_wrapped_json_is_not_recovered(self) -> None:
+        """Recovery is intentionally narrower than fenced JSON cleanup."""
+        classifier = Classifier(api_key="test-key")
+        response = """```json
+{{"relevant": true, "enforcement_related": true, "taxonomy_category_id": "brothels", "taxonomy_subcategory_id": "administrative_closure", "confidence": "high"}}
+```"""
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.confidence == "low"
+        assert classifier.warning_counts["parse_failure_count"] == 1
+        diagnostics = classifier.parse_failure_diagnostics
+        assert diagnostics["category_counts"]["object_like_non_json"] == 1
+        sample = diagnostics["samples"][0]
+        assert sample["starts_with_code_fence"] is True
+        assert sample["ends_with_code_fence"] is True
+        assert sample["inner_json_object_candidate"] is True
+
+    def test_double_wrapped_invalid_taxonomy_pair_still_rejects_normally(self) -> None:
+        """Recovery must not bypass taxonomy validity policy."""
+        classifier = Classifier(api_key="test-key")
+        response = (
+            '{{"relevant": true, "enforcement_related": true, '
+            '"taxonomy_category_id": "human_trafficking", '
+            '"taxonomy_subcategory_id": "phenomenon_coverage", '
+            '"confidence": "high"}}'
+        )
+
+        result = classifier._parse_response(response)
+
+        assert result.relevant is False
+        assert result.enforcement_related is False
+        assert result.category == Category.NOT_RELEVANT
+        assert result.taxonomy_category_id is None
+        assert result.taxonomy_subcategory_id is None
+        assert classifier.warning_counts == {
+            "parse_failure_count": 0,
+            "invalid_taxonomy_pair_count": 1,
+            "invalid_legacy_pair_count": 0,
+            "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 1,
+        }
+        assert classifier.parse_failure_diagnostics["sample_count"] == 0
 
     def test_parse_failure_tail_shape_is_bounded_and_sanitized(self) -> None:
         """Tail signatures should expose only bounded structure classes."""
@@ -368,6 +440,7 @@ class TestClassifierParsing:
             "invalid_taxonomy_pair_count": 0,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 0,
         }
 
     def test_parse_invalid_taxonomy_pair_falls_back_to_not_relevant(self) -> None:
@@ -495,6 +568,7 @@ class TestClassifierParsing:
             "invalid_taxonomy_pair_count": 0,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 0,
         }
         assert classifier.parse_failure_diagnostics["sample_count"] == 0
         assert all(

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -351,6 +351,7 @@ class TestFetchAndClassifyHelpers:
             classifier_warning_counts={
                 "parse_failure_count": 2,
                 "invalid_taxonomy_pair_count": 1,
+                "double_wrapper_recovery_count": 3,
             },
             classifier_parse_failure_diagnostics={
                 "category_counts": {
@@ -393,6 +394,7 @@ class TestFetchAndClassifyHelpers:
             "invalid_taxonomy_pair_count": 1,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 3,
         }
         assert classifier_summary["parse_failure_diagnostics"] == {
             "category_counts": {
@@ -1915,6 +1917,7 @@ class TestRunPipelineAsync:
         classifier.warning_counts = {
             "parse_failure_count": 2,
             "invalid_taxonomy_pair_count": 1,
+            "double_wrapper_recovery_count": 3,
         }
         classifier.parse_failure_diagnostics = {
             "category_counts": {
@@ -1995,6 +1998,7 @@ class TestRunPipelineAsync:
             "invalid_taxonomy_pair_count": 1,
             "invalid_legacy_pair_count": 0,
             "relevant_without_usable_taxonomy_count": 0,
+            "double_wrapper_recovery_count": 3,
         }
         assert (
             result.debug_payload["classifier_summary"]["parse_failure_diagnostics"][
@@ -2010,6 +2014,7 @@ class TestRunPipelineAsync:
                 "invalid_taxonomy_pair_count": 1,
                 "invalid_legacy_pair_count": 0,
                 "relevant_without_usable_taxonomy_count": 0,
+                "double_wrapper_recovery_count": 3,
             },
             "parse_failure_diagnostics": {
                 "category_counts": {
@@ -3537,6 +3542,7 @@ class TestRunPipeline:
                     "warning_counts": {
                         "parse_failure_count": 2,
                         "invalid_taxonomy_pair_count": 1,
+                        "double_wrapper_recovery_count": 3,
                     },
                 },
                 "problems": {"all_unseen_rejected": True},
@@ -3571,6 +3577,7 @@ class TestRunPipeline:
         assert summary_payload["classifier_summary"]["warning_counts"] == {
             "parse_failure_count": 2,
             "invalid_taxonomy_pair_count": 1,
+            "double_wrapper_recovery_count": 3,
         }
 
     def test_run_job_from_config_best_effort_debug_write_still_persists_snapshot(

--- a/tests/unit/test_run_snapshots.py
+++ b/tests/unit/test_run_snapshots.py
@@ -149,6 +149,7 @@ class TestRunSnapshots:
                         "invalid_taxonomy_pair_count": 0,
                         "invalid_legacy_pair_count": 0,
                         "relevant_without_usable_taxonomy_count": 0,
+                        "double_wrapper_recovery_count": 2,
                     },
                     "parse_failure_diagnostics": {
                         "category_counts": {"object_like_non_json": 1},
@@ -214,6 +215,7 @@ class TestRunSnapshots:
                 "invalid_taxonomy_pair_count": 0,
                 "invalid_legacy_pair_count": 0,
                 "relevant_without_usable_taxonomy_count": 0,
+                "double_wrapper_recovery_count": 2,
             },
             "parse_failure_diagnostics": {
                 "category_counts": {"object_like_non_json": 1},


### PR DESCRIPTION
## Planning notation

- Notation: `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY`
- Parent milestone: `Phase C`
- Plan source: `.agent-plan.md`, `README.md`, and `docs/discovery_operations.md`

## Summary

This PR adds the bounded parser recovery justified by PR #134 / `CLASSIFIER-PR-PARSE-FAILURE-STRUCTURE-INTERPRETATION`.

PR #134 found five parse failures across 100 fallback classifier inputs. All five were `object_like_non_json`, one-line, not code-fenced, with `json_error_kind=missing_property_name` at line 1 column 2. The sanitized structure fields were consistent across the samples: `leading_brace_count=2`, `trailing_brace_count=2`, `brace_balance=0`, `starts_with_double_open_object=true`, `ends_with_double_close_object=true`, `outer_wrapper_candidate=true`, `inner_object_candidate=true`, `contains_balanced_inner_object=true`, and `inner_json_object_candidate=true`.

## Parser behavior added

The classifier parser now attempts recovery only after the initial `json.loads` fails and only for the proven balanced double-wrapper shape:

- the normalized response has exactly two leading `{` characters;
- the normalized response has exactly two trailing `}` characters;
- quote-aware brace balance is zero;
- trimming exactly one outer wrapper leaves a balanced inner object candidate;
- the inner substring parses as a JSON object.

When those conditions hold, the recovered dict is fed through the same existing classifier validation path used by ordinary parsed JSON. That means taxonomy validity, legacy mapping, confidence normalization, and warning counters are not bypassed. Recoveries increment `double_wrapper_recovery_count` in the existing classifier summary counters so the next evidence pass can distinguish recovered outputs from ordinary valid JSON.

## Negative boundaries kept rejected

This PR keeps these cases rejected or counted by the existing warning paths:

- pseudo-JSON inside double braces;
- balanced-but-not-valid-JSON inner object text;
- unbalanced wrappers;
- ordinary non-object JSON;
- code-fenced recoverable double-wrapped JSON, because recovery is intentionally narrower than Markdown fence cleanup;
- recovered JSON with invalid taxonomy pairs, which still increments `invalid_taxonomy_pair_count` and returns not relevant.

## Out of scope

This does not change classifier prompts, taxonomy validity policy, legacy taxonomy policy, queue behavior, scraper behavior, scrape caps, source-family support, source-targeted query fanout, generated data tracking, browser/CDP behavior, or live-network behavior.

## Docs and planning

- Documents the narrow recovery boundary and `double_wrapper_recovery_count` in `README.md` and `docs/discovery_operations.md`.
- Adds an implementation addendum to the January 2026 wet-test evidence doc without making a new wet-test claim.
- Updates `.agent-plan.md` with mainline semantics and sets the next item to post-recovery evidence checking.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_classifier.py`
- `.venv/bin/pytest -q tests/unit/test_pipeline_core.py tests/unit/test_backfill_pipeline.py tests/unit/test_run_snapshots.py`
- `.venv/bin/pytest -q tests/unit`

All validation passed locally. The full unit suite passed with 853 tests and one pre-existing runtime warning from `test_module_main_invokes_typer_app`.