### PR TITLE
Add TFHT review workbench Pages app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,5 @@ uv.lock
 
 .live_checks/
 .temp/
+.wrangler/
+review_app/.wrangler/

--- a/review_app/README.md
+++ b/review_app/README.md
@@ -9,10 +9,18 @@ rows from Supabase.
 - Sort the fetched review queue by a local likelihood score.
 - Let allowed reviewers mark rows as include, exclude, needs review, or internal only.
 - Let reviewers assign the Phase C taxonomy pair, index relevance, notes, city, event label, and tags.
+- Provide a local day/night theme preference for long review sessions.
 - Store `news_items` annotations on the existing operational row fields.
 - Store discovery-only candidate annotations under `persistent_candidates.metadata.review_app_annotation`.
 
 This app does not publish public release bundles, change scrape queue behavior, or run discovery.
+
+## Theme
+
+Day mode is the default. Night mode is a browser-local UI preference stored in `localStorage` under
+`tfht-review-theme`; it is not a user profile setting, permission, or server-side identity claim.
+The page applies the stored theme in an early `<head>` script before first paint and scopes dark
+colors through `:root[data-theme="night"]`.
 
 ## Cloudflare Pages
 

--- a/review_app/README.md
+++ b/review_app/README.md
@@ -52,12 +52,9 @@ Current standard workflow tags:
 
 ## Cloudflare Pages
 
-Use the private Cloudflare account associated with `shaypal5@gmail.com`, not the Adanim account.
-The token is loaded from the documented personal env file on this laptop:
-
-```bash
-source /Users/shaypalachy/.config/noa/cloudflare_api_token.env
-```
+Use the Cloudflare account that owns the `tfht-review-workbench` Pages project, not the Adanim
+account. Load your personal Cloudflare API token before running wrangler commands — the token file
+path varies per contributor and should be kept outside the repo (e.g. under `~/.config/`).
 
 Expected Pages project name:
 
@@ -81,12 +78,11 @@ Deploy:
 ```bash
 npx wrangler pages deploy review_app/public \
   --project-name tfht-review-workbench \
-  --branch main \
-  --commit-dirty=true
+  --branch main
 ```
 
 From inside `review_app/`, the equivalent command is:
 
 ```bash
-npx wrangler pages deploy public --project-name tfht-review-workbench --branch main --commit-dirty=true
+npx wrangler pages deploy public --project-name tfht-review-workbench --branch main
 ```

--- a/review_app/README.md
+++ b/review_app/README.md
@@ -1,0 +1,56 @@
+# TFHT Review Workbench
+
+Cloudflare Pages app for reviewing DenBust/TFHT discovery candidates and materialized `news_items`
+rows from Supabase.
+
+## Scope
+
+- Read operational rows from Supabase through Cloudflare Pages Functions.
+- Sort the fetched review queue by a local likelihood score.
+- Let allowed reviewers mark rows as include, exclude, needs review, or internal only.
+- Let reviewers assign the Phase C taxonomy pair, index relevance, notes, city, event label, and tags.
+- Store `news_items` annotations on the existing operational row fields.
+- Store discovery-only candidate annotations under `persistent_candidates.metadata.review_app_annotation`.
+
+This app does not publish public release bundles, change scrape queue behavior, or run discovery.
+
+## Cloudflare Pages
+
+Use the private Cloudflare account associated with `shaypal5@gmail.com`, not the Adanim account.
+The token is loaded from the documented personal env file on this laptop:
+
+```bash
+source /Users/shaypalachy/.config/noa/cloudflare_api_token.env
+```
+
+Expected Pages project name:
+
+```text
+tfht-review-workbench
+```
+
+Required Pages secrets:
+
+```text
+DENBUST_SUPABASE_URL
+DENBUST_SUPABASE_SERVICE_ROLE_KEY
+TFHT_REVIEW_ALLOWED_EMAILS
+```
+
+`TFHT_REVIEW_ALLOWED_EMAILS` is a comma-separated allow-list. Cloudflare Access should also protect
+the Pages hostname with OTP/email authentication for the same reviewer set.
+
+Deploy:
+
+```bash
+npx wrangler pages deploy review_app/public \
+  --project-name tfht-review-workbench \
+  --branch main \
+  --commit-dirty=true
+```
+
+From inside `review_app/`, the equivalent command is:
+
+```bash
+npx wrangler pages deploy public --project-name tfht-review-workbench --branch main --commit-dirty=true
+```

--- a/review_app/README.md
+++ b/review_app/README.md
@@ -8,7 +8,9 @@ rows from Supabase.
 - Read operational rows from Supabase through Cloudflare Pages Functions.
 - Sort the fetched review queue by a local likelihood score.
 - Let allowed reviewers mark rows as include, exclude, needs review, or internal only.
-- Let reviewers assign the Phase C taxonomy pair, index relevance, notes, city, event label, and tags.
+- Let reviewers assign the Phase C taxonomy pair, index relevance, notes, city, case/event label,
+  and workflow tags.
+- Show the standard workflow tag vocabulary before allowing custom tag additions.
 - Provide a local day/night theme preference for long review sessions.
 - Store `news_items` annotations on the existing operational row fields.
 - Store discovery-only candidate annotations under `persistent_candidates.metadata.review_app_annotation`.
