### PR TITLE
BACKFILL-PR-2026-RELEASE-DAILY-ONLINE

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,26 +6,21 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `CLASSIFIER-PR-POST-RECOVERY-EVIDENCE-CHECK` ran a fresh bounded
-  January 1-7 Brave+Exa/no-Google Phase C fallback-classifier evidence pass after double-wrapper
-  recovery landed. The pass produced `double_wrapper_recovery_count=4`, reduced the prior 5/100
-  fallback parse-failure pattern to `parse_failure_count=0`, kept invalid taxonomy warnings at
-  `1/100`, and showed no retained fallback rows with invalid taxonomy pairs. One retained
-  low-confidence partial fallback row had only a legacy category and no TFHT taxonomy leaf, so
-  parser-output hardening pauses while fallback retention without usable taxonomy becomes the next
-  classifier question.
-- Next planned PR: `CLASSIFIER-PR-FALLBACK-MISSING-TAXONOMY-INTERPRETATION` should inspect the
-  retained candidate-fallback row without a usable TFHT taxonomy leaf and decide whether
-  candidate-fallback retention should require taxonomy-complete classification or report
-  legacy-only fallback rows separately, without changing parser recovery, classifier prompts,
-  taxonomy validity policy, queue behavior, scraper behavior, scrape caps, source-family support,
-  source-targeted fanout, or generated-data tracking until that evidence is interpreted.
+- Last merged PR on main: `BACKFILL-PR-2026-RELEASE-DAILY-ONLINE` added the broad 2026 backfill
+  run plan, a budget-guarded backfill/release harness, Brave-only source-targeted scheduled
+  discovery config, release no-publication controls, Supabase schema/persistence hardening, and a
+  partial 2026-01-01 through 2026-03-25 run report that stopped on an external Anthropic workspace
+  API usage limit before release generation.
+- Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should resume the 2026 backfill from the
+  first incomplete window after classifier quota or credentials are restored, then build the
+  no-publication release bundle if the resumed run completes.
 - Current blockers on main: Google CSE support remains in code, but local wet tests may need
   `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
   access. The January 1-7 Chrome-CDP evidence is summarized in
   `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`; the first no-CDP scrape attempt was
-  aborted/reset and should not be interpreted as valid scrape evidence. Follow-up PRs should use the
-  new partial-page diagnostics to justify source-family expansion.
+  aborted/reset and should not be interpreted as valid scrape evidence. The 2026 backfill is also
+  blocked on Anthropic workspace API usage limits until quota or credentials are restored; the
+  2026-05-15 run stopped with provider access scheduled to return on 2026-06-01 00:00 UTC.
 
 ## Task Ledger
 
@@ -166,12 +161,20 @@
   the prior 5/100 parse-failure pattern to zero parse failures with four double-wrapper recoveries
   and no retained invalid taxonomy pairs, and defer broader parser, prompt, queue, scraper,
   scrape-cap, source-family, or source-targeted fanout work.
-- [next] `CLASSIFIER-PR-FALLBACK-MISSING-TAXONOMY-INTERPRETATION`: inspect the retained
+- [done] `CLASSIFIER-PR-FALLBACK-MISSING-TAXONOMY-INTERPRETATION`: inspect the retained
   low-confidence candidate-fallback row without a usable TFHT taxonomy leaf and decide whether
   fallback retention should require taxonomy-complete classification or report legacy-only fallback
   rows separately, without changing parser recovery, classifier prompts, taxonomy validity policy,
   queue behavior, scraper behavior, scrape caps, source-family support, source-targeted fanout, or
   generated-data tracking until that evidence is interpreted.
+- [done] `BACKFILL-PR-2026-RELEASE-DAILY-ONLINE`: add the broad 2026 backfill/release plan,
+  explicit release no-publication controls, budget-guarded orchestration harness, source-targeted
+  Brave discovery config, Supabase schema/persistence hardening, documentation, and a partial
+  2026-01-01 through 2026-03-25 run report that records the Anthropic quota blocker before public
+  release generation.
+- [next] `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: after Anthropic quota or replacement credentials
+  are available, resume from the first incomplete window, finish the 2026-01-01 through 2026-05-15
+  backfill, run the no-publication release bundle, and produce a final publication go/no-go report.
 
 ## Planning Workflow
 

--- a/agents/news/github.yaml
+++ b/agents/news/github.yaml
@@ -58,6 +58,42 @@ classifier:
 dedup:
   similarity_threshold: 0.7
 
+discovery:
+  enabled: true
+  persist_candidates: true
+  engines:
+    brave:
+      enabled: true
+      api_key_env: DENBUST_BRAVE_SEARCH_API_KEY
+      max_results_per_query: 20
+    exa:
+      enabled: true
+      api_key_env: DENBUST_EXA_API_KEY
+      max_results_per_query: 20
+      allow_find_similar: true
+    google_cse:
+      enabled: false
+      api_key_env: DENBUST_GOOGLE_CSE_API_KEY
+      cse_id_env: DENBUST_GOOGLE_CSE_ID
+      max_results_per_query: 10
+
+source_discovery:
+  enabled: true
+  persist_candidates: true
+
+candidates:
+  keep_search_only_fallbacks: true
+  require_review_for_search_only: true
+  allow_retry_on_fetch_failure: true
+
+backfill:
+  enabled: true
+  batch_window_days: 7
+  max_candidates_per_run: 500
+  max_scrape_attempts_per_run: 100
+  query_kinds:
+    - source_targeted
+
 output:
   formats:
     - cli

--- a/agents/release/news_items.yaml
+++ b/agents/release/news_items.yaml
@@ -3,6 +3,7 @@
 # Publication targets are intentionally configured through env/secrets:
 # - DENBUST_KAGGLE_DATASET enables Kaggle publishing
 # - DENBUST_HUGGINGFACE_REPO_ID enables Hugging Face publishing
+# - DENBUST_RELEASE_PUBLISH=false disables configured public targets for a dry run
 # - if neither target is configured, the release job still builds the bundle and
 #   writes release metadata/state, but skips public publication
 # - if a target is configured but its required auth secret is missing, the release job fails

--- a/agents/release/news_items_no_publish.yaml
+++ b/agents/release/news_items_no_publish.yaml
@@ -1,0 +1,25 @@
+# Release configuration for building a news_items bundle without public publication.
+#
+# Use this for release-readiness checks, dry runs, and pre-publication QA. The
+# bundle is still generated and release metadata is still written, but configured
+# Kaggle/Hugging Face targets are ignored even if their env vars are present.
+name: news-items-release-no-publish
+dataset_name: news_items
+job_name: release
+
+output:
+  formats:
+    - cli
+
+store:
+  state_root: data
+
+operational:
+  provider: supabase
+
+release:
+  schema_version: news_items-v1
+  include_csv: true
+  publish_public_targets: false
+  rights_policy_version: news_items-v1
+  privacy_policy_version: news_items-v1

--- a/docs/2026_backfill_release_daily_online_plan.md
+++ b/docs/2026_backfill_release_daily_online_plan.md
@@ -1,0 +1,150 @@
+# 2026 Backfill, Release-Ready Bundle, And Daily Online Acquisition Plan
+
+Date planned: 2026-05-15
+
+Status update: the first full-range attempt stopped during the 2026-03-19 through 2026-03-25
+window because Anthropic returned a workspace API usage-limit error. The run remained under budget,
+release generation was skipped, and public publication was not attempted. See
+[2026_backfill_release_daily_online_report_2026_05_15.md](2026_backfill_release_daily_online_report_2026_05_15.md).
+
+## Goal
+
+Deliver one large operational PR that moves `news_items` from diagnostic slices to a backfilled,
+release-ready dataset. The target historical range is 2026-01-01 through 2026-05-15. The work should
+also prove the daily online acquisition path enough for operator use, but it should stop before
+public Kaggle or Hugging Face publication.
+
+## Operating Decisions
+
+- Backfill range: 2026-01-01 through 2026-05-15.
+- Public publication: build and validate the release bundle, but stop before public publication.
+- Operational store: local runs may write to Supabase.
+- State repo: generated state commits may be pushed to `DataHackIL/tfht_enforce_idx_state` as long
+  as each checkpoint is reversible and clearly documented.
+- Provider budget: keep Brave, Exa, Anthropic, and other paid API usage under 50 USD total, with a
+  soft stop near 40 USD.
+- Article adjudication: the agent may inspect public articles directly, decide inclusion/taxonomy,
+  and record concise rationale.
+- Scheduled daily verification: no need to wait for the next cron; a manual/local equivalent is
+  enough for this pass.
+- Code-repo PR policy: ship as one large PR in `tfht_enforce_idx`; do not split into diagnostic
+  micro-PRs.
+
+## Cost Guard
+
+The run should maintain a provider usage ledger in generated local artifacts. Use request counts and
+provider pricing to estimate spend after every batch window. Stop before the projected total crosses
+50 USD and pause for operator input if the soft stop near 40 USD is exceeded.
+
+Initial budget assumptions:
+
+- Brave Search API Search: approximately 5 USD per 1,000 requests.
+- Exa Search: approximately 7 USD per 1,000 search requests, with possible extra cost for content
+  retrieval depending on request shape.
+- Anthropic classifier calls are also part of the budget and should be tracked from fallback/full
+  classifier input counts when exact provider billing telemetry is not available.
+
+Provider strategy:
+
+- The checked-in run harness defaults to Brave-only backfill discovery to keep the full 2026 window
+  within budget.
+- Exa is used selectively with `--search-mode brave-exa` when cost headroom remains or when
+  Brave-only windows are low-yield.
+- Google CSE remains disabled unless the existing entitlement blocker is resolved.
+
+## Workstreams
+
+### 1. Long-Run Harness And Safety
+
+- Create a branch from latest `main`: `codex/2026-backfill-release-daily-online`.
+- Add a generated run ledger outside tracked source files.
+- Add or update orchestration tooling so weekly discovery/scrape windows can run without manual
+  command reconstruction.
+- Add an explicit release dry-run/no-publication guard if the existing release command can publish
+  when credentials are present.
+- Record the initial state-repo commit before pushing generated state changes.
+
+### 2. Backfill Execution
+
+Run weekly windows from 2026-01-01 through 2026-05-15.
+
+For each window:
+
+1. Run `backfill_discover`.
+2. Run `diagnose-discovery` after discovery.
+3. Run `backfill_scrape` repeatedly until the window is exhausted, blocked, or intentionally
+   deferred by budget/time risk.
+4. Run `diagnose-discovery` after scrape drains.
+5. Record discovered, attempted, retained, rejected, partial, failed, unsupported, remaining
+   eligible, provider request counts, and estimated cost.
+6. Push reversible state-repo checkpoints when state changes are ready to preserve.
+
+Generated artifacts under `data/` and state repo outputs are not committed to the code repo.
+
+### 3. Article-Level Adjudication
+
+For retained rows, high-impact candidates, missing-taxonomy rows, and ambiguous partials, inspect
+public source articles directly. Record concise decisions without copying article text:
+
+- candidate id or canonical URL
+- include/exclude decision
+- TFHT taxonomy category/subcategory when included
+- report relevance
+- public release eligibility
+- rationale
+- remaining uncertainty, if any
+
+Ambiguous rows should be treated conservatively for public release.
+
+### 4. Dataset Quality Gate
+
+Before release bundle generation:
+
+- Verify Supabase row counts and run provenance.
+- Verify public release rows do not include internal-only, invalid-taxonomy, missing-taxonomy,
+  search-result-only, suppressed, or privacy-unsafe rows unless policy explicitly allows them.
+- Summarize counts by date, source, taxonomy, confidence, content basis, review status, and
+  publication status.
+- Decide whether fallback rows without usable TFHT taxonomy should be suppressed or reported
+  separately.
+
+### 5. Release-Ready Bundle
+
+- Build the release bundle with public publication disabled.
+- Validate generated CSV/JSON schemas, row counts, metadata, and exclusion behavior.
+- Record the local or state-repo bundle path.
+- Stop before Kaggle or Hugging Face publication.
+
+### 6. Daily Online Acquisition Readiness
+
+Prove a manual/local equivalent of the daily path:
+
+- discovery writes candidates
+- scrape/ingest consumes candidates
+- Supabase rows are written
+- diagnostics and run artifacts are emitted
+- daily review/reporting handoff is either working or explicitly documented as follow-up
+
+If workflow or config changes are required, include them in this PR.
+
+## Final PR Contents
+
+The single PR should include:
+
+- orchestration, guardrail, or pipeline code needed for the long run
+- tests for any changed behavior
+- workflow/config updates for daily acquisition or release dry-run behavior
+- docs/runbook updates
+- `.agent-plan.md` updated in mainline semantics
+- a detailed final report with commands, artifacts, state repo commits, cost estimates, counts,
+  article adjudication summary, release bundle path, daily acquisition proof, and remaining risks
+
+## Definition Of Done
+
+- The 2026-01-01 through 2026-05-15 backfill has a documented status for every window.
+- Operational rows intended to persist are written to Supabase or explicitly staged for operator
+  approval.
+- The release bundle is built and validated but not publicly published.
+- The daily acquisition path is proven by manual/local equivalent.
+- Generated artifacts and raw article content remain out of the code repo.
+- One non-draft PR is open against `main` with Phase C milestone, labels, and a detailed body.

