### PR TITLE
docs(ops): labeling semantics and review workbench UX reference

### DIFF
--- a/docs/ops/labeling-semantics.md
+++ b/docs/ops/labeling-semantics.md
@@ -1,0 +1,168 @@
+# Labeling & Tagging Semantics
+
+Reference for all label, tag, and status values used in the TFHT Enforcement Index pipeline.
+Covers the full lifecycle from discovery through publication.
+
+---
+
+## Review Decisions (Human Operator)
+
+The review workbench asks the operator to make exactly one decision per item.
+
+| Decision | Description |
+|---|---|
+| **Include** | Article is on-topic; should be published in the public index. Sets `publication_status = 'approved'`. |
+| **Exclude** | Article is off-topic or a false positive; should never appear publicly. Sets `publication_status = 'suppressed'` + `suppression_reason = 'false_positive'`. |
+| **Internal only** | Article is real but too sensitive to publish externally (e.g. victim details, unverified allegations). Sets `publication_status = 'internal_only'`. |
+
+> **Important – no data is deleted.**
+> All three decisions keep the record in Supabase permanently. `is_publicly_releasable()` requires `publication_status IN ('approved', 'published')`. Records with `suppressed` or `internal_only` status are retained as internal evidence and are suitable training data for the classifier.
+
+---
+
+## Publication Status Enum
+
+Full set of `publication_status` values a `news_items` row can hold:
+
+| Value | Who sets it | Publicly releasable |
+|---|---|---|
+| `draft` | Default on ingest | No |
+| `approved` | Human review → Include | Yes |
+| `published` | Release pipeline post-publish | Yes |
+| `suppressed` | Human review → Exclude | No (retained internally) |
+| `internal_only` | Human review → Internal only | No (retained internally) |
+
+---
+
+## `index_relevant` Field
+
+A boolean field on `news_items` rows.
+
+- Automatically **pre-ticked** in the review workbench when an unreviewed item is loaded.
+- Selecting **Index relevant** in the UI automatically switches the **Decision** to **Include** (not vice versa — changing Decision does not affect Index relevant).
+- Semantics: `index_relevant = true` means the operator considers the article a meaningful data point for the enforcement index itself (i.e. worth counting and categorising, not just archiving).
+
+---
+
+## Taxonomy Labels
+
+Taxonomy labels classify an article into the enforcement typology. Two levels:
+
+| Level | Field | UI control |
+|---|---|---|
+| **Category** | `primary_category` (inferred) | Checkbox grid — select all that apply |
+| **Subcategory** | `subcategory_tags` (list) | Checkbox grid nested under selected category |
+
+Taxonomy values are defined in `src/denbust/taxonomy/` and drive both the discovery query vocabulary and the classifier prompt. Do not add taxonomy values only in the UI — they must be added to the taxonomy module first.
+
+---
+
+## Workflow Tags (`topic_tags`)
+
+Workflow tags are a free-form `text[]` column on `news_items`. They augment (not replace) taxonomy. The review app and ingest app present the following named tags as toggles:
+
+| Tag | Hebrew UI label | Usage guidance |
+|---|---|---|
+| `false-positive` | תוצאה שגויה | Item was returned by discovery or the classifier but is clearly off-topic. Use with **Exclude** decision to build a clean false-positive training corpus. |
+| `needs-verification` | דורש אימות | Claim is plausible but unverified; do not publish until confirmed. Use with **Internal only** decision. |
+| `victim-sensitive` | רגיש לנפגע | Contains identifying details about a victim. Use with **Internal only** decision. |
+| `police-operation` | מבצע משטרתי | Article covers an active or recent enforcement operation. |
+| `conviction` | הרשעה | Article reports a conviction or sentencing. |
+| `plea-deal` | הסדר טיעון | Article covers a plea agreement. |
+| `arrest` | מעצר | Article reports an arrest or detention. |
+| `indictment` | כתב אישום | Article covers charges being filed. |
+| `legislation` | חקיקה | Article covers a new law, amendment, or proposed legislation. |
+| `ngo-report` | דו"ח ארגון | Article summarises or cites a civil-society or NGO report. |
+| `media-investigation` | חקירת עיתונות | Article is an investigative journalism piece. |
+
+Tags are stored as-is (lowercase English strings). The Hebrew labels are display-only and exist only in the UI translation layer — they do not touch the DB schema.
+
+Multiple tags may be applied to the same item. Tags accumulate on the array; the UI never removes existing tags (to preserve audit history set by earlier sessions).
+
+---
+
+## Bulk False-Positive Action
+
+The review workbench supports bulk exclusion for efficiently clearing obviously off-topic items.
+
+**Flow:**
+
+1. Use the checkbox on the left edge of each candidate card to select one or more items.
+2. A sticky **Bulk bar** appears at the bottom of the left panel, showing the count of selected items.
+3. Press **Mark as false positive** to apply, in a single operation, to all selected items:
+   - `publication_status = 'suppressed'`
+   - `suppression_reason = 'false_positive'`
+   - `topic_tags` appended with `'false-positive'`
+   - `review_status = 'reviewed'`
+   - `manually_reviewed = true`
+
+**Data retention:** bulk-excluded items are retained in Supabase exactly like single-item exclusions. Nothing is deleted.
+
+---
+
+## Suppression Reasons
+
+When an item is suppressed (`publication_status = 'suppressed'`), a reason is recorded:
+
+| Reason | Set by |
+|---|---|
+| `false_positive` | Review decision → Exclude (single or bulk) |
+| *(future values TBD)* | |
+
+---
+
+## Audit Trail
+
+Every review action writes:
+
+| Field | Value |
+|---|---|
+| `manually_reviewed` | `true` |
+| `manually_overridden` | `true` |
+| `review_status` | `'reviewed'` |
+| `annotation_source` | `'review_app'` or `'ingest_app'` |
+
+Ingest-app items additionally set `content_basis = 'candidate_only'` on creation.
+
+---
+
+## Label Flow (Lifecycle Diagram)
+
+```
+Discovery run
+  │
+  ▼
+Candidate (CandidateStatus.NEW)
+  │
+  ├── classify_search_noise() → UNSUPPORTED_SOURCE  (no DB write to news_items)
+  │
+  └── Scrape → news_items row created
+        publication_status = 'draft'
+        review_status = 'pending'
+        index_relevant = true (default)
+        │
+        ▼
+      Human review (review workbench)
+        │
+        ├── Include → approved + taxonomy + tags
+        ├── Exclude → suppressed + false_positive tag
+        └── Internal only → internal_only + sensitive tags
+              │
+              ▼
+            Release pipeline
+              approved → published (publicly releasable)
+```
+
+---
+
+## Agent Action Boundaries
+
+Agents (Claude-based automation) may:
+- Set `publication_status`, `review_status`, `annotation_source`, `content_basis`
+- Add taxonomy tags, workflow tags
+- Write `index_relevant`
+
+Agents must **not**:
+- Delete rows from `news_items` or the candidate state
+- Publish items with `publication_status != 'approved'`
+- Override a human `manually_reviewed = true` decision

