### PR TITLE
feat(backfill): cross-run query execution tracking

### DIFF
--- a/src/denbust/discovery/models.py
+++ b/src/denbust/discovery/models.py
@@ -278,6 +278,19 @@ class DiscoveryRun(BaseModel):
         return self
 
 
+class ExecutedBackfillQuery(BaseModel):
+    """Record of a backfill search-engine query that was successfully issued."""
+
+    engine: str
+    query_kind: DiscoveryQueryKind
+    query_text: str
+    source_hint: str | None = None
+    date_from: datetime
+    date_to: datetime
+    executed_at: datetime = Field(default_factory=_utc_now)
+    batch_id: str
+
+
 class BackfillBatch(BaseModel):
     """Durable metadata for a historical backfill invocation."""
 

--- a/src/denbust/discovery/models.py
+++ b/src/denbust/discovery/models.py
@@ -266,6 +266,7 @@ class DiscoveryRun(BaseModel):
     job_name: JobName = JobName.DISCOVER
     status: DiscoveryRunStatus = DiscoveryRunStatus.PENDING
     query_count: int = Field(default=0, ge=0)
+    skipped_query_count: int = Field(default=0, ge=0)
     candidate_count: int = Field(default=0, ge=0)
     merged_candidate_count: int = Field(default=0, ge=0)
     queued_for_scrape_count: int = Field(default=0, ge=0)

--- a/src/denbust/discovery/persistence.py
+++ b/src/denbust/discovery/persistence.py
@@ -12,6 +12,7 @@ from denbust.discovery.models import (
     CandidateProvenance,
     CandidateStatus,
     DiscoveryRun,
+    ExecutedBackfillQuery,
     PersistentCandidate,
     ScrapeAttempt,
 )
@@ -135,3 +136,15 @@ class ScrapeAttemptStore(ABC):
         limit: int | None = None,
     ) -> list[ScrapeAttempt]:
         """Return scrape attempts for a candidate."""
+
+
+class ExecutedQueryStore(ABC):
+    """Persistence interface for cross-run backfill query deduplication."""
+
+    @abstractmethod
+    def load_executed_backfill_query_keys(self) -> frozenset[tuple[str, ...]]:
+        """Return the set of already-executed backfill query keys."""
+
+    @abstractmethod
+    def append_executed_backfill_queries(self, queries: Sequence[ExecutedBackfillQuery]) -> None:
+        """Append records of newly executed backfill queries."""

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -35,6 +35,7 @@ class DiscoveryStatePaths(BaseModel):
     engine_overlap_latest_path: Path
     discovery_diagnostics_latest_path: Path
     source_suggestions_latest_path: Path
+    backfill_executed_queries_path: Path
 
 
 def resolve_discovery_state_paths(
@@ -67,6 +68,7 @@ def resolve_discovery_state_paths(
         engine_overlap_latest_path=metrics_dir / "engine_overlap_latest.json",
         discovery_diagnostics_latest_path=metrics_dir / "discovery_diagnostics_latest.json",
         source_suggestions_latest_path=metrics_dir / "source_suggestions_latest.json",
+        backfill_executed_queries_path=backfill_batches_dir / "executed_queries.jsonl",
     )
 
 

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -16,6 +16,7 @@ from denbust.discovery.models import (
     CandidateProvenance,
     CandidateStatus,
     DiscoveryRun,
+    ExecutedBackfillQuery,
     PersistentCandidate,
     ScrapeAttempt,
 )
@@ -24,6 +25,7 @@ from denbust.discovery.persistence import (
     BackfillCandidateCounts,
     CandidateStore,
     DiscoveryRunStore,
+    ExecutedQueryStore,
     ProvenanceStore,
     ScrapeAttemptStore,
 )
@@ -47,12 +49,24 @@ def _remove_postgres_unsupported_nuls(value: Any) -> Any:
     return value
 
 
+def _executed_query_key(record: ExecutedBackfillQuery) -> tuple[str, ...]:
+    return (
+        record.engine,
+        record.query_kind.value,
+        record.query_text,
+        record.source_hint or "",
+        record.date_from.isoformat(),
+        record.date_to.isoformat(),
+    )
+
+
 class DiscoveryPersistence(
     DiscoveryRunStore,
     CandidateStore,
     BackfillBatchStore,
     ProvenanceStore,
     ScrapeAttemptStore,
+    ExecutedQueryStore,
 ):
     """Combined discovery persistence boundary."""
 
@@ -150,6 +164,12 @@ class NullDiscoveryPersistence(DiscoveryPersistence):
     ) -> list[ScrapeAttempt]:
         del candidate_id, limit
         return []