--- a/docs/2026_backfill_release_daily_online_report_2026_05_15.md
+++ b/docs/2026_backfill_release_daily_online_report_2026_05_15.md
@@ -1,0 +1,122 @@
+# 2026 Backfill, Release, And Daily Online Acquisition Report
+
+Date reported: 2026-05-15
+
+## Scope
+
+This report covers the `BACKFILL-PR-2026-RELEASE-DAILY-ONLINE` pass for `news_items`.
+The intended historical range was 2026-01-01 through 2026-05-15. Public Kaggle/Hugging Face
+publication was intentionally disabled for this pass.
+
+## Result
+
+The run did not complete the full 2026-01-01 through 2026-05-15 range. It stopped during the
+2026-03-19 through 2026-03-25 scrape/classification window because Anthropic returned a workspace
+API usage-limit error:
+
+```text
+You have reached your specified workspace API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.
+```
+
+The harness recorded the failure, appended an `abort` ledger row, and skipped release generation.
+No public publication was attempted.
+
+## Implemented Run Safety
+
+- Added a budget-guarded backfill/release harness:
+  `scripts/run_2026_backfill_release_daily.py`.
+- Added `DENBUST_RELEASE_PUBLISH=false` support and `denbust release --no-publish` so release
+  bundles can be built without publishing to public destinations.
+- Added `agents/release/news_items_no_publish.yaml`.
+- Added Supabase schema-completion migrations for discovery annotations and operational
+  `news_items` columns.
+- Hardened Supabase discovery persistence against provider text containing NUL characters.
+- Added Brave backfill date-window handling with `freshness=YYYY-MM-DDtoYYYY-MM-DD`.
+- Added local preferred-domain enforcement for Brave source-targeted queries.
+- Added backfill-only query-kind override and configured the long run to use source-targeted
+  Brave discovery only.
+- Made backfill candidate scraping skip current-window source-adapter browser searches and use
+  candidate-page generic fetches.
+- Hardened backfill retention so undated or out-of-window fallback rows are not silently retained
+  as 2026 records.
+- Added diagnostics output-directory creation for scripted runs.
+
+## Supabase State
+
+The final attempted full run wrote operational state to Supabase and then stopped on classifier
+quota.
+
+- Completed through diagnostics: 2026-03-12 through 2026-03-18.
+- Failed window: 2026-03-19 through 2026-03-25.
+- Backfill batch statuses at stop: 8 `discovered`, 4 `partial`.
+- Persistent candidates in `backfill-2026-*` batches: 1,471.
+- Scrape attempts in `backfill-2026-*` batches: 1,174.
+- Retained `news_items`: 9.
+- Retained rows by source: Walla 4, ICE 2, Ynet 2, TheMarker 1.
+
+## Provider Cost Ledger
+
+Primary artifact:
+
+```text
+data/2026_backfill_run_20260515T_full_source_targeted_domain/ledger.md
+```
+
+The harness-estimated cumulative spend at abort was 14.64 USD:
+
+- 12 discovery windows started.
+- 11 scrape windows completed.
+- The 12th scrape window failed on Anthropic quota.
+- The run remained below the configured 50 USD hard budget and 45 USD soft budget.
+
+## Key Evidence And Decisions
+
+Early proof runs showed three issues before the full run was attempted:
+
+- Brave-only discovery without date handling returned stale/out-of-window candidates.
+- Broad and taxonomy-targeted historical queries produced too much web noise for unattended
+  backfill.
+- Brave sometimes returned off-domain results for source-targeted `site:` queries.
+
+The PR therefore narrowed historical discovery to source-targeted Brave queries, added local
+date/domain enforcement, and kept broad/taxonomy discovery available for non-backfill discovery.
+
+The first clean source-targeted/domain-enforced proof window for 2026-01-01 through 2026-01-07
+completed with:
+
+- 144 Brave requests.
+- 109 persisted candidates.
+- 100 scrape attempts.
+- 0 retained rows.
+- No Supabase persistence failures.
+
+That result justified scaling the run while preserving conservative release boundaries.
+
+## Release Status
+
+Release generation did not run for the final full-range pass because the harness stops after a
+failed step and skips release after abort. There is no release-ready bundle for 2026-01-01 through
+2026-05-15 from this run.
+
+The next run should resume from 2026-03-19 through 2026-03-25 after classifier quota or replacement
+credentials are available, then generate the no-publication release bundle.
+
+## Supabase Security Advisory
+
+Supabase reported Row Level Security disabled on operational tables during setup. This PR does not
+enable RLS because doing so can break service-role/API behavior without a policy design. The
+advisory should be handled as a separate operator-approved security/configuration pass.
+
+## Validation
+
+Targeted validations were run during implementation for:
+
+- release config and CLI no-publication behavior
+- backfill harness abort/ledger behavior
+- Brave date/domain filtering
+- backfill query-kind override
+- backfill candidate selection and candidate-only scrape behavior
+- Supabase discovery persistence and NUL sanitization
+- backfill publication-window retention guards
+
+Full final validation should be run before merge after any report/doc updates.

--- a/docs/discovery_operations.md
+++ b/docs/discovery_operations.md
@@ -42,6 +42,30 @@ from the packaged TFHT taxonomy in addition to the coarse operator keyword list.
 When source-targeted taxonomy expansion is enabled for backfill, each window is capped by
 `backfill.max_source_targeted_taxonomy_queries_per_window` so historical recovery does not
 silently multiply search-engine quota use across every source and taxonomy term.
+Historical backfills may set `backfill.query_kinds` to use a narrower query mix than daily
+discovery. The 2026 long-run harness uses source-targeted Brave queries only, with local Brave
+date-window and preferred-domain enforcement, because broad/taxonomy historical searches produced
+too much off-domain noise for unattended recovery.
+
+For the budget-guarded 2026 backfill/release pass, use:
+
+```bash
+direnv exec . .venv/bin/python scripts/run_2026_backfill_release_daily.py \
+  --date-from 2026-01-01 \
+  --date-to 2026-05-15 \
+  --state-root data/2026_backfill_state_<run_id> \
+  --artifacts-root data/2026_backfill_run_<run_id> \
+  --max-budget-usd 50 \
+  --soft-budget-usd 45 \
+  --operational-provider supabase \
+  --max-scrape-drains-per-window 1 \
+  --denbust-bin .venv/bin/denbust
+```
+
+The harness forces release publication off and skips release generation after any failed step.
+The 2026-05-15 attempt stopped during the 2026-03-19 through 2026-03-25 window when Anthropic
+reported a workspace API usage limit until 2026-06-01 00:00 UTC; see the checked-in run report for
+the current resume point and counts.
 
 Use `agents/news/local_search.yaml` only when intentionally exercising source-native discovery
 plus Brave, Exa, and Google CSE locally:
@@ -528,6 +552,35 @@ Optional email-output secrets for ingest-family jobs:
 
 Backfill workflows reuse the same discovery and ingest secrets. They do not require any extra
 credential surface beyond the explicit `workflow_dispatch` inputs.
+
+## 2026 Backfill Harness And Release Dry Run
+
+`scripts/run_2026_backfill_release_daily.py` is the operator harness for the broad 2026 catch-up
+pass. It slices the requested date range into configured backfill windows, runs discovery and scrape
+drains, captures discovery diagnostics, and then builds the release bundle with public publication
+disabled.
+
+The default provider mode is Brave-only:
+
+```bash
+.venv/bin/python scripts/run_2026_backfill_release_daily.py \
+  --date-from 2026-01-01 \
+  --date-to 2026-05-15 \
+  --state-root data/2026_backfill_state \
+  --artifacts-root data/2026_backfill_run
+```
+
+The harness writes generated ledgers and logs below the configured `--artifacts-root`; those files
+remain outside the code repo commit. It also writes a generated effective config there so operator
+runs can switch between:
+
+- `--search-mode brave-only`, the default budget-safe mode;
+- `--search-mode brave-exa`, for selected low-yield windows when cost headroom remains;
+- `--search-mode config`, for using the checked-in config exactly as written.
+
+All harness runs set `DENBUST_RELEASE_PUBLISH=false`. The release command also supports
+`--no-publish`, and `agents/release/news_items_no_publish.yaml` keeps release-readiness checks from
+publishing to Kaggle or Hugging Face even when public-target env vars are present.
 
 ## State Repo Layout And Workflow Ownership
 

