### PR TITLE
docs(plan): update agent plan post PRs #140–#144

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,23 +6,20 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `REVIEW-APP-PHASE-C-WORKBENCH` (PR #138) shipped the TFHT review
-  workbench — a Cloudflare Pages app backed by Supabase for reviewing `persistent_candidates` and
-  materialized `news_items` rows. Includes Copilot-review security and data-integrity fixes: fail-
-  closed allow-list auth, dev-email bypass gated behind `TFHT_REVIEW_DEV_MODE`, geography_city
-  sync with manual_city, always-write topic_tags, internal_only round-trip, string confidence
-  scoring, taxonomy-only-for-include, indexRelevant defaulting, not-found PATCH detection, and
-  README cleanup.
-- Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should resume the 2026 backfill from the
-  first incomplete window after classifier quota or credentials are restored, then build the
-  no-publication release bundle if the resumed run completes.
-- Current blockers on main: Google CSE support remains in code, but local wet tests may need
-  `agents/news/local_search_brave_exa.yaml` when Google CSE returns `403 PERMISSION_DENIED` / no API
-  access. The January 1-7 Chrome-CDP evidence is summarized in
-  `docs/january_2026_backfill_wet_test_evidence_2026_05_13.md`; the first no-CDP scrape attempt was
-  aborted/reset and should not be interpreted as valid scrape evidence. The 2026 backfill is also
-  blocked on Anthropic workspace API usage limits until quota or credentials are restored; the
-  2026-05-15 run stopped with provider access scheduled to return on 2026-06-01 00:00 UTC.
+- Last merged PR on main: PRs #140–#144 landed in sequence on 2026-05-16: sport1.maariv.co.il
+  domain exclusion (#140), labeling/workbench UX reference docs (#141), Cloudflare Pages manual
+  ingest workbench (#142), review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery
+  keywords (קורבנות סחר, רשת סחר, ניצול מיני) + title-noise pre-scrape filter + few-shot
+  classifier examples + source scrape-priority ordering (#143), and cross-run backfill query
+  execution tracking with `executed_queries.jsonl` persistence in the state repo (#144).
+- Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should run the CI backfill-discover job
+  for the 3 new keywords over 2026-01-01 → 2026-05-15 (discovery does not require Anthropic),
+  run CI backfill-scrape, then once Anthropic quota is restored (estimated 2026-06-01) run ingest
+  and build the no-publication release bundle.
+- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
+  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
+  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
+  returns `403 PERMISSION_DENIED`.
 
 ## Task Ledger
 
@@ -177,9 +174,26 @@
 - [done] `REVIEW-APP-PHASE-C-WORKBENCH`: Cloudflare Pages review workbench for `persistent_candidates`
   and `news_items` with Phase C taxonomy, index-relevance, case/event labeling, workflow tags, night
   mode, and Copilot-review security/data-integrity hardening.
-- [next] `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: after Anthropic quota or replacement credentials
-  are available, resume from the first incomplete window, finish the 2026-01-01 through 2026-05-15
-  backfill, run the no-publication release bundle, and produce a final publication go/no-go report.
+- [done] `DISC-PR-SPORT1-EXCLUDE` (#140): classify `sport1.maariv.co.il` as an irrelevant-content
+  domain, filtering it at the 3-layer candidate pipeline (search noise, scrape queue, review app)
+  while keeping `www.maariv.co.il` article candidates fully scrape-eligible.
+- [done] `DOCS-PR-LABELING-WORKBENCH` (#141): add labeling semantics reference and review workbench
+  UX guide so reviewers have a single authoritative document for category/taxonomy decisions.
+- [done] `INGEST-APP-PR-WORKBENCH` (#142): Cloudflare Pages manual ingest workbench for
+  triggering and monitoring ingest jobs from the browser.
+- [done] `REVIEW-APP-UX-3KW-FILTER` (#143): HE/EN language toggle, bulk false-positive exclude,
+  sort-order toggle, pending-filter fix, 3 new source_targeted discovery keywords, pre-scrape
+  title-noise filter (IDF/political/off-topic terms), 5 few-shot classifier examples, and
+  source-scrape priority ordering by true-positive signal density.
+- [done] `BACKFILL-PR-QUERY-TRACKING` (#144): cross-run backfill query execution tracking — persist
+  `(engine, query_kind, keyword, source_hint, date_from, date_to)` tuples to
+  `backfill_batches/executed_queries.jsonl` in the state repo; skip already-executed queries on
+  re-runs to avoid double-charging Brave/Exa. Seed file covers 5,760 records from the Jan–May 2026
+  source_targeted backfill run.
+- [next] `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: run CI backfill-discover for the 3 new keywords
+  (קורבנות סחר, רשת סחר, ניצול מיני) over 2026-01-01 → 2026-05-15, run CI backfill-scrape,
+  then once Anthropic quota is restored (estimated 2026-06-01) run ingest and build the
+  no-publication release bundle.
 
 ## Planning Workflow
 


### PR DESCRIPTION
## Summary

- Updates `.agent-plan.md` to present-tense main truth after five squash-merges on 2026-05-16
- Adds `[done]` task ledger entries for #140–#144
- Corrects **Mainline Status**: last merged PR is now #144, not #138
- Clarifies **Next planned PR** (`BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`): backfill-discover and backfill-scrape can run immediately; only ingest/classify is blocked on Anthropic quota (estimated return 2026-06-01)
- Tightens **Current Blockers** — quota blocks classification only, not discovery/scraping

## Test plan

- [ ] `validate-agent-plan` CI check passes (one `[next]`, correct headings, no invalid prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)