### PR TITLE
feat(backfill): enforce max_candidates_per_run cap with early window exit

### DIFF
--- a/agents/news/github.yaml
+++ b/agents/news/github.yaml
@@ -92,7 +92,6 @@ candidates:
 backfill:
   enabled: true
   batch_window_days: 7
-  max_candidates_per_run: 500
   max_scrape_attempts_per_run: 100
   query_kinds:
     - source_targeted

--- a/agents/news/local_search.yaml
+++ b/agents/news/local_search.yaml
@@ -87,7 +87,6 @@ source_discovery:
 backfill:
   enabled: true
   batch_window_days: 7
-  max_candidates_per_run: 500
   max_scrape_attempts_per_run: 100
 
 output:

--- a/agents/news/local_search_brave_exa.yaml
+++ b/agents/news/local_search_brave_exa.yaml
@@ -96,7 +96,6 @@ source_discovery:
 backfill:
   enabled: true
   batch_window_days: 7
-  max_candidates_per_run: 500
   max_scrape_attempts_per_run: 100
 
 output:

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -397,7 +397,7 @@ class BackfillConfig(BaseModel):
 
     enabled: bool = False
     batch_window_days: int = Field(default=7, ge=1)
-    max_candidates_per_run: int = Field(default=500, ge=1)
+    max_candidates_per_run: int = Field(default=5000, ge=1)
     max_scrape_attempts_per_run: int = Field(default=100, ge=1)
     max_source_targeted_taxonomy_queries_per_window: int = Field(default=50, ge=0)
     query_kinds: list[DiscoveryQueryKind] | None = None

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -2386,6 +2386,8 @@ async def run_news_backfill_discover_job(
         persisted_runs: list[PersistedSourceDiscovery] = []
 
         for window in windows:
+            window_run_start = len(persisted_runs)
+
             if source_native_can_run:
                 persisted = await _run_source_native_backfill_discovery(
                     config=config,
@@ -2430,11 +2432,27 @@ async def run_news_backfill_discover_job(
                         )
                     )
 
+            discovered_count += sum(
+                p.run.candidate_count for p in persisted_runs[window_run_start:]
+            )
+            if discovered_count >= config.backfill.max_candidates_per_run:
+                logger.info(
+                    "backfill batch %s: candidate cap %d reached after window %d/%d, stopping early",
+                    batch.batch_id,
+                    config.backfill.max_candidates_per_run,
+                    window.index,
+                    len(windows),
+                )
+                batch_warnings.append(
+                    f"candidate cap {config.backfill.max_candidates_per_run} reached after "
+                    f"window {window.index}/{len(windows)}"
+                )
+                break
+
         total_skipped = 0
         for persisted in persisted_runs:
             query_count += persisted.run.query_count
             total_skipped += persisted.run.skipped_query_count
-            discovered_count += persisted.run.candidate_count
             result.raw_article_count += persisted.run.candidate_count
             result.errors.extend(persisted.run.errors)
             batch_errors.extend(persisted.run.errors)

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -1352,3 +1352,136 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
     assert processed.warnings == ["raw_articles_skipped_outside_backfill_window=1"]
     assert [article.title for article in process.await_args.kwargs["all_articles"]] == ["title"]
     assert processed_store.get_backfill_batch("batch-1") is not None
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_stops_at_candidate_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When max_candidates_per_run is reached the job stops after that window and warns."""
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_FROM", "2026-01-01T00:00:00+00:00")
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_TO", "2026-01-21T00:00:00+00:00")
+
+    store = StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+    windows_seen: list[int] = []
+
+    async def fake_engine(
+        *,
+        config: Config,
+        run_id: str,
+        batch_id: str,
+        window,
+        engine_name: str,
+    ) -> PersistedSourceDiscovery:
+        del config, run_id, engine_name
+        windows_seen.append(window.index)
+        candidate = build_candidate(batch_id).model_copy(
+            update={"candidate_id": f"c-{window.index}"}
+        )
+        store.upsert_candidates([candidate])
+        return PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id=f"run-{window.index}",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.BACKFILL_DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                query_count=1,
+                candidate_count=3,
+                merged_candidate_count=3,
+            ),
+            candidates=[candidate],
+            provenance=[],
+            warnings=[],
+        )
+
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+    monkeypatch.setattr("denbust.pipeline._run_backfill_engine_discovery", fake_engine)
+
+    result = await run_news_backfill_discover_job(
+        Config(
+            job_name=JobName.BACKFILL_DISCOVER,
+            store={"state_root": tmp_path},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"brave": {"enabled": True}},
+            },
+            backfill={"max_candidates_per_run": 5},
+        )
+    )
+
+    assert result.fatal is False
+    # With cap=5 and 3 candidates per window, cap is hit after window 1 (total 3 < 5)
+    # then after window 2 (total 6 >= 5), so only 2 windows run.
+    assert len(windows_seen) == 2
+    assert any("candidate cap" in w for w in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_run_news_backfill_discover_job_processes_all_windows_under_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When discovered candidates stay below the cap, all windows are processed."""
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_FROM", "2026-01-01T00:00:00+00:00")
+    monkeypatch.setenv("DENBUST_BACKFILL_DATE_TO", "2026-01-14T00:00:00+00:00")
+
+    store = StateRepoDiscoveryPersistence(
+        resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    )
+    windows_seen: list[int] = []
+
+    async def fake_engine(
+        *,
+        config: Config,
+        run_id: str,
+        batch_id: str,
+        window,
+        engine_name: str,
+    ) -> PersistedSourceDiscovery:
+        del config, run_id, engine_name
+        windows_seen.append(window.index)
+        candidate = build_candidate(batch_id).model_copy(
+            update={"candidate_id": f"c-{window.index}"}
+        )
+        store.upsert_candidates([candidate])
+        return PersistedSourceDiscovery(
+            run=DiscoveryRun(
+                run_id=f"run-{window.index}",
+                dataset_name=DatasetName.NEWS_ITEMS,
+                job_name=JobName.BACKFILL_DISCOVER,
+                status=DiscoveryRunStatus.SUCCEEDED,
+                query_count=1,
+                candidate_count=1,
+                merged_candidate_count=1,
+            ),
+            candidates=[candidate],
+            provenance=[],
+            warnings=[],
+        )
+
+    monkeypatch.setattr("denbust.pipeline.create_discovery_persistence", lambda _config: store)
+    monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+    monkeypatch.setattr("denbust.pipeline._run_backfill_engine_discovery", fake_engine)
+
+    result = await run_news_backfill_discover_job(
+        Config(
+            job_name=JobName.BACKFILL_DISCOVER,
+            store={"state_root": tmp_path},
+            discovery={
+                "enabled": True,
+                "persist_candidates": True,
+                "engines": {"brave": {"enabled": True}},
+            },
+            backfill={"max_candidates_per_run": 100},
+        )
+    )
+
+    assert result.fatal is False
+    # 2 windows over 14 days, all should run
+    assert len(windows_seen) == 2
+    assert not any("candidate cap" in w for w in result.warnings)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -322,7 +322,7 @@ class TestConfig:
         config = BackfillConfig()
 
         assert config.batch_window_days == 7
-        assert config.max_candidates_per_run == 500
+        assert config.max_candidates_per_run == 5000
         assert config.max_scrape_attempts_per_run == 100
         assert config.max_source_targeted_taxonomy_queries_per_window == 50
 


### PR DESCRIPTION
## Summary

- Wires the existing `max_candidates_per_run` field in `BackfillConfig` into the discovery window loop: after each window's runs complete, the cumulative candidate count is checked and the loop exits early if the cap is reached, appending a warning to the batch.
- Raises the default cap from 500 → 5000 so normal runs are not artificially throttled.
- Removes the now-redundant `max_candidates_per_run: 500` lines from all three agent YAML configs (`github.yaml`, `local_search.yaml`, `local_search_brave_exa.yaml`).

## Changed files

| File | Change |
|------|--------|
| `src/denbust/pipeline.py` | Add `window_run_start` sentinel + cumulative count check + early break inside window loop |
| `src/denbust/config.py` | Raise default `max_candidates_per_run` 500 → 5000 |
| `agents/news/*.yaml` | Remove overridden `max_candidates_per_run: 500` from `backfill:` blocks |
| `tests/unit/test_backfill_pipeline.py` | Two new tests: cap-triggered early exit and no-stop-under-cap |
| `tests/unit/test_config.py` | Update default assertion 500 → 5000 |

## Test plan

- [x] `test_run_news_backfill_discover_job_stops_at_candidate_cap` — 3-window range, cap=5, fake engine returns 3 per window → only 2 windows run, warning emitted
- [x] `test_run_news_backfill_discover_job_processes_all_windows_under_cap` — 2-window range, cap=100, fake engine returns 1 per window → both windows run, no warning
- [x] All 911 unit tests pass locally
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)