--- a/scripts/run_2026_backfill_release_daily.py
+++ b/scripts/run_2026_backfill_release_daily.py
@@ -1,0 +1,514 @@
+"""Run the 2026 news_items backfill with cost guards and release dry-run output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, time
+from pathlib import Path
+
+import yaml
+
+from denbust.config import Config, load_config
+from denbust.discovery.backfill import BackfillWindow, build_backfill_queries, plan_backfill_windows
+
+BRAVE_SEARCH_REQUEST_USD = 0.005
+EXA_SEARCH_REQUEST_USD = 0.007
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """One command or guardrail event emitted by the backfill harness."""
+
+    step: str
+    status: str
+    batch_id: str | None
+    window_start: str | None
+    window_end: str | None
+    command: list[str]
+    log_path: str | None
+    estimated_cost_usd: float
+    cumulative_estimated_cost_usd: float
+    returncode: int | None = None
+    note: str | None = None
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected YYYY-MM-DD, got {value!r}") from exc
+
+
+def _day_start(value: date) -> datetime:
+    return datetime.combine(value, time.min, tzinfo=UTC)
+
+
+def _day_end(value: date) -> datetime:
+    return datetime.combine(value, time.max, tzinfo=UTC)
+
+
+def _batch_id(window: BackfillWindow) -> str:
+    start = window.date_from.date().isoformat()
+    end = window.date_to.date().isoformat()
+    return f"backfill-2026-{start}_{end}"
+
+
+def _enabled_search_engines(config: Config) -> list[str]:
+    engines: list[str] = []
+    if config.discovery.engines.brave.enabled:
+        engines.append("brave")
+    if config.discovery.engines.exa.enabled:
+        engines.append("exa")
+    if config.discovery.engines.google_cse.enabled:
+        engines.append("google_cse")
+    return engines
+
+
+def _estimate_discover_cost(config: Config, window: BackfillWindow) -> tuple[float, str]:
+    query_count = len(build_backfill_queries(config, window=window))
+    engines = _enabled_search_engines(config)
+    brave_requests = query_count if "brave" in engines else 0
+    exa_requests = query_count if "exa" in engines else 0
+    unknown_requests = query_count if "google_cse" in engines else 0
+    cost = (brave_requests * BRAVE_SEARCH_REQUEST_USD) + (exa_requests * EXA_SEARCH_REQUEST_USD)
+    note = (
+        f"estimated query_count={query_count}, brave_requests={brave_requests}, "
+        f"exa_requests={exa_requests}, google_cse_requests={unknown_requests}"
+    )
+    return cost, note
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_markdown(path: Path, entries: list[LedgerEntry]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# 2026 Backfill Run Ledger",
+        "",
+        "| step | status | batch | estimated cost | cumulative | note |",
+        "| --- | --- | --- | ---: | ---: | --- |",
+    ]
+    for entry in entries:
+        lines.append(
+            "| {step} | {status} | {batch} | ${cost:.2f} | ${cumulative:.2f} | {note} |".format(
+                step=entry.step,
+                status=entry.status,
+                batch=entry.batch_id or "",
+                cost=entry.estimated_cost_usd,
+                cumulative=entry.cumulative_estimated_cost_usd,
+                note=(entry.note or "").replace("|", "\\|"),
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_command(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    log_path: Path,
+) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_file:
+        completed = subprocess.run(
+            command,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            check=False,
+        )
+    return completed.returncode
+
+
+def _add_entry(
+    entries: list[LedgerEntry],
+    *,
+    step: str,
+    status: str,
+    batch_id: str | None,
+    window: BackfillWindow | None,
+    command: list[str],
+    log_path: Path | None,
+    estimated_cost_usd: float,
+    returncode: int | None = None,
+    note: str | None = None,
+) -> float:
+    cumulative = sum(entry.estimated_cost_usd for entry in entries) + estimated_cost_usd
+    entries.append(
+        LedgerEntry(
+            step=step,
+            status=status,
+            batch_id=batch_id,
+            window_start=window.date_from.isoformat() if window else None,
+            window_end=window.date_to.isoformat() if window else None,
+            command=command,
+            log_path=str(log_path) if log_path else None,
+            estimated_cost_usd=round(estimated_cost_usd, 4),
+            cumulative_estimated_cost_usd=round(cumulative, 4),
+            returncode=returncode,
+            note=note,
+        )
+    )
+    return cumulative
+
+
+def _guard_budget(
+    entries: list[LedgerEntry],
+    *,
+    projected_cost: float,
+    max_budget_usd: float,
+) -> None:
+    current = sum(entry.estimated_cost_usd for entry in entries)
+    if current + projected_cost > max_budget_usd:
+        raise RuntimeError(
+            f"estimated budget would exceed ${max_budget_usd:.2f}: "
+            f"current=${current:.2f}, projected_step=${projected_cost:.2f}"
+        )
+
+
+def _base_env(args: argparse.Namespace) -> dict[str, str]:
+    env = dict(os.environ)
+    env["DENBUST_STATE_ROOT"] = str(args.state_root)
+    env["DENBUST_RELEASE_PUBLISH"] = "false"
+    return env
+
+
+def _command(args: argparse.Namespace, *parts: str) -> list[str]:
+    return [args.denbust_bin, *parts]
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, object]:
+    raw_config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw_config, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return raw_config
+
+
+def _apply_operational_overrides(raw_config: dict[str, object], args: argparse.Namespace) -> None:
+    if args.operational_provider == "config":
+        return
+    operational = raw_config.setdefault("operational", {})
+    if not isinstance(operational, dict):
+        raise ValueError("operational config must be a mapping")
+    operational["provider"] = args.operational_provider
+    if args.operational_provider == "local_json":
+        output = raw_config.setdefault("output", {})
+        if not isinstance(output, dict):
+            raise ValueError("output config must be a mapping")
+        output["formats"] = ["cli"]
+
+
+def _effective_config_path(args: argparse.Namespace) -> Path:
+    raw_config = _load_yaml_mapping(args.config)
+    _apply_operational_overrides(raw_config, args)
+    if args.search_mode == "config":
+        path = args.artifacts_root / "effective_config.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(raw_config, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        return path
+
+    discovery = raw_config.setdefault("discovery", {})
+    if not isinstance(discovery, dict):
+        raise ValueError("discovery config must be a mapping")
+    engines = discovery.setdefault("engines", {})
+    if not isinstance(engines, dict):
+        raise ValueError("discovery.engines config must be a mapping")
+
+    brave = engines.setdefault("brave", {})
+    exa = engines.setdefault("exa", {})
+    google_cse = engines.setdefault("google_cse", {})
+    if not all(isinstance(engine, dict) for engine in (brave, exa, google_cse)):
+        raise ValueError("discovery engine configs must be mappings")
+
+    brave["enabled"] = True
+    exa["enabled"] = args.search_mode == "brave-exa"
+    google_cse["enabled"] = False
+    path = args.artifacts_root / "effective_config.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(raw_config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _effective_release_config_path(args: argparse.Namespace) -> Path:
+    raw_config = _load_yaml_mapping(args.release_config)
+    _apply_operational_overrides(raw_config, args)
+    release = raw_config.setdefault("release", {})
+    if not isinstance(release, dict):
+        raise ValueError("release config must be a mapping")
+    release["publish_public_targets"] = False
+    path = args.artifacts_root / "effective_release_config.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(raw_config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date-from", type=_parse_date, default=date(2026, 1, 1))
+    parser.add_argument("--date-to", type=_parse_date, default=date(2026, 5, 15))
+    parser.add_argument("--config", type=Path, default=Path("agents/news/github.yaml"))
+    parser.add_argument(
+        "--release-config",
+        type=Path,
+        default=Path("agents/release/news_items_no_publish.yaml"),
+    )
+    parser.add_argument("--state-root", type=Path, default=Path("data/2026_backfill_state"))
+    parser.add_argument("--artifacts-root", type=Path, default=Path("data/2026_backfill_run"))
+    parser.add_argument("--denbust-bin", default="denbust")
+    parser.add_argument(
+        "--search-mode",
+        choices=["brave-only", "brave-exa", "config"],
+        default="brave-only",
+        help="Provider mix for generated effective config; default keeps full run under budget.",
+    )
+    parser.add_argument("--max-budget-usd", type=float, default=50.0)
+    parser.add_argument("--soft-budget-usd", type=float, default=40.0)
+    parser.add_argument(
+        "--operational-provider",
+        choices=["local_json", "supabase", "config"],
+        default="local_json",
+        help="Operational store for this harness run; local_json avoids placeholder Supabase env.",
+    )
+    parser.add_argument("--max-scrape-drains-per-window", type=int, default=2)
+    parser.add_argument("--estimated-classifier-cost-per-scrape-run-usd", type=float, default=0.5)
+    parser.add_argument("--skip-discover", action="store_true")
+    parser.add_argument("--skip-scrape", action="store_true")
+    parser.add_argument("--skip-release", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    if args.date_from > args.date_to:
+        raise SystemExit("--date-from must be on or before --date-to")
+    if args.max_scrape_drains_per_window < 0:
+        raise SystemExit("--max-scrape-drains-per-window must be non-negative")
+
+    effective_config_path = _effective_config_path(args)
+    effective_release_config_path = _effective_release_config_path(args)
+    config = load_config(effective_config_path)
+    windows = plan_backfill_windows(
+        date_from=_day_start(args.date_from),
+        date_to=_day_end(args.date_to),
+        batch_window_days=config.backfill.batch_window_days,
+    )
+    ledger_entries: list[LedgerEntry] = []
+    ledger_json = args.artifacts_root / "ledger.json"
+    ledger_md = args.artifacts_root / "ledger.md"
+    logs_dir = args.artifacts_root / "logs"
+    diagnostics_dir = args.artifacts_root / "diagnostics"
+    env = _base_env(args)
+    abort_run = False
+
+    try:
+        for window in windows:
+            if abort_run:
+                break
+            batch_id = _batch_id(window)
+            window_env = {
+                **env,
+                "DENBUST_BACKFILL_DATE_FROM": window.date_from.isoformat(),
+                "DENBUST_BACKFILL_DATE_TO": window.date_to.isoformat(),
+                "DENBUST_BACKFILL_BATCH_ID": batch_id,
+            }
+            if not args.skip_discover:
+                estimate, note = _estimate_discover_cost(config, window)
+                _guard_budget(
+                    ledger_entries,
+                    projected_cost=estimate,
+                    max_budget_usd=args.max_budget_usd,
+                )
+                command = _command(
+                    args,
+                    "run",
+                    "--dataset",
+                    "news_items",
+                    "--job",
+                    "backfill_discover",
+                    "--config",
+                    str(effective_config_path),
+                )
+                log_path = logs_dir / f"{batch_id}_discover.log"
+                returncode = (
+                    0 if args.dry_run else _run_command(command, env=window_env, log_path=log_path)
+                )
+                status = "dry_run" if args.dry_run else ("ok" if returncode == 0 else "failed")
+                _add_entry(
+                    ledger_entries,
+                    step="backfill_discover",
+                    status=status,
+                    batch_id=batch_id,
+                    window=window,
+                    command=command,
+                    log_path=log_path,
+                    estimated_cost_usd=estimate,
+                    returncode=returncode,
+                    note=note,
+                )
+                if returncode != 0:
+                    abort_run = True
+                    break
+
+            if not args.skip_scrape:
+                for drain_index in range(args.max_scrape_drains_per_window):
+                    estimate = args.estimated_classifier_cost_per_scrape_run_usd
+                    _guard_budget(
+                        ledger_entries,
+                        projected_cost=estimate,
+                        max_budget_usd=args.max_budget_usd,
+                    )
+                    command = _command(
+                        args,
+                        "run",
+                        "--dataset",
+                        "news_items",
+                        "--job",
+                        "backfill_scrape",
+                        "--config",
+                        str(effective_config_path),
+                    )
+                    log_path = logs_dir / f"{batch_id}_scrape_{drain_index + 1:02d}.log"
+                    returncode = (
+                        0
+                        if args.dry_run
+                        else _run_command(command, env=window_env, log_path=log_path)
+                    )
+                    status = "dry_run" if args.dry_run else ("ok" if returncode == 0 else "failed")
+                    _add_entry(
+                        ledger_entries,
+                        step=f"backfill_scrape_{drain_index + 1}",
+                        status=status,
+                        batch_id=batch_id,
+                        window=window,
+                        command=command,
+                        log_path=log_path,
+                        estimated_cost_usd=estimate,
+                        returncode=returncode,
+                        note="rough classifier cost estimate for one scrape drain",
+                    )
+                    if returncode != 0:
+                        abort_run = True
+                        break
+
+            if not abort_run:
+                diagnose_command = _command(
+                    args,
+                    "diagnose-discovery",
+                    "--config",
+                    str(effective_config_path),
+                    "--format",
+                    "json",
+                    "--output",
+                    str(diagnostics_dir / f"{batch_id}.json"),
+                )
+                diagnose_log = logs_dir / f"{batch_id}_diagnose_discovery.log"
+                diagnose_returncode = (
+                    0
+                    if args.dry_run
+                    else _run_command(diagnose_command, env=window_env, log_path=diagnose_log)
+                )
+                diagnose_status = (
+                    "dry_run" if args.dry_run else ("ok" if diagnose_returncode == 0 else "failed")
+                )
+                _add_entry(
+                    ledger_entries,
+                    step="diagnose_discovery",
+                    status=diagnose_status,
+                    batch_id=batch_id,
+                    window=window,
+                    command=diagnose_command,
+                    log_path=diagnose_log,
+                    estimated_cost_usd=0.0,
+                    returncode=diagnose_returncode,
+                    note="local diagnostics only",
+                )
+                if diagnose_returncode != 0:
+                    abort_run = True
+
+            _write_json(ledger_json, [asdict(entry) for entry in ledger_entries])
+            _write_markdown(ledger_md, ledger_entries)
+            if abort_run:
+                _add_entry(
+                    ledger_entries,
+                    step="abort",
+                    status="failed",
+                    batch_id=batch_id,
+                    window=window,
+                    command=[],
+                    log_path=None,
+                    estimated_cost_usd=0.0,
+                    note="stopped after failed step; release skipped",
+                )
+                break
+            if sum(entry.estimated_cost_usd for entry in ledger_entries) >= args.soft_budget_usd:
+                _add_entry(
+                    ledger_entries,
+                    step="soft_budget_notice",
+                    status="notice",
+                    batch_id=None,
+                    window=None,
+                    command=[],
+                    log_path=None,
+                    estimated_cost_usd=0.0,
+                    note=f"estimated cost reached soft budget ${args.soft_budget_usd:.2f}",
+                )
+                break
+
+        if not args.skip_release and not abort_run:
+            release_command = _command(
+                args,
+                "release",
+                "--dataset",
+                "news_items",
+                "--config",
+                str(effective_release_config_path),
+                "--no-publish",
+            )
+            release_log = logs_dir / "release_no_publish.log"
+            release_returncode = (
+                0 if args.dry_run else _run_command(release_command, env=env, log_path=release_log)
+            )
+            release_status = (
+                "dry_run" if args.dry_run else ("ok" if release_returncode == 0 else "failed")
+            )
+            _add_entry(
+                ledger_entries,
+                step="release_no_publish",
+                status=release_status,
+                batch_id=None,
+                window=None,
+                command=release_command,
+                log_path=release_log,
+                estimated_cost_usd=0.0,
+                returncode=release_returncode,
+                note="public publication disabled",
+            )
+    finally:
+        _write_json(ledger_json, [asdict(entry) for entry in ledger_entries])
+        _write_markdown(ledger_md, ledger_entries)
+
+    failed = [entry for entry in ledger_entries if entry.status == "failed"]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for denbust."""
 
