### PR TITLE
CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK: Document recovery evidence

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,19 +6,20 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY` adds bounded parser
-  recovery for the proven balanced double-wrapped classifier-output shape only: exactly two leading
-  object braces, exactly two trailing object braces, quote-aware balanced braces, a balanced inner
-  object candidate after trimming one outer wrapper, and a valid parseable inner JSON object. The
-  recovered object flows through the same taxonomy validation and legacy handling as ordinary JSON,
-  and `double_wrapper_recovery_count` keeps the path observable in run summaries. Invalid taxonomy
-  pairs remain rejected and counted without prompt, taxonomy-policy, queue, scraper, scrape-cap,
-  source-family, source-targeted fanout, or generated-data changes.
-- Next planned PR: `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK` should run or interpret the next
-  bounded Phase C fallback classifier evidence pass after double-wrapper recovery lands, verify
-  whether parse-failure counts drop without invalid-taxonomy leakage or retained-row taxonomy
-  corruption, and keep any further classifier-output, queue, scraper, or source-family changes
-  deferred until fresh evidence justifies them.
+- Last merged PR on main: `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK` ran a fresh bounded
+  January 1-7 Brave+Exa/no-Google Phase C fallback-classifier evidence pass after double-wrapper
+  recovery landed. The pass produced `double_wrapper_recovery_count=4`, reduced the prior 5/100
+  fallback parse-failure pattern to `parse_failure_count=0`, kept invalid taxonomy warnings at
+  `1/100`, and showed no retained fallback rows with invalid taxonomy pairs. One retained
+  low-confidence partial fallback row had only a legacy category and no TFHT taxonomy leaf, so
+  parser-output hardening pauses while fallback retention without usable taxonomy becomes the next
+  classifier question.
+- Next planned PR: `CLASSIFIER-PR-FALLBACK-MISSING-TAXONOMY-INTERPRETATION` should inspect the
+  retained candidate-fallback row without a usable TFHT taxonomy leaf and decide whether
+  candidate-fallback retention should require taxonomy-complete classification or report
+  legacy-only fallback rows separately, without changing parser recovery, classifier prompts,
+  taxonomy validity policy, queue behavior, scraper behavior, scrape caps, source-family support,
+  source-targeted fanout, or generated-data tracking until that evidence is interpreted.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
@@ -160,11 +161,17 @@
   JSON, invalid taxonomy pairs, and unrelated parse-failure categories. Keep prompts, taxonomy
   validity policy, legacy taxonomy policy, queue behavior, scraper behavior, scrape caps,
   source-family support, and generated-data boundaries unchanged.
-- [next] `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK`: run or interpret a bounded Phase C fallback
-  classifier evidence pass after double-wrapper recovery is on main, confirm whether recovered
-  outputs reduce parse-failure counts without introducing invalid taxonomy retention, and defer any
-  broader parser, prompt, taxonomy-policy, queue, scraper, scrape-cap, source-family, or
-  source-targeted fanout work until that evidence exists.
+- [done] `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK`: run a bounded Phase C fallback classifier
+  evidence pass after double-wrapper recovery is on main, confirm that recovered outputs reduced
+  the prior 5/100 parse-failure pattern to zero parse failures with four double-wrapper recoveries
+  and no retained invalid taxonomy pairs, and defer broader parser, prompt, queue, scraper,
+  scrape-cap, source-family, or source-targeted fanout work.
+- [next] `CLASSIFIER-PR-FALLBACK-MISSING-TAXONOMY-INTERPRETATION`: inspect the retained
+  low-confidence candidate-fallback row without a usable TFHT taxonomy leaf and decide whether
+  fallback retention should require taxonomy-complete classification or report legacy-only fallback
+  rows separately, without changing parser recovery, classifier prompts, taxonomy validity policy,
+  queue behavior, scraper behavior, scrape caps, source-family support, source-targeted fanout, or
+  generated-data tracking until that evidence is interpreted.
 
 ## Planning Workflow
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Planned future datasets:
   objects still use the normal taxonomy validation path and increment
   `double_wrapper_recovery_count`, while pseudo-JSON, unbalanced wrappers, non-object JSON,
   code-fenced malformed JSON, and invalid taxonomy pairs remain rejected
+- Interprets the first post-recovery bounded Phase C evidence pass: four double-wrapper recoveries
+  replaced the prior five-parse-failure pattern with zero parse failures across 100 fallback
+  classifier inputs, invalid taxonomy warnings stayed at one, and no retained fallback row carried
+  an invalid taxonomy pair. One retained low-confidence partial fallback row had only a legacy
+  category and no TFHT taxonomy leaf, so parser-output hardening pauses while the next Phase C
+  classifier item investigates fallback retention without usable taxonomy.
 - Keeps source-suggestion scrape diagnostics evidence-driven by reporting generic partial
   recoveries separately from definite scrape failures, without otherwise changing source-suggestion
   ranking

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -746,6 +746,35 @@ behavior, browser/CDP scraper behavior, scrape caps, source-family support, sour
 query fanout, or
 generated-data artifact tracking.
 
+After `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK`, the first post-recovery bounded Phase C
+January 1-7 evidence pass used `data/may_26_followup/20260514T231311Z/` with the same tracked
+Brave+Exa/no-Google config and Chrome-CDP scrape shape. The generated artifacts remain untracked.
+The discovery leg persisted 1,878 candidates, all from Brave, because Exa returned
+`402 Payment Required` near the end of discovery; Google CSE stayed disabled by the local config.
+The scrape drain selected 100 fallback classifier inputs, recorded 160 scrape attempts, retained 33
+candidate-fallback operational rows, left 1,431 eligible candidates, and stopped at
+`budget_cap_reached`. Mako browser search attempts repeatedly timed out behind the Chrome-CDP
+challenge path, so this pass should be read as classifier-output evidence with provider and
+browser-source caveats, not as clean source-adapter health evidence.
+
+Both the full scrape debug payload and compact summary recorded
+`double_wrapper_recovery_count=4`, `parse_failure_count=0`, `invalid_taxonomy_pair_count=1`,
+`invalid_legacy_pair_count=0`, and `relevant_without_usable_taxonomy_count=0` under both
+`classifier_summary.warning_counts` and `fallback_classifier_summary.warning_counts`. The
+parse-failure diagnostics were empty. Compared with the prior 5/100 parse-failure structure pass,
+the parser recovery removed the repeated double-wrapper parse failures without increasing invalid
+taxonomy warnings.
+
+The matching post-scrape discovery diagnostic reported
+`invalid_taxonomy_pair_record_count=0`, so no retained fallback row carried an invalid taxonomy
+pair. It also reported `fallback_record_without_taxonomy_count=1` and
+`partial_page_fallback_without_taxonomy_count=1`: a single low-confidence, internal-only Globes
+partial fallback row retained a legacy `trafficking` category with no TFHT taxonomy leaf. That is
+not parser corruption, but it is the next classifier-retention policy question. Further
+classifier-output parser hardening should pause; the next Phase C classifier item should
+investigate whether retained candidate-fallback rows require usable TFHT taxonomy or should be
+reported separately when they are legacy-only.
+
 ## One-Time 90-Day Re-Scan
 
 `C-8` does not add a dedicated workflow. The catch-up run uses the existing backfill jobs with the

--- a/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
+++ b/docs/january_2026_backfill_wet_test_evidence_2026_05_13.md
@@ -634,3 +634,92 @@ paths as before. The slice does not change classifier prompts, taxonomy validity
 taxonomy policy, queue behavior, scrape candidate selection, generic fetch behavior, browser/CDP
 scraper behavior, scrape caps, source-family support, source-targeted query fanout, or generated
 data tracking.
+
+## 2026-05-15 Addendum: Post-Recovery Evidence Check
+
+`CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK` found no existing post-PR #135 generated artifact
+under `data/may_26_followup/`, so it generated a new bounded Phase C January 1-7 pass. The
+generated local evidence root is `data/may_26_followup/20260514T231311Z/`; generated artifacts
+remain untracked.
+
+The run reused `agents/news/local_search_brave_exa.yaml`, the January 1-7 UTC date window, an
+isolated state root at `data/may_26_followup/20260514T231311Z/state`, and a temporary Chrome-CDP
+endpoint at `http://127.0.0.1:9222`.
+
+Exact inspected artifacts:
+
+- Discovery log:
+  `data/may_26_followup/20260514T231311Z/logs/backfill_discover_2026_01_01_07_brave_exa.log`
+- Post-discovery diagnostic:
+  `data/may_26_followup/20260514T231311Z/artifacts/diagnose_discovery_after_discover_brave_exa.json`
+- Scrape log:
+  `data/may_26_followup/20260514T231311Z/logs/backfill_scrape_2026_01_01_07_brave_exa_chrome_cdp.log`
+- Full scrape debug payload:
+  `data/may_26_followup/20260514T231311Z/state/news_items/backfill_scrape/logs/2026-05-14T23-19-42-898391Z.json`
+- Compact scrape debug summary:
+  `data/may_26_followup/20260514T231311Z/state/news_items/backfill_scrape/logs/2026-05-14T23-19-42-898391Z.summary.json`
+- Post-scrape discovery diagnostic:
+  `data/may_26_followup/20260514T231311Z/artifacts/diagnose_discovery_after_scrape_brave_exa_chrome_cdp.json`
+
+The run reported:
+
+| Figure | Value |
+| --- | ---: |
+| Persisted candidates | 1,878 |
+| Fallback classifier inputs | 100 |
+| Attempted candidates | 100 |
+| Persisted scrape attempts | 160 |
+| Provisional operational rows retained | 33 |
+| Partial pages | 97 |
+| Scrape failures | 3 |
+| Remaining eligible candidates | 1,431 |
+| Inferred stop reason | `budget_cap_reached` |
+
+Discovery caveat: Exa returned `402 Payment Required` near the end of the discovery leg, so the
+post-discovery diagnostic showed `brave=1878`, `exa=0`, and `google_cse=0`. Google CSE remained
+disabled by the tracked no-Google config. Browser caveat: Chrome-CDP was reachable, but Mako search
+attempts repeatedly timed out during challenge navigation. This pass is therefore useful for the
+fallback classifier recovery question, but it should not be interpreted as clean Exa coverage or
+clean Mako source-adapter health evidence.
+
+Both the full debug payload and compact summary recorded the same warning and recovery counters:
+
+| Counter | Count | Rate |
+| --- | ---: | ---: |
+| `classifier_summary.warning_counts.parse_failure_count` | 0 | 0% of 100 fallback classifier inputs |
+| `classifier_summary.warning_counts.invalid_taxonomy_pair_count` | 1 | 1% of 100 fallback classifier inputs |
+| `classifier_summary.warning_counts.invalid_legacy_pair_count` | 0 | 0% |
+| `classifier_summary.warning_counts.relevant_without_usable_taxonomy_count` | 0 | 0% |
+| `classifier_summary.warning_counts.double_wrapper_recovery_count` | 4 | 4% of 100 fallback classifier inputs |
+| `fallback_classifier_summary.warning_counts.parse_failure_count` | 0 | 0% of 100 fallback classifier inputs |
+| `fallback_classifier_summary.warning_counts.invalid_taxonomy_pair_count` | 1 | 1% of 100 fallback classifier inputs |
+| `fallback_classifier_summary.warning_counts.invalid_legacy_pair_count` | 0 | 0% |
+| `fallback_classifier_summary.warning_counts.relevant_without_usable_taxonomy_count` | 0 | 0% |
+| `fallback_classifier_summary.warning_counts.double_wrapper_recovery_count` | 4 | 4% of 100 fallback classifier inputs |
+
+The parse-failure diagnostics in both summary objects were empty: all category counts were zero,
+`samples=[]`, and `sample_count=0`.
+
+The matching post-scrape discovery diagnostic reported:
+
+| Retained-row diagnostic | Value |
+| --- | ---: |
+| `candidate_fallback_record_count` | 33 |
+| `partial_page_fallback_record_count` | 33 |
+| `fallback_record_without_taxonomy_count` | 1 |
+| `partial_page_fallback_without_taxonomy_count` | 1 |
+| `invalid_taxonomy_pair_record_count` | 0 |
+| `low_confidence_fallback_record_count` | 33 |
+
+Direct inspection of the generated local operational rows showed the missing-taxonomy retained row
+was a low-confidence, internal-only Globes partial fallback with legacy `category=trafficking` and
+no TFHT taxonomy leaf. The row did not contain an invalid taxonomy pair.
+
+Interpretation: `double_wrapper_recovery_count` appeared, and the prior five-parse-failure
+fallback pattern dropped to zero parse failures across the same 100-input fallback scrape shape.
+Invalid taxonomy warnings did not rise unexpectedly compared with the prior structure pass
+(`1/100` before and `1/100` after), and invalid taxonomy did not leak into retained fallback rows.
+The result supports pausing further parser hardening. The remaining classifier question is not
+another parser recovery path; it is whether retained candidate-fallback rows without usable TFHT
+taxonomy should be retained, suppressed, or reported separately from taxonomy-complete fallback
+rows.


