### PR TITLE
docs(plan): update agent plan post PRs #145–#146

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,12 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: PRs #140–#144 landed in sequence on 2026-05-16: sport1.maariv.co.il
-  domain exclusion (#140), labeling/workbench UX reference docs (#141), Cloudflare Pages manual
-  ingest workbench (#142), review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery
-  keywords (קורבנות סחר, רשת סחר, ניצול מיני) + title-noise pre-scrape filter + few-shot
-  classifier examples + source scrape-priority ordering (#143), and cross-run backfill query
-  execution tracking with `executed_queries.jsonl` persistence in the state repo (#144).
+- Last merged PR on main: PRs #140–#146 landed on 2026-05-16: sport1.maariv.co.il domain
+  exclusion (#140), labeling/workbench UX reference docs (#141), Cloudflare Pages manual ingest
+  workbench (#142), review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery keywords
+  (קורבנות סחר, רשת סחר, ניצול מיני) + title-noise pre-scrape filter + few-shot classifier
+  examples + source scrape-priority ordering (#143), cross-run backfill query execution tracking
+  with `executed_queries.jsonl` persistence in the state repo (#144), agent-plan post-144 update
+  (#145), and backfill `max_candidates_per_run` cap enforcement with early window exit + default
+  raised 500 → 5000 (#146).
 - Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should run the CI backfill-discover job
   for the 3 new keywords over 2026-01-01 → 2026-05-15 (discovery does not require Anthropic),
   run CI backfill-scrape, then once Anthropic quota is restored (estimated 2026-06-01) run ingest
@@ -190,6 +192,12 @@
   `backfill_batches/executed_queries.jsonl` in the state repo; skip already-executed queries on
   re-runs to avoid double-charging Brave/Exa. Seed file covers 5,760 records from the Jan–May 2026
   source_targeted backfill run.
+- [done] `DOCS-PR-PLAN-UPDATE-POST-144` (#145): update `.agent-plan.md` to reflect PRs #140–#144
+  merged and clarify that backfill-discover and backfill-scrape can proceed immediately while only
+  classify/ingest is blocked on Anthropic quota restoration.
+- [done] `BACKFILL-PR-CANDIDATE-CAP` (#146): wire the existing `max_candidates_per_run`
+  `BackfillConfig` field into the discovery window loop so runs exit early once the cap is reached;
+  raise the default 500 → 5000; remove redundant explicit overrides from agent YAML configs.
 - [next] `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`: run CI backfill-discover for the 3 new keywords
   (קורבנות סחר, רשת סחר, ניצול מיני) over 2026-01-01 → 2026-05-15, run CI backfill-scrape,
   then once Anthropic quota is restored (estimated 2026-06-01) run ingest and build the


### PR DESCRIPTION
## Summary

- Records PRs #145 (plan update) and #146 (backfill candidate-cap enforcement) as `[done]` in the Task Ledger.
- Updates the Mainline Status "Last merged PR on main" summary to cover #140–#146.

Docs-only change; no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)