+import os
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated
@@ -172,6 +173,7 @@ def diagnose_discovery(
     )
 
     if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(report.model_dump_json(indent=2), encoding="utf-8")
 
     if format == DiagnosticOutputFormat.JSON:
@@ -191,12 +193,29 @@ def release(
         Path | None,
         typer.Option("--config", "-c", help="Path to YAML config file"),
     ] = None,
+    publish: Annotated[
+        bool | None,
+        typer.Option(
+            "--publish/--no-publish",
+            help="Enable or disable publication to configured public targets.",
+        ),
+    ] = None,
 ) -> None:
     """Run the scaffolded release job for a dataset."""
     from denbust.pipeline import run_release
 
     config_path = config or Path("agents/release/news_items.yaml")
-    run_release(config_path=config_path, dataset_name=dataset)
+    previous_publish = os.environ.get("DENBUST_RELEASE_PUBLISH")
+    try:
+        if publish is not None:
+            os.environ["DENBUST_RELEASE_PUBLISH"] = "true" if publish else "false"
+        run_release(config_path=config_path, dataset_name=dataset)
+    finally:
+        if publish is not None:
+            if previous_publish is None:
+                os.environ.pop("DENBUST_RELEASE_PUBLISH", None)
+            else:
+                os.environ["DENBUST_RELEASE_PUBLISH"] = previous_publish
 
 
 @app.command()

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -174,6 +174,7 @@ class ReleaseConfig(BaseModel):
 
     schema_version: str = "news_items-v1"
     include_csv: bool = True
+    publish_public_targets: bool = True
     kaggle_dataset: str | None = None
     huggingface_repo_id: str | None = None
     rights_policy_version: str = "news_items-v1"
@@ -193,7 +194,22 @@ class ReleaseConfig(BaseModel):
             normalized["kaggle_dataset"] = os.environ["DENBUST_KAGGLE_DATASET"]
         if os.environ.get("DENBUST_HUGGINGFACE_REPO_ID"):
             normalized["huggingface_repo_id"] = os.environ["DENBUST_HUGGINGFACE_REPO_ID"]
+        if os.environ.get("DENBUST_RELEASE_PUBLISH") is not None:
+            normalized["publish_public_targets"] = _parse_env_bool(
+                os.environ["DENBUST_RELEASE_PUBLISH"],
+                env_name="DENBUST_RELEASE_PUBLISH",
+            )
         return normalized
+
+
+def _parse_env_bool(raw_value: str, *, env_name: str) -> bool:
+    """Parse a boolean environment variable with explicit accepted values."""
+    normalized = raw_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{env_name} must be a boolean value")
 
 
 class GoogleDriveBackupConfig(BaseModel):
@@ -384,6 +400,7 @@ class BackfillConfig(BaseModel):
     max_candidates_per_run: int = Field(default=500, ge=1)
     max_scrape_attempts_per_run: int = Field(default=100, ge=1)
     max_source_targeted_taxonomy_queries_per_window: int = Field(default=50, ge=0)
+    query_kinds: list[DiscoveryQueryKind] | None = None
 
 
 # Default keywords for searching news articles (Hebrew)

--- a/src/denbust/discovery/backfill.py
+++ b/src/denbust/discovery/backfill.py
@@ -105,7 +105,8 @@ def build_backfill_queries(
     from denbust.discovery.queries import _taxonomy_query_specs
 
     keywords = _normalize_keywords(config.keywords)
-    taxonomy_enabled = DiscoveryQueryKind.TAXONOMY_TARGETED in config.discovery.default_query_kinds
+    query_kinds = config.backfill.query_kinds or config.discovery.default_query_kinds
+    taxonomy_enabled = DiscoveryQueryKind.TAXONOMY_TARGETED in query_kinds
     if not keywords and not taxonomy_enabled:
         return []
 
@@ -113,7 +114,7 @@ def build_backfill_queries(
     seen_keys: set[tuple[object, ...]] = set()
     source_domains = enabled_discovery_domains(config)
     for keyword in keywords:
-        if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
+        if DiscoveryQueryKind.BROAD in query_kinds:
             broad_key = (DiscoveryQueryKind.BROAD, keyword, window.index)
             if broad_key not in seen_keys:
                 queries.append(
@@ -128,7 +129,7 @@ def build_backfill_queries(
                 )
                 seen_keys.add(broad_key)
 
-        if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+        if DiscoveryQueryKind.SOURCE_TARGETED in query_kinds:
             for source_name, domain in source_domains:
                 source_key = (
                     DiscoveryQueryKind.SOURCE_TARGETED,
@@ -152,7 +153,7 @@ def build_backfill_queries(
                     )
                 )
                 seen_keys.add(source_key)
-        if DiscoveryQueryKind.SOCIAL_TARGETED in config.discovery.default_query_kinds:
+        if DiscoveryQueryKind.SOCIAL_TARGETED in query_kinds:
             for domain in SOCIAL_DISCOVERY_DOMAINS:
                 queries.append(
                     DiscoveryQuery(
@@ -188,7 +189,7 @@ def build_backfill_queries(
                 )
             )
             seen_keys.add(taxonomy_key)
-            if DiscoveryQueryKind.SOURCE_TARGETED in config.discovery.default_query_kinds:
+            if DiscoveryQueryKind.SOURCE_TARGETED in query_kinds:
                 for source_name, domain in source_domains:
                     if source_targeted_taxonomy_query_count >= source_targeted_taxonomy_query_limit:
                         break

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import HttpUrl
@@ -63,6 +64,7 @@ class BraveSearchEngine:
                         self._max_results_per_query,
                     ),
                     "search_lang": query.language or "he",
+                    **_freshness_params(query),
                 },
             )
             response.raise_for_status()
@@ -99,14 +101,18 @@ class BraveSearchEngine:
         url = result.get("url")
         if not isinstance(url, str) or not url:
             return None
+        if not _matches_preferred_domains(url, query.preferred_domains):
+            return None
         publication_datetime_hint: datetime | None = None
         page_age = result.get("page_age")
         if isinstance(page_age, str):
             normalized = page_age.replace("Z", "+00:00")
             try:
-                publication_datetime_hint = datetime.fromisoformat(normalized)
+                publication_datetime_hint = _normalize_datetime(datetime.fromisoformat(normalized))
             except ValueError:
                 publication_datetime_hint = None
+        if not _matches_query_date_window(publication_datetime_hint, query):
+            return None
         try:
             parsed_url = HttpUrl(url)
             canonical_url = HttpUrl(canonicalize_news_url(url))
@@ -139,3 +145,50 @@ class BraveSearchEngine:
             )
         except ValueError:
             return None
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _freshness_params(query: DiscoveryQuery) -> dict[str, str]:
+    if not _is_backfill_query(query) or query.date_from is None or query.date_to is None:
+        return {}
+    date_from = _normalize_datetime(query.date_from).date().isoformat()
+    date_to = _normalize_datetime(query.date_to).date().isoformat()
+    return {"freshness": f"{date_from}to{date_to}"}
+
+
+def _matches_query_date_window(
+    publication_datetime_hint: datetime | None,
+    query: DiscoveryQuery,
+) -> bool:
+    if publication_datetime_hint is None or not _is_backfill_query(query):
+        return True
+    hint = _normalize_datetime(publication_datetime_hint)
+    if query.date_from is not None and hint < _normalize_datetime(query.date_from):
+        return False
+    return not (query.date_to is not None and hint > _normalize_datetime(query.date_to))
+
+
+def _is_backfill_query(query: DiscoveryQuery) -> bool:
+    return "backfill" in query.tags
+
+
+def _matches_preferred_domains(url: str, preferred_domains: list[str]) -> bool:
+    if not preferred_domains:
+        return True
+    result_domain = _normalize_domain(urlparse(url).netloc)
+    if not result_domain:
+        return False
+    return any(
+        result_domain == preferred_domain or result_domain.endswith(f".{preferred_domain}")
+        for preferred_domain in {_normalize_domain(domain) for domain in preferred_domains}
+    )
+
+
+def _normalize_domain(domain: str) -> str:
+    normalized = domain.lower().strip().removeprefix("www.")
+    return normalized

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -157,6 +157,17 @@ def _backfill_publication_datetime(candidate: PersistentCandidate) -> datetime |
     )
 
 