--- a/docs/ops/review-workbench.md
+++ b/docs/ops/review-workbench.md
@@ -1,0 +1,231 @@
+# Review Workbench — UI/UX Reference
+
+The review workbench is a Cloudflare Pages application that allows human operators to review, label, and approve discovery candidates before publication.
+
+**URL (production):** `https://tfht-review-workbench.pages.dev`
+**Source:** `review_app/` in this repository
+**Authentication:** Google OAuth; allowed emails configured in `review_app/functions/_shared.js`
+
+---
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  TFHT Review                    [Night mode]  [EN/HE]  [User email] │
+├──────────────────────────────┬───────────────────────────────────────┤
+│  FILTER BAR                  │  DETAIL PANE                          │
+│  [keyword] [source] [status] │  Title / URL / metadata               │
+│  [sort order]                │  ─────────────────────────────────    │
+├──────────────────────────────│  REVIEW FORM                          │
+│  CANDIDATE LIST              │  Decision  ○ Include ○ Exclude        │
+│                              │            ○ Internal only            │
+│  ┌──────────────────────┐   │                                        │
+│  │ ☐ │ Card body        │   │  [✓] Index relevant                    │
+│  │   │ score / domain   │   │                                        │
+│  │   │ snippet          │   │  Taxonomy (categories + subcategories) │
+│  └──────────────────────┘   │  Workflow tags                         │
+│  ┌──────────────────────┐   │  Notes (free text)                     │
+│  │ ☐ │ Card body        │   │                                        │
+│  └──────────────────────┘   │  [Save]                                │
+│  …                           │                                        │
+├──────────────────────────────┤                                        │
+│  BULK BAR (when items        │                                        │
+│  selected)                   │                                        │
+│  3 selected [Mark FP] [✕]    │                                        │
+└──────────────────────────────┴───────────────────────────────────────┘
+```
+
+---
+
+## Filter Bar
+
+Controls which candidates appear in the left panel.
+
+| Control | Description |
+|---|---|
+| **Keyword search** | Free-text filter on title/snippet |
+| **Source filter** | Drop-down to show only a specific news source |
+| **Status filter** | `pending` (unreviewed), `reviewed`, or `all` |
+| **Sort order** | `High score first` (default) or `Low score first` — useful for bulk-excluding clearly irrelevant low-scored items |
+
+Filters apply immediately on change. The list reloads from the Cloudflare Function.
+
+---
+
+## Summary Row
+
+A single line above the candidate list shows the total count matching current filters.
+
+---
+
+## Candidate Card Anatomy
+
+Each card in the left column has two interactive regions:
+
+```
+┌─────────────────────────────────────────┐
+│ ☐  │ [Title of article]                 │
+│    │  source.co.il · score: 0.87        │
+│    │  Publication date                  │
+│    │  Snippet of text…                  │
+└─────────────────────────────────────────┘
+  ↑        ↑
+checkbox  click to open in detail pane
+(bulk     (does not tick checkbox)
+ select)
+```
+
+- The **checkbox** on the left edge is for bulk selection only. Ticking it does NOT open the detail pane.
+- The **card body** (title, domain, score, snippet) is a button. Clicking it loads the item in the detail pane and highlights the card.
+- Cards with an existing review decision show a coloured left border:
+  - Green: Include / Approved
+  - Red: Exclude / Suppressed
+  - Amber: Internal only
+
+---
+
+## Bulk Selection
+
+Multiple cards can be selected simultaneously using their checkboxes.
+
+When at least one card is checked, a **Bulk bar** appears at the bottom of the left panel:
+
+```
+  3 selected  [Mark as false positive]  [✕ Clear]
+```
+
+- **Mark as false positive**: applies `Exclude` + `false-positive` tag to all selected items in a single API call.
+- **Clear (✕)**: deselects all items without making any changes.
+- The bulk bar automatically disappears when the selection is cleared.
+
+See [labeling-semantics.md](./labeling-semantics.md#bulk-false-positive-action) for the exact fields written.
+
+---
+
+## Detail Pane
+
+Clicking a card loads its full detail on the right:
+
+| Section | Content |
+|---|---|
+| **Header** | Title (linked to original URL), source domain, publication date |
+| **Score** | Classifier relevance score (0.0–1.0); shown with a label like "very high" / "high" / "medium" / "low" |
+| **Query info** | Discovery query text and query kind (broad, source-targeted, taxonomy-targeted) |
+| **Snippet** | Summary text from the search result or scrape |
+| **Metadata** | Taxonomy categories assigned by classifier, workflow tags already applied |
+
+---
+
+## Review Form
+
+Below the detail metadata sits the review form.
+
+### Decision (radio group)
+
+- **Include** — on-topic; approve for publication
+- **Exclude** — false positive; suppress
+- **Internal only** — real but not for external publication
+
+When loading an **unreviewed** item:
+- All radios start unselected (no default decision is forced)
+- **Index relevant** is pre-ticked
+
+### Index Relevant (checkbox)
+
+- Pre-ticked on load for all unreviewed items.
+- Ticking it automatically selects the **Include** radio.
+- The reverse is not true: changing the Decision radio does not affect the checkbox.
+
+### Taxonomy
+
+A two-level grid:
+
+1. **Categories** — checkboxes for top-level taxonomy categories (e.g. Prostitution, Human Trafficking, Legislation…)
+2. **Subcategories** — once a category is checked, its subcategories expand inline
+
+Values come from the same taxonomy used by the classifier. See `src/denbust/taxonomy/`.
+
+### Workflow Tags
+
+A row of toggle-buttons for pre-defined operational tags. Multiple may be active at once.
+See [labeling-semantics.md](./labeling-semantics.md#workflow-tags-topic_tags) for the full tag vocabulary.
+
+### Notes
+
+A free-text textarea. Stored in the `notes` field on the `news_items` row. Useful for flagging edge cases for team review.
+
+### Save Button
+
+Writes the decision, taxonomy, tags, and notes to Supabase via a PATCH request. The button shows a spinner while saving and a checkmark on success.
+
+---
+
+## Queue Behaviour
+
+- Items with `review_status = 'pending'` are the default view.
+- After saving a review, the workbench automatically advances to the next unreviewed item in the list.
+- The left panel does not automatically reload; use the filter controls or browser refresh to get fresh data.
+
+---
+
+## Language Toggle (HE/EN)
+
+A toggle in the header switches the entire UI between **Hebrew** (default, RTL) and **English** (LTR).
+
+- All button labels, field descriptions, headers, and placeholder text switch language.
+- Underlying field values, DB column names, tag strings, and schema are never affected.
+- The `<html dir>` and `<html lang>` attributes update on toggle.
+
+---
+
+## Night Mode
+
+A moon/sun icon in the header toggles between light and dark themes. Preference is not persisted across sessions.
+
+---
+
+## Authentication
+
+Access is restricted to a Google-OAuth allowlist. Unauthenticated requests receive a `401`. The allowed email list is maintained in `review_app/functions/_shared.js` → `ALLOWED_EMAILS`.
+
+Current allowed emails (case-insensitive):
+- `shaypal5@gmail.com`
+- `Eden@tfht.org`
+- `moria@tfht.org`
+- `Shaked@tfht.org`
+
+---
+
+## Deployment
+
+The app is deployed to Cloudflare Pages as `tfht-review-workbench`.
+
+```bash
+# Deploy (must cd into review_app first so wrangler picks up functions/)
+cd review_app/
+npx wrangler pages deploy public --project-name tfht-review-workbench
+```
+
+> **Important:** deploying from the repo root with `npx wrangler pages deploy review_app/public` silently omits the `functions/` bundle. Always `cd review_app/` first.
+
+Environment variables (set in Cloudflare dashboard → Pages → Settings → Variables):
+
+| Variable | Description |
+|---|---|
+| `DENBUST_SUPABASE_URL` | Supabase project URL |
+| `DENBUST_SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (write access) |
+| `GOOGLE_CLIENT_ID` | OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | OAuth client secret |
+| `SESSION_SECRET` | Signing secret for session cookies |
+
+---
+
+## API Endpoints (Cloudflare Functions)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/candidates` | Paginated candidate list; supports `?filter=`, `?source=`, `?status=`, `?sort=` |
+| `PATCH` | `/api/review` | Save a review decision for a single candidate |
+| `GET` | `/api/taxonomy` | Taxonomy category/subcategory tree |
+| `GET` | `/api/me` | Current authenticated user info |