+
+    def load_executed_backfill_query_keys(self) -> frozenset[tuple[str, ...]]:
+        return frozenset()
+
+    def append_executed_backfill_queries(self, queries: Sequence[ExecutedBackfillQuery]) -> None:
+        del queries
 
     def close(self) -> None:
         return None
@@ -387,6 +407,13 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
         if limit is not None:
             return attempts[:limit]
         return attempts
+
+    def load_executed_backfill_query_keys(self) -> frozenset[tuple[str, ...]]:
+        records = self._read_jsonl(self.paths.backfill_executed_queries_path, ExecutedBackfillQuery)
+        return frozenset(_executed_query_key(r) for r in records)
+
+    def append_executed_backfill_queries(self, queries: Sequence[ExecutedBackfillQuery]) -> None:
+        self._append_jsonl(self.paths.backfill_executed_queries_path, queries)
 
     def close(self) -> None:
         return None
@@ -665,6 +692,12 @@ class SupabaseDiscoveryPersistence(DiscoveryPersistence):
             return [ScrapeAttempt.model_validate(item) for item in payload]
         return []
 
+    def load_executed_backfill_query_keys(self) -> frozenset[tuple[str, ...]]:
+        return frozenset()
+
+    def append_executed_backfill_queries(self, queries: Sequence[ExecutedBackfillQuery]) -> None:
+        del queries
+
     def _request(
         self,
         method: str,
@@ -821,6 +854,14 @@ class CompositeDiscoveryPersistence(DiscoveryPersistence):
         limit: int | None = None,
     ) -> list[ScrapeAttempt]:
         return self.primary.list_attempts(candidate_id, limit=limit)
+
+    def load_executed_backfill_query_keys(self) -> frozenset[tuple[str, ...]]:
+        return self.primary.load_executed_backfill_query_keys()
+
+    def append_executed_backfill_queries(self, queries: Sequence[ExecutedBackfillQuery]) -> None:
+        self.primary.append_executed_backfill_queries(queries)
+        for mirror in self.mirrors:
+            mirror.append_executed_backfill_queries(queries)
 
 
 def create_discovery_persistence(config: Config) -> DiscoveryPersistence:

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -49,8 +49,10 @@ from denbust.discovery.models import (
     BackfillBatch,
     BackfillBatchStatus,
     DiscoveredCandidate,
+    DiscoveryQuery,
     DiscoveryRun,
     DiscoveryRunStatus,
+    ExecutedBackfillQuery,
     PersistentCandidate,
 )
 from denbust.discovery.queries import build_discovery_queries