+def _matches_backfill_window(candidate: PersistentCandidate) -> bool:
+    publication_datetime = _backfill_publication_datetime(candidate)
+    if publication_datetime is None:
+        return True
+    window_start = _metadata_datetime(candidate, "backfill_window_start")
+    if window_start is not None and publication_datetime < window_start:
+        return False
+    window_end = _metadata_datetime(candidate, "backfill_window_end")
+    return not (window_end is not None and publication_datetime > window_end)
+
+
 def select_backfill_candidates_for_scrape(
     persistence: DiscoveryPersistence,
     *,
@@ -174,6 +185,7 @@ def select_backfill_candidates_for_scrape(
         candidate
         for candidate in listed_candidates
         if candidate.backfill_batch_id is not None
+        and _matches_backfill_window(candidate)
         and (
             candidate.next_scrape_attempt_at is None
             or candidate.next_scrape_attempt_at <= current_time
@@ -454,7 +466,7 @@ async def scrape_candidates(
                 else None
             )
 
-            if source_name is not None:
+            if source_name is not None and not backfill_mode:
                 source = sources_by_name[source_name]
                 try:
                     articles = source_articles_cache.get(source_name)

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -324,6 +324,7 @@ def persist_discovered_candidates(
     run.merged_candidate_count = len(persisted_candidates)
     run.queued_for_scrape_count = 0
     try:
+        persistence.write_run(run)
         persistence.upsert_candidates(persisted_candidates)
         persistence.append_provenance(provenance_events)
     except Exception as exc:

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -36,6 +36,17 @@ from denbust.discovery.state_paths import (
 )
 
 
+def _remove_postgres_unsupported_nuls(value: Any) -> Any:
+    """Remove NUL characters before sending JSON/text payloads to PostgREST."""
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [_remove_postgres_unsupported_nuls(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _remove_postgres_unsupported_nuls(item) for key, item in value.items()}
+    return value
+
+
 class DiscoveryPersistence(
     DiscoveryRunStore,
     CandidateStore,
@@ -427,17 +438,23 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
         self._request(
             "POST",
             self._table_names["discovery_runs"],
-            json={
-                **run.model_dump(mode="json"),
-                "errors": run.errors,
-            },
-            extra_headers={"Prefer": "return=minimal"},
+            params={"on_conflict": "run_id"},
+            json=_remove_postgres_unsupported_nuls(
+                {
+                    **run.model_dump(mode="json"),
+                    "errors": run.errors,
+                }
+            ),
+            extra_headers={"Prefer": "resolution=merge-duplicates,return=minimal"},
         )
 
     def upsert_candidates(self, candidates: Sequence[PersistentCandidate]) -> None:
         if not candidates:
             return
-        payload = [candidate.model_dump(mode="json") for candidate in candidates]
+        payload = [
+            _remove_postgres_unsupported_nuls(candidate.model_dump(mode="json"))
+            for candidate in candidates
+        ]
         self._request(
             "POST",
             self._table_names["persistent_candidates"],
@@ -449,7 +466,9 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
     def upsert_backfill_batches(self, batches: Sequence[BackfillBatch]) -> None:
         if not batches:
             return
-        payload = [batch.model_dump(mode="json") for batch in batches]
+        payload = [
+            _remove_postgres_unsupported_nuls(batch.model_dump(mode="json")) for batch in batches
+        ]
         self._request(
             "POST",
             self._table_names["backfill_batches"],
@@ -589,7 +608,9 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
         self._request(
             "POST",
             self._table_names["candidate_provenance"],
-            json=[event.model_dump(mode="json") for event in events],
+            json=[
+                _remove_postgres_unsupported_nuls(event.model_dump(mode="json")) for event in events
+            ],
             extra_headers={"Prefer": "return=minimal"},
         )
 
@@ -618,7 +639,10 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
         self._request(
             "POST",
             self._table_names["scrape_attempts"],
-            json=[attempt.model_dump(mode="json") for attempt in attempts],
+            json=[
+                _remove_postgres_unsupported_nuls(attempt.model_dump(mode="json"))
+                for attempt in attempts
+            ],
             extra_headers={"Prefer": "return=minimal"},
         )
 
@@ -667,7 +691,15 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
             json=json,
             headers=headers,
         )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            body = response.text[:1000]
+            raise httpx.HTTPStatusError(
+                f"{exc}; response_body={body}",
+                request=exc.request,
+                response=exc.response,
+            ) from exc
         return response
 
 

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -345,7 +345,7 @@ def _fallback_source_name(candidate: PersistentCandidate) -> str:
     return candidate.domain or "candidate_fallback"
 
 
-def _fallback_publication_datetime(candidate: PersistentCandidate) -> datetime:
+def _fallback_publication_datetime(candidate: PersistentCandidate) -> datetime | None:
     value = candidate.metadata.get("fallback_publication_datetime")
     if isinstance(value, str):
         try:
@@ -356,7 +356,12 @@ def _fallback_publication_datetime(candidate: PersistentCandidate) -> datetime:
             if parsed.tzinfo is None:
                 return parsed.replace(tzinfo=UTC)
             return parsed.astimezone(UTC)
-    return candidate.last_seen_at
+    return None
+
+
+def _fallback_publication_datetime_or_seen(candidate: PersistentCandidate) -> datetime:
+    """Return a fallback publication datetime for legacy non-backfill paths."""
+    return _fallback_publication_datetime(candidate) or candidate.last_seen_at
 
 
 def _fallback_text(candidate: PersistentCandidate) -> tuple[str | None, str | None]:
@@ -372,17 +377,33 @@ def _fallback_text(candidate: PersistentCandidate) -> tuple[str | None, str | No
     return normalized_title or None, normalized_snippet or None
 
 
-def _fallback_input_article(candidate: PersistentCandidate) -> RawArticle | None:
+def _fallback_input_article(
+    candidate: PersistentCandidate,
+    *,
+    require_publication_datetime: bool = False,
+) -> RawArticle | None:
     title, snippet = _fallback_text(candidate)
     if title is None and snippet is None:
+        return None
+    publication_datetime = _fallback_publication_datetime(candidate)
+    if require_publication_datetime and publication_datetime is None:
         return None
     return RawArticle(
         url=candidate.canonical_url or candidate.current_url,
         title=title or snippet or str(candidate.current_url),
         snippet=snippet or title or "",
-        date=_fallback_publication_datetime(candidate),
+        date=publication_datetime or candidate.last_seen_at,
         source_name=_fallback_source_name(candidate),
     )
+
+
+def _article_in_window(article: RawArticle, *, start: datetime, end: datetime) -> bool:
+    article_date = article.date
+    if article_date.tzinfo is None:
+        article_date = article_date.replace(tzinfo=UTC)
+    else:
+        article_date = article_date.astimezone(UTC)
+    return start <= article_date <= end
 
 
 def _fallback_combined_privacy_input(item: UnifiedItem) -> str:
@@ -427,10 +448,19 @@ async def _build_fallback_operational_records(
     *,
     candidates: list[PersistentCandidate],
     classifier: Classifier,
+    require_publication_datetime: bool = False,
+    publication_window: tuple[datetime, datetime] | None = None,
 ) -> list[NewsItemOperationalRecord]:
     fallback_inputs: list[tuple[PersistentCandidate, RawArticle]] = []
     for candidate in candidates:
-        article = _fallback_input_article(candidate)
+        article = _fallback_input_article(
+            candidate,
+            require_publication_datetime=require_publication_datetime,
+        )
+        if article is not None and publication_window is not None:
+            start, end = publication_window
+            if not _article_in_window(article, start=start, end=end):
+                article = None
         if article is not None:
             fallback_inputs.append((candidate, article))
     if not fallback_inputs:
@@ -2469,6 +2499,8 @@ async def run_news_backfill_scrape_job(
             fallback_records = await _build_fallback_operational_records(
                 candidates=scrape_batch.fallback_candidates,
                 classifier=classifier,
+                require_publication_datetime=True,
+                publication_window=(batch.requested_date_from, batch.requested_date_to),
             )
         except ClassifierProviderError as exc:
             sanitized_error = _mark_classifier_provider_error(result, exc)
@@ -2478,6 +2510,11 @@ async def run_news_backfill_scrape_job(
             )
             result.seen_count_after = seen_store.count
             return result.finish("fatal: classifier provider error")
+        skipped_fallback_count = len(scrape_batch.fallback_candidates) - len(fallback_records)
+        if skipped_fallback_count > 0:
+            result.warnings.append(
+                f"fallback_candidates_without_retained_rows={skipped_fallback_count}"
+            )
         if fallback_records and store is not None:
             store.upsert_records(
                 config.dataset_name.value,
@@ -2490,6 +2527,39 @@ async def run_news_backfill_scrape_job(
             result.finish(
                 "fallback retention completed with "
                 f"{len(fallback_records)} provisional row(s) for backfill batch {batch_id}"
+            )
+            result.set_debug_payload(
+                _build_scrape_candidate_debug_payload(
+                    result=result,
+                    classifier=classifier,
+                    scrape_batch=scrape_batch,
+                    fallback_record_count=len(fallback_records),
+                    batch_id=batch_id,
+                )
+            )
+            return result
+
+        out_of_window_article_count = len(scrape_batch.raw_articles)
+        scrape_batch.raw_articles = [
+            article
+            for article in scrape_batch.raw_articles
+            if _article_in_window(
+                article,
+                start=batch.requested_date_from,
+                end=batch.requested_date_to,
+            )
+        ]
+        out_of_window_article_count -= len(scrape_batch.raw_articles)
+        if out_of_window_article_count > 0:
+            result.warnings.append(
+                f"raw_articles_skipped_outside_backfill_window={out_of_window_article_count}"
+            )
+        if not scrape_batch.raw_articles:
+            result.unified_item_count = len(fallback_records)
+            result.finish(
+                "backfill batch "
+                f"{batch_id}: no raw articles remained inside requested backfill window; "
+                f"retained {len(fallback_records)} fallback row(s)"
             )
             result.set_debug_payload(
                 _build_scrape_candidate_debug_payload(
@@ -2594,11 +2664,14 @@ async def run_news_items_release_job(
         publication_dir=config.state_paths.publication_dir,
         rows=corrected_rows,
     )
-    published_targets = publish_release_bundle(
-        config=config,
-        release_dir=config.state_paths.publication_dir / manifest.release_version,
-        manifest=manifest,
-    )
+    if config.release.publish_public_targets:
+        published_targets = publish_release_bundle(
+            config=config,
+            release_dir=config.state_paths.publication_dir / manifest.release_version,
+            manifest=manifest,
+        )
+    else:
+        published_targets = []
     result.release_manifest = manifest.model_dump(mode="json")
     result.unified_item_count = manifest.row_count
     if published_targets:
@@ -2614,6 +2687,10 @@ async def run_news_items_release_job(
             dataset_name,
             public_ids,
             "published",
+        )
+    elif not config.release.publish_public_targets:
+        result.warnings.append(
+            "Public publication disabled by release config; built release bundle only."
         )
     else:
         result.warnings.append("No publication targets configured; built release bundle only.")

--- a/supabase/migrations/20260515_discovery_annotations_schema_completion.sql
+++ b/supabase/migrations/20260515_discovery_annotations_schema_completion.sql
@@ -1,0 +1,77 @@
+alter table public.persistent_candidates
+    add column if not exists titles jsonb not null default '[]'::jsonb,
+    add column if not exists snippets jsonb not null default '[]'::jsonb,
+    add column if not exists discovered_via jsonb not null default '[]'::jsonb,
+    add column if not exists discovery_queries jsonb not null default '[]'::jsonb,
+    add column if not exists source_hints jsonb not null default '[]'::jsonb;
+
+create table if not exists public.news_items_corrections (
+    dataset_name text not null,
+    record_id text,
+    canonical_url text,
+    relevant boolean,
+    enforcement_related boolean,
+    taxonomy_version text,
+    taxonomy_category_id text,
+    taxonomy_subcategory_id text,
+    category text,
+    sub_category text,
+    summary_one_sentence text,
+    manual_city text,
+    manual_address text,
+    manual_event_label text,
+    manual_status text,
+    reviewer text,
+    reviewed_at timestamptz,
+    annotation_notes text,
+    active boolean not null default true,
+    annotation_source text not null default 'manual_correction',
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    constraint news_items_corrections_identity_chk
+        check (record_id is not null or canonical_url is not null)
+);
+
+create unique index if not exists news_items_corrections_record_id_idx
+    on public.news_items_corrections (dataset_name, record_id)
+    where record_id is not null;
+
+create unique index if not exists news_items_corrections_canonical_url_idx
+    on public.news_items_corrections (dataset_name, canonical_url)
+    where canonical_url is not null;
+
+create index if not exists news_items_corrections_active_idx
+    on public.news_items_corrections (dataset_name, active, reviewed_at desc);
+
+create table if not exists public.news_items_missing_items (
+    dataset_name text not null,
+    annotation_id text not null,
+    source_url text not null,
+    canonical_url text,
+    title text not null,
+    event_date timestamptz not null,
+    source_name text not null,
+    taxonomy_version text,
+    taxonomy_category_id text not null,
+    taxonomy_subcategory_id text not null,
+    category text,
+    sub_category text,
+    summary_one_sentence text,
+    manual_city text,
+    manual_address text,
+    manual_event_label text,
+    manual_status text,
+    reviewer text,
+    reviewed_at timestamptz,
+    annotation_notes text,
+    active boolean not null default true,
+    promotion_status text not null default 'promoted',
+    annotation_source text not null default 'missing_item_annotation',
+    index_relevant boolean,
+    created_at timestamptz not null default timezone('utc', now()),
+    updated_at timestamptz not null default timezone('utc', now()),
+    primary key (dataset_name, annotation_id)
+);
+
+create index if not exists news_items_missing_items_active_idx
+    on public.news_items_missing_items (dataset_name, active, event_date desc);

--- a/supabase/migrations/20260516_news_items_operational_schema_completion.sql
+++ b/supabase/migrations/20260516_news_items_operational_schema_completion.sql
@@ -1,0 +1,21 @@
+alter table public.news_items
+    add column if not exists taxonomy_version text,
+    add column if not exists taxonomy_category_id text,
+    add column if not exists taxonomy_subcategory_id text,
+    add column if not exists index_relevant boolean not null default false,
+    add column if not exists manual_address text,
+    add column if not exists manual_event_label text,
+    add column if not exists manual_status text,
+    add column if not exists manually_overridden boolean not null default false,
+    add column if not exists annotation_source text,
+    add column if not exists manual_city text,
+    add column if not exists manually_reviewed boolean not null default false,
+    add column if not exists reviewer text,
+    add column if not exists reviewed_at timestamptz,
+    add column if not exists annotation_notes text;
+
+create index if not exists news_items_taxonomy_idx
+    on public.news_items (taxonomy_category_id, taxonomy_subcategory_id);
+
+create index if not exists news_items_index_relevant_idx
+    on public.news_items (index_relevant);

--- a/tests/unit/test_backfill_harness.py
+++ b/tests/unit/test_backfill_harness.py
@@ -1,0 +1,71 @@
+"""Focused tests for the 2026 backfill harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.run_2026_backfill_release_daily as harness
+
+from denbust.config import Config
+
+
+def test_backfill_harness_aborts_after_failed_scrape_and_skips_release(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A failed scrape must not continue into later windows or release output."""
+    effective_config = tmp_path / "effective_config.yaml"
+    effective_release_config = tmp_path / "effective_release_config.yaml"
+    effective_config.write_text("dataset_name: news_items\n", encoding="utf-8")
+    effective_release_config.write_text("dataset_name: news_items\n", encoding="utf-8")
+    monkeypatch.setattr(harness, "_effective_config_path", lambda _args: effective_config)
+    monkeypatch.setattr(
+        harness,
+        "_effective_release_config_path",
+        lambda _args: effective_release_config,
+    )
+    monkeypatch.setattr(harness, "load_config", lambda _path: Config())
+    monkeypatch.setattr(harness, "_estimate_discover_cost", lambda _config, _window: (0.0, "test"))
+
+    calls: list[list[str]] = []
+
+    def fake_run_command(command: list[str], *, env: dict[str, str], log_path: Path) -> int:
+        del env
+        calls.append(command)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("log\n", encoding="utf-8")
+        if "--job" in command and command[command.index("--job") + 1] == "backfill_scrape":
+            return 1
+        return 0
+
+    monkeypatch.setattr(harness, "_run_command", fake_run_command)
+
+    result = harness.main(
+        [
+            "--date-from",
+            "2026-01-01",
+            "--date-to",
+            "2026-01-14",
+            "--state-root",
+            str(tmp_path / "state"),
+            "--artifacts-root",
+            str(tmp_path / "artifacts"),
+            "--denbust-bin",
+            "denbust",
+        ]
+    )
+
+    assert result == 1
+    command_text = [" ".join(command) for command in calls]
+    assert sum("backfill_discover" in command for command in command_text) == 1
+    assert sum("backfill_scrape" in command for command in command_text) == 1
+    assert all("diagnose-discovery" not in command for command in command_text)
+    assert all(" release " not in f" {command} " for command in command_text)
+
+    ledger = json.loads((tmp_path / "artifacts" / "ledger.json").read_text(encoding="utf-8"))
+    assert [entry["step"] for entry in ledger] == [
+        "backfill_discover",
+        "backfill_scrape_1",
+        "abort",
+    ]

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -721,12 +721,19 @@ async def test_run_news_backfill_scrape_job_marks_classifier_provider_error_fata
             return_value=build_scrape_batch(
                 raw_articles=[
                     RawArticle(
+                        url=HttpUrl("https://example.com/outside-window"),
+                        title="outside",
+                        snippet="outside",
+                        date=datetime(2026, 3, 2, tzinfo=UTC),
+                        source_name="ynet",
+                    ),
+                    RawArticle(
                         url=HttpUrl("https://example.com/raw"),
                         title="title",
                         snippet="snippet",
                         date=datetime(2026, 1, 2, tzinfo=UTC),
                         source_name="ynet",
-                    )
+                    ),
                 ]
             )
         ),
@@ -773,7 +780,20 @@ async def test_run_news_backfill_scrape_job_marks_fallback_provider_error_fatal(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
             return_value=build_scrape_batch(
-                fallback_candidates=[build_candidate("batch-1")],
+                fallback_candidates=[
+                    build_candidate("batch-1").model_copy(
+                        update={
+                            "metadata": {
+                                "backfill_window_start": datetime(
+                                    2026, 1, 1, tzinfo=UTC
+                                ).isoformat(),
+                                "fallback_publication_datetime": datetime(
+                                    2026, 1, 2, tzinfo=UTC
+                                ).isoformat(),
+                            }
+                        }
+                    )
+                ],
                 raw_articles=[],
             )
         ),
@@ -1275,12 +1295,19 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
             return_value=build_scrape_batch(
                 raw_articles=[
                     RawArticle(
+                        url=HttpUrl("https://example.com/outside-window"),
+                        title="outside",
+                        snippet="outside",
+                        date=datetime(2026, 3, 2, tzinfo=UTC),
+                        source_name="ynet",
+                    ),
+                    RawArticle(
                         url=HttpUrl("https://example.com/raw"),
                         title="title",
                         snippet="snippet",
                         date=datetime(2026, 1, 2, tzinfo=UTC),
                         source_name="ynet",
-                    )
+                    ),
                 ]
             )
         ),
@@ -1289,11 +1316,14 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
         "denbust.pipeline._build_fallback_operational_records",
         AsyncMock(return_value=[]),
     )
-    processed_snapshot = RunSnapshot(job_name=JobName.BACKFILL_SCRAPE).finish("processed 1 article")
-    monkeypatch.setattr(
-        "denbust.pipeline._process_ingest_articles",
-        AsyncMock(return_value=processed_snapshot),
-    )
+
+    async def fake_process_ingest_articles(**kwargs: object) -> RunSnapshot:
+        result = kwargs["result"]
+        assert isinstance(result, RunSnapshot)
+        return result.finish("processed 1 article")
+
+    process = AsyncMock(side_effect=fake_process_ingest_articles)
+    monkeypatch.setattr("denbust.pipeline._process_ingest_articles", process)
 
     processed = await run_news_backfill_scrape_job(
         Config(job_name=JobName.BACKFILL_SCRAPE, store={"state_root": tmp_path / "processed"})
@@ -1301,4 +1331,6 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
 
     assert processed.result_summary == "backfill batch batch-1: processed 1 article"
     assert processed.debug_payload == {"batch_id": "batch-1"}
+    assert processed.warnings == ["raw_articles_skipped_outside_backfill_window=1"]
+    assert [article.title for article in process.await_args.kwargs["all_articles"]] == ["title"]
     assert processed_store.get_backfill_batch("batch-1") is not None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 """Unit tests for CLI command wiring."""
 
 import json
+import os
 import runpy
 from pathlib import Path
 
@@ -123,6 +124,25 @@ class TestCli:
         assert backup_result.exit_code == 0
         assert release_calls == [(Path("agents/release/news_items.yaml"), DatasetName.NEWS_ITEMS)]
         assert backup_calls == [(Path("agents/backup/news_items.yaml"), DatasetName.NEWS_ITEMS)]
+
+    def test_release_no_publish_sets_temporary_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """release --no-publish should disable public targets for that invocation only."""
+        seen_values: list[str | None] = []
+        monkeypatch.delenv("DENBUST_RELEASE_PUBLISH", raising=False)
+
+        def fake_run_release(*, config_path: Path, dataset_name: DatasetName) -> None:
+            del config_path, dataset_name
+            seen_values.append(os.environ.get("DENBUST_RELEASE_PUBLISH"))
+
+        monkeypatch.setattr("denbust.pipeline.run_release", fake_run_release)
+
+        result = runner.invoke(app, ["release", "--no-publish"])
+
+        assert result.exit_code == 0
+        assert seen_values == ["false"]
+        assert os.environ.get("DENBUST_RELEASE_PUBLISH") is None
 
     def test_report_monthly_forwards_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """report monthly should forward its explicit options to the pipeline wrapper."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -347,6 +347,24 @@ class TestConfig:
 
         assert config.kaggle_dataset == "owner/news-items"
         assert config.huggingface_repo_id == "org/news-items"
+        assert config.publish_public_targets is True
+
+    def test_release_config_publish_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Release config should allow an explicit public-publication kill switch."""
+        monkeypatch.setenv("DENBUST_RELEASE_PUBLISH", "false")
+
+        config = ReleaseConfig.model_validate(None)
+
+        assert config.publish_public_targets is False
+
+    def test_release_config_publish_env_rejects_ambiguous_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Publication env override should not accept ambiguous truthy strings."""
+        monkeypatch.setenv("DENBUST_RELEASE_PUBLISH", "maybe")
+
+        with pytest.raises(ValueError, match="DENBUST_RELEASE_PUBLISH must be a boolean value"):
+            ReleaseConfig.model_validate(None)
 
     def test_release_config_validator_passthrough_for_non_mapping(self) -> None:
         """ReleaseConfig's pre-validator should leave non-mapping values untouched."""
@@ -525,3 +543,17 @@ store:
         assert config.source_discovery.persist_candidates is True
         assert config.backfill.enabled is True
         assert config.backfill.batch_window_days == 7
+
+    def test_github_news_config_enables_brave_exa_search_and_backfill(self) -> None:
+        """The scheduled GitHub config should run online discovery without Google CSE."""
+        config = load_config(Path("agents/news/github.yaml"))
+
+        assert config.discovery.enabled is True
+        assert config.discovery.engines.brave.enabled is True
+        assert config.discovery.engines.exa.enabled is True
+        assert config.discovery.engines.google_cse.enabled is False
+        assert config.source_discovery.enabled is True
+        assert config.candidates.keep_search_only_fallbacks is True
+        assert config.candidates.require_review_for_search_only is True
+        assert config.backfill.enabled is True
+        assert config.backfill.max_scrape_attempts_per_run == 100

--- a/tests/unit/test_discovery_backfill.py
+++ b/tests/unit/test_discovery_backfill.py
@@ -238,6 +238,37 @@ def test_build_backfill_queries_normalizes_keywords_and_emits_source_targeted() 
     }
 
 
+def test_build_backfill_queries_can_override_query_kinds_for_historical_runs() -> None:
+    """Backfill can use a narrower query mix than always-on daily discovery."""
+    config = Config(
+        keywords=["זנות"],
+        sources=[
+            {"name": "mako", "type": "scraper", "enabled": True},
+            {"name": "ynet", "type": "rss", "url": "https://www.ynet.co.il/rss", "enabled": True},
+        ],
+        discovery={
+            "default_query_kinds": [
+                "broad",
+                "source_targeted",
+                "taxonomy_targeted",
+                "social_targeted",
+            ]
+        },
+        backfill={"query_kinds": ["source_targeted"]},
+    )
+    window = plan_backfill_windows(
+        date_from=datetime(2026, 1, 1, tzinfo=UTC),
+        date_to=datetime(2026, 1, 7, tzinfo=UTC),
+        batch_window_days=7,
+    )[0]
+
+    queries = build_backfill_queries(config, window=window)
+
+    assert queries
+    assert all(query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED for query in queries)
+    assert all(query.preferred_domains for query in queries)
+
+
 def test_build_backfill_queries_excludes_news1_source_targeted_fanout() -> None:
     """Candidate-only News1 evidence should not spend recurring backfill query budget."""
     config = Config(

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -21,6 +21,7 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
     def handler(request: httpx.Request) -> httpx.Response:
         captured["query"] = request.url.params["q"]
         captured["count"] = request.url.params["count"]
+        captured["freshness"] = request.url.params["freshness"]
         captured["token"] = request.headers["X-Subscription-Token"]
         return httpx.Response(
             200,
@@ -51,10 +52,12 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
             DiscoveryQuery(
                 query_text="בית בושת",
                 query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                date_from=datetime(2026, 4, 15, 0, 0, tzinfo=UTC),
+                date_to=datetime(2026, 4, 15, 23, 59, tzinfo=UTC),
                 preferred_domains=["www.ynet.co.il"],
                 source_hint="ynet",
                 language="he",
-                tags=["ynet", "taxonomy", "category:brothels"],
+                tags=["backfill", "ynet", "taxonomy", "category:brothels"],
             )
         ],
         DiscoveryContext(run_id="run-1", max_results_per_query=5),
@@ -65,6 +68,7 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
         "query": "(site:www.ynet.co.il) בית בושת",
         "count": "5",
         "token": "brave-key",
+        "freshness": "2026-04-15to2026-04-15",
     }
     assert len(candidates) == 1
     assert candidates[0].producer_name == "brave"
@@ -75,7 +79,12 @@ async def test_brave_search_engine_normalizes_results_and_renders_site_query() -
     assert str(candidates[0].canonical_url) == "https://ynet.co.il/news/article/abc"
     assert candidates[0].publication_datetime_hint == datetime(2026, 4, 15, 8, 0, tzinfo=UTC)
     assert candidates[0].metadata["query_kind"] == "source_targeted"
-    assert candidates[0].metadata["query_tags"] == ["ynet", "taxonomy", "category:brothels"]
+    assert candidates[0].metadata["query_tags"] == [
+        "backfill",
+        "ynet",
+        "taxonomy",
+        "category:brothels",
+    ]
     assert candidates[0].metadata["source_targeted_taxonomy"] is True
     assert candidates[0].metadata["result_url"] == "https://www.ynet.co.il/news/article/abc"
     assert candidates[0].metadata["result_title"] == "פשיטה על בית בושת"
@@ -240,3 +249,103 @@ async def test_brave_search_engine_ignores_invalid_page_age() -> None:
 
     assert len(candidates) == 1
     assert candidates[0].publication_datetime_hint is None
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_filters_dated_results_outside_query_window() -> None:
+    """Historical backfill queries should not retain dated Brave results outside their window."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["freshness"] == "2026-01-01to2026-01-07"
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://www.ynet.co.il/news/article/old",
+                            "title": "old",
+                            "page_age": "2025-12-31T23:59:00Z",
+                        },
+                        {
+                            "url": "https://www.ynet.co.il/news/article/in-window",
+                            "title": "in window",
+                            "page_age": "2026-01-03T09:00:00Z",
+                        },
+                        {
+                            "url": "https://www.ynet.co.il/news/article/undated",
+                            "title": "undated",
+                        },
+                    ]
+                }
+            },
+        )
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="זנות",
+                query_kind=DiscoveryQueryKind.BROAD,
+                date_from=datetime(2026, 1, 1, tzinfo=UTC),
+                date_to=datetime(2026, 1, 7, 23, 59, tzinfo=UTC),
+                tags=["backfill"],
+            )
+        ],
+        DiscoveryContext(run_id="run-6"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://www.ynet.co.il/news/article/in-window",
+        "https://www.ynet.co.il/news/article/undated",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_filters_off_domain_source_targeted_results() -> None:
+    """Provider results must still honor preferred-domain contracts locally."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://he.wikipedia.org/wiki/%D7%96%D7%A0%D7%95%D7%AA",
+                            "title": "off domain",
+                        },
+                        {
+                            "url": "https://news.walla.co.il/item/3806949",
+                            "title": "on domain",
+                        },
+                    ]
+                }
+            },
+        )
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    candidates = await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="זנות",
+                query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                preferred_domains=["news.walla.co.il"],
+            )
+        ],
+        DiscoveryContext(run_id="run-7"),
+    )
+    await engine.aclose()
+
+    assert [str(candidate.candidate_url) for candidate in candidates] == [
+        "https://news.walla.co.il/item/3806949"
+    ]