@@ -21,6 +23,32 @@ Day mode is the default. Night mode is a browser-local UI preference stored in `
 `tfht-review-theme`; it is not a user profile setting, permission, or server-side identity claim.
 The page applies the stored theme in an early `<head>` script before first paint and scopes dark
 colors through `:root[data-theme="night"]`.
+
+## Review Vocabulary
+
+The app keeps taxonomy and workflow tagging separate:
+
+- `Case / event label` is free text for a short human-readable case name.
+- `Workflow tags` are selected from a visible standard list first.
+- Reviewers can add a custom workflow tag only from the custom-tag control shown below the standard
+  list.
+
+Current standard workflow tags:
+
+- `strong-positive`
+- `weak-positive`
+- `false-positive`
+- `duplicate-risk`
+- `needs-source-check`
+- `needs-fact-check`
+- `needs-privacy-check`
+- `paywall`
+- `partial-page`
+- `policy-context`
+- `court`
+- `police`
+- `welfare`
+- `reporting-context`
 
 ## Cloudflare Pages
 

--- a/review_app/functions/_shared.js
+++ b/review_app/functions/_shared.js
@@ -1,0 +1,541 @@
+const DEFAULT_LIMIT = 250;
+const MAX_LIMIT = 1000;
+
+export const TAXONOMY = {
+  version: "1",
+  categories: [
+    {
+      id: "human_trafficking",
+      labelHe: "סחר בבני אדם",
+      labelEn: "Human trafficking",
+      subcategories: [
+        {
+          id: "trafficking_sexual_exploitation",
+          labelHe: "סחר למטרת ניצול מיני (זנות)",
+          labelEn: "Trafficking for sexual exploitation",
+          indexRelevant: true,
+        },
+        {
+          id: "trafficking_forced_marriage",
+          labelHe: "סחר למטרת נישואין בכפייה",
+          labelEn: "Trafficking for forced marriage",
+          indexRelevant: true,
+        },
+        {
+          id: "trafficking_forced_labor",
+          labelHe: "סחר למטרת עבודת כפייה",
+          labelEn: "Trafficking for forced labor",
+          indexRelevant: false,
+        },
+        {
+          id: "trafficking_organ_harvesting",
+          labelHe: "סחר למטרת נטילת איברים",
+          labelEn: "Trafficking for organ harvesting",
+          indexRelevant: false,
+        },
+        {
+          id: "trafficking_cross_border_prostitution",
+          labelHe: "הבאת אדם למדינה אחרת לשם העיסוק בזנות",
+          labelEn: "Cross-border prostitution trafficking",
+          indexRelevant: true,
+        },
+        {
+          id: "trafficking_slavery_conditions",
+          labelHe: "החזקה בתנאי עבדות",
+          labelEn: "Holding in slavery conditions",
+          indexRelevant: true,
+        },
+        {
+          id: "sexual_slavery",
+          labelHe: "עבדות מינית",
+          labelEn: "Sexual slavery",
+          indexRelevant: true,
+        },
+        {
+          id: "trafficking_women",
+          labelHe: "סחר בנשים",
+          labelEn: "Women trafficking",
+          indexRelevant: true,
+        },
+      ],
+    },
+    {
+      id: "pimping_prostitution",
+      labelHe: "סרסור וזנות",
+      labelEn: "Pimping and prostitution",
+      subcategories: [
+        { id: "pimping", labelHe: "סרסור", labelEn: "Pimping", indexRelevant: true },
+        {
+          id: "bringing_into_prostitution",
+          labelHe: "הבאת אדם לידי זנות",
+          labelEn: "Bringing a person into prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "soliciting_prostitution",
+          labelHe: "שידול לזנות",
+          labelEn: "Soliciting prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "women_testimonies",
+          labelHe: "עדויות של נשים בזנות",
+          labelEn: "Testimonies of women in prostitution",
+          indexRelevant: false,
+        },
+        {
+          id: "phenomenon_coverage",
+          labelHe: "סיקור תופעת הזנות",
+          labelEn: "Coverage of prostitution as a phenomenon",
+          indexRelevant: false,
+        },
+        {
+          id: "online_prostitution",
+          labelHe: "זנות מקוונת",
+          labelEn: "Online prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "nordic_model_law",
+          labelHe: "חוק איסור צריכת זנות / המודל הנורדי",
+          labelEn: "Nordic model / prohibition on buying prostitution",
+          indexRelevant: false,
+        },
+      ],
+    },
+    {
+      id: "brothels",
+      labelHe: "בתי בושת",
+      labelEn: "Brothels",
+      subcategories: [
+        {
+          id: "keeping_brothel",
+          labelHe: "החזקת מקום לשם זנות",
+          labelEn: "Keeping a place for prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "renting_brothel",
+          labelHe: "השכרת מקום לשם זנות",
+          labelEn: "Renting a place for prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "advertising_prostitution",
+          labelHe: "פרסום זנות",
+          labelEn: "Advertising prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "client_fine",
+          labelHe: "קנס בגין צריכת זנות",
+          labelEn: "Fine for buying prostitution",
+          indexRelevant: true,
+        },
+        {
+          id: "administrative_closure",
+          labelHe: "סגירה מנהלית / צו מנהלי לפי חוק הגבלת שימוש במקום לשם ביצוע עבירה",
+          labelEn: "Administrative closure order",
+          indexRelevant: true,
+        },
+        {
+          id: "closure_appeal",
+          labelHe: "ערעור על צו מנהלי",
+          labelEn: "Appeal on closure order",
+          indexRelevant: true,
+        },
+        {
+          id: "brothel_indictment",
+          labelHe: "כתב אישום על החזקת/השכרת מקום לשם זנות",
+          labelEn: "Indictment for keeping or renting a brothel",
+          indexRelevant: true,
+        },
+      ],
+    },
+  ],
+};
+
+const STRONG_TERMS = [
+  "סחר",
+  "סרסור",
+  "זנות",
+  "בית בושת",
+  "בתי בושת",
+  "ניצול מיני",
+  "עבדות",
+  "צו סגירה",
+  "החזקת מקום",
+  "השכרת מקום",
+  "פרסום זנות",
+  "צריכת זנות",
+];
+
+const WEAK_NOISE_TERMS = [
+  "רכילות",
+  "סלב",
+  "אינסטגרם",
+  "וידאו",
+  "פודקאסט",
+  "ספורט",
+  "מניות",
+  "נדלן",
+];
+
+export function jsonResponse(data, init = {}) {
+  const status = init.status || 200;
+  const headers = new Headers(init.headers || {});
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", "no-store");
+  return new Response(JSON.stringify(data, null, 2), { status, headers });
+}
+
+export function errorResponse(message, status = 500, details = undefined) {
+  return jsonResponse({ error: message, details }, { status });
+}
+
+export function getAccessEmail(request, env) {
+  return (
+    request.headers.get("cf-access-authenticated-user-email") ||
+    request.headers.get("CF-Access-Authenticated-User-Email") ||
+    env.TFHT_REVIEW_DEV_EMAIL ||
+    ""
+  ).trim();
+}
+
+export function parseAllowedEmails(env) {
+  return String(env.TFHT_REVIEW_ALLOWED_EMAILS || "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function requireReviewer(request, env) {
+  const email = getAccessEmail(request, env).toLowerCase();
+  const allowed = parseAllowedEmails(env);
+  if (!email) {
+    return { ok: false, email: "", response: errorResponse("Cloudflare Access email is missing.", 401) };
+  }
+  if (allowed.length > 0 && !allowed.includes(email)) {
+    return { ok: false, email, response: errorResponse("Reviewer email is not allowed.", 403) };
+  }
+  return { ok: true, email, response: null };
+}
+
+export function getSupabaseConfig(env) {
+  const baseUrl = String(env.DENBUST_SUPABASE_URL || "").replace(/\/$/, "");
+  const serviceRoleKey = env.DENBUST_SUPABASE_SERVICE_ROLE_KEY;
+  if (!baseUrl || !serviceRoleKey) {
+    throw new Error("Missing DENBUST_SUPABASE_URL or DENBUST_SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  return { baseUrl, serviceRoleKey };
+}
+
+export async function supabaseFetch(env, table, { method = "GET", params, body } = {}) {
+  const { baseUrl, serviceRoleKey } = getSupabaseConfig(env);
+  const url = new URL(`${baseUrl}/rest/v1/${table}`);
+  if (params) {
+    for (const [key, value] of params.entries()) {
+      url.searchParams.append(key, value);
+    }
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+      "content-type": "application/json",
+      prefer: method === "GET" ? "count=exact" : "return=representation",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+  if (!response.ok) {
+    throw new Error(`Supabase ${method} ${table} failed: ${response.status} ${JSON.stringify(payload)}`);
+  }
+  return { payload, count: parseContentRangeCount(response.headers.get("content-range")) };
+}
+
+export function parseLimit(value) {
+  const parsed = Number.parseInt(value || "", 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+export function parseOffset(value) {
+  const parsed = Number.parseInt(value || "", 10);
+  if (Number.isNaN(parsed) || parsed < 0) return 0;
+  return parsed;
+}
+
+export function normalizeNewsItem(row) {
+  const title = row.title || row.summary_one_sentence || row.url || "Untitled news item";
+  const text = [title, row.summary_one_sentence, row.category, row.sub_category, row.source_name]
+    .filter(Boolean)
+    .join(" ");
+  const { score, reasons } = scoreItem({
+    text,
+    confidence: row.classification_confidence || row.record_confidence,
+    status: row.publication_status,
+    basis: row.content_basis,
+    needsReview: row.review_status && row.review_status !== "none",
+    sourceHints: [],
+    discoveryHits: [],
+  });
+
+  return {
+    itemType: "news_item",
+    id: row.id,
+    url: row.canonical_url || row.url,
+    title,
+    snippet: row.summary_one_sentence || "",
+    sourceName: row.source_name || row.source_domain || "",
+    sourceDomain: row.source_domain || domainFromUrl(row.canonical_url || row.url),
+    publicationDatetime: row.publication_datetime || row.retrieval_datetime || row.created_at,
+    confidence: row.classification_confidence || row.record_confidence || null,
+    taxonomyCategoryId: row.taxonomy_category_id || "",
+    taxonomySubcategoryId: row.taxonomy_subcategory_id || "",
+    taxonomyVersion: row.taxonomy_version || "",
+    indexRelevant: row.index_relevant,
+    reviewStatus: row.review_status || "",
+    publicationStatus: row.publication_status || "",
+    contentBasis: row.content_basis || "",
+    candidateStatus: "",
+    score,
+    scoreReasons: reasons,
+    metadata: {
+      rightsClass: row.rights_class || "",
+      privacyRiskLevel: row.privacy_risk_level || "",
+      manualStatus: row.manual_status || "",
+      manuallyReviewed: Boolean(row.manually_reviewed),
+      annotationNotes: row.annotation_notes || "",
+      organizations: row.organizations_mentioned || [],
+      topicTags: row.topic_tags || [],
+    },
+  };
+}
+
+export function normalizeCandidate(row) {
+  const titles = arrayValue(row.titles);
+  const snippets = arrayValue(row.snippets);
+  const sourceHints = arrayValue(row.source_hints);
+  const discoveryQueries = arrayValue(row.discovery_queries);
+  const latestMetadata = row.metadata?.latest_discovery_metadata || {};
+  const title = titles[0] || latestMetadata.result_title || row.canonical_url || "Untitled candidate";
+  const snippet = snippets[0] || latestMetadata.result_snippet || "";
+  const text = [title, snippet, row.domain].filter(Boolean).join(" ");
+  const discoveryHits = arrayValue(row.discovered_via);
+  const { score, reasons } = scoreItem({
+    text,
+    confidence: latestMetadata.classification_confidence || null,
+    status: row.candidate_status,
+    basis: row.content_basis,
+    needsReview: Boolean(row.needs_review),
+    sourceHints,
+    discoveryHits,
+  });
+
+  return {
+    itemType: "candidate",
+    id: row.candidate_id,
+    url: row.canonical_url || row.current_url,
+    title,
+    snippet,
+    sourceName: row.domain || "",
+    sourceDomain: row.domain || domainFromUrl(row.canonical_url || row.current_url),
+    publicationDatetime: latestMetadata.result_published_date || row.first_seen_at,
+    confidence: latestMetadata.classification_confidence || null,
+    taxonomyCategoryId: row.metadata?.review_app_annotation?.taxonomyCategoryId || "",
+    taxonomySubcategoryId: row.metadata?.review_app_annotation?.taxonomySubcategoryId || "",
+    taxonomyVersion: row.metadata?.review_app_annotation?.taxonomyVersion || "",
+    indexRelevant: row.metadata?.review_app_annotation?.indexRelevant ?? null,
+    reviewStatus: row.needs_review ? "needs_review" : "",
+    publicationStatus: row.metadata?.review_app_annotation?.decision || "",
+    contentBasis: row.content_basis || "",
+    candidateStatus: row.candidate_status || "",
+    score,
+    scoreReasons: reasons,
+    metadata: {
+      annotation: row.metadata?.review_app_annotation || null,
+      sourceHints,
+      discoveryQueries,
+      discoveredVia: discoveryHits,
+      scrapeAttemptCount: row.scrape_attempt_count || 0,
+      lastScrapeErrorCode: row.last_scrape_error_code || "",
+      lastScrapeErrorMessage: row.last_scrape_error_message || "",
+      latestDiscoveryMetadata: latestMetadata,
+    },
+  };
+}
+
+export function applyFilters(items, searchParams) {
+  const status = searchParams.get("status") || "pending";
+  const query = normalizeSearch(searchParams.get("q") || "");
+  const domain = normalizeSearch(searchParams.get("domain") || "");
+  const source = normalizeSearch(searchParams.get("source") || "");
+
+  return items.filter((item) => {
+    if (status === "pending" && isCompleted(item)) return false;
+    if (status === "approved" && item.publicationStatus !== "approved" && item.publicationStatus !== "include") return false;
+    if (status === "suppressed" && item.publicationStatus !== "suppressed" && item.publicationStatus !== "exclude") return false;
+    if (status === "candidate_only" && item.itemType !== "candidate") return false;
+    if (status === "news_items" && item.itemType !== "news_item") return false;
+
+    const haystack = normalizeSearch(
+      [
+        item.title,
+        item.snippet,
+        item.sourceName,
+        item.sourceDomain,
+        item.url,
+        item.taxonomyCategoryId,
+        item.taxonomySubcategoryId,
+      ].join(" "),
+    );
+    if (query && !haystack.includes(query)) return false;
+    if (domain && !normalizeSearch(item.sourceDomain).includes(domain)) return false;
+    if (source && !normalizeSearch(item.sourceName).includes(source)) return false;
+    return true;
+  });
+}
+
+export function sortItems(items) {
+  return items.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return String(b.publicationDatetime || "").localeCompare(String(a.publicationDatetime || ""));
+  });
+}
+
+export function findTaxonomyPair(categoryId, subcategoryId) {
+  const category = TAXONOMY.categories.find((entry) => entry.id === categoryId);
+  if (!category) return null;
+  const subcategory = category.subcategories.find((entry) => entry.id === subcategoryId);
+  if (!subcategory) return null;
+  return { category, subcategory };
+}
+
+export function parseReviewBody(rawBody) {
+  const body = rawBody && typeof rawBody === "object" ? rawBody : {};
+  const decision = cleanString(body.decision);
+  const itemType = cleanString(body.itemType);
+  const id = cleanString(body.id);
+  if (!["news_item", "candidate"].includes(itemType)) {
+    throw new Error("itemType must be news_item or candidate.");
+  }
+  if (!id) throw new Error("id is required.");
+  if (!["include", "exclude", "needs_review", "internal_only"].includes(decision)) {
+    throw new Error("decision must be include, exclude, needs_review, or internal_only.");
+  }
+
+  const taxonomyCategoryId = cleanString(body.taxonomyCategoryId);
+  const taxonomySubcategoryId = cleanString(body.taxonomySubcategoryId);
+  if (decision === "include" && !findTaxonomyPair(taxonomyCategoryId, taxonomySubcategoryId)) {
+    throw new Error("A valid taxonomy category and subcategory are required for include decisions.");
+  }
+
+  return {
+    itemType,
+    id,
+    decision,
+    taxonomyCategoryId,
+    taxonomySubcategoryId,
+    taxonomyVersion: taxonomyCategoryId && taxonomySubcategoryId ? TAXONOMY.version : "",
+    indexRelevant: Boolean(body.indexRelevant),
+    notes: cleanString(body.notes),
+    manualEventLabel: cleanString(body.manualEventLabel),
+    manualCity: cleanString(body.manualCity),
+    tags: Array.isArray(body.tags) ? body.tags.map(cleanString).filter(Boolean).slice(0, 20) : [],
+  };
+}
+
+function scoreItem({ text, confidence, status, basis, needsReview, sourceHints, discoveryHits }) {
+  let score = 0;
+  const reasons = [];
+  const normalized = normalizeSearch(text);
+
+  for (const term of STRONG_TERMS) {
+    if (normalized.includes(normalizeSearch(term))) {
+      score += 8;
+      reasons.push(`term: ${term}`);
+    }
+  }
+
+  for (const term of WEAK_NOISE_TERMS) {
+    if (normalized.includes(normalizeSearch(term))) {
+      score -= 5;
+      reasons.push(`noise: ${term}`);
+    }
+  }
+
+  if (confidence !== null && confidence !== undefined && confidence !== "" && Number.isFinite(Number(confidence))) {
+    const confidenceScore = Math.round(Number(confidence) * 20);
+    score += confidenceScore;
+    reasons.push(`classifier confidence +${confidenceScore}`);
+  }
+  if (basis === "source_article" || basis === "article") {
+    score += 8;
+    reasons.push("article content");
+  }
+  if (needsReview) {
+    score += 6;
+    reasons.push("needs review");
+  }
+  if (status === "approved" || status === "include") {
+    score += 20;
+    reasons.push("already approved");
+  }
+  if (status === "suppressed" || status === "exclude") {
+    score -= 20;
+    reasons.push("already excluded");
+  }
+  if (sourceHints.length > 0) {
+    score += Math.min(sourceHints.length * 2, 8);
+    reasons.push("source hints");
+  }
+  if (discoveryHits.length > 1) {
+    score += Math.min(discoveryHits.length * 2, 10);
+    reasons.push("repeated discovery");
+  }
+  return { score, reasons: [...new Set(reasons)].slice(0, 8) };
+}
+
+function isCompleted(item) {
+  return ["approved", "suppressed", "include", "exclude"].includes(item.publicationStatus);
+}
+
+function parseContentRangeCount(value) {
+  if (!value || !value.includes("/")) return null;
+  const count = value.split("/").pop();
+  if (!count || count === "*") return null;
+  const parsed = Number.parseInt(count, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function domainFromUrl(value) {
+  try {
+    return new URL(value).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function normalizeSearch(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function cleanString(value) {
+  return String(value || "").trim();
+}

--- a/review_app/functions/_shared.js
+++ b/review_app/functions/_shared.js
@@ -194,12 +194,16 @@ export function errorResponse(message, status = 500, details = undefined) {
 }
 
 export function getAccessEmail(request, env) {
-  return (
+  const cfEmail = (
     request.headers.get("cf-access-authenticated-user-email") ||
     request.headers.get("CF-Access-Authenticated-User-Email") ||
-    env.TFHT_REVIEW_DEV_EMAIL ||
     ""
   ).trim();
+  if (cfEmail) return cfEmail;
+  if (env.TFHT_REVIEW_DEV_MODE && env.TFHT_REVIEW_DEV_EMAIL) {
+    return String(env.TFHT_REVIEW_DEV_EMAIL).trim();
+  }
+  return "";
 }
 
 export function parseAllowedEmails(env) {
@@ -215,7 +219,7 @@ export function requireReviewer(request, env) {
   if (!email) {
     return { ok: false, email: "", response: errorResponse("Cloudflare Access email is missing.", 401) };
   }
-  if (allowed.length > 0 && !allowed.includes(email)) {
+  if (allowed.length === 0 || !allowed.includes(email)) {
     return { ok: false, email, response: errorResponse("Reviewer email is not allowed.", 403) };
   }
   return { ok: true, email, response: null };
@@ -316,6 +320,8 @@ export function normalizeNewsItem(row) {
       rightsClass: row.rights_class || "",
       privacyRiskLevel: row.privacy_risk_level || "",
       manualStatus: row.manual_status || "",
+      manualEventLabel: row.manual_event_label || "",
+      manualCity: row.manual_city || "",
       manuallyReviewed: Boolean(row.manually_reviewed),
       annotationNotes: row.annotation_notes || "",
       organizations: row.organizations_mentioned || [],
@@ -476,8 +482,9 @@ function scoreItem({ text, confidence, status, basis, needsReview, sourceHints, 
     }
   }
 
-  if (confidence !== null && confidence !== undefined && confidence !== "" && Number.isFinite(Number(confidence))) {
-    const confidenceScore = Math.round(Number(confidence) * 20);
+  const resolvedConfidence = resolveConfidence(confidence);
+  if (resolvedConfidence !== null) {
+    const confidenceScore = Math.round(resolvedConfidence * 20);
     score += confidenceScore;
     reasons.push(`classifier confidence +${confidenceScore}`);
   }
@@ -508,8 +515,17 @@ function scoreItem({ text, confidence, status, basis, needsReview, sourceHints, 
   return { score, reasons: [...new Set(reasons)].slice(0, 8) };
 }
 
+function resolveConfidence(confidence) {
+  if (confidence === null || confidence === undefined || confidence === "") return null;
+  const CONFIDENCE_MAP = { high: 0.9, medium: 0.6, low: 0.3 };
+  const lc = String(confidence).toLowerCase();
+  if (lc in CONFIDENCE_MAP) return CONFIDENCE_MAP[lc];
+  const numeric = Number(confidence);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
 function isCompleted(item) {
-  return ["approved", "suppressed", "include", "exclude"].includes(item.publicationStatus);
+  return ["approved", "suppressed", "include", "exclude", "internal_only"].includes(item.publicationStatus);
 }
 
 function parseContentRangeCount(value) {

--- a/review_app/functions/_shared.js
+++ b/review_app/functions/_shared.js
@@ -444,17 +444,20 @@ export function parseReviewBody(rawBody) {
 
   const taxonomyCategoryId = cleanString(body.taxonomyCategoryId);
   const taxonomySubcategoryId = cleanString(body.taxonomySubcategoryId);
-  if (decision === "include" && !findTaxonomyPair(taxonomyCategoryId, taxonomySubcategoryId)) {
+  const taxonomyPair = findTaxonomyPair(taxonomyCategoryId, taxonomySubcategoryId);
+  if (decision === "include" && !taxonomyPair) {
     throw new Error("A valid taxonomy category and subcategory are required for include decisions.");
   }
+  const validCategoryId = taxonomyPair ? taxonomyCategoryId : "";
+  const validSubcategoryId = taxonomyPair ? taxonomySubcategoryId : "";
 
   return {
     itemType,
     id,
     decision,
-    taxonomyCategoryId,
-    taxonomySubcategoryId,
-    taxonomyVersion: taxonomyCategoryId && taxonomySubcategoryId ? TAXONOMY.version : "",
+    taxonomyCategoryId: validCategoryId,
+    taxonomySubcategoryId: validSubcategoryId,
+    taxonomyVersion: validCategoryId && validSubcategoryId ? TAXONOMY.version : "",
     indexRelevant: Boolean(body.indexRelevant),
     notes: cleanString(body.notes),
     manualEventLabel: cleanString(body.manualEventLabel),

--- a/review_app/functions/api/candidates.js
+++ b/review_app/functions/api/candidates.js
@@ -1,0 +1,127 @@
+import {
+  applyFilters,
+  errorResponse,
+  jsonResponse,
+  normalizeCandidate,
+  normalizeNewsItem,
+  parseLimit,
+  parseOffset,
+  requireReviewer,
+  sortItems,
+  supabaseFetch,
+} from "../_shared.js";
+
+const NEWS_SELECT = [
+  "id",
+  "source_name",
+  "source_domain",
+  "url",
+  "canonical_url",
+  "publication_datetime",
+  "retrieval_datetime",
+  "title",
+  "category",
+  "sub_category",
+  "summary_one_sentence",
+  "organizations_mentioned",
+  "topic_tags",
+  "rights_class",
+  "privacy_risk_level",
+  "review_status",
+  "publication_status",
+  "event_candidate_ids",
+  "classification_confidence",
+  "content_basis",
+  "record_confidence",
+  "taxonomy_version",
+  "taxonomy_category_id",
+  "taxonomy_subcategory_id",
+  "index_relevant",
+  "manual_status",
+  "manual_city",
+  "manual_event_label",
+  "manually_reviewed",
+  "annotation_notes",
+  "created_at",
+  "updated_at",
+].join(",");
+
+const CANDIDATE_SELECT = [
+  "candidate_id",
+  "canonical_url",
+  "current_url",
+  "domain",
+  "first_seen_at",
+  "last_seen_at",
+  "candidate_status",
+  "scrape_attempt_count",
+  "last_scrape_error_code",
+  "last_scrape_error_message",
+  "content_basis",
+  "needs_review",
+  "metadata",
+  "titles",
+  "snippets",
+  "discovered_via",
+  "discovery_queries",
+  "source_hints",
+].join(",");
+
+export async function onRequestGet({ request, env }) {
+  const reviewer = requireReviewer(request, env);
+  if (!reviewer.ok) return reviewer.response;
+
+  try {
+    const url = new URL(request.url);
+    const limit = parseLimit(url.searchParams.get("limit"));
+    const offset = parseOffset(url.searchParams.get("offset"));
+    const fetchLimit = Math.min(Math.max(limit * 2, 500), 1000);
+
+    const newsParams = new URLSearchParams({
+      select: NEWS_SELECT,
+      order: "publication_datetime.desc.nullslast,created_at.desc",
+      limit: String(Math.min(fetchLimit, 500)),
+    });
+    const candidateParams = new URLSearchParams({
+      select: CANDIDATE_SELECT,
+      order: "last_seen_at.desc.nullslast,first_seen_at.desc",
+      limit: String(fetchLimit),
+    });
+
+    const [newsResult, candidateResult] = await Promise.all([
+      supabaseFetch(env, "news_items", { params: newsParams }),
+      supabaseFetch(env, "persistent_candidates", { params: candidateParams }),
+    ]);
+
+    const newsItems = Array.isArray(newsResult.payload) ? newsResult.payload.map(normalizeNewsItem) : [];
+    const linkedCandidateIds = new Set(
+      (Array.isArray(newsResult.payload) ? newsResult.payload : [])
+        .flatMap((row) => (Array.isArray(row.event_candidate_ids) ? row.event_candidate_ids : []))
+        .filter(Boolean),
+    );
+    const candidates = (Array.isArray(candidateResult.payload) ? candidateResult.payload : [])
+      .filter((row) => !linkedCandidateIds.has(row.candidate_id))
+      .map(normalizeCandidate);
+
+    const allItems = sortItems(applyFilters([...newsItems, ...candidates], url.searchParams));
+    const pageItems = allItems.slice(offset, offset + limit);
+
+    return jsonResponse({
+      reviewer: reviewer.email,
+      offset,
+      limit,
+      returned: pageItems.length,
+      totalFiltered: allItems.length,
+      fetched: {
+        newsItems: newsItems.length,
+        candidates: candidates.length,
+        newsTotal: newsResult.count,
+        candidateTotal: candidateResult.count,
+      },
+      items: pageItems,
+      nextOffset: offset + pageItems.length < allItems.length ? offset + pageItems.length : null,
+    });
+  } catch (error) {
+    return errorResponse("Could not load review candidates.", 500, error.message);
+  }
+}

--- a/review_app/functions/api/me.js
+++ b/review_app/functions/api/me.js
@@ -1,0 +1,8 @@
+import { getAccessEmail, jsonResponse, parseAllowedEmails } from "../_shared.js";
+
+export async function onRequestGet({ request, env }) {
+  const email = getAccessEmail(request, env);
+  const allowedEmails = parseAllowedEmails(env);
+  const allowed = Boolean(email) && (allowedEmails.length === 0 || allowedEmails.includes(email.toLowerCase()));
+  return jsonResponse({ email, allowed });
+}

--- a/review_app/functions/api/review.js
+++ b/review_app/functions/api/review.js
@@ -1,0 +1,106 @@
+import {
+  errorResponse,
+  jsonResponse,
+  parseReviewBody,
+  requireReviewer,
+  supabaseFetch,
+} from "../_shared.js";
+
+export async function onRequestPost({ request, env }) {
+  const reviewer = requireReviewer(request, env);
+  if (!reviewer.ok) return reviewer.response;
+
+  try {
+    const review = parseReviewBody(await request.json());
+    if (review.itemType === "news_item") {
+      const result = await updateNewsItem(env, review, reviewer.email);
+      return jsonResponse({ ok: true, itemType: review.itemType, id: review.id, row: result });
+    }
+    const result = await updateCandidate(env, review, reviewer.email);
+    return jsonResponse({ ok: true, itemType: review.itemType, id: review.id, row: result });
+  } catch (error) {
+    return errorResponse("Could not save review.", 400, error.message);
+  }
+}
+
+async function updateNewsItem(env, review, reviewerEmail) {
+  const now = new Date().toISOString();
+  const patch = {
+    updated_at: now,
+    reviewed_at: now,
+    reviewer: reviewerEmail,
+    manually_reviewed: true,
+    manually_overridden: true,
+    annotation_source: "tfht_review_workbench",
+    annotation_notes: review.notes,
+    manual_event_label: review.manualEventLabel || null,
+    manual_city: review.manualCity || null,
+    manual_status: review.decision,
+    taxonomy_version: review.taxonomyVersion || null,
+    taxonomy_category_id: review.taxonomyCategoryId || null,
+    taxonomy_subcategory_id: review.taxonomySubcategoryId || null,
+    index_relevant: review.decision === "include" ? review.indexRelevant : false,
+  };
+  if (review.tags.length > 0) {
+    patch.topic_tags = review.tags;
+  }
+
+  if (review.decision === "include") {
+    patch.publication_status = "approved";
+    patch.review_status = "none";
+    patch.suppression_reason = null;
+  } else if (review.decision === "exclude") {
+    patch.publication_status = "suppressed";
+    patch.review_status = "none";
+    patch.suppression_reason = "review_app_rejected";
+  } else if (review.decision === "needs_review") {
+    patch.publication_status = "internal_only";
+    patch.review_status = "needs_fact_review";
+    patch.suppression_reason = "review_app_needs_review";
+  } else {
+    patch.publication_status = "internal_only";
+    patch.review_status = "none";
+    patch.suppression_reason = "review_app_internal_only";
+  }
+
+  const params = new URLSearchParams({ id: `eq.${review.id}` });
+  const response = await supabaseFetch(env, "news_items", { method: "PATCH", params, body: patch });
+  return Array.isArray(response.payload) ? response.payload[0] : response.payload;
+}
+
+async function updateCandidate(env, review, reviewerEmail) {
+  const readParams = new URLSearchParams({
+    select: "candidate_id,metadata",
+    candidate_id: `eq.${review.id}`,
+    limit: "1",
+  });
+  const existing = await supabaseFetch(env, "persistent_candidates", { params: readParams });
+  const row = Array.isArray(existing.payload) ? existing.payload[0] : null;
+  if (!row) throw new Error("Candidate was not found.");
+
+  const now = new Date().toISOString();
+  const metadata = {
+    ...(row.metadata || {}),
+    review_app_annotation: {
+      reviewedAt: now,
+      reviewer: reviewerEmail,
+      decision: review.decision,
+      taxonomyVersion: review.taxonomyVersion,
+      taxonomyCategoryId: review.taxonomyCategoryId,
+      taxonomySubcategoryId: review.taxonomySubcategoryId,
+      indexRelevant: review.decision === "include" ? review.indexRelevant : false,
+      notes: review.notes,
+      manualEventLabel: review.manualEventLabel,
+      manualCity: review.manualCity,
+      tags: review.tags,
+    },
+  };
+
+  const patch = {
+    metadata,
+    needs_review: review.decision === "needs_review",
+  };
+  const params = new URLSearchParams({ candidate_id: `eq.${review.id}` });
+  const response = await supabaseFetch(env, "persistent_candidates", { method: "PATCH", params, body: patch });
+  return Array.isArray(response.payload) ? response.payload[0] : response.payload;
+}

--- a/review_app/functions/api/review.js
+++ b/review_app/functions/api/review.js
@@ -35,15 +35,14 @@ async function updateNewsItem(env, review, reviewerEmail) {
     annotation_notes: review.notes,
     manual_event_label: review.manualEventLabel || null,
     manual_city: review.manualCity || null,
+    geography_city: review.manualCity || null,
     manual_status: review.manualEventLabel || null,
     taxonomy_version: review.taxonomyVersion || null,
     taxonomy_category_id: review.taxonomyCategoryId || null,
     taxonomy_subcategory_id: review.taxonomySubcategoryId || null,
     index_relevant: review.decision === "include" ? review.indexRelevant : false,
   };
-  if (review.tags.length > 0) {
-    patch.topic_tags = review.tags;
-  }
+  patch.topic_tags = review.tags;
 
   if (review.decision === "include") {
     patch.publication_status = "approved";
@@ -65,7 +64,9 @@ async function updateNewsItem(env, review, reviewerEmail) {
 
   const params = new URLSearchParams({ id: `eq.${review.id}` });
   const response = await supabaseFetch(env, "news_items", { method: "PATCH", params, body: patch });
-  return Array.isArray(response.payload) ? response.payload[0] : response.payload;
+  const row = Array.isArray(response.payload) ? response.payload[0] : null;
+  if (!row) throw new Error("News item was not found.");
+  return row;
 }
 
 async function updateCandidate(env, review, reviewerEmail) {

--- a/review_app/functions/api/review.js
+++ b/review_app/functions/api/review.js
@@ -35,7 +35,7 @@ async function updateNewsItem(env, review, reviewerEmail) {
     annotation_notes: review.notes,
     manual_event_label: review.manualEventLabel || null,
     manual_city: review.manualCity || null,
-    manual_status: review.decision,
+    manual_status: review.manualEventLabel || null,
     taxonomy_version: review.taxonomyVersion || null,
     taxonomy_category_id: review.taxonomyCategoryId || null,
     taxonomy_subcategory_id: review.taxonomySubcategoryId || null,

--- a/review_app/functions/api/taxonomy.js
+++ b/review_app/functions/api/taxonomy.js
@@ -1,0 +1,5 @@
+import { jsonResponse, TAXONOMY } from "../_shared.js";
+
+export async function onRequestGet() {
+  return jsonResponse(TAXONOMY);
+}

--- a/review_app/public/app.js
+++ b/review_app/public/app.js
@@ -7,6 +7,23 @@ const state = {
   theme: "day",
 };
 
+const WORKFLOW_TAGS = [
+  { id: "strong-positive", label: "Strong positive" },
+  { id: "weak-positive", label: "Weak positive" },
+  { id: "false-positive", label: "False positive" },
+  { id: "duplicate-risk", label: "Duplicate risk" },
+  { id: "needs-source-check", label: "Needs source check" },
+  { id: "needs-fact-check", label: "Needs fact check" },
+  { id: "needs-privacy-check", label: "Needs privacy check" },
+  { id: "paywall", label: "Paywall" },
+  { id: "partial-page", label: "Partial page" },
+  { id: "policy-context", label: "Policy context" },
+  { id: "court", label: "Court" },
+  { id: "police", label: "Police" },
+  { id: "welfare", label: "Welfare" },
+  { id: "reporting-context", label: "Reporting context" },
+];
+
 const els = {
   reviewerEmail: document.querySelector("#reviewerEmail"),
   syncState: document.querySelector("#syncState"),
@@ -35,7 +52,10 @@ const els = {
   indexRelevantInput: document.querySelector("#indexRelevantInput"),
   eventLabelInput: document.querySelector("#eventLabelInput"),
   cityInput: document.querySelector("#cityInput"),
-  tagsInput: document.querySelector("#tagsInput"),
+  tagOptions: document.querySelector("#tagOptions"),
+  customTagInput: document.querySelector("#customTagInput"),
+  addCustomTagButton: document.querySelector("#addCustomTagButton"),
+  selectedTags: document.querySelector("#selectedTags"),
   notesInput: document.querySelector("#notesInput"),
   saveButton: document.querySelector("#saveButton"),
   saveState: document.querySelector("#saveState"),
@@ -61,6 +81,13 @@ function bindEvents() {
   els.domainFilter.addEventListener("input", debounce(() => refresh(), 250));
   els.categorySelect.addEventListener("change", () => renderSubcategories());
   els.subcategorySelect.addEventListener("change", () => syncIndexRelevantFromSubcategory());
+  els.addCustomTagButton.addEventListener("click", () => addCustomTag());
+  els.customTagInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      addCustomTag();
+    }
+  });
   els.reviewForm.addEventListener("submit", saveReview);
 }
 
@@ -185,8 +212,47 @@ function renderDetail(item) {
   els.indexRelevantInput.checked = Boolean(item.indexRelevant);
   els.eventLabelInput.value = item.metadata?.annotation?.manualEventLabel || item.metadata?.manualStatus || "";
   els.cityInput.value = item.metadata?.annotation?.manualCity || "";
-  els.tagsInput.value = Array.isArray(item.metadata?.annotation?.tags) ? item.metadata.annotation.tags.join(", ") : "";
+  renderWorkflowTags(tagsFromItem(item));
   els.notesInput.value = item.metadata?.annotation?.notes || item.metadata?.annotationNotes || "";
+}
+
+function renderWorkflowTags(selected = []) {
+  const selectedSet = new Set(selected);
+  const standardTagIds = new Set(WORKFLOW_TAGS.map((tag) => tag.id));
+  const customTags = selected.filter((tag) => !standardTagIds.has(tag));
+  const allTags = [...WORKFLOW_TAGS, ...customTags.map((tag) => ({ id: tag, label: tag }))];
+  els.tagOptions.innerHTML = allTags
+    .map(
+      (tag) => `
+        <label class="tagOption">
+          <input type="checkbox" name="workflowTag" value="${escapeAttr(tag.id)}" ${selectedSet.has(tag.id) ? "checked" : ""} />
+          <span>${escapeHtml(tag.label)}</span>
+        </label>
+      `,
+    )
+    .join("");
+  els.customTagInput.value = "";
+  updateSelectedTagSummary();
+  els.tagOptions.querySelectorAll('input[name="workflowTag"]').forEach((input) => {
+    input.addEventListener("change", updateSelectedTagSummary);
+  });
+}
+
+function addCustomTag() {
+  const tag = normalizeTag(els.customTagInput.value);
+  if (!tag) return;
+  const selected = new Set(selectedWorkflowTags());
+  selected.add(tag);
+  renderWorkflowTags([...selected]);
+}
+
+function selectedWorkflowTags() {
+  return [...els.tagOptions.querySelectorAll('input[name="workflowTag"]:checked')].map((input) => input.value);
+}
+
+function updateSelectedTagSummary() {
+  const tags = selectedWorkflowTags();
+  els.selectedTags.textContent = tags.length > 0 ? `Selected: ${tags.join(", ")}` : "No workflow tags selected";
 }
 
 function renderTaxonomy() {
@@ -230,10 +296,7 @@ async function saveReview(event) {
     indexRelevant: els.indexRelevantInput.checked,
     manualEventLabel: els.eventLabelInput.value,
     manualCity: els.cityInput.value,
-    tags: els.tagsInput.value
-      .split(",")
-      .map((tag) => tag.trim())
-      .filter(Boolean),
+    tags: selectedWorkflowTags(),
     notes: els.notesInput.value,
   };
 
@@ -250,6 +313,12 @@ async function saveReview(event) {
   } finally {
     els.saveButton.disabled = false;
   }
+}
+
+function tagsFromItem(item) {
+  if (Array.isArray(item.metadata?.annotation?.tags)) return item.metadata.annotation.tags;
+  if (Array.isArray(item.metadata?.topicTags)) return item.metadata.topicTags;
+  return [];
 }
 
 function metaItems(item) {
@@ -330,6 +399,16 @@ function escapeHtml(value) {
 
 function escapeAttr(value) {
   return escapeHtml(value);
+}
+
+function normalizeTag(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replaceAll("_", "-")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
 }
 
 boot().catch((error) => {

--- a/review_app/public/app.js
+++ b/review_app/public/app.js
@@ -4,11 +4,13 @@ const state = {
   selected: null,
   nextOffset: 0,
   loading: false,
+  theme: "day",
 };
 
 const els = {
   reviewerEmail: document.querySelector("#reviewerEmail"),
   syncState: document.querySelector("#syncState"),
+  themeToggle: document.querySelector("#themeToggle"),
   searchInput: document.querySelector("#searchInput"),
   statusFilter: document.querySelector("#statusFilter"),
   domainFilter: document.querySelector("#domainFilter"),
@@ -40,6 +42,7 @@ const els = {
 };
 
 async function boot() {
+  initializeTheme();
   bindEvents();
   setSyncState("Loading");
   const [me, taxonomy] = await Promise.all([fetchJson("/api/me"), fetchJson("/api/taxonomy")]);
@@ -50,6 +53,7 @@ async function boot() {
 }
 
 function bindEvents() {
+  els.themeToggle.addEventListener("click", () => toggleTheme());
   els.refreshButton.addEventListener("click", () => refresh());
   els.loadMoreButton.addEventListener("click", () => loadCandidates({ append: true }));
   els.searchInput.addEventListener("input", debounce(() => refresh(), 250));
@@ -58,6 +62,26 @@ function bindEvents() {
   els.categorySelect.addEventListener("change", () => renderSubcategories());
   els.subcategorySelect.addEventListener("change", () => syncIndexRelevantFromSubcategory());
   els.reviewForm.addEventListener("submit", saveReview);
+}
+
+function initializeTheme() {
+  const storedTheme = window.localStorage.getItem("tfht-review-theme");
+  state.theme = storedTheme === "night" ? "night" : "day";
+  applyTheme();
+}
+
+function toggleTheme() {
+  state.theme = state.theme === "night" ? "day" : "night";
+  window.localStorage.setItem("tfht-review-theme", state.theme);
+  applyTheme();
+}
+
+function applyTheme() {
+  document.documentElement.dataset.theme = state.theme;
+  document.body.classList.toggle("theme-night", state.theme === "night");
+  document.body.classList.toggle("theme-day", state.theme !== "night");
+  els.themeToggle.setAttribute("aria-pressed", String(state.theme === "night"));
+  els.themeToggle.textContent = state.theme === "night" ? "Day mode" : "Night mode";
 }
 
 async function refresh() {

--- a/review_app/public/app.js
+++ b/review_app/public/app.js
@@ -1,0 +1,314 @@
+const state = {
+  taxonomy: null,
+  items: [],
+  selected: null,
+  nextOffset: 0,
+  loading: false,
+};
+
+const els = {
+  reviewerEmail: document.querySelector("#reviewerEmail"),
+  syncState: document.querySelector("#syncState"),
+  searchInput: document.querySelector("#searchInput"),
+  statusFilter: document.querySelector("#statusFilter"),
+  domainFilter: document.querySelector("#domainFilter"),
+  refreshButton: document.querySelector("#refreshButton"),
+  visibleCount: document.querySelector("#visibleCount"),
+  filteredCount: document.querySelector("#filteredCount"),
+  candidateCount: document.querySelector("#candidateCount"),
+  newsCount: document.querySelector("#newsCount"),
+  candidateList: document.querySelector("#candidateList"),
+  loadMoreButton: document.querySelector("#loadMoreButton"),
+  emptyState: document.querySelector("#emptyState"),
+  detailView: document.querySelector("#detailView"),
+  detailKind: document.querySelector("#detailKind"),
+  detailTitle: document.querySelector("#detailTitle"),
+  detailLink: document.querySelector("#detailLink"),
+  detailSnippet: document.querySelector("#detailSnippet"),
+  detailMeta: document.querySelector("#detailMeta"),
+  scoreReasons: document.querySelector("#scoreReasons"),
+  reviewForm: document.querySelector("#reviewForm"),
+  categorySelect: document.querySelector("#categorySelect"),
+  subcategorySelect: document.querySelector("#subcategorySelect"),
+  indexRelevantInput: document.querySelector("#indexRelevantInput"),
+  eventLabelInput: document.querySelector("#eventLabelInput"),
+  cityInput: document.querySelector("#cityInput"),
+  tagsInput: document.querySelector("#tagsInput"),
+  notesInput: document.querySelector("#notesInput"),
+  saveButton: document.querySelector("#saveButton"),
+  saveState: document.querySelector("#saveState"),
+};
+
+async function boot() {
+  bindEvents();
+  setSyncState("Loading");
+  const [me, taxonomy] = await Promise.all([fetchJson("/api/me"), fetchJson("/api/taxonomy")]);
+  els.reviewerEmail.textContent = me.email ? `${me.email}${me.allowed ? "" : " (not allowed)"}` : "No Access identity";
+  state.taxonomy = taxonomy;
+  renderTaxonomy();
+  await refresh();
+}
+
+function bindEvents() {
+  els.refreshButton.addEventListener("click", () => refresh());
+  els.loadMoreButton.addEventListener("click", () => loadCandidates({ append: true }));
+  els.searchInput.addEventListener("input", debounce(() => refresh(), 250));
+  els.statusFilter.addEventListener("change", () => refresh());
+  els.domainFilter.addEventListener("input", debounce(() => refresh(), 250));
+  els.categorySelect.addEventListener("change", () => renderSubcategories());
+  els.subcategorySelect.addEventListener("change", () => syncIndexRelevantFromSubcategory());
+  els.reviewForm.addEventListener("submit", saveReview);
+}
+
+async function refresh() {
+  state.items = [];
+  state.selected = null;
+  state.nextOffset = 0;
+  renderList();
+  renderDetail(null);
+  await loadCandidates({ append: false });
+}
+
+async function loadCandidates({ append }) {
+  if (state.loading) return;
+  state.loading = true;
+  setSyncState("Loading");
+  els.loadMoreButton.disabled = true;
+
+  const params = new URLSearchParams({
+    limit: "250",
+    offset: String(append ? state.nextOffset || 0 : 0),
+    status: els.statusFilter.value,
+    q: els.searchInput.value,
+    domain: els.domainFilter.value,
+  });
+  try {
+    const payload = await fetchJson(`/api/candidates?${params.toString()}`);
+    state.items = append ? [...state.items, ...payload.items] : payload.items;
+    state.nextOffset = payload.nextOffset;
+    renderList();
+    renderSummary(payload);
+    setSyncState("Ready");
+  } catch (error) {
+    setSyncState("Error");
+    els.candidateList.innerHTML = `<p class="emptyState">${escapeHtml(error.message)}</p>`;
+  } finally {
+    state.loading = false;
+    els.loadMoreButton.disabled = false;
+  }
+}
+
+function renderSummary(payload) {
+  els.visibleCount.textContent = state.items.length;
+  els.filteredCount.textContent = payload.totalFiltered;
+  els.candidateCount.textContent = payload.fetched.candidates;
+  els.newsCount.textContent = payload.fetched.newsItems;
+  els.loadMoreButton.hidden = payload.nextOffset === null;
+}
+
+function renderList() {
+  if (state.items.length === 0) {
+    els.candidateList.innerHTML = '<p class="emptyState">No rows loaded.</p>';
+    return;
+  }
+  els.candidateList.innerHTML = "";
+  for (const item of state.items) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `candidateCard${state.selected?.id === item.id ? " active" : ""}`;
+    button.innerHTML = `
+      <div class="cardLine">
+        <span class="pill score">Score ${item.score}</span>
+        <span class="pill">${escapeHtml(labelForKind(item.itemType))}</span>
+        ${statusPill(item)}
+      </div>
+      <h3>${escapeHtml(item.title)}</h3>
+      <div class="cardMeta">
+        <span class="pill">${escapeHtml(item.sourceDomain || "unknown source")}</span>
+        <span class="pill">${escapeHtml(formatDate(item.publicationDatetime))}</span>
+      </div>
+    `;
+    button.addEventListener("click", () => {
+      state.selected = item;
+      renderList();
+      renderDetail(item);
+    });
+    els.candidateList.appendChild(button);
+  }
+}
+
+function renderDetail(item) {
+  if (!item) {
+    els.emptyState.hidden = false;
+    els.detailView.hidden = true;
+    return;
+  }
+  els.emptyState.hidden = true;
+  els.detailView.hidden = false;
+  els.saveState.textContent = "";
+  els.detailKind.textContent = `${labelForKind(item.itemType)} · ${item.sourceDomain || "unknown source"}`;
+  els.detailTitle.textContent = item.title;
+  els.detailLink.href = item.url || "#";
+  els.detailSnippet.textContent = item.snippet || "No snippet or summary is available.";
+  els.detailMeta.innerHTML = metaItems(item)
+    .map((entry) => `<div class="metaItem"><span>${escapeHtml(entry.label)}</span><strong>${escapeHtml(entry.value)}</strong></div>`)
+    .join("");
+  els.scoreReasons.innerHTML = item.scoreReasons.map((reason) => `<span class="pill">${escapeHtml(reason)}</span>`).join("");
+
+  selectRadio("decision", decisionFromItem(item));
+  els.categorySelect.value = item.taxonomyCategoryId || state.taxonomy.categories[0].id;
+  renderSubcategories(item.taxonomySubcategoryId);
+  els.indexRelevantInput.checked = Boolean(item.indexRelevant);
+  els.eventLabelInput.value = item.metadata?.annotation?.manualEventLabel || item.metadata?.manualStatus || "";
+  els.cityInput.value = item.metadata?.annotation?.manualCity || "";
+  els.tagsInput.value = Array.isArray(item.metadata?.annotation?.tags) ? item.metadata.annotation.tags.join(", ") : "";
+  els.notesInput.value = item.metadata?.annotation?.notes || item.metadata?.annotationNotes || "";
+}
+
+function renderTaxonomy() {
+  els.categorySelect.innerHTML = state.taxonomy.categories
+    .map((category) => `<option value="${escapeAttr(category.id)}">${escapeHtml(category.labelEn)} · ${escapeHtml(category.labelHe)}</option>`)
+    .join("");
+  renderSubcategories();
+}
+
+function renderSubcategories(selectedId = "") {
+  const category = state.taxonomy.categories.find((entry) => entry.id === els.categorySelect.value) || state.taxonomy.categories[0];
+  els.subcategorySelect.innerHTML = category.subcategories
+    .map(
+      (subcategory) =>
+        `<option value="${escapeAttr(subcategory.id)}">${escapeHtml(subcategory.labelEn)} · ${escapeHtml(subcategory.labelHe)}</option>`,
+    )
+    .join("");
+  if (selectedId && category.subcategories.some((entry) => entry.id === selectedId)) {
+    els.subcategorySelect.value = selectedId;
+  }
+  syncIndexRelevantFromSubcategory();
+}
+
+function syncIndexRelevantFromSubcategory() {
+  const category = state.taxonomy.categories.find((entry) => entry.id === els.categorySelect.value);
+  const subcategory = category?.subcategories.find((entry) => entry.id === els.subcategorySelect.value);
+  els.indexRelevantInput.checked = Boolean(subcategory?.indexRelevant);
+}
+
+async function saveReview(event) {
+  event.preventDefault();
+  if (!state.selected) return;
+  els.saveButton.disabled = true;
+  els.saveState.textContent = "Saving...";
+  const body = {
+    itemType: state.selected.itemType,
+    id: state.selected.id,
+    decision: selectedRadio("decision"),
+    taxonomyCategoryId: els.categorySelect.value,
+    taxonomySubcategoryId: els.subcategorySelect.value,
+    indexRelevant: els.indexRelevantInput.checked,
+    manualEventLabel: els.eventLabelInput.value,
+    manualCity: els.cityInput.value,
+    tags: els.tagsInput.value
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+    notes: els.notesInput.value,
+  };
+
+  try {
+    await fetchJson("/api/review", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    els.saveState.textContent = "Saved";
+    await refresh();
+  } catch (error) {
+    els.saveState.textContent = error.message;
+  } finally {
+    els.saveButton.disabled = false;
+  }
+}
+
+function metaItems(item) {
+  return [
+    { label: "URL", value: item.url || "" },
+    { label: "Publication date", value: formatDate(item.publicationDatetime) },
+    { label: "Publication status", value: item.publicationStatus || "none" },
+    { label: "Review status", value: item.reviewStatus || "none" },
+    { label: "Content basis", value: item.contentBasis || "unknown" },
+    { label: "Confidence", value: item.confidence ?? "none" },
+    { label: "Taxonomy", value: [item.taxonomyCategoryId, item.taxonomySubcategoryId].filter(Boolean).join(" / ") || "none" },
+    { label: "Candidate status", value: item.candidateStatus || "none" },
+  ];
+}
+
+function decisionFromItem(item) {
+  if (item.publicationStatus === "approved" || item.publicationStatus === "include") return "include";
+  if (item.publicationStatus === "suppressed" || item.publicationStatus === "exclude") return "exclude";
+  if (item.reviewStatus && item.reviewStatus !== "none") return "needs_review";
+  return "include";
+}
+
+function statusPill(item) {
+  const status = item.publicationStatus || item.reviewStatus || item.candidateStatus || "pending";
+  const className = ["suppressed", "exclude"].includes(status) ? "danger" : item.reviewStatus ? "warning" : "";
+  return `<span class="pill ${className}">${escapeHtml(status)}</span>`;
+}
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload.details || payload.error || `${response.status} ${response.statusText}`);
+  }
+  return payload;
+}
+
+function setSyncState(value) {
+  els.syncState.textContent = value;
+}
+
+function selectedRadio(name) {
+  return document.querySelector(`input[name="${name}"]:checked`)?.value || "";
+}
+
+function selectRadio(name, value) {
+  const input = document.querySelector(`input[name="${name}"][value="${value}"]`);
+  if (input) input.checked = true;
+}
+
+function labelForKind(kind) {
+  return kind === "news_item" ? "news item" : "candidate";
+}
+
+function formatDate(value) {
+  if (!value) return "undated";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString().slice(0, 10);
+}
+
+function debounce(fn, wait) {
+  let timeout = null;
+  return (...args) => {
+    window.clearTimeout(timeout);
+    timeout = window.setTimeout(() => fn(...args), wait);
+  };
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value);
+}
+
+boot().catch((error) => {
+  setSyncState("Error");
+  els.candidateList.innerHTML = `<p class="emptyState">${escapeHtml(error.message)}</p>`;
+});

--- a/review_app/public/app.js
+++ b/review_app/public/app.js
@@ -210,8 +210,9 @@ function renderDetail(item) {
   els.categorySelect.value = item.taxonomyCategoryId || state.taxonomy.categories[0].id;
   renderSubcategories(item.taxonomySubcategoryId);
   els.indexRelevantInput.checked = Boolean(item.indexRelevant);
-  els.eventLabelInput.value = item.metadata?.annotation?.manualEventLabel || item.metadata?.manualStatus || "";
-  els.cityInput.value = item.metadata?.annotation?.manualCity || "";
+  els.eventLabelInput.value =
+    item.metadata?.annotation?.manualEventLabel ?? item.metadata?.manualEventLabel ?? item.metadata?.manualStatus ?? "";
+  els.cityInput.value = item.metadata?.annotation?.manualCity ?? item.metadata?.manualCity ?? "";
   renderWorkflowTags(tagsFromItem(item));
   els.notesInput.value = item.metadata?.annotation?.notes || item.metadata?.annotationNotes || "";
 }
@@ -337,13 +338,15 @@ function metaItems(item) {
 function decisionFromItem(item) {
   if (item.publicationStatus === "approved" || item.publicationStatus === "include") return "include";
   if (item.publicationStatus === "suppressed" || item.publicationStatus === "exclude") return "exclude";
+  if (item.publicationStatus === "internal_only") return "internal_only";
   if (item.reviewStatus && item.reviewStatus !== "none") return "needs_review";
   return "include";
 }
 
 function statusPill(item) {
   const status = item.publicationStatus || item.reviewStatus || item.candidateStatus || "pending";
-  const className = ["suppressed", "exclude"].includes(status) ? "danger" : item.reviewStatus ? "warning" : "";
+  const needsReview = item.reviewStatus && item.reviewStatus !== "none";
+  const className = ["suppressed", "exclude"].includes(status) ? "danger" : needsReview ? "warning" : "";
   return `<span class="pill ${className}">${escapeHtml(status)}</span>`;
 }
 

--- a/review_app/public/app.js
+++ b/review_app/public/app.js
@@ -209,7 +209,9 @@ function renderDetail(item) {
   selectRadio("decision", decisionFromItem(item));
   els.categorySelect.value = item.taxonomyCategoryId || state.taxonomy.categories[0].id;
   renderSubcategories(item.taxonomySubcategoryId);
-  els.indexRelevantInput.checked = Boolean(item.indexRelevant);
+  if (item.taxonomyCategoryId) {
+    els.indexRelevantInput.checked = Boolean(item.indexRelevant);
+  }
   els.eventLabelInput.value =
     item.metadata?.annotation?.manualEventLabel ?? item.metadata?.manualEventLabel ?? item.metadata?.manualStatus ?? "";
   els.cityInput.value = item.metadata?.annotation?.manualCity ?? item.metadata?.manualCity ?? "";
@@ -288,12 +290,13 @@ async function saveReview(event) {
   if (!state.selected) return;
   els.saveButton.disabled = true;
   els.saveState.textContent = "Saving...";
+  const decision = selectedRadio("decision");
   const body = {
     itemType: state.selected.itemType,
     id: state.selected.id,
-    decision: selectedRadio("decision"),
-    taxonomyCategoryId: els.categorySelect.value,
-    taxonomySubcategoryId: els.subcategorySelect.value,
+    decision,
+    taxonomyCategoryId: decision === "include" ? els.categorySelect.value : "",
+    taxonomySubcategoryId: decision === "include" ? els.subcategorySelect.value : "",
     indexRelevant: els.indexRelevantInput.checked,
     manualEventLabel: els.eventLabelInput.value,
     manualCity: els.cityInput.value,

--- a/review_app/public/index.html
+++ b/review_app/public/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TFHT Review Workbench</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">DenBust News</p>
+        <h1>TFHT Review Workbench</h1>
+      </div>
+      <div class="userbox">
+        <span id="reviewerEmail">Checking access...</span>
+        <span id="syncState" class="state">Loading</span>
+      </div>
+    </header>
+
+    <main class="shell">
+      <section class="filters" aria-label="Candidate filters">
+        <label>
+          Search
+          <input id="searchInput" type="search" placeholder="Title, URL, source, taxonomy..." />
+        </label>
+        <label>
+          Status
+          <select id="statusFilter">
+            <option value="pending">Pending review</option>
+            <option value="all">All fetched</option>
+            <option value="candidate_only">Discovery candidates</option>
+            <option value="news_items">Materialized news items</option>
+            <option value="approved">Approved</option>
+            <option value="suppressed">Suppressed</option>
+          </select>
+        </label>
+        <label>
+          Domain
+          <input id="domainFilter" type="search" placeholder="mako.co.il" />
+        </label>
+        <button id="refreshButton" type="button">Refresh</button>
+      </section>
+
+      <section class="summary" aria-label="Review summary">
+        <div><strong id="visibleCount">0</strong><span>shown</span></div>
+        <div><strong id="filteredCount">0</strong><span>matching</span></div>
+        <div><strong id="candidateCount">0</strong><span>candidates fetched</span></div>
+        <div><strong id="newsCount">0</strong><span>news rows fetched</span></div>
+      </section>
+
+      <section class="workspace">
+        <aside class="listPane" aria-label="Candidate list">
+          <div id="candidateList" class="candidateList"></div>
+          <button id="loadMoreButton" class="loadMore" type="button" hidden>Load more</button>
+        </aside>
+
+        <section class="detailPane" aria-label="Review details">
+          <div id="emptyState" class="emptyState">
+            <h2>Select a candidate</h2>
+            <p>Rows are sorted by the app's current likelihood score, strongest review candidates first.</p>
+          </div>
+
+          <article id="detailView" class="detailView" hidden>
+            <div class="detailHeader">
+              <div>
+                <p id="detailKind" class="eyebrow"></p>
+                <h2 id="detailTitle"></h2>
+              </div>
+              <a id="detailLink" class="sourceLink" href="#" target="_blank" rel="noreferrer">Open source</a>
+            </div>
+
+            <p id="detailSnippet" class="snippet"></p>
+            <div id="detailMeta" class="metaGrid"></div>
+            <div id="scoreReasons" class="chips"></div>
+
+            <form id="reviewForm" class="reviewForm">
+              <fieldset>
+                <legend>Decision</legend>
+                <div class="decisionGrid">
+                  <label><input type="radio" name="decision" value="include" checked /> Include</label>
+                  <label><input type="radio" name="decision" value="needs_review" /> Needs review</label>
+                  <label><input type="radio" name="decision" value="exclude" /> Exclude</label>
+                  <label><input type="radio" name="decision" value="internal_only" /> Internal only</label>
+                </div>
+              </fieldset>
+
+              <div class="taxonomyGrid">
+                <label>
+                  Category
+                  <select id="categorySelect"></select>
+                </label>
+                <label>
+                  Subcategory
+                  <select id="subcategorySelect"></select>
+                </label>
+                <label class="checkLabel">
+                  <input id="indexRelevantInput" type="checkbox" />
+                  Index relevant
+                </label>
+              </div>
+
+              <div class="fieldGrid">
+                <label>
+                  Event label
+                  <input id="eventLabelInput" type="text" placeholder="Short internal label" />
+                </label>
+                <label>
+                  City
+                  <input id="cityInput" type="text" placeholder="Optional city" />
+                </label>
+              </div>
+
+              <label>
+                Tags
+                <input id="tagsInput" type="text" placeholder="comma-separated operational tags" />
+              </label>
+
+              <label>
+                Review notes
+                <textarea id="notesInput" rows="4" placeholder="Why this belongs, why it does not, or what needs checking"></textarea>
+              </label>
+
+              <div class="actions">
+                <button id="saveButton" type="submit">Save review</button>
+                <span id="saveState" class="saveState"></span>
+              </div>
+            </form>
+          </article>
+        </section>
+      </section>
+    </main>
+
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/review_app/public/index.html
+++ b/review_app/public/index.html
@@ -4,6 +4,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TFHT Review Workbench</title>
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("tfht-review-theme");
+        const theme = storedTheme === "night" ? "night" : "day";
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -13,6 +20,7 @@
         <h1>TFHT Review Workbench</h1>
       </div>
       <div class="userbox">
+        <button id="themeToggle" class="themeToggle" type="button" aria-pressed="false">Night mode</button>
         <span id="reviewerEmail">Checking access...</span>
         <span id="syncState" class="state">Loading</span>
       </div>

--- a/review_app/public/index.html
+++ b/review_app/public/index.html
@@ -110,8 +110,8 @@
 
               <div class="fieldGrid">
                 <label>
-                  Event label
-                  <input id="eventLabelInput" type="text" placeholder="Short internal label" />
+                  Case / event label
+                  <input id="eventLabelInput" type="text" placeholder="Short unique case name" />
                 </label>
                 <label>
                   City
@@ -119,10 +119,15 @@
                 </label>
               </div>
 
-              <label>
-                Tags
-                <input id="tagsInput" type="text" placeholder="comma-separated operational tags" />
-              </label>
+              <fieldset class="tagFieldset">
+                <legend>Workflow tags</legend>
+                <div id="tagOptions" class="tagOptions"></div>
+                <div class="customTagRow">
+                  <input id="customTagInput" type="text" placeholder="Add custom tag after reviewing the list" />
+                  <button id="addCustomTagButton" type="button">Add tag</button>
+                </div>
+                <div id="selectedTags" class="selectedTags" aria-live="polite"></div>
+              </fieldset>
 
               <label>
                 Review notes

--- a/review_app/public/styles.css
+++ b/review_app/public/styles.css
@@ -1,0 +1,422 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f6f4;
+  --panel: #ffffff;
+  --panel-strong: #f0f2ee;
+  --text: #1e2524;
+  --muted: #69736f;
+  --line: #d8ded9;
+  --accent: #0f766e;
+  --accent-strong: #0b5f59;
+  --danger: #a43b33;
+  --warning: #a16312;
+  --shadow: 0 10px 32px rgba(20, 35, 30, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.topbar {
+  min-height: 88px;
+  padding: 18px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  background: #17201d;
+  color: #fff;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.topbar h1,
+.detailPane h2,
+.emptyState h2 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #8fb9ac;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.userbox {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #dce5e1;
+  font-size: 13px;
+}
+
+.state,
+.saveState {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.state {
+  min-width: 72px;
+  padding: 5px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  color: #dce5e1;
+  text-align: center;
+}
+
+.shell {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 22px 24px 32px;
+}
+
+.filters,
+.summary,
+.workspace {
+  display: grid;
+  gap: 14px;
+}
+
+.filters {
+  grid-template-columns: minmax(240px, 1fr) 180px minmax(180px, 240px) 110px;
+  align-items: end;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--text);
+  padding: 10px 11px;
+  outline: none;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.14);
+}
+
+button {
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  min-height: 40px;
+  padding: 9px 14px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+button:hover {
+  background: var(--accent-strong);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.summary {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 18px 0;
+}
+
+.summary div {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+
+.summary strong {
+  display: block;
+  font-size: 26px;
+}
+
+.summary span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.workspace {
+  grid-template-columns: minmax(360px, 42%) minmax(0, 1fr);
+  align-items: start;
+}
+
+.listPane,
+.detailPane {
+  min-height: calc(100vh - 245px);
+}
+
+.candidateList {
+  display: grid;
+  gap: 10px;
+}
+
+.candidateCard {
+  width: 100%;
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 13px;
+  box-shadow: none;
+  text-align: left;
+  color: var(--text);
+}
+
+.candidateCard:hover,
+.candidateCard.active {
+  border-color: var(--accent);
+  background: #fbfdfc;
+}
+
+.candidateCard h3 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.cardLine,
+.cardMeta,
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-strong);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.pill.score {
+  background: #d9f3ef;
+  color: #06544d;
+  border-color: #b5dcd5;
+}
+
+.pill.warning {
+  background: #fff4df;
+  color: var(--warning);
+  border-color: #f1d4a7;
+}
+
+.pill.danger {
+  background: #fdecea;
+  color: var(--danger);
+  border-color: #efc0bc;
+}
+
+.detailPane {
+  position: sticky;
+  top: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.emptyState {
+  padding: 34px;
+  color: var(--muted);
+}
+
+.detailView {
+  padding: 24px;
+}
+
+.detailHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+
+.sourceLink {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.sourceLink:hover {
+  text-decoration: underline;
+}
+
+.snippet {
+  color: #34403c;
+  line-height: 1.55;
+  margin: 16px 0;
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 16px 0;
+}
+
+.metaItem {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px;
+  background: #fafbf9;
+}
+
+.metaItem span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.metaItem strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.reviewForm {
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+}
+
+fieldset {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 0;
+}
+
+legend {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.decisionGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.decisionGrid label,
+.checkLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  background: #fff;
+}
+
+.decisionGrid input,
+.checkLabel input {
+  width: auto;
+}
+
+.taxonomyGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr) 160px;
+  gap: 12px;
+  align-items: end;
+}
+
+.fieldGrid {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+  gap: 12px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.loadMore {
+  width: 100%;
+  margin-top: 12px;
+  background: #26332f;
+}
+
+@media (max-width: 980px) {
+  .topbar,
+  .detailHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filters,
+  .summary,
+  .workspace,
+  .taxonomyGrid,
+  .fieldGrid,
+  .decisionGrid,
+  .metaGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .detailPane {
+    position: static;
+  }
+}

--- a/review_app/public/styles.css
+++ b/review_app/public/styles.css
@@ -314,6 +314,8 @@ button:disabled {
 .detailPane {
   position: sticky;
   top: 18px;
+  max-height: calc(100vh - 36px);
+  overflow: auto;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--panel);
@@ -409,7 +411,8 @@ legend {
 }
 
 .decisionGrid label,
-.checkLabel {
+.checkLabel,
+.tagOption {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -422,8 +425,39 @@ legend {
 }
 
 .decisionGrid input,
-.checkLabel input {
+.checkLabel input,
+.tagOption input {
   width: auto;
+}
+
+.tagFieldset {
+  display: grid;
+  gap: 12px;
+}
+
+.tagOptions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.tagOption {
+  min-height: 34px;
+  padding: 7px 9px;
+  font-size: 12px;
+}
+
+.customTagRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 110px;
+  gap: 10px;
+}
+
+.selectedTags {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
 }
 
 .taxonomyGrid {
@@ -464,6 +498,8 @@ legend {
   .taxonomyGrid,
   .fieldGrid,
   .decisionGrid,
+  .tagOptions,
+  .customTagRow,
   .metaGrid {
     grid-template-columns: 1fr;
   }

--- a/review_app/public/styles.css
+++ b/review_app/public/styles.css
@@ -3,6 +3,10 @@
   --bg: #f5f6f4;
   --panel: #ffffff;
   --panel-strong: #f0f2ee;
+  --panel-hover: #fbfdfc;
+  --field-bg: #ffffff;
+  --topbar-bg: #17201d;
+  --topbar-text: #ffffff;
   --text: #1e2524;
   --muted: #69736f;
   --line: #d8ded9;
@@ -11,6 +15,41 @@
   --danger: #a43b33;
   --warning: #a16312;
   --shadow: 0 10px 32px rgba(20, 35, 30, 0.08);
+  --snippet: #34403c;
+  --score-bg: #d9f3ef;
+  --score-text: #06544d;
+  --score-line: #b5dcd5;
+  --warning-bg: #fff4df;
+  --warning-line: #f1d4a7;
+  --danger-bg: #fdecea;
+  --danger-line: #efc0bc;
+}
+
+:root[data-theme="night"] {
+  color-scheme: dark;
+  --bg: #101815;
+  --panel: #17211d;
+  --panel-strong: #202c27;
+  --panel-hover: #1b2924;
+  --field-bg: #111b17;
+  --topbar-bg: #0b1210;
+  --topbar-text: #edf7f3;
+  --text: #edf7f3;
+  --muted: #a4b7af;
+  --line: #34423c;
+  --accent: #40c4b3;
+  --accent-strong: #62d8c9;
+  --danger: #ffb0a8;
+  --warning: #ffd38c;
+  --shadow: 0 12px 36px rgba(0, 0, 0, 0.32);
+  --snippet: #cbd9d4;
+  --score-bg: #123f38;
+  --score-text: #9cf0df;
+  --score-line: #23695e;
+  --warning-bg: #3c2d14;
+  --warning-line: #735526;
+  --danger-bg: #44201e;
+  --danger-line: #7a3934;
 }
 
 * {
@@ -41,7 +80,8 @@ textarea {
   justify-content: space-between;
   gap: 24px;
   background: #17201d;
-  color: #fff;
+  background: var(--topbar-bg);
+  color: var(--topbar-text);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
@@ -68,6 +108,18 @@ textarea {
   gap: 12px;
   color: #dce5e1;
   font-size: 13px;
+}
+
+.themeToggle {
+  min-height: 32px;
+  padding: 5px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--topbar-text);
+}
+
+.themeToggle:hover {
+  background: rgba(255, 255, 255, 0.16);
 }
 
 .state,
@@ -119,7 +171,7 @@ textarea {
   width: 100%;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #fff;
+  background: var(--field-bg);
   color: var(--text);
   padding: 10px 11px;
   outline: none;
@@ -210,7 +262,7 @@ button:disabled {
 .candidateCard:hover,
 .candidateCard.active {
   border-color: var(--accent);
-  background: #fbfdfc;
+  background: var(--panel-hover);
 }
 
 .candidateCard h3 {
@@ -242,21 +294,21 @@ button:disabled {
 }
 
 .pill.score {
-  background: #d9f3ef;
-  color: #06544d;
-  border-color: #b5dcd5;
+  background: var(--score-bg);
+  color: var(--score-text);
+  border-color: var(--score-line);
 }
 
 .pill.warning {
-  background: #fff4df;
+  background: var(--warning-bg);
   color: var(--warning);
-  border-color: #f1d4a7;
+  border-color: var(--warning-line);
 }
 
 .pill.danger {
-  background: #fdecea;
+  background: var(--danger-bg);
   color: var(--danger);
-  border-color: #efc0bc;
+  border-color: var(--danger-line);
 }
 
 .detailPane {
@@ -296,7 +348,7 @@ button:disabled {
 }
 
 .snippet {
-  color: #34403c;
+  color: var(--snippet);
   line-height: 1.55;
   margin: 16px 0;
 }
@@ -312,7 +364,7 @@ button:disabled {
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 10px;
-  background: #fafbf9;
+  background: var(--panel-strong);
 }
 
 .metaItem span {
@@ -366,7 +418,7 @@ legend {
   border: 1px solid var(--line);
   border-radius: 6px;
   color: var(--text);
-  background: #fff;
+  background: var(--field-bg);
 }
 
 .decisionGrid input,

--- a/review_app/wrangler.toml
+++ b/review_app/wrangler.toml
@@ -1,0 +1,3 @@
+name = "tfht-review-workbench"
+pages_build_output_dir = "public"
+compatibility_date = "2026-05-14"


### PR DESCRIPTION
## Summary

Builds the first Cloudflare Pages version of the TFHT Review Workbench: a protected operational GUI for reviewing existing Supabase `news_items` rows and discovery-only `persistent_candidates` rows.

## What changed

- Adds `review_app/` with a static review UI and Cloudflare Pages Functions API.
- Reads Supabase `news_items` and `persistent_candidates` through server-side Pages Functions using the existing service-role secret boundary.
- Sorts fetched review rows by a bounded likelihood score using visible title/snippet/source signals, classifier confidence where present, review status, and repeated discovery signals.
- Lets authorized reviewers save include / exclude / needs-review / internal-only decisions.
- Writes materialized `news_items` decisions to existing annotation, taxonomy, publication, and review-status fields.
- Writes discovery-only candidate decisions under `persistent_candidates.metadata.review_app_annotation` without changing scrape queue fairness or source prioritization.
- Includes the Phase C taxonomy options directly in the app and documents the Cloudflare Pages setup.

## Deployment state

- Cloudflare Pages project: `tfht-review-workbench`
- Production URL: https://tfht-review-workbench.pages.dev/
- Access protection: enabled for production and wildcard preview hostnames.
- Current allow-list: `shaypal5@gmail.com`
- Required Pages secrets are set in Cloudflare, not committed.

## Deliberately out of scope

- No public release publishing from the GUI.
- No discovery, scraping, classifier, queue-priority, or source-routing changes.
- No schema migration; this uses existing operational columns and JSON metadata.
- No bulk approval workflow yet; this first version is per-row review.

## Validation

- `node --check review_app/public/app.js`
- `node --check review_app/functions/_shared.js`
- `node --check review_app/functions/api/candidates.js`
- `node --check review_app/functions/api/review.js`
- `node --check review_app/functions/api/me.js`
- `node --check review_app/functions/api/taxonomy.js`
- `.venv/bin/python scripts/validate_agent_plan.py`
- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/`
- Local `wrangler pages dev` smoke against live Supabase: loaded 250 of 510 filtered rows from 15 `news_items` and 500 fetched candidates, with Supabase reporting 7,692 total candidates.
- Production unauthenticated smoke: `curl -I https://tfht-review-workbench.pages.dev/` returns `HTTP/2 302` to Cloudflare Access.