### PR DESCRIPTION
## Summary

Adds two new operator-facing reference documents under `docs/ops/`:

- **`labeling-semantics.md`** — authoritative reference for all label, tag, and status values in the pipeline
- **`review-workbench.md`** — full UI/UX walkthrough of the Cloudflare Pages review app

These replace the wiki PR #2 that was opened in `DataHackIL/datahack-agent-wiki` and then closed in favour of keeping documentation co-located with the code.

---

### `docs/ops/labeling-semantics.md` covers

- **Review decisions** (Include / Exclude / Internal only) → exact DB fields written for each
- **Publication status enum** — all 5 values, who sets them, whether they're publicly releasable
- **`index_relevant` field** — pre-tick behaviour, one-way binding to the Include decision
- **Taxonomy labels** — two-level category/subcategory grid, pointer to the taxonomy module
- **Workflow tags (`topic_tags`)** — full table of all 11 named tags with Hebrew UI labels and usage guidance
- **Bulk false-positive action** — step-by-step, exact fields written, data retention guarantee
- **Suppression reasons** — enum of `suppression_reason` values
- **Audit trail fields** — `manually_reviewed`, `manually_overridden`, `review_status`, `annotation_source`
- **Label flow lifecycle diagram** — discovery → candidate → scrape → review → publish
- **Agent action boundaries** — what agents may/must not do

### `docs/ops/review-workbench.md` covers

- ASCII layout diagram of the two-panel UI
- Filter bar controls (keyword, source, status, sort order)
- Candidate card anatomy — checkbox (bulk) vs card body (detail) click targets
- Bulk selection flow and bulk bar
- Detail pane sections
- Review form: Decision radio, Index relevant checkbox, Taxonomy grid, Workflow tags, Notes, Save button
- Queue behaviour (auto-advance, no auto-reload)
- Language toggle (HE/EN, RTL/LTR)
- Night mode
- Authentication (Google OAuth allowlist)
- Deployment instructions (must `cd review_app/` first — common footgun documented)
- Environment variable reference
- API endpoint table

## Test plan

- [x] Docs render correctly as GitHub Markdown
- [x] All cross-links between the two documents are correct
- [x] Pre-commit hook (trailing whitespace) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)