--- a/tests/unit/test_discovery_scrape_queue.py
+++ b/tests/unit/test_discovery_scrape_queue.py
@@ -18,6 +18,7 @@ from denbust.discovery.models import (
     ContentBasis,
     FetchStatus,
     PersistentCandidate,
+    ScrapeAttemptKind,
 )
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
@@ -338,6 +339,49 @@ def test_select_backfill_candidates_for_scrape_uses_batch_filter_when_provided(
     assert [candidate.candidate_id for candidate in selected] == ["first"]
 
 
+def test_select_backfill_candidates_for_scrape_skips_dated_candidates_outside_window(
+    tmp_path: Path,
+) -> None:
+    """Backfill scrape drains should not spend budget on candidates with out-of-window hints."""
+    store = build_store(tmp_path)
+    window_start = "2026-01-01T00:00:00+00:00"
+    window_end = "2026-01-07T23:59:59+00:00"
+    outside = build_candidate("outside", status=CandidateStatus.NEW).model_copy(
+        update={
+            "backfill_batch_id": "batch-1",
+            "metadata": {
+                "backfill_window_start": window_start,
+                "backfill_window_end": window_end,
+                "latest_publication_datetime_hint": "2025-12-31T23:59:00+00:00",
+            },
+        }
+    )
+    in_window = build_candidate("in-window", status=CandidateStatus.NEW).model_copy(
+        update={
+            "backfill_batch_id": "batch-1",
+            "metadata": {
+                "backfill_window_start": window_start,
+                "backfill_window_end": window_end,
+                "latest_publication_datetime_hint": "2026-01-03T12:00:00+00:00",
+            },
+        }
+    )
+    undated = build_candidate("undated", status=CandidateStatus.NEW).model_copy(
+        update={
+            "backfill_batch_id": "batch-1",
+            "metadata": {
+                "backfill_window_start": window_start,
+                "backfill_window_end": window_end,
+            },
+        }
+    )
+    store.upsert_candidates([outside, in_window, undated])
+
+    selected = select_backfill_candidates_for_scrape(store, limit=10, batch_id="batch-1")
+
+    assert [candidate.candidate_id for candidate in selected] == ["in-window", "undated"]
+
+
 @pytest.mark.asyncio
 async def test_scrape_candidates_returns_empty_batch_for_no_candidates(tmp_path: Path) -> None:
     """An empty scrape pass should return an empty batch without persistence writes."""
@@ -387,6 +431,47 @@ async def test_scrape_candidates_records_success_and_updates_candidate(tmp_path:
     assert len(batch.attempts) == 1
     assert batch.attempts[0].fetch_status is FetchStatus.SUCCESS
     assert source.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_scrape_candidates_skips_source_adapter_fetch(tmp_path: Path) -> None:
+    """Backfill candidate drains should avoid current-window source adapter searches."""
+    store = build_store(tmp_path)
+    candidate = build_candidate("candidate-backfill", status=CandidateStatus.NEW).model_copy(
+        update={"backfill_batch_id": "batch-1"}
+    )
+    store.upsert_candidates([candidate])
+    source = FailingSource("ynet", RuntimeError("source adapter should not run"))
+    original_fetch = scrape_candidates.__globals__["_fetch_partial_page"]
+
+    async def fake_fetch_partial_page(
+        _candidate: PersistentCandidate, *, client: object
+    ) -> GenericFetchResult:
+        del client
+        return GenericFetchResult(
+            fetch_status=FetchStatus.PARTIAL,
+            title="candidate title",
+            snippet="candidate snippet",
+            publication_datetime=datetime(2026, 1, 3, tzinfo=UTC),
+        )
+
+    scrape_candidates.__globals__["_fetch_partial_page"] = fake_fetch_partial_page
+
+    try:
+        batch = await scrape_candidates(
+            config=Config(store={"state_root": tmp_path}),
+            persistence=store,
+            candidates=[candidate],
+            sources=[source],
+            backfill_mode=True,
+        )
+    finally:
+        scrape_candidates.__globals__["_fetch_partial_page"] = original_fetch
+
+    assert source.calls == 0
+    assert len(batch.fallback_candidates) == 1
+    assert len(batch.attempts) == 1
+    assert batch.attempts[0].attempt_kind is ScrapeAttemptKind.GENERIC_FETCH
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -563,8 +563,9 @@ def test_persist_discovered_candidates_writes_failed_run_before_reraising() -> N
     else:
         raise AssertionError("expected RuntimeError")
 
-    assert len(persistence.written_runs) == 1
-    failed_run = persistence.written_runs[0]
+    assert len(persistence.written_runs) == 2
+    assert persistence.written_runs[0].status.value == "pending"
+    failed_run = persistence.written_runs[1]
     assert failed_run.status.value == "failed"
     assert failed_run.finished_at is not None
     assert failed_run.errors == ["persistence: RuntimeError: candidate write failed"]

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -616,12 +616,46 @@ def test_supabase_discovery_persistence_crud_and_headers() -> None:
 
     assert client.closed is True
     assert client.calls[0]["url"] == "https://supabase.example.com/rest/v1/discovery_runs"
+    assert client.calls[0]["params"] == {"on_conflict": "run_id"}
     assert client.calls[0]["json"]["errors"] == ["boom"]  # type: ignore[index]
     assert client.calls[5]["params"]["backfill_batch_id"] == "eq.batch-1"  # type: ignore[index]
     headers = client.calls[0]["headers"]
     assert isinstance(headers, dict)
     assert headers["Accept-Profile"] == "custom"
     assert headers["Authorization"] == "Bearer service-role"
+
+
+def test_supabase_discovery_persistence_strips_nul_characters_from_candidate_payloads() -> None:
+    """PostgREST payloads should not contain NUL characters rejected by Postgres JSON/text."""
+    client = FakeHttpClient([httpx.Response(200, json=[])])
+    store = SupabaseDiscoveryPersistence(
+        base_url="https://supabase.example.com",
+        service_role_key="service-role",
+        schema="public",
+        table_names={
+            "discovery_runs": "discovery_runs",
+            "persistent_candidates": "persistent_candidates",
+            "backfill_batches": "backfill_batches",
+            "candidate_provenance": "candidate_provenance",
+            "scrape_attempts": "scrape_attempts",
+        },
+        client=client,
+    )
+    candidate = build_candidate().model_copy(
+        update={
+            "titles": ["bad\x00title"],
+            "snippets": ["bad\x00snippet"],
+            "metadata": {"nested": ["bad\x00metadata"]},
+        }
+    )
+
+    store.upsert_candidates([candidate])
+
+    payload = client.calls[0]["json"]
+    assert isinstance(payload, list)
+    assert payload[0]["titles"] == ["badtitle"]
+    assert payload[0]["snippets"] == ["badsnippet"]
+    assert payload[0]["metadata"] == {"nested": ["badmetadata"]}
 
 
 def test_supabase_discovery_persistence_counts_candidates_server_side() -> None:

--- a/tests/unit/test_news_items_phase_b.py
+++ b/tests/unit/test_news_items_phase_b.py
@@ -1136,3 +1136,88 @@ async def test_release_publication_dir_and_release_job_mark_published(
 
     assert result.result_summary == "release built for 1 public row(s)"
     assert store.mark_calls == [("news_items", ["row-1"], "published")]
+
+
+@pytest.mark.asyncio
+async def test_release_job_no_publish_builds_bundle_without_publication(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    release_config = Config(
+        job_name="release",
+        store={"publication_dir": tmp_path / "release-pub"},
+        release={
+            "publish_public_targets": False,
+            "kaggle_dataset": "owner/news",
+            "huggingface_repo_id": "org/news-items",
+        },
+    )
+
+    class FakeStore:
+        def __init__(self) -> None:
+            self.mark_calls: list[tuple[str, list[str], str]] = []
+
+        def fetch_records(
+            self, dataset_name: str, *, limit: int | None = None
+        ) -> list[dict[str, Any]]:
+            del dataset_name, limit
+            return [{"id": "row-1"}]
+
+        def mark_publication_state(
+            self, dataset_name: str, record_ids: list[str], publication_status: str
+        ) -> None:
+            self.mark_calls.append((dataset_name, record_ids, publication_status))
+
+        def write_run_metadata(self, snapshot: RunSnapshot) -> None:
+            del snapshot
+
+        def upsert_records(self, dataset_name: str, records: list[dict[str, Any]]) -> None:
+            del dataset_name, records
+
+        def fetch_suppression_rules(self, dataset_name: str) -> list[dict[str, Any]]:
+            del dataset_name
+            return []
+
+        def fetch_news_item_corrections(self, dataset_name: str) -> list[dict[str, Any]]:
+            del dataset_name
+            return []
+
+        def fetch_missing_news_items(self, dataset_name: str) -> list[dict[str, Any]]:
+            del dataset_name
+            return []
+
+        def upsert_news_item_corrections(
+            self, dataset_name: str, records: list[dict[str, Any]]
+        ) -> None:
+            del dataset_name, records
+
+        def upsert_missing_news_items(
+            self, dataset_name: str, records: list[dict[str, Any]]
+        ) -> None:
+            del dataset_name, records
+
+    manifest = ReleaseManifest(dataset_name="news_items", release_version="2026-03-19", row_count=1)
+
+    class FakeBuilder:
+        def __init__(self, *, config: Config) -> None:
+            del config
+
+        def build_release_bundle(
+            self, *, publication_dir: Path, rows: list[dict[str, Any]]
+        ) -> ReleaseManifest:
+            del publication_dir, rows
+            return manifest
+
+    monkeypatch.setattr("denbust.pipeline.NewsItemsReleaseBuilder", FakeBuilder)
+    monkeypatch.setattr(
+        "denbust.pipeline.publish_release_bundle",
+        lambda **_kwargs: pytest.fail("public publishers must not run"),
+    )
+
+    store = FakeStore()
+    result = await run_news_items_release_job(release_config, operational_store=store)
+
+    assert result.result_summary == "release built for 1 public row(s)"
+    assert store.mark_calls == []
+    assert result.warnings == [
+        "Public publication disabled by release config; built release bundle only."
+    ]

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -604,9 +604,10 @@ class TestFetchAndClassifyHelpers:
             }
         )
         assert pipeline_module._fallback_source_name(no_text_candidate) == "example.com"
-        assert pipeline_module._fallback_publication_datetime(no_text_candidate) == datetime(
-            2026, 4, 11, 9, 0, tzinfo=UTC
-        )
+        assert pipeline_module._fallback_publication_datetime(no_text_candidate) is None
+        assert pipeline_module._fallback_publication_datetime_or_seen(
+            no_text_candidate
+        ) == datetime(2026, 4, 11, 9, 0, tzinfo=UTC)
         assert pipeline_module._fallback_input_article(no_text_candidate) is None
 
         candidate_fallback = no_text_candidate.model_copy(
@@ -628,7 +629,8 @@ class TestFetchAndClassifyHelpers:
         invalid_publication_candidate = candidate.model_copy(
             update={"metadata": {"fallback_publication_datetime": "not-a-date"}}
         )
-        assert pipeline_module._fallback_publication_datetime(
+        assert pipeline_module._fallback_publication_datetime(invalid_publication_candidate) is None
+        assert pipeline_module._fallback_publication_datetime_or_seen(
             invalid_publication_candidate
         ) == datetime(2026, 4, 11, 9, 0, tzinfo=UTC)
 
@@ -694,6 +696,60 @@ class TestFetchAndClassifyHelpers:
         assert record.source_name == "brave"
         assert record.title == "Relevant title"
         assert record.summary_one_sentence == "Enriched: Relevant title"
+
+    @pytest.mark.asyncio
+    async def test_build_fallback_operational_records_can_require_publication_datetime(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Backfill fallback rows should require a real extracted publication date."""
+        dated_candidate = build_persistent_candidate(
+            "candidate-dated",
+            current_url="https://example.com/dated",
+        ).model_copy(
+            update={
+                "metadata": {
+                    "fallback_title": "Dated title",
+                    "fallback_snippet": "Dated summary",
+                    "fallback_publication_datetime": "2026-01-02T12:00:00+00:00",
+                },
+            }
+        )
+        undated_candidate = build_persistent_candidate(
+            "candidate-undated",
+            current_url="https://example.com/undated",
+        ).model_copy(
+            update={
+                "metadata": {
+                    "fallback_title": "Undated title",
+                    "fallback_snippet": "Undated summary",
+                },
+            }
+        )
+        classifier = MagicMock()
+        classifier.classify_batch = AsyncMock(
+            return_value=[build_classified_article("https://example.com/dated", relevant=True)]
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.fallback_enrichment",
+            lambda item: NewsItemEnrichment(summary_one_sentence=f"Enriched: {item.headline}"),
+        )
+        monkeypatch.setattr(
+            "denbust.pipeline.infer_privacy_risk",
+            lambda _text: (PrivacyRisk.LOW, "low"),
+        )
+
+        records = await pipeline_module._build_fallback_operational_records(
+            candidates=[dated_candidate, undated_candidate],
+            classifier=classifier,
+            require_publication_datetime=True,
+            publication_window=(
+                datetime(2026, 1, 1, tzinfo=UTC),
+                datetime(2026, 1, 7, tzinfo=UTC),
+            ),
+        )
+
+        assert [record.event_candidate_ids for record in records] == [["candidate-dated"]]
+        classifier.classify_batch.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_fallback_operational_records_rejects_classifier_length_mismatch(


### PR DESCRIPTION
## Summary

This PR implements `BACKFILL-PR-2026-RELEASE-DAILY-ONLINE`: a guarded, resumable harness for the January 1, 2026 through May 15, 2026 news-items backfill, plus the release controls needed to stop before public publication.

The PR is intentionally broad because the work needed to move from planning slices to a real release candidate spans the discovery harness, Supabase operational persistence, release publication safety, backfill query shaping, and operator docs.

## Evidence and scope decisions

The live run showed that broad historical discovery was too noisy and expensive for a long backfill. The implementation therefore narrows the backfill lane to source-targeted queries while leaving normal daily discovery behavior intact.

The full source-targeted run was started against Supabase and progressed through diagnostics for the `2026-03-12` to `2026-03-18` window. It stopped during the `2026-03-19` to `2026-03-25` scrape window because Anthropic returned a workspace quota error:

`You have reached your specified workspace API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.`

At the stop point, the harness had recorded an estimated cumulative provider cost of `$14.64` and skipped release generation because the scrape phase failed. Supabase contained 1,471 backfill persistent candidates, 1,174 scrape attempts, and 9 retained `news_items` rows. Generated artifacts remain local under `data/2026_backfill_run_20260515T_full_source_targeted_domain/` and are not committed.

## What changed

- Added `scripts/run_2026_backfill_release_daily.py`, a resumable date-window harness with ledger output, effective config capture, diagnostics capture, provider budget tracking, and release skipping on failed discovery/scrape/diagnose phases.
- Added no-publication release controls via `publish_public_targets`, `DENBUST_RELEASE_PUBLISH`, and `denbust release --publish/--no-publish`.
- Added `agents/release/news_items_no_publish.yaml` so release dry-runs can be configured without relying only on CLI flags.
- Hardened Supabase persistence for the long run: schema-completion migrations, run-row upsert behavior, FK ordering, response-body error detail, and recursive NUL sanitization before PostgREST writes.
- Added source-targeted backfill query selection and scoped Brave historical date/domain filtering only for backfill-tagged queries.
- Added backfill-window filtering for generic raw articles and candidate fallback retention, and candidate-only backfill scrape behavior that avoids current-window browser source adapters.
- Updated docs and `.agent-plan.md` with the actual backfill status, blocker, and next planned work.

## Intentionally out of scope

- No public publication is performed by this PR.
- No final release bundle is claimed, because the full run stopped on external classifier quota.
- No queue fairness or source priority changes are included.
- No unrelated browser scraper behavior is changed for current-window Mako/Haaretz flows.
- Supabase RLS is not enabled automatically. The live project reports RLS-disabled advisories for operational tables; that should be handled as an explicit security follow-up, not hidden inside this backfill harness PR.
- Exa is supported by config mode but not used by the default harness path; the default run remains Brave-only for cost control.

## Validation

Ran locally:

- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- `.venv/bin/pytest -q tests/unit/test_backfill_harness.py tests/unit/test_backfill_pipeline.py tests/unit/test_pipeline_core.py tests/unit/test_discovery_brave.py tests/unit/test_discovery_backfill.py tests/unit/test_discovery_scrape_queue.py tests/unit/test_discovery_storage.py tests/unit/test_cli.py tests/unit/test_config.py tests/unit/test_news_items_phase_b.py tests/unit/test_discovery_source_native.py`
- `.venv/bin/pytest -q tests/unit/test_discovery_brave.py tests/unit/test_ynet_search_recall_fixture.py`
- pre-commit during commit, including ruff, mypy, and smoke tests
- pre-push during `git push`, including unit and integration hooks

## Next work

The next planned slice is `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: resume from the failed `2026-03-19` to `2026-03-25` window after quota is restored or after switching to an approved lower-cost classifier path, complete the through-2026-05-15 run, inspect diagnostics, then generate the no-publication release candidate.