### PR DESCRIPTION
## Planning notation

- Notation: `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK`
- Parent milestone: Phase C
- Plan source: `.agent-plan.md`

## Summary

This PR documents the first bounded Phase C fallback-classifier evidence pass after PR #135 / `CLASSIFIER-PR-PARSE-FAILURE-DOUBLE-WRAP-RECOVERY` landed on `main`.

No existing post-#135 artifact with classifier warning summaries and parse-failure diagnostics was present under `data/may_26_followup/`, so I generated a fresh local evidence pass under `data/may_26_followup/20260514T231311Z/`. The generated data remains untracked; this PR only commits the interpretation and planning/doc updates.

## Evidence source

The run reused the established Jan 1-7 UTC local evidence pattern:

- Config: `agents/news/local_search_brave_exa.yaml`
- Window: `2026-01-01T00:00:00+00:00` through `2026-01-07T23:59:59+00:00`
- Isolated state root: `data/may_26_followup/20260514T231311Z/state`
- Chrome-CDP endpoint: `http://127.0.0.1:9222`

Exact generated artifacts are listed in `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`.

## Metrics and interpretation

The post-recovery fallback classifier evidence showed:

- `fallback_classifier_input_count=100`
- `fallback_operational_record_count=33`
- `parse_failure_count=0` in both `classifier_summary.warning_counts` and `fallback_classifier_summary.warning_counts`
- `double_wrapper_recovery_count=4` in both summary objects
- `invalid_taxonomy_pair_count=1`, with `invalid_legacy_pair_count=0` and `relevant_without_usable_taxonomy_count=0`
- Empty parse-failure diagnostics: all category counts zero and `sample_count=0`

