### PR TITLE
docs(plan): update plan post PR #138 review workbench merge

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,13 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `BACKFILL-PR-2026-RELEASE-DAILY-ONLINE` added the broad 2026 backfill
-  run plan, a budget-guarded backfill/release harness, Brave-only source-targeted scheduled
-  discovery config, release no-publication controls, Supabase schema/persistence hardening, and a
-  partial 2026-01-01 through 2026-03-25 run report that stopped on an external Anthropic workspace
-  API usage limit before release generation.
+- Last merged PR on main: `REVIEW-APP-PHASE-C-WORKBENCH` (PR #138) shipped the TFHT review
+  workbench — a Cloudflare Pages app backed by Supabase for reviewing `persistent_candidates` and
+  materialized `news_items` rows. Includes Copilot-review security and data-integrity fixes: fail-
+  closed allow-list auth, dev-email bypass gated behind `TFHT_REVIEW_DEV_MODE`, geography_city
+  sync with manual_city, always-write topic_tags, internal_only round-trip, string confidence
+  scoring, taxonomy-only-for-include, indexRelevant defaulting, not-found PATCH detection, and
+  README cleanup.
 - Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should resume the 2026 backfill from the
   first incomplete window after classifier quota or credentials are restored, then build the
   no-publication release bundle if the resumed run completes.
@@ -172,6 +174,9 @@
   Brave discovery config, Supabase schema/persistence hardening, documentation, and a partial
   2026-01-01 through 2026-03-25 run report that records the Anthropic quota blocker before public
   release generation.
+- [done] `REVIEW-APP-PHASE-C-WORKBENCH`: Cloudflare Pages review workbench for `persistent_candidates`
+  and `news_items` with Phase C taxonomy, index-relevance, case/event labeling, workflow tags, night
+  mode, and Copilot-review security/data-integrity hardening.
 - [next] `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: after Anthropic quota or replacement credentials
   are available, resume from the first incomplete window, finish the 2026-01-01 through 2026-05-15
   backfill, run the no-publication release bundle, and produce a final publication go/no-go report.


### PR DESCRIPTION
Updates `.agent-plan.md` to reflect the squash-merge of PR #138 (TFHT review workbench).

- Updates `Last merged PR on main` to reference #138 and summarize its scope
- Adds a `[done]` entry for `REVIEW-APP-PHASE-C-WORKBENCH`
- Keeps `[next]` as `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` (unchanged)