### PR TITLE
feat(filters): expand domain and title-noise exclusion lists from triage evidence

### DIFF
--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -41,6 +41,13 @@ _SOCIAL_PROFILE_DOMAINS: frozenset[str] = frozenset(
 _IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
     {
         "sport1.maariv.co.il",  # sports vertical — consistently off-topic
+        "he.wikipedia.org",  # encyclopedia — never enforcement news
+        "srugim.co.il",  # Orthodox community site — off-topic
+        "themarker.com",  # financial/business news — off-topic
+        "collab.mako.co.il",  # Mako user-generated content subdomain
+        "kikar.co.il",  # ultra-Orthodox news — off-topic
+        "atzat-nefesh.org",  # mental health org — off-topic
+        "il.bongogirls.ru",  # noise
     }
 )
 
@@ -59,16 +66,42 @@ _SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
 
 _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
     {
+        # ── military / geopolitical ──────────────────────────────────────────
         'צה"ל',  # IDF — ASCII double-quote form
         "צה״ל",  # IDF — Hebrew gershayim form
         "צהל",  # IDF — no punctuation form
-        "איראן",  # Iran — geopolitical
-        "נתניהו",  # Netanyahu — political
-        "טראמפ",  # Trump — political
-        "חיזבאללה",  # Hezbollah — military
-        "ספורט",  # sports
+        "איראן",  # Iran
+        "חיזבאללה",  # Hezbollah
+        "עזה",  # Gaza
+        "קטאר",  # Qatar — geopolitical/sports noise
+        "ונצואלה",  # Venezuela
+        "מדורו",  # Maduro — Venezuelan politics
+        "ממדאני",  # Madani — UN SG noise
+        # ── politics ─────────────────────────────────────────────────────────
+        "נתניהו",  # Netanyahu
+        "טראמפ",  # Trump
+        "בלפור",  # Balfour St protests — covers בלפור and בבלפור
+        "פוליטי",  # generic political commentary
+        # ── finance / business ───────────────────────────────────────────────
         "מניות",  # stocks / financial markets
-        "עזה",  # Gaza — military/geopolitical
+        "שוק ההון",  # capital markets
+        "גלובס",  # Globes financial news brand
+        "themarker",  # TheMarker financial news brand (case-insensitive match)
+        # ── supermarkets / retail noise ──────────────────────────────────────
+        "שופרסל",  # Shufersal supermarket chain
+        "ויקטורי",  # Victory supermarket chain
+        "רמי לוי",  # Rami Levy supermarket chain
+        "ksp",  # KSP electronics chain (case-insensitive)
+        # ── sports ───────────────────────────────────────────────────────────
+        "ספורט",  # sports
+        "מכבי",  # Maccabi sports teams (Maccabi Haifa, Tel Aviv, etc.)
+        # ── media brand names appearing as title suffixes ────────────────────
+        "ויקיפדיה",  # Wikipedia entries
+        "סרוגים",  # Srugim site brand name
+        "כיכר השבת",  # Kikar HaShabbat ultra-Orthodox site brand
+        "וואלה חדשות",  # Walla News brand in title (topic/nav pages)
+        # ── celebrity / entertainment ────────────────────────────────────────
+        "אייל גולן",  # Israeli singer — consistently off-topic
     }
 )
 


### PR DESCRIPTION
## Summary

Expands the pre-scrape candidate filter lists based on manual triage evidence from reviewing ~550 candidates across 3 new backfill keywords (קורבנות סחר, רשת סחר, ניצול מיני), where 499/550 (~91%) were excluded as noise.

### Domain exclusions added to `_IRRELEVANT_CONTENT_DOMAINS` (7 new)

| Domain | Reason |
|---|---|
| `he.wikipedia.org` | Encyclopedia — never enforcement news |
| `srugim.co.il` | Orthodox community site — off-topic |
| `themarker.com` | Financial/business news — off-topic |
| `collab.mako.co.il` | Mako user-generated content subdomain |
| `kikar.co.il` | Ultra-Orthodox news — off-topic |
| `atzat-nefesh.org` | Mental health org — off-topic |
| `il.bongogirls.ru` | Noise |

Note: `tiktok.com` was not added to domain exclusions because TikTok video posts (path pattern `/@.../video/...`) are a valid source type and are already routed through the social-post filter; only profile pages are suppressed.

### Title-noise terms added to `_EXCLUDED_TITLE_TERMS` (19 new)

| Term | Category |
|---|---|
| `קטאר`, `ונצואלה`, `מדורו`, `ממדאני` | Geopolitical noise |
| `בלפור`, `פוליטי` | Political noise |
| `שוק ההון`, `גלובס`, `themarker` | Finance/business noise |
| `שופרסל`, `ויקטורי`, `רמי לוי`, `ksp` | Supermarket/retail noise |
| `מכבי` | Sports (Maccabi teams) |
| `ויקיפדיה`, `סרוגים`, `כיכר השבת`, `וואלה חדשות` | Media brand suffixes in titles |
| `אייל גולן` | Celebrity/entertainment |

Multi-word terms (`שוק ההון`, `רמי לוי`, `כיכר השבת`, `וואלה חדשות`) use the existing substring casefold match so they only fire when the phrase appears verbatim — avoiding false positives on individual words that may appear in on-topic articles.

Terms with high false-positive risk were deliberately excluded: `נישואין`, `חתונה`, `רשת` appear in both noise and actual enforcement-news titles.

## Test plan

- [x] All 48 existing filter unit tests pass: `pytest -q tests/unit/test_candidate_filters.py`
- [x] Sanity checks: `נישואין בכפייה` and `קורבן סחר` titles are NOT filtered; `TheMarker`, `אייל גולן`, `כיכר השבת` titles ARE filtered
- [x] `ruff format .` and `ruff check .` clean
- [x] `mypy src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)