Compared with the prior structure pass, the repeated `5/100` double-wrapper parse-failure pattern dropped to zero parse failures, while invalid taxonomy warnings stayed at `1/100`. That supports pausing further parser-output hardening rather than broadening parser recovery or changing prompts.

Retained-row diagnostics stayed invalid-taxonomy safe: `invalid_taxonomy_pair_record_count=0`. The run did surface one retained low-confidence partial fallback row with only a legacy `trafficking` category and no TFHT taxonomy leaf (`fallback_record_without_taxonomy_count=1`, `partial_page_fallback_without_taxonomy_count=1`). That is not invalid taxonomy leakage from recovery, but it becomes the next classifier-retention question.

## Out of scope

This PR intentionally does not change:

- classifier prompts
- parser behavior
- taxonomy validity or legacy taxonomy policy
- queue behavior or scrape caps
- scraper behavior or Chrome-CDP handling
- source-family support or source-targeted fanout
- generated-data tracking

## Caveats

The discovery leg persisted 1,878 candidates, all from Brave, because Exa returned `402 Payment Required` near the end of discovery; Google CSE remained disabled by the tracked no-Google config. Chrome-CDP was reachable, but Mako search attempts repeatedly timed out during challenge navigation. This evidence is useful for the fallback classifier recovery question, but it should not be treated as clean Exa coverage or clean Mako source-adapter health evidence.

## Validation

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- Commit hook: pre-commit checks including mypy and smoke tests
- Push hook: unit tests and integration tests
