### PR TITLE
feat(discovery): exclude sport1.maariv.co.il — 3-layer off-topic domain filter

### DIFF
--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -34,10 +34,9 @@ from denbust.taxonomy import default_taxonomy
 _SEARCH_ENGINE_NAMES: tuple[str, ...] = ("brave", "exa", "google_cse")
 _SOURCE_SUGGESTION_EXCLUDED_DOMAINS: frozenset[str] = frozenset({"facebook.com"})
 _SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS: dict[str, tuple[str, str]] = {
-    "sport1.maariv.co.il": (
-        "sports_vertical_candidate_only",
-        "candidate-only sports-vertical pressure; keep scrape-eligible until attempted evidence exists",
-    )
+    # sport1.maariv.co.il was here; it is now in candidate_filters._IRRELEVANT_CONTENT_DOMAINS
+    # and excluded from all broad/taxonomy search queries. Remove diagnostic tracking once
+    # existing candidates from this domain have been flushed from the DB.
 }
 _RETRY_BACKLOG_STATUSES: tuple[CandidateStatus, ...] = (
     CandidateStatus.QUEUED,

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -34,6 +34,16 @@ _SOCIAL_PROFILE_DOMAINS: frozenset[str] = frozenset(
     }
 )
 
+# Domains that consistently produce off-topic candidates and waste classifier
+# API budget.  All subdomains are matched (e.g. sport1.maariv.co.il matches
+# "sport1.maariv.co.il").  Add new entries here when a domain is confirmed
+# irrelevant via review-workbench bulk-exclusion or diagnostics evidence.
+_IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
+    {
+        "sport1.maariv.co.il",  # sports vertical — consistently off-topic
+    }
+)
+
 _SOCIAL_PROFILE_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
     "linkedin.com": ("/company/", "/in/", "/school/", "/showcase/"),
     "youtube.com": ("/@", "/channel/", "/c/", "/user/"),
@@ -53,6 +63,7 @@ class SearchNoiseReason(StrEnum):
     APP_STORE = "app_store"
     SOCIAL_PROFILE = "social_profile"
     UNSUPPORTED_SEARCH_DOMAIN = "unsupported_search_domain"
+    IRRELEVANT_CONTENT_DOMAIN = "irrelevant_content_domain"
 
 
 @dataclass(frozen=True)
@@ -61,6 +72,16 @@ class SearchNoiseClassification:
 
     reason: SearchNoiseReason
     matched_domain: str
+
+
+def globally_excluded_search_domains() -> frozenset[str]:
+    """Return the set of domains excluded from all broad/taxonomy search queries.
+
+    These are domains that are structurally off-topic (sports verticals, utility
+    sites, etc.) and should never consume search-engine quota.  The list mirrors
+    ``_IRRELEVANT_CONTENT_DOMAINS``; callers should not duplicate it.
+    """
+    return _IRRELEVANT_CONTENT_DOMAINS
 
 
 def normalize_domain(domain: str | None) -> str | None:
@@ -177,6 +198,11 @@ def classify_search_noise(
     if (matched_domain := match_domain(domain, _UTILITY_SEARCH_DOMAINS)) is not None:
         return SearchNoiseClassification(
             reason=SearchNoiseReason.UNSUPPORTED_SEARCH_DOMAIN,
+            matched_domain=matched_domain,
+        )
+    if (matched_domain := match_domain(domain, _IRRELEVANT_CONTENT_DOMAINS)) is not None:
+        return SearchNoiseClassification(
+            reason=SearchNoiseReason.IRRELEVANT_CONTENT_DOMAIN,
             matched_domain=matched_domain,
         )
     if _is_social_profile_candidate(discovered):

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -84,10 +84,17 @@ class BraveSearchEngine:
         return candidates
 
     def _render_query(self, query: DiscoveryQuery) -> str:
-        if not query.preferred_domains:
-            return query.query_text
-        site_filters = " OR ".join(f"site:{domain}" for domain in query.preferred_domains)
-        return f"({site_filters}) {query.query_text}"
+        parts: list[str] = []
+        if query.preferred_domains:
+            site_filters = " OR ".join(f"site:{domain}" for domain in query.preferred_domains)
+            parts.append(f"({site_filters})")
+        parts.append(query.query_text)
+        # Brave has no native excludeDomains parameter; use -site: operators
+        # instead.  Only applied when the query is not already scoped to a
+        # preferred domain (source-targeted queries don't need it).
+        if query.excluded_domains and not query.preferred_domains:
+            parts.extend(f"-site:{domain}" for domain in query.excluded_domains)
+        return " ".join(parts)
 
     def _result_to_candidate(
         self,

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
 from denbust.config import Config, SourceConfig, SourceType
+from denbust.discovery.candidate_filters import globally_excluded_search_domains
 from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
 from denbust.discovery.source_families import generic_fetch_source_domains
 from denbust.taxonomy import default_taxonomy
@@ -97,6 +98,11 @@ def build_discovery_queries(
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
     source_domains = enabled_discovery_domains(config)
+    # Domains that are structurally off-topic — excluded from every broad and
+    # taxonomy query to avoid wasting search-engine quota and classifier credits.
+    # Source-targeted queries are already scoped to a single preferred domain, so
+    # exclusions are not needed there.
+    excluded_domains = sorted(globally_excluded_search_domains())
 
     for keyword in keywords:
         if DiscoveryQueryKind.BROAD in config.discovery.default_query_kinds:
@@ -109,6 +115,7 @@ def build_discovery_queries(
                         date_from=date_from,
                         date_to=date_to,
                         query_kind=DiscoveryQueryKind.BROAD,
+                        excluded_domains=excluded_domains,
                     )
                 )
                 seen_keys.add(broad_key)
@@ -161,6 +168,7 @@ def build_discovery_queries(
                     date_to=date_to,
                     query_kind=DiscoveryQueryKind.TAXONOMY_TARGETED,
                     tags=tags,
+                    excluded_domains=excluded_domains,
                 )
             )
             seen_keys.add(taxonomy_key)

--- a/tests/unit/test_discovery_brave.py
+++ b/tests/unit/test_discovery_brave.py
@@ -307,6 +307,67 @@ async def test_brave_search_engine_filters_dated_results_outside_query_window() 
 
 
 @pytest.mark.asyncio
+async def test_brave_search_engine_appends_site_exclusions_for_broad_queries() -> None:
+    """Broad queries with excluded_domains should append -site: operators to the query string."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = request.url.params["q"]
+        return httpx.Response(200, json={"web": {"results": []}})
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="זנות",
+                query_kind=DiscoveryQueryKind.BROAD,
+                excluded_domains=["sport1.maariv.co.il"],
+            )
+        ],
+        DiscoveryContext(run_id="run-excl-1"),
+    )
+    await engine.aclose()
+
+    assert "-site:sport1.maariv.co.il" in str(captured["query"])
+    assert str(captured["query"]).startswith("זנות")
+
+
+@pytest.mark.asyncio
+async def test_brave_search_engine_omits_site_exclusions_for_source_targeted_queries() -> None:
+    """Source-targeted queries with preferred_domains must not append -site: exclusions."""
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = request.url.params["q"]
+        return httpx.Response(200, json={"web": {"results": []}})
+
+    engine = BraveSearchEngine(
+        api_key="brave-key",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await engine.discover(
+        [
+            DiscoveryQuery(
+                query_text="זנות",
+                query_kind=DiscoveryQueryKind.SOURCE_TARGETED,
+                preferred_domains=["www.maariv.co.il"],
+                excluded_domains=["sport1.maariv.co.il"],
+            )
+        ],
+        DiscoveryContext(run_id="run-excl-2"),
+    )
+    await engine.aclose()
+
+    assert "-site:" not in str(captured["query"])
+    assert str(captured["query"]) == "(site:www.maariv.co.il) זנות"
+
+
+@pytest.mark.asyncio
 async def test_brave_search_engine_filters_off_domain_source_targeted_results() -> None:
     """Provider results must still honor preferred-domain contracts locally."""
 

--- a/tests/unit/test_discovery_candidate_filters.py
+++ b/tests/unit/test_discovery_candidate_filters.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import HttpUrl
 
-from denbust.discovery.candidate_filters import classify_search_noise
+from denbust.discovery.candidate_filters import (
+    classify_search_noise,
+    globally_excluded_search_domains,
+)
 from denbust.discovery.models import DiscoveredCandidate, ProducerKind
 
 
@@ -36,6 +39,11 @@ def _search_candidate(url: str) -> DiscoveredCandidate:
             "https://apps.apple.com/il/app/example/id123456789",
             "app_store",
             "apps.apple.com",
+        ),
+        (
+            "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
+            "irrelevant_content_domain",
+            "sport1.maariv.co.il",
         ),
         ("https://morfix.co.il/example", "unsupported_search_domain", "morfix.co.il"),
         (
@@ -75,7 +83,6 @@ def test_classify_search_noise_marks_expected_noise_domains(
     [
         "https://www.ynet.co.il/news/article/abc123",
         "https://www.maariv.co.il/news/law/article-1270778",
-        "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
         "https://x.com/example/status/123456789",
         "https://mobile.twitter.com/example/status/123456789",
         "https://facebook.com/story.php?story_fbid=5&id=6",
@@ -98,3 +105,33 @@ def test_classify_search_noise_ignores_source_native_candidates() -> None:
     )
 
     assert classify_search_noise(candidate) is None
+
+
+def test_classify_search_noise_irrelevant_content_domain_subdomain_match() -> None:
+    """Subdomain of an irrelevant-content domain should also be classified as noise."""
+    # sport1.maariv.co.il is a sub-domain of maariv.co.il but only the sub-domain
+    # is listed — maariv.co.il articles should still pass through.
+    maariv_candidate = _search_candidate("https://www.maariv.co.il/news/law/article-1")
+    sport1_candidate = _search_candidate(
+        "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884"
+    )
+
+    assert classify_search_noise(maariv_candidate) is None
+    classification = classify_search_noise(sport1_candidate)
+    assert classification is not None
+    assert classification.reason == "irrelevant_content_domain"
+    assert classification.matched_domain == "sport1.maariv.co.il"
+
+
+def test_globally_excluded_search_domains_contains_sport1_maariv() -> None:
+    """The globally-excluded domain set should include the sports sub-domain."""
+    excluded = globally_excluded_search_domains()
+
+    assert "sport1.maariv.co.il" in excluded
+
+
+def test_globally_excluded_search_domains_does_not_contain_parent_domain() -> None:
+    """Only the off-topic sub-domain is excluded, not the broader news outlet."""
+    excluded = globally_excluded_search_domains()
+
+    assert "maariv.co.il" not in excluded

--- a/tests/unit/test_discovery_diagnostics.py
+++ b/tests/unit/test_discovery_diagnostics.py
@@ -1309,10 +1309,11 @@ def test_build_discovery_diagnostic_report_builds_source_suggestions(tmp_path: P
     assert "Source suggestions" in render_discovery_diagnostic_report(report)
 
 
-def test_source_suggestions_classify_sport1_candidate_only_pressure_without_demoting(
+def test_source_suggestions_still_surface_sport1_domain_from_existing_db_candidates(
     tmp_path: Path,
 ) -> None:
-    """Sport1 candidate-only pressure should be diagnostic, not an eligibility filter."""
+    """sport1 candidates already in DB should surface in source suggestions without a special
+    diagnostic classification (the domain is now globally excluded so no new ones will arrive)."""
     now = datetime.now(UTC)
     config = Config(store={"state_root": tmp_path})
     persistence = StateRepoDiscoveryPersistence(config.discovery_state_paths)
@@ -1373,9 +1374,12 @@ def test_source_suggestions_classify_sport1_candidate_only_pressure_without_demo
     assert suggestion.unsupported_count == 0
     assert suggestion.run_count == 2
     assert suggestion.score == 4.5
-    assert suggestion.diagnostic_classification == "sports_vertical_candidate_only"
-    assert "candidate-only sports-vertical pressure" in (suggestion.diagnostic_note or "")
-    assert "diagnostic=sports_vertical_candidate_only" in render_discovery_diagnostic_report(report)
+    # sport1.maariv.co.il is now globally excluded from search queries and classified as
+    # IRRELEVANT_CONTENT_DOMAIN at the candidate-filter layer.  It no longer appears in
+    # _SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS and therefore carries no diagnostic label —
+    # existing DB candidates (inserted before the exclusion) still surface in the report.
+    assert suggestion.diagnostic_classification is None
+    assert suggestion.diagnostic_note is None
 
 
 def test_build_discovery_diagnostic_report_ignores_candidates_without_domain(

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -282,6 +282,58 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
     }
 
 
+def test_build_discovery_queries_broad_queries_carry_excluded_domains() -> None:
+    """Broad queries should include the globally-excluded domain list."""
+    config = Config(
+        keywords=["בית בושת"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["broad"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    broad_queries = [query for query in queries if query.query_kind is DiscoveryQueryKind.BROAD]
+    assert broad_queries
+    for query in broad_queries:
+        assert "sport1.maariv.co.il" in query.excluded_domains
+
+
+def test_build_discovery_queries_taxonomy_queries_carry_excluded_domains() -> None:
+    """Taxonomy-targeted queries should include the globally-excluded domain list."""
+    config = Config(
+        keywords=[],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["taxonomy_targeted"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    taxonomy_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.TAXONOMY_TARGETED
+    ]
+    assert taxonomy_queries
+    for query in taxonomy_queries:
+        assert "sport1.maariv.co.il" in query.excluded_domains
+
+
+def test_build_discovery_queries_source_targeted_queries_have_no_excluded_domains() -> None:
+    """Source-targeted queries are already scoped; they must not carry excluded_domains."""
+    config = Config(
+        keywords=["בית בושת"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["source_targeted"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    source_queries = [
+        query for query in queries if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED
+    ]
+    assert source_queries
+    for query in source_queries:
+        assert not query.excluded_domains
+
+
 def test_build_discovery_queries_can_disable_social_targeted_generation() -> None:
     """Explicit query-kind configuration should still allow social discovery to be disabled."""
     config = Config(

--- a/tests/unit/test_discovery_source_native.py
+++ b/tests/unit/test_discovery_source_native.py
@@ -6,7 +6,6 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import pytest
 from pydantic import HttpUrl
 
 from denbust.data_models import RawArticle
@@ -308,18 +307,11 @@ def test_persist_discovered_candidates_marks_search_noise_unsupported(
     }
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://www.maariv.co.il/news/law/article-1270778",
-        "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884",
-    ],
-)
-def test_persist_discovered_candidates_keeps_maariv_and_sport1_articles_scrapeable(
-    url: str,
+def test_persist_discovered_candidates_keeps_maariv_articles_scrapeable(
     tmp_path: Path,
 ) -> None:
-    """Candidate-only Sport1 evidence should not demote article-like candidates."""
+    """Articles from the main maariv.co.il domain should remain scrapeable candidates."""
+    url = "https://www.maariv.co.il/news/law/article-1270778"
     paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
     persistence = StateRepoDiscoveryPersistence(paths)
     discovery = DiscoveredCandidate(
@@ -344,6 +336,37 @@ def test_persist_discovered_candidates_keeps_maariv_and_sport1_articles_scrapeab
     assert candidate.candidate_status.value == "new"
     assert candidate.needs_review is False
     assert "unsupported_source_filter" not in candidate.metadata
+
+
+def test_persist_discovered_candidates_demotes_sport1_as_irrelevant_content_domain(
+    tmp_path: Path,
+) -> None:
+    """sport1.maariv.co.il is an off-topic vertical: candidates must be marked unsupported."""
+    url = "https://sport1.maariv.co.il/israeli-soccer/ligat-haal/article/1739884"
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    persistence = StateRepoDiscoveryPersistence(paths)
+    discovery = DiscoveredCandidate(
+        producer_name="brave",
+        producer_kind=ProducerKind.SEARCH_ENGINE,
+        query_text="בית בושת",
+        candidate_url=HttpUrl(url),
+        canonical_url=HttpUrl(url),
+        title="ליגת העל",
+        snippet="כדורגל ישראלי",
+        discovered_at=datetime(2026, 4, 11, 9, 0, tzinfo=UTC),
+        metadata={"query_kind": "broad"},
+    )
+
+    persisted = persist_discovered_candidates(
+        run=DiscoveryRun(run_id="run-sport1-excluded"),
+        discovered_candidates=[discovery],
+        persistence=persistence,
+    )
+
+    candidate = persisted.candidates[0]
+    assert candidate.candidate_status.value == "unsupported_source"
+    assert candidate.metadata.get("unsupported_source_reason") == "irrelevant_content_domain"
+    assert candidate.metadata.get("unsupported_source_domain") == "sport1.maariv.co.il"
 
 
 def test_persist_discovered_candidates_demotes_existing_unattempted_search_noise(


### PR DESCRIPTION
## Summary

`sport1.maariv.co.il` is a sports sub-domain of Maariv that consistently surfaces off-topic candidates, wasting Brave/Exa search quota and Anthropic API credits on irrelevant content. This PR adds a three-layer exclusion so no new candidates from this domain can enter the pipeline.

### Layer 1 — Query level (search quota saved)

- New `_IRRELEVANT_CONTENT_DOMAINS` frozenset in `candidate_filters.py` (single source of truth)
- New `globally_excluded_search_domains()` public helper so query builders stay in sync automatically
- `build_discovery_queries()` in `queries.py` now injects `excluded_domains=sorted(globally_excluded_search_domains())` into every **broad** and **taxonomy** `DiscoveryQuery`
- Exa already honoured `excluded_domains`; **Brave's `_render_query()` now appends `-site:` operators** for each entry
- Source-targeted queries are intentionally skipped — they already carry `preferred_domains` that scope them to a specific site

### Layer 2 — Candidate filter level (Anthropic API credits saved)

- Added `SearchNoiseReason.IRRELEVANT_CONTENT_DOMAIN = "irrelevant_content_domain"` to `candidate_filters.py`
- `classify_search_noise()` now returns `IRRELEVANT_CONTENT_DOMAIN` for any URL whose host matches the set (subdomain-aware: `sport1.maariv.co.il` matches, `maariv.co.il` does not)
- Candidates from this domain are classified before any enrichment or scrape attempts

### Layer 3 — Persistence level (defence in depth)

- `persist_discovered_candidates()` already maps all `classify_search_noise()` results to `CandidateStatus.UNSUPPORTED_SOURCE`; the new classification flows through automatically
- Metadata fields `unsupported_source_reason` and `unsupported_source_domain` are set for observability

### Diagnostics

- Removed `sport1.maariv.co.il` from `_SOURCE_SUGGESTION_DIAGNOSTIC_DOMAINS` in `diagnostics/discovery.py` — it was tracked there as a soft signal, but is now globally excluded
- Existing DB candidates (predating this change) still surface in source-suggestion reports, just without a diagnostic classification tag
- Comment left in the dict explaining the removal and when it can be fully cleaned up

## Tests

- 9 new/updated test cases across 5 test files:
  - `test_discovery_candidate_filters.py`: new parametrized case for `irrelevant_content_domain`; new tests for `globally_excluded_search_domains()`; sport1 removed from "keeps scrapeable" params
  - `test_discovery_queries.py`: broad and taxonomy queries carry `excluded_domains`; source-targeted queries do not
  - `test_discovery_brave.py`: broad queries emit `-site:` operators; source-targeted queries do not
  - `test_discovery_source_native.py`: maariv.co.il stays `new`; sport1 gets `unsupported_source` + correct metadata
  - `test_discovery_diagnostics.py`: sport1 source suggestion has `diagnostic_classification=None`

## Test plan

- [x] `ruff format .` — clean
- [x] `ruff check .` — clean
- [x] `mypy src/` — clean
- [x] `pytest -q` — 1046 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)