@@ -982,6 +984,17 @@ async def _run_google_cse_discovery(
         persistence.close()
 
 
+def _backfill_query_execution_key(engine: str, query: DiscoveryQuery) -> tuple[str, ...]:
+    return (
+        engine,
+        query.query_kind.value,
+        query.query_text,
+        query.source_hint or "",
+        query.date_from.isoformat() if query.date_from is not None else "",
+        query.date_to.isoformat() if query.date_to is not None else "",
+    )
+
+
 async def _run_backfill_engine_discovery(
     *,
     config: Config,
@@ -991,7 +1004,12 @@ async def _run_backfill_engine_discovery(
     engine_name: str,
 ) -> PersistedSourceDiscovery:
     """Run one search engine over a historical window and persist tagged candidates."""
-    queries = build_backfill_queries(config, window=window)
+    all_queries = build_backfill_queries(config, window=window)
+    persistence = create_discovery_persistence(config)
+    executed_keys = persistence.load_executed_backfill_query_keys()
+    queries = [
+        q for q in all_queries if _backfill_query_execution_key(engine_name, q) not in executed_keys
+    ]
     discovery_run = DiscoveryRun(
         run_id=run_id,
         dataset_name=config.dataset_name,
@@ -999,7 +1017,6 @@ async def _run_backfill_engine_discovery(
         status=DiscoveryRunStatus.RUNNING,
         query_count=len(queries),
     )
-    persistence = create_discovery_persistence(config)
     if not queries:
         try:
             return persist_discovered_candidates(
@@ -1090,6 +1107,22 @@ async def _run_backfill_engine_discovery(
                 await engine.discover(queries, context=context),
                 batch_id=batch_id,
                 window=window,
+            )
+            executed_at = datetime.now(UTC)
+            persistence.append_executed_backfill_queries(
+                [
+                    ExecutedBackfillQuery(
+                        engine=engine_name,
+                        query_kind=q.query_kind,
+                        query_text=q.query_text,
+                        source_hint=q.source_hint,
+                        date_from=q.date_from or window.date_from,
+                        date_to=q.date_to or window.date_to,
+                        executed_at=executed_at,
+                        batch_id=batch_id,
+                    )
+                    for q in queries
+                ]
             )
         except Exception as exc:
             discovery_run.errors.append(f"{engine_name}: {type(exc).__name__}: {exc}")

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -1010,12 +1010,23 @@ async def _run_backfill_engine_discovery(
     queries = [
         q for q in all_queries if _backfill_query_execution_key(engine_name, q) not in executed_keys
     ]
+    skipped_count = len(all_queries) - len(queries)
+    if skipped_count:
+        logger.info(
+            "backfill engine=%s window=%d: %d/%d queries skipped (already executed), running %d",
+            engine_name,
+            window.index,
+            skipped_count,
+            len(all_queries),
+            len(queries),
+        )
     discovery_run = DiscoveryRun(
         run_id=run_id,
         dataset_name=config.dataset_name,
         job_name=config.job_name,
         status=DiscoveryRunStatus.RUNNING,
         query_count=len(queries),
+        skipped_query_count=skipped_count,
     )
     if not queries:
         try:
@@ -2334,6 +2345,15 @@ async def run_news_backfill_discover_job(
             result.fatal = True
             result.errors.append(f"Backfill batch {batch_id} already exists")
             return result.finish(f"fatal: backfill batch {batch_id} already exists")
+        enabled_engines = [
+            name
+            for name, engine_cfg in [
+                ("brave", config.discovery.engines.brave),
+                ("exa", config.discovery.engines.exa),
+                ("google_cse", config.discovery.engines.google_cse),
+            ]
+            if engine_cfg.enabled
+        ]
         batch = BackfillBatch(
             batch_id=batch_id,
             created_at=result.run_timestamp,
@@ -2348,6 +2368,13 @@ async def run_news_backfill_discover_job(
             metadata={
                 "requested_date_from_env": BACKFILL_DATE_FROM_ENV,
                 "requested_date_to_env": BACKFILL_DATE_TO_ENV,
+                "keywords": list(config.keywords),
+                "keyword_count": len(config.keywords),
+                "engines": enabled_engines,
+                "query_kinds": [
+                    k.value if hasattr(k, "value") else str(k)
+                    for k in (config.backfill.query_kinds or config.discovery.default_query_kinds)
+                ],
             },
         )
         persistence.upsert_backfill_batches([batch])
@@ -2403,12 +2430,21 @@ async def run_news_backfill_discover_job(
                         )
                     )
 
+        total_skipped = 0
         for persisted in persisted_runs:
             query_count += persisted.run.query_count
+            total_skipped += persisted.run.skipped_query_count
             discovered_count += persisted.run.candidate_count
             result.raw_article_count += persisted.run.candidate_count
             result.errors.extend(persisted.run.errors)
             batch_errors.extend(persisted.run.errors)
+        logger.info(
+            "backfill batch %s: %d queries run, %d skipped (already executed), %d candidates discovered",
+            batch.batch_id,
+            query_count,
+            total_skipped,
+            discovered_count,
+        )
 
         merged_candidate_count, _ = _batch_candidate_counts(persistence, batch_id=batch.batch_id)
         status = BackfillBatchStatus.DISCOVERED

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -20,6 +20,8 @@ from denbust.discovery.models import (
     BackfillBatchStatus,
     CandidateStatus,
     DiscoveredCandidate,
+    DiscoveryQuery,
+    DiscoveryQueryKind,
     DiscoveryRun,
     DiscoveryRunStatus,
     PersistentCandidate,
@@ -88,6 +90,18 @@ def build_window(index: int = 0) -> BackfillWindow:
         index=index,
         date_from=datetime(2026, 1, 1 + index, tzinfo=UTC),
         date_to=datetime(2026, 1, 2 + index, tzinfo=UTC),
+    )
+
+
+def build_query() -> DiscoveryQuery:
+    """Create a minimal DiscoveryQuery fixture for backfill engine tests."""
+    w = build_window()
+    return DiscoveryQuery(
+        query_text="test-keyword",
+        query_kind=DiscoveryQueryKind.BROAD,
+        date_from=w.date_from,
+        date_to=w.date_to,
+        language="he",
     )
 
 
@@ -401,7 +415,9 @@ async def test_run_backfill_engine_discovery_handles_empty_queries_and_errors(
     )
     assert empty.run.candidate_count == 0
 
-    monkeypatch.setattr("denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: ["q"])
+    monkeypatch.setattr(
+        "denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: [build_query()]
+    )
     missing_brave = await pipeline_module._run_backfill_engine_discovery(
         config=build_config(
             tmp_path,
@@ -474,7 +490,9 @@ async def test_run_backfill_engine_discovery_covers_exa_and_google_variants(
     """Backfill engine discovery should build Exa and Google contexts and handle missing Google config."""
     store = build_store(tmp_path)
     monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
-    monkeypatch.setattr("denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: ["q"])
+    monkeypatch.setattr(
+        "denbust.pipeline.build_backfill_queries", lambda *_args, **_kwargs: [build_query()]
+    )
     monkeypatch.setattr(
         "denbust.pipeline.persist_discovered_candidates",
         lambda **kwargs: PersistedSourceDiscovery(

--- a/tests/unit/test_backfill_query_tracking.py
+++ b/tests/unit/test_backfill_query_tracking.py
@@ -1,0 +1,153 @@
+"""Unit tests for cross-run backfill query execution tracking."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from denbust.discovery.models import (
+    DiscoveryQuery,
+    DiscoveryQueryKind,
+    ExecutedBackfillQuery,
+)
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence, _executed_query_key
+from denbust.models.common import DatasetName
+from denbust.pipeline import _backfill_query_execution_key
+
+_T0 = datetime(2024, 1, 1, tzinfo=UTC)
+_T1 = datetime(2024, 1, 7, 23, 59, 59, tzinfo=UTC)
+
+
+def _make_executed(
+    engine: str = "brave",
+    keyword: str = "זנות",
+    query_kind: DiscoveryQueryKind = DiscoveryQueryKind.BROAD,
+    source_hint: str | None = None,
+    date_from: datetime = _T0,
+    date_to: datetime = _T1,
+    batch_id: str = "batch-1",
+) -> ExecutedBackfillQuery:
+    return ExecutedBackfillQuery(
+        engine=engine,
+        query_kind=query_kind,
+        query_text=keyword,
+        source_hint=source_hint,
+        date_from=date_from,
+        date_to=date_to,
+        batch_id=batch_id,
+    )
+
+
+def _make_query(
+    keyword: str = "זנות",
+    query_kind: DiscoveryQueryKind = DiscoveryQueryKind.BROAD,
+    source_hint: str | None = None,
+    date_from: datetime = _T0,
+    date_to: datetime = _T1,
+) -> DiscoveryQuery:
+    return DiscoveryQuery(
+        query_text=keyword,
+        query_kind=query_kind,
+        source_hint=source_hint,
+        date_from=date_from,
+        date_to=date_to,
+        language="he",
+    )
+
+
+class TestExecutedQueryKey:
+    def test_storage_key_matches_pipeline_key(self) -> None:
+        record = _make_executed()
+        query = _make_query()
+        assert _executed_query_key(record) == _backfill_query_execution_key("brave", query)
+
+    def test_keys_differ_by_engine(self) -> None:
+        query = _make_query()
+        assert _backfill_query_execution_key("brave", query) != _backfill_query_execution_key(
+            "exa", query
+        )
+
+    def test_keys_differ_by_keyword(self) -> None:
+        q1 = _make_query(keyword="זנות")
+        q2 = _make_query(keyword="ליווי")
+        assert _backfill_query_execution_key("brave", q1) != _backfill_query_execution_key(
+            "brave", q2
+        )
+
+    def test_keys_differ_by_source_hint(self) -> None:
+        q_none = _make_query(source_hint=None)
+        q_ynet = _make_query(source_hint="ynet")
+        assert _backfill_query_execution_key("brave", q_none) != _backfill_query_execution_key(
+            "brave", q_ynet
+        )
+
+    def test_keys_differ_by_date_window(self) -> None:
+        q1 = _make_query(date_from=_T0, date_to=_T1)
+        q2 = _make_query(
+            date_from=datetime(2024, 1, 8, tzinfo=UTC),
+            date_to=datetime(2024, 1, 14, tzinfo=UTC),
+        )
+        assert _backfill_query_execution_key("brave", q1) != _backfill_query_execution_key(
+            "brave", q2
+        )
+
+    def test_query_with_none_dates_never_matches_executed_record(self) -> None:
+        q_no_dates = DiscoveryQuery(query_text="זנות", language="he")
+        record = _make_executed()
+        assert _backfill_query_execution_key("brave", q_no_dates) != _executed_query_key(record)
+
+
+class TestStateRepoExecutedQueryPersistence:
+    def test_load_returns_empty_frozenset_when_no_file(self, tmp_path: Path) -> None:
+        paths = resolve_discovery_state_paths(
+            state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
+        )
+        store = StateRepoDiscoveryPersistence(paths)
+        assert store.load_executed_backfill_query_keys() == frozenset()
+
+    def test_append_then_load_roundtrip(self, tmp_path: Path) -> None:
+        paths = resolve_discovery_state_paths(
+            state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
+        )
+        store = StateRepoDiscoveryPersistence(paths)
+        record = _make_executed()
+        store.append_executed_backfill_queries([record])
+
+        keys = store.load_executed_backfill_query_keys()
+        assert _executed_query_key(record) in keys
+
+    def test_appends_accumulate_across_calls(self, tmp_path: Path) -> None:
+        paths = resolve_discovery_state_paths(
+            state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
+        )
+        store = StateRepoDiscoveryPersistence(paths)
+        r1 = _make_executed(keyword="זנות")
+        r2 = _make_executed(keyword="ליווי")
+        store.append_executed_backfill_queries([r1])
+        store.append_executed_backfill_queries([r2])
+
+        keys = store.load_executed_backfill_query_keys()
+        assert _executed_query_key(r1) in keys
+        assert _executed_query_key(r2) in keys
+
+    def test_different_engines_tracked_independently(self, tmp_path: Path) -> None:
+        paths = resolve_discovery_state_paths(
+            state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
+        )
+        store = StateRepoDiscoveryPersistence(paths)
+        brave_record = _make_executed(engine="brave")
+        store.append_executed_backfill_queries([brave_record])
+
+        keys = store.load_executed_backfill_query_keys()
+        exa_query = _make_query()
+        assert _backfill_query_execution_key("exa", exa_query) not in keys
+        assert _backfill_query_execution_key("brave", exa_query) in keys
+
+    def test_executed_queries_path_is_in_backfill_batches_dir(self, tmp_path: Path) -> None:
+        paths = resolve_discovery_state_paths(
+            state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
+        )
+        assert paths.backfill_executed_queries_path == (
+            tmp_path / "news_items" / "discover" / "backfill_batches" / "executed_queries.jsonl"
+        )


### PR DESCRIPTION
## Summary

**Cross-run query execution tracking** so repeated backfill runs over the same date range don't re-charge Brave/Exa/Google CSE for already-covered (engine, keyword, window) combinations.

- Adds `ExecutedBackfillQuery` model tracking `(engine, query_kind, keyword, source_hint, date_from, date_to)` tuples
- Persists executed query records to `backfill_batches/executed_queries.jsonl` (append-only JSONL, committed by the existing workflow on every run)
- In `_run_backfill_engine_discovery`, filters `build_backfill_queries()` output against the persisted set before calling `engine.discover()` — already-executed queries are silently skipped
- Queries are only recorded **after** `engine.discover()` returns successfully; engine failures leave queries unrecorded so they are automatically retried

**Logging improvements** so every backfill run is self-describing:

- `DiscoveryRun.skipped_query_count` field records how many queries were skipped per engine/window run
- Per-engine INFO log: `"backfill engine=brave window=3: 144/144 queries skipped (already executed), running 0"`
- Per-batch summary log: `"backfill batch <id>: N queries run, M skipped, K candidates discovered"`
- `BackfillBatch.metadata` now stores `keywords`, `keyword_count`, `engines`, and `query_kinds` at batch creation time — every batch record is self-describing

**Seed file**: `data/news_items/discover/backfill_batches/executed_queries.jsonl` has been seeded with 5,760 records reconstructed from the 2026-01-01→2026-05-15 `full_source_targeted_domain` run (18 original keywords × 8 source domains × 20 windows × 2 engines). This means re-running discovery for the 3 new keywords over that period will only charge for those 3 new keywords, not re-run the 18 old ones.

## Key design decisions

- Key granularity is per-engine: Brave and Exa track coverage independently
- `None` dates in `DiscoveryQuery` produce an empty-string key component that never matches a persisted record — those queries always run
- Engine failures leave queries unrecorded → automatic retry on next run (conservative/safe)
- Supabase backend is a no-op for query tracking (no new table); state-repo file is sufficient since the workflow already commits `backfill_batches/`

## Test plan

- [ ] `tests/unit/test_backfill_query_tracking.py` — 11 tests covering key matching, JSONL roundtrip, multi-engine independence, path resolution
- [ ] `tests/unit/test_backfill_pipeline.py` — updated 3 mocks; all 21 tests pass
- [ ] Full unit suite: 877 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)