### PR TITLE
feat(triage): add local pre-scrape triage workbench

### DIFF
--- a/triage_app/public/app.js
+++ b/triage_app/public/app.js
@@ -53,6 +53,7 @@ async function postTriage(candidateId, action) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ candidate_id: candidateId, action }),
   });
+  if (!res.ok) throw new Error(`triage failed: ${res.status}`);
   return res.json();
 }
 
@@ -162,10 +163,16 @@ async function load(resetPage = false) {
 
 // ── triage action ─────────────────────────────────────────────────────────
 async function triage(candidateId, action) {
-  const result = await postTriage(candidateId, action);
+  let result;
+  try {
+    result = await postTriage(candidateId, action);
+  } catch (err) {
+    showToast(`שגיאה: ${err.message}`);
+    return;
+  }
   if (result.stats) renderStats(result.stats);
 
-  // optimistically update the local item so the row re-renders immediately
+  // update local item only after server confirmed the decision
   const item = state.items.find(c => c.candidate_id === candidateId);
   if (item) {
     if (action === 'exclude')    { item.triage = 'excluded';    item.candidate_status = 'suppressed'; }

--- a/triage_app/public/app.js
+++ b/triage_app/public/app.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const API = '';  // same origin
+const LIMIT = 50;
+
+let state = {
+  batchId: '',
+  status: 'all',
+  q: '',
+  page: 1,
+  total: 0,
+  pages: 1,
+  items: [],
+  selectedIdx: -1,
+};
+
+// ── DOM refs ──────────────────────────────────────────────────────────────
+const tbody       = document.getElementById('tbody');
+const emptyEl     = document.getElementById('empty');
+const resultCount = document.getElementById('result-count');
+const pgInfo      = document.getElementById('pg-info');
+const pgPrev      = document.getElementById('pg-prev');
+const pgNext      = document.getElementById('pg-next');
+const batchSel    = document.getElementById('batch-select');
+const searchEl    = document.getElementById('search');
+const toast       = document.getElementById('toast');
+const statTotal   = document.getElementById('stat-total');
+const statUnrev   = document.getElementById('stat-unreviewed');
+const statPri     = document.getElementById('stat-prioritized');
+const statExcl    = document.getElementById('stat-excluded');
+
+// ── API ───────────────────────────────────────────────────────────────────
+async function fetchCandidates() {
+  const params = new URLSearchParams({
+    status: state.status,
+    page: state.page,
+    limit: LIMIT,
+  });
+  if (state.batchId) params.set('batch_id', state.batchId);
+  if (state.q)       params.set('q', state.q);
+  const res = await fetch(`${API}/api/candidates?${params}`);
+  return res.json();
+}
+
+async function fetchStats() {
+  const res = await fetch(`${API}/api/stats`);
+  return res.json();
+}
+
+async function postTriage(candidateId, action) {
+  const res = await fetch(`${API}/api/triage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ candidate_id: candidateId, action }),
+  });
+  return res.json();
+}
+
+// ── render ────────────────────────────────────────────────────────────────
+function renderStats(s) {
+  statTotal.textContent  = s.total;
+  statUnrev.textContent  = s.unreviewed;
+  statPri.textContent    = s.prioritized;
+  statExcl.textContent   = s.excluded;
+}
+
+function renderBatchOptions(batchIds) {
+  // preserve current selection
+  const cur = batchSel.value;
+  while (batchSel.options.length > 1) batchSel.remove(1);
+  for (const bid of batchIds) {
+    const opt = document.createElement('option');
+    opt.value = bid;
+    opt.textContent = bid.slice(0, 8) + '…';
+    opt.title = bid;
+    batchSel.appendChild(opt);
+  }
+  if (cur) batchSel.value = cur;
+}
+
+function triagebadge(triage) {
+  if (triage === 'excluded')    return `<span class="triage-badge excluded">● הוחרג</span>`;
+  if (triage === 'prioritized') return `<span class="triage-badge prioritized">● עדיפות</span>`;
+  return `<span class="triage-badge unreviewed">○ לא סוקר</span>`;
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try { return iso.slice(0, 10); } catch { return iso; }
+}
+
+function renderRows() {
+  const { items, selectedIdx } = state;
+  if (!items.length) {
+    tbody.innerHTML = '';
+    emptyEl.style.display = '';
+    return;
+  }
+  emptyEl.style.display = 'none';
+
+  const rows = items.map((c, i) => {
+    const sel = i === selectedIdx ? 'selected' : '';
+    const triageCls = c.triage ? c.triage : '';
+    const badge = triagebadge(c.triage);
+    const shortUrl = c.url.replace(/^https?:\/\//, '').slice(0, 60);
+    const title = escHtml(c.title || c.url);
+    const snippet = escHtml(c.snippet || '');
+    const actionBtns = c.triage === 'excluded'
+      ? `<button class="btn btn-prioritize" data-id="${c.candidate_id}" data-action="prioritize">עדיפות</button>
+         <button class="btn btn-reset"      data-id="${c.candidate_id}" data-action="reset">אפס</button>`
+      : c.triage === 'prioritized'
+      ? `<button class="btn btn-exclude" data-id="${c.candidate_id}" data-action="exclude">החרג</button>
+         <button class="btn btn-reset"   data-id="${c.candidate_id}" data-action="reset">אפס</button>`
+      : `<button class="btn btn-exclude"    data-id="${c.candidate_id}" data-action="exclude">החרג</button>
+         <button class="btn btn-prioritize" data-id="${c.candidate_id}" data-action="prioritize">עדיפות</button>`;
+
+    return `<tr class="candidate ${triageCls} ${sel}" data-idx="${i}" data-id="${c.candidate_id}">
+      <td>
+        <div class="domain">${escHtml(c.domain)}</div>
+        <a class="url-link" href="${escHtml(c.url)}" target="_blank" rel="noopener">${escHtml(shortUrl)}</a>
+      </td>
+      <td><div class="title">${title}</div></td>
+      <td><div class="snippet">${snippet}</div></td>
+      <td><div class="date">${formatDate(c.first_seen_at)}</div></td>
+      <td class="actions" style="text-align:left">
+        ${badge}
+        <div style="display:flex;gap:6px;margin-top:4px">${actionBtns}</div>
+      </td>
+    </tr>`;
+  });
+
+  tbody.innerHTML = rows.join('');
+}
+
+function renderPagination() {
+  pgPrev.disabled = state.page <= 1;
+  pgNext.disabled = state.page >= state.pages;
+  pgInfo.textContent = `עמוד ${state.page} מתוך ${state.pages}`;
+  resultCount.textContent = `${state.total} תוצאות`;
+}
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── load ──────────────────────────────────────────────────────────────────
+async function load(resetPage = false) {
+  if (resetPage) { state.page = 1; state.selectedIdx = -1; }
+  const [data, stats] = await Promise.all([fetchCandidates(), fetchStats()]);
+  state.total = data.total;
+  state.pages = data.pages;
+  state.items = data.items;
+  renderStats(stats);
+  renderBatchOptions(stats.batch_ids);
+  renderRows();
+  renderPagination();
+}
+
+// ── triage action ─────────────────────────────────────────────────────────
+async function triage(candidateId, action) {
+  const result = await postTriage(candidateId, action);
+  if (result.stats) renderStats(result.stats);
+
+  // optimistically update the local item so the row re-renders immediately
+  const item = state.items.find(c => c.candidate_id === candidateId);
+  if (item) {
+    if (action === 'exclude')    { item.triage = 'excluded';    item.candidate_status = 'suppressed'; }
+    if (action === 'prioritize') { item.triage = 'prioritized'; item.retry_priority = 100; }
+    if (action === 'reset')      { item.triage = '';            item.candidate_status = 'new'; item.retry_priority = 0; }
+  }
+  renderRows();
+
+  const labels = { exclude: 'הוחרג', prioritize: 'עדיפות', reset: 'אופס' };
+  showToast(labels[action] || action);
+}
+
+// ── toast ─────────────────────────────────────────────────────────────────
+let _toastTimer;
+function showToast(msg) {
+  toast.textContent = msg;
+  toast.classList.add('show');
+  clearTimeout(_toastTimer);
+  _toastTimer = setTimeout(() => toast.classList.remove('show'), 1200);
+}
+
+// ── selection ─────────────────────────────────────────────────────────────
+function selectRow(idx) {
+  if (idx < 0 || idx >= state.items.length) return;
+  state.selectedIdx = idx;
+  renderRows();
+  const row = tbody.querySelector(`tr[data-idx="${idx}"]`);
+  if (row) row.scrollIntoView({ block: 'nearest' });
+}
+
+// ── keyboard ──────────────────────────────────────────────────────────────
+document.addEventListener('keydown', async e => {
+  // don't intercept when typing in inputs
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') {
+    if (e.key === 'Escape') { e.target.blur(); searchEl.value = ''; state.q = ''; load(true); }
+    return;
+  }
+
+  const { selectedIdx, items } = state;
+  const sel = items[selectedIdx];
+
+  switch (e.key) {
+    case 'j': case 'ArrowDown':
+      e.preventDefault(); selectRow(Math.min(selectedIdx + 1, items.length - 1)); break;
+    case 'k': case 'ArrowUp':
+      e.preventDefault(); selectRow(Math.max(selectedIdx - 1, 0)); break;
+    case 'e': if (sel) { e.preventDefault(); await triage(sel.candidate_id, 'exclude'); } break;
+    case 'p': if (sel) { e.preventDefault(); await triage(sel.candidate_id, 'prioritize'); } break;
+    case 'r': if (sel) { e.preventDefault(); await triage(sel.candidate_id, 'reset'); } break;
+    case '/': e.preventDefault(); searchEl.focus(); break;
+    case 'ArrowLeft':  e.preventDefault(); if (state.page < state.pages)  { state.page++; load(); } break;
+    case 'ArrowRight': e.preventDefault(); if (state.page > 1) { state.page--; load(); } break;
+  }
+});
+
+// ── event wiring ──────────────────────────────────────────────────────────
+tbody.addEventListener('click', async e => {
+  const btn = e.target.closest('[data-action]');
+  if (btn) {
+    e.stopPropagation();
+    await triage(btn.dataset.id, btn.dataset.action);
+    return;
+  }
+  const row = e.target.closest('tr[data-idx]');
+  if (row) selectRow(Number(row.dataset.idx));
+});
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    tab.classList.add('active');
+    state.status = tab.dataset.status;
+    load(true);
+  });
+});
+
+batchSel.addEventListener('change', () => {
+  state.batchId = batchSel.value;
+  load(true);
+});
+
+let _searchTimer;
+searchEl.addEventListener('input', () => {
+  clearTimeout(_searchTimer);
+  _searchTimer = setTimeout(() => { state.q = searchEl.value.trim(); load(true); }, 250);
+});
+
+pgPrev.addEventListener('click', () => { if (state.page > 1) { state.page--; load(); } });
+pgNext.addEventListener('click', () => { if (state.page < state.pages) { state.page++; load(); } });
+
+// ── init ──────────────────────────────────────────────────────────────────
+(async () => {
+  await load(true);
+  // Default: select new-batch filter if a batch exists and has candidates
+  const stats = await fetchStats();
+  if (stats.batch_ids.length > 0) {
+    // pre-select the most recent batch (last in list = most recently added)
+    const latestBatch = stats.batch_ids[stats.batch_ids.length - 1];
+    batchSel.value = latestBatch;
+    state.batchId = latestBatch;
+    await load(true);
+  }
+  if (state.items.length > 0) selectRow(0);
+})();

--- a/triage_app/public/index.html
+++ b/triage_app/public/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Triage Workbench</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --border: #2e3146;
+      --text: #e2e4f0;
+      --muted: #8b8fa8;
+      --accent: #6c75f0;
+      --red: #e05c6a;
+      --green: #4caf82;
+      --orange: #e09a4c;
+      --row-hover: #22263a;
+      --row-selected: #1e2540;
+      --radius: 6px;
+    }
+
+    body { background: var(--bg); color: var(--text); font-family: system-ui, -apple-system, sans-serif; font-size: 14px; height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
+
+    /* ── top bar ── */
+    #topbar { background: var(--surface); border-bottom: 1px solid var(--border); padding: 10px 16px; display: flex; align-items: center; gap: 16px; flex-shrink: 0; }
+    #topbar h1 { font-size: 15px; font-weight: 600; color: var(--accent); white-space: nowrap; }
+    .stat { display: flex; flex-direction: column; align-items: center; min-width: 56px; }
+    .stat-val { font-size: 18px; font-weight: 700; line-height: 1; }
+    .stat-lbl { font-size: 10px; color: var(--muted); margin-top: 2px; }
+    .stat-val.unreviewed { color: var(--text); }
+    .stat-val.excluded { color: var(--red); }
+    .stat-val.prioritized { color: var(--green); }
+    #topbar .spacer { flex: 1; }
+    #kbd-hint { font-size: 11px; color: var(--muted); white-space: nowrap; }
+
+    /* ── filter bar ── */
+    #filterbar { background: var(--surface); border-bottom: 1px solid var(--border); padding: 8px 16px; display: flex; align-items: center; gap: 10px; flex-shrink: 0; flex-wrap: wrap; }
+    select, input[type=text] { background: var(--bg); border: 1px solid var(--border); color: var(--text); border-radius: var(--radius); padding: 5px 8px; font-size: 13px; outline: none; }
+    select:focus, input[type=text]:focus { border-color: var(--accent); }
+    .tabs { display: flex; gap: 4px; }
+    .tab { padding: 5px 12px; border-radius: var(--radius); border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; font-size: 12px; transition: all .15s; }
+    .tab.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+    #filterbar .spacer { flex: 1; }
+    #search { width: 220px; direction: ltr; }
+    #result-count { font-size: 12px; color: var(--muted); white-space: nowrap; }
+
+    /* ── table area ── */
+    #table-wrap { flex: 1; overflow-y: auto; }
+    table { width: 100%; border-collapse: collapse; }
+    thead { position: sticky; top: 0; background: var(--surface); z-index: 10; }
+    th { padding: 8px 12px; text-align: right; font-weight: 600; font-size: 12px; color: var(--muted); border-bottom: 1px solid var(--border); white-space: nowrap; }
+    th:last-child { text-align: left; }
+    td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tr.candidate { cursor: pointer; transition: background .1s; }
+    tr.candidate:hover { background: var(--row-hover); }
+    tr.candidate.selected { outline: 1px solid var(--accent) inset; }
+    tr.candidate.excluded  { background: rgba(224, 92, 106, 0.07); }
+    tr.candidate.excluded:hover  { background: rgba(224, 92, 106, 0.13); }
+    tr.candidate.excluded td { opacity: .6; }
+    tr.candidate.prioritized { background: rgba(76, 175, 130, 0.08); }
+    tr.candidate.prioritized:hover { background: rgba(76, 175, 130, 0.14); }
+
+    .domain { font-size: 12px; color: var(--muted); white-space: nowrap; }
+    .title { font-size: 13px; font-weight: 500; direction: rtl; }
+    .snippet { font-size: 12px; color: var(--muted); direction: rtl; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; max-width: 480px; }
+    .date { font-size: 11px; color: var(--muted); white-space: nowrap; direction: ltr; }
+    .url-link { font-size: 11px; color: var(--accent); word-break: break-all; direction: ltr; }
+    .triage-badge { display: inline-block; padding: 3px 9px; border-radius: 99px; font-size: 12px; font-weight: 700; letter-spacing: .01em; }
+    .triage-badge.unreviewed  { background: #1e2030; color: var(--muted); }
+    .triage-badge.excluded    { background: #3a1820; color: var(--red); }
+    .triage-badge.prioritized { background: #182e24; color: var(--green); }
+
+    .actions { display: flex; gap: 6px; align-items: center; }
+    .btn { border: none; border-radius: var(--radius); padding: 4px 10px; font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity .1s; white-space: nowrap; }
+    .btn:hover { opacity: .85; }
+    .btn-exclude { background: #3a1820; color: var(--red); }
+    .btn-prioritize { background: #182e24; color: var(--green); }
+    .btn-reset { background: #22263a; color: var(--muted); }
+
+    /* ── pagination ── */
+    #pagination { background: var(--surface); border-top: 1px solid var(--border); padding: 8px 16px; display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+    .pg-btn { background: var(--bg); border: 1px solid var(--border); color: var(--text); border-radius: var(--radius); padding: 4px 10px; cursor: pointer; font-size: 12px; }
+    .pg-btn:disabled { opacity: .35; cursor: default; }
+    #pg-info { font-size: 12px; color: var(--muted); }
+    #pagination .spacer { flex: 1; }
+
+    /* ── toast ── */
+    #toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); background: var(--surface); border: 1px solid var(--border); padding: 8px 18px; border-radius: 99px; font-size: 13px; opacity: 0; transition: opacity .2s; pointer-events: none; z-index: 100; }
+    #toast.show { opacity: 1; }
+
+    #empty { padding: 48px; text-align: center; color: var(--muted); }
+  </style>
+</head>
+<body>
+
+<div id="topbar">
+  <h1>Triage Workbench</h1>
+  <div class="stat"><span class="stat-val" id="stat-total">–</span><span class="stat-lbl">סה"כ</span></div>
+  <div class="stat"><span class="stat-val unreviewed" id="stat-unreviewed">–</span><span class="stat-lbl">לסקירה</span></div>
+  <div class="stat"><span class="stat-val prioritized" id="stat-prioritized">–</span><span class="stat-lbl">עדיפות</span></div>
+  <div class="stat"><span class="stat-val excluded" id="stat-excluded">–</span><span class="stat-lbl">הוחרגו</span></div>
+  <div class="spacer"></div>
+  <span id="kbd-hint">e=החרג &nbsp; p=עדיפות &nbsp; r=אפס &nbsp; j/k=ניווט &nbsp; /=חיפוש</span>
+</div>
+
+<div id="filterbar">
+  <select id="batch-select">
+    <option value="">כל ה-batches</option>
+  </select>
+  <div class="tabs">
+    <button class="tab active" data-status="all">הכל</button>
+    <button class="tab" data-status="unreviewed">לא סוקר</button>
+    <button class="tab" data-status="prioritized">עדיפות</button>
+    <button class="tab" data-status="excluded">הוחרגו</button>
+  </div>
+  <div class="spacer"></div>
+  <input type="text" id="search" placeholder="חפש…" dir="rtl">
+  <span id="result-count"></span>
+</div>
+
+<div id="table-wrap">
+  <table id="tbl">
+    <thead>
+      <tr>
+        <th>מקור</th>
+        <th>כותרת</th>
+        <th>תקציר</th>
+        <th>תאריך</th>
+        <th style="text-align:left">סטטוס / פעולה</th>
+      </tr>
+    </thead>
+    <tbody id="tbody"></tbody>
+  </table>
+  <div id="empty" style="display:none">אין תוצאות</div>
+</div>
+
+<div id="pagination">
+  <button class="pg-btn" id="pg-prev">‹ הקודם</button>
+  <span id="pg-info"></span>
+  <div class="spacer"></div>
+  <button class="pg-btn" id="pg-next">הבא ›</button>
+</div>
+
+<div id="toast"></div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/triage_app/serve.py
+++ b/triage_app/serve.py
@@ -37,13 +37,14 @@ DEFAULT_PORT = 7070
 
 _candidates: dict[str, dict[str, Any]] = {}
 _batch_ids: list[str] = []
+_origin: str = f"http://localhost:{DEFAULT_PORT}"
 
 
 def _load_candidates() -> None:
     if not CANDIDATES_FILE.exists():
         print(f"ERROR: candidates file not found: {CANDIDATES_FILE}", file=sys.stderr)
         sys.exit(1)
-    with CANDIDATES_FILE.open() as fh:
+    with CANDIDATES_FILE.open(encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if not line:
@@ -62,7 +63,7 @@ def _load_candidates() -> None:
 def _load_decisions() -> None:
     if not DECISIONS_FILE.exists():
         return
-    with DECISIONS_FILE.open() as fh:
+    with DECISIONS_FILE.open(encoding="utf-8") as fh:
         latest: dict[str, dict[str, Any]] = {}
         for line in fh:
             line = line.strip()
@@ -73,7 +74,11 @@ def _load_decisions() -> None:
     for d in latest.values():
         cid = d["candidate_id"]
         if cid in _candidates:
-            _apply(_candidates[cid], d["action"])
+            c = _candidates[cid]
+            # Snapshot original priority before any decision so reset is idempotent
+            if "_orig_priority" not in c:
+                c["_orig_priority"] = c.get("retry_priority", 0)
+            _apply(c, d["action"])
 
 
 def _apply(candidate: dict[str, Any], action: str) -> None:
@@ -103,7 +108,7 @@ def _record_decision(candidate_id: str, action: str) -> bool:
         "decided_at": datetime.now(UTC).isoformat(),
         "batch_id": c.get("backfill_batch_id"),
     }
-    with DECISIONS_FILE.open("a") as fh:
+    with DECISIONS_FILE.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(d, ensure_ascii=False) + "\n")
     return True
 
@@ -192,13 +197,13 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", _origin)
         self.end_headers()
         self.wfile.write(body)
 
     def do_OPTIONS(self) -> None:
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", _origin)
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
@@ -208,21 +213,31 @@ class Handler(BaseHTTPRequestHandler):
         qs = parse_qs(parsed.query)
 
         if parsed.path == "/api/candidates":
+            try:
+                page = max(1, int(qs.get("page", ["1"])[0]))
+                limit = max(1, min(200, int(qs.get("limit", ["50"])[0])))
+            except ValueError:
+                self._json({"error": "invalid page or limit"}, 400)
+                return
             self._json(
                 _query_candidates(
                     batch_id=qs.get("batch_id", [None])[0],
                     status=qs.get("status", ["all"])[0],
                     q=qs.get("q", [""])[0],
-                    page=int(qs.get("page", ["1"])[0]),
-                    limit=int(qs.get("limit", ["50"])[0]),
+                    page=page,
+                    limit=limit,
                 )
             )
         elif parsed.path == "/api/stats":
             self._json(_stats())
         else:
-            # Static files
+            # Static files — resolve and confine to PUBLIC_DIR
             rel = parsed.path.lstrip("/") or "index.html"
-            filepath = PUBLIC_DIR / rel
+            filepath = (PUBLIC_DIR / rel).resolve()
+            if not filepath.is_relative_to(PUBLIC_DIR.resolve()):
+                self.send_response(403)
+                self.end_headers()
+                return
             if not filepath.exists() or not filepath.is_file():
                 self.send_response(404)
                 self.end_headers()
@@ -262,6 +277,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Local pre-scrape triage server")
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
     args = parser.parse_args()
+
+    global _origin
+    _origin = f"http://localhost:{args.port}"
 
     print(f"Loading candidates from {CANDIDATES_FILE} …")
     _load_candidates()

--- a/triage_app/serve.py
+++ b/triage_app/serve.py
@@ -21,9 +21,17 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.models.common import DatasetName, JobName
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CANDIDATES_FILE = REPO_ROOT / "data/news_items/discover/candidates/latest_candidates.jsonl"
-DECISIONS_FILE = REPO_ROOT / "data/news_items/discover/candidates/triage_decisions.jsonl"
+_STATE = resolve_discovery_state_paths(
+    state_root=REPO_ROOT / "data",
+    dataset_name=DatasetName.NEWS_ITEMS,
+    job_name=JobName.DISCOVER,
+)
+CANDIDATES_FILE = _STATE.latest_candidates_path
+DECISIONS_FILE = _STATE.candidates_dir / "triage_decisions.jsonl"
 PUBLIC_DIR = Path(__file__).resolve().parent / "public"
 DEFAULT_PORT = 7070
 

--- a/triage_app/serve.py
+++ b/triage_app/serve.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Local pre-scrape triage server.
+
+Serves candidates from the local state JSONL for fast batch exclude/prioritize
+decisions before the scrape phase.  No Supabase reads during a review session —
+use sync.py when you're done to push decisions upstream.
+
+Usage:
+    python triage_app/serve.py [--port 7070]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import sys
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANDIDATES_FILE = REPO_ROOT / "data/news_items/discover/candidates/latest_candidates.jsonl"
+DECISIONS_FILE = REPO_ROOT / "data/news_items/discover/candidates/triage_decisions.jsonl"
+PUBLIC_DIR = Path(__file__).resolve().parent / "public"
+DEFAULT_PORT = 7070
+
+_candidates: dict[str, dict[str, Any]] = {}
+_batch_ids: list[str] = []
+
+
+def _load_candidates() -> None:
+    if not CANDIDATES_FILE.exists():
+        print(f"ERROR: candidates file not found: {CANDIDATES_FILE}", file=sys.stderr)
+        sys.exit(1)
+    with CANDIDATES_FILE.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            c = json.loads(line)
+            _candidates[c["candidate_id"]] = c
+
+    seen: set[str] = set()
+    for c in _candidates.values():
+        bid = c.get("backfill_batch_id")
+        if bid and bid not in seen:
+            seen.add(bid)
+            _batch_ids.append(bid)
+
+
+def _load_decisions() -> None:
+    if not DECISIONS_FILE.exists():
+        return
+    with DECISIONS_FILE.open() as fh:
+        latest: dict[str, dict[str, Any]] = {}
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            latest[d["candidate_id"]] = d
+    for d in latest.values():
+        cid = d["candidate_id"]
+        if cid in _candidates:
+            _apply(_candidates[cid], d["action"])
+
+
+def _apply(candidate: dict[str, Any], action: str) -> None:
+    if action == "exclude":
+        candidate["candidate_status"] = "suppressed"
+        candidate["_triage"] = "excluded"
+    elif action == "prioritize":
+        candidate["retry_priority"] = 100
+        candidate["_triage"] = "prioritized"
+    elif action == "reset":
+        candidate["candidate_status"] = "new"
+        candidate["retry_priority"] = candidate.get("_orig_priority", 0)
+        candidate.pop("_triage", None)
+
+
+def _record_decision(candidate_id: str, action: str) -> bool:
+    if candidate_id not in _candidates:
+        return False
+    # Preserve original priority before first triage so reset can restore it
+    c = _candidates[candidate_id]
+    if "_orig_priority" not in c:
+        c["_orig_priority"] = c.get("retry_priority", 0)
+    _apply(c, action)
+    d = {
+        "candidate_id": candidate_id,
+        "action": action,
+        "decided_at": datetime.now(UTC).isoformat(),
+        "batch_id": c.get("backfill_batch_id"),
+    }
+    with DECISIONS_FILE.open("a") as fh:
+        fh.write(json.dumps(d, ensure_ascii=False) + "\n")
+    return True
+
+
+def _stats() -> dict[str, Any]:
+    vals = list(_candidates.values())
+    return {
+        "total": len(vals),
+        "unreviewed": sum(1 for c in vals if "_triage" not in c),
+        "excluded": sum(1 for c in vals if c.get("_triage") == "excluded"),
+        "prioritized": sum(1 for c in vals if c.get("_triage") == "prioritized"),
+        "batch_ids": _batch_ids,
+    }
+
+
+def _serialize(c: dict[str, Any]) -> dict[str, Any]:
+    titles = c.get("titles") or []
+    snippets = c.get("snippets") or []
+    return {
+        "candidate_id": c["candidate_id"],
+        "url": str(c.get("current_url") or c.get("canonical_url") or ""),
+        "domain": c.get("domain", ""),
+        "title": titles[0] if titles else "",
+        "snippet": snippets[0] if snippets else "",
+        "first_seen_at": str(c.get("first_seen_at", "")),
+        "backfill_batch_id": c.get("backfill_batch_id"),
+        "candidate_status": c.get("candidate_status", "new"),
+        "retry_priority": c.get("retry_priority", 0),
+        "triage": c.get("_triage", ""),
+    }
+
+
+def _query_candidates(
+    batch_id: str | None,
+    status: str,
+    q: str,
+    page: int,
+    limit: int,
+) -> dict[str, Any]:
+    items = list(_candidates.values())
+
+    if batch_id:
+        items = [c for c in items if c.get("backfill_batch_id") == batch_id]
+
+    if status == "unreviewed":
+        items = [c for c in items if "_triage" not in c]
+    elif status == "excluded":
+        items = [c for c in items if c.get("_triage") == "excluded"]
+    elif status == "prioritized":
+        items = [c for c in items if c.get("_triage") == "prioritized"]
+
+    if q:
+        ql = q.lower()
+        items = [
+            c
+            for c in items
+            if ql in (c.get("domain") or "").lower()
+            or any(ql in t.lower() for t in (c.get("titles") or []))
+            or any(ql in s.lower() for s in (c.get("snippets") or []))
+        ]
+
+    def _sort_key(c: dict[str, Any]) -> tuple[int, str]:
+        t = c.get("_triage", "")
+        order = 0 if t == "prioritized" else 1 if t == "" else 2
+        return (order, str(c.get("first_seen_at", "")))
+
+    items.sort(key=_sort_key)
+
+    total = len(items)
+    start = (page - 1) * limit
+    return {
+        "total": total,
+        "page": page,
+        "limit": limit,
+        "pages": max(1, (total + limit - 1) // limit),
+        "items": [_serialize(c) for c in items[start : start + limit]],
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args: object) -> None:  # silence access log
+        pass
+
+    def _json(self, data: Any, status: int = 200) -> None:
+        body = json.dumps(data, ensure_ascii=False).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        qs = parse_qs(parsed.query)
+
+        if parsed.path == "/api/candidates":
+            self._json(
+                _query_candidates(
+                    batch_id=qs.get("batch_id", [None])[0],
+                    status=qs.get("status", ["all"])[0],
+                    q=qs.get("q", [""])[0],
+                    page=int(qs.get("page", ["1"])[0]),
+                    limit=int(qs.get("limit", ["50"])[0]),
+                )
+            )
+        elif parsed.path == "/api/stats":
+            self._json(_stats())
+        else:
+            # Static files
+            rel = parsed.path.lstrip("/") or "index.html"
+            filepath = PUBLIC_DIR / rel
+            if not filepath.exists() or not filepath.is_file():
+                self.send_response(404)
+                self.end_headers()
+                return
+            mime, _ = mimetypes.guess_type(str(filepath))
+            body = filepath.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", mime or "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        if self.path != "/api/triage":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(length))
+        except Exception:
+            self._json({"error": "bad json"}, 400)
+            return
+        cid = body.get("candidate_id", "")
+        action = body.get("action", "")
+        if not cid or action not in ("exclude", "prioritize", "reset"):
+            self._json({"error": "invalid request"}, 400)
+            return
+        ok = _record_decision(cid, action)
+        if not ok:
+            self._json({"error": "unknown candidate"}, 404)
+            return
+        self._json({"ok": True, "stats": _stats()})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Local pre-scrape triage server")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    args = parser.parse_args()
+
+    print(f"Loading candidates from {CANDIDATES_FILE} …")
+    _load_candidates()
+    _load_decisions()
+    s = _stats()
+    print(
+        f"  {s['total']} candidates  |  "
+        f"{s['unreviewed']} unreviewed  |  "
+        f"{s['excluded']} excluded  |  "
+        f"{s['prioritized']} prioritized"
+    )
+    if _batch_ids:
+        print(f"  Batch IDs: {', '.join(_batch_ids)}")
+    print(f"\nOpen http://localhost:{args.port}  (Ctrl-C to stop)\n")
+    HTTPServer(("localhost", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/triage_app/sync.py
+++ b/triage_app/sync.py
@@ -44,7 +44,7 @@ def load_decisions() -> dict[str, dict[str, str]]:
         print("No triage_decisions.jsonl found — nothing to sync.")
         sys.exit(0)
     latest: dict[str, dict[str, str]] = {}
-    with DECISIONS_FILE.open() as fh:
+    with DECISIONS_FILE.open(encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if line:
@@ -57,7 +57,7 @@ def load_candidate_index() -> dict[str, dict[str, object]]:
     index: dict[str, dict[str, object]] = {}
     if not CANDIDATES_FILE.exists():
         return index
-    with CANDIDATES_FILE.open() as fh:
+    with CANDIDATES_FILE.open(encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
             if line:

--- a/triage_app/sync.py
+++ b/triage_app/sync.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Sync triage decisions to Supabase (lightweight PATCH per changed candidate).
+
+Reads triage_decisions.jsonl, applies latest decision per candidate, and
+PATCHes only the two changed fields (candidate_status, retry_priority) for
+each decided candidate.
+
+Usage:
+    python triage_app/sync.py [--dry-run]
+
+Env vars required (same as .env.local):
+    DENBUST_SUPABASE_URL
+    DENBUST_SUPABASE_SERVICE_ROLE_KEY
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANDIDATES_FILE = REPO_ROOT / "data/news_items/discover/candidates/latest_candidates.jsonl"
+DECISIONS_FILE = REPO_ROOT / "data/news_items/discover/candidates/triage_decisions.jsonl"
+
+TABLE = "persistent_candidates"
+
+
+def load_decisions() -> dict[str, dict[str, str]]:
+    """Return latest decision per candidate_id."""
+    if not DECISIONS_FILE.exists():
+        print("No triage_decisions.jsonl found — nothing to sync.")
+        sys.exit(0)
+    latest: dict[str, dict[str, str]] = {}
+    with DECISIONS_FILE.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                d = json.loads(line)
+                latest[d["candidate_id"]] = d
+    return latest
+
+
+def load_candidate_index() -> dict[str, dict[str, object]]:
+    index: dict[str, dict[str, object]] = {}
+    if not CANDIDATES_FILE.exists():
+        return index
+    with CANDIDATES_FILE.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                c = json.loads(line)
+                index[c["candidate_id"]] = c
+    return index
+
+
+_ACTION_PATCHES: dict[str, dict[str, object]] = {
+    "exclude": {"candidate_status": "suppressed"},
+    "prioritize": {"candidate_status": "new", "retry_priority": 100},
+}
+
+
+def decision_to_patch(action: str, original_priority: int) -> dict[str, object]:
+    if action in _ACTION_PATCHES:
+        return dict(_ACTION_PATCHES[action])
+    if action == "reset":
+        return {"candidate_status": "new", "retry_priority": original_priority}
+    raise ValueError(f"Unknown action: {action}")
+
+
+def patch_candidate(
+    client: httpx.Client,
+    supabase_url: str,
+    service_key: str,
+    candidate_id: str,
+    patch: dict[str, object],
+    dry_run: bool,
+) -> bool:
+    if dry_run:
+        print(f"  [dry-run] PATCH {candidate_id}: {patch}")
+        return True
+    url = f"{supabase_url}/rest/v1/{TABLE}?candidate_id=eq.{candidate_id}"
+    resp = client.patch(
+        url,
+        headers={
+            "apikey": service_key,
+            "Authorization": f"Bearer {service_key}",
+            "Content-Type": "application/json",
+            "Prefer": "return=minimal",
+        },
+        json=patch,
+    )
+    if resp.status_code not in (200, 204):
+        print(
+            f"  ERROR {candidate_id}: HTTP {resp.status_code} — {resp.text[:200]}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sync triage decisions to Supabase")
+    parser.add_argument("--dry-run", action="store_true", help="Print without writing")
+    args = parser.parse_args()
+
+    supabase_url = os.environ.get("DENBUST_SUPABASE_URL", "").rstrip("/")
+    service_key = os.environ.get("DENBUST_SUPABASE_SERVICE_ROLE_KEY", "")
+    if not args.dry_run and (not supabase_url or not service_key):
+        print(
+            "ERROR: DENBUST_SUPABASE_URL and DENBUST_SUPABASE_SERVICE_ROLE_KEY must be set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    decisions = load_decisions()
+    candidates = load_candidate_index()
+
+    if not decisions:
+        print("No decisions found — nothing to sync.")
+        return
+
+    # Collapse to final state per candidate
+    final: list[tuple[str, dict[str, object]]] = []
+    for cid, d in decisions.items():
+        raw_priority = (candidates.get(cid) or {}).get("retry_priority", 0)
+        orig_priority = int(raw_priority) if isinstance(raw_priority, (int, float, str)) else 0
+        patch = decision_to_patch(d["action"], orig_priority)
+        final.append((cid, patch))
+
+    print(
+        f"Syncing {len(final)} candidate decisions to Supabase "
+        f"({'dry-run' if args.dry_run else 'live'}) …"
+    )
+
+    ok = 0
+    err = 0
+    with httpx.Client(timeout=30) as client:
+        for cid, patch in final:
+            success = patch_candidate(client, supabase_url, service_key, cid, patch, args.dry_run)
+            if success:
+                ok += 1
+                if not args.dry_run:
+                    print(f"  ✓ {cid[:8]}… → {patch}")
+            else:
+                err += 1
+
+    print(f"\nDone: {ok} synced, {err} errors.")
+    if err:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/triage_app/sync.py
+++ b/triage_app/sync.py
@@ -23,9 +23,17 @@ from pathlib import Path
 
 import httpx
 
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.models.common import DatasetName, JobName
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CANDIDATES_FILE = REPO_ROOT / "data/news_items/discover/candidates/latest_candidates.jsonl"
-DECISIONS_FILE = REPO_ROOT / "data/news_items/discover/candidates/triage_decisions.jsonl"
+_STATE = resolve_discovery_state_paths(
+    state_root=REPO_ROOT / "data",
+    dataset_name=DatasetName.NEWS_ITEMS,
+    job_name=JobName.DISCOVER,
+)
+CANDIDATES_FILE = _STATE.latest_candidates_path
+DECISIONS_FILE = _STATE.candidates_dir / "triage_decisions.jsonl"
 
 TABLE = "persistent_candidates"
 


### PR DESCRIPTION
## Summary

Adds a self-contained local triage workbench for bulk exclude/prioritize decisions on persistent candidates **before** the scrape phase. The tool is purely read-local / write-local during a review session; decisions are synced to Supabase in one batch afterward.

### Components

| File | Purpose |
|---|---|
| `triage_app/serve.py` | Python stdlib HTTP server — no framework dependency |
| `triage_app/public/index.html` | Dark-theme RTL Hebrew UI |
| `triage_app/public/app.js` | Vanilla JS client |
| `triage_app/sync.py` | Batch-sync triage decisions to Supabase via PATCH |

### Workflow

```bash
# 1. Start the server (reads latest_candidates.jsonl)
python triage_app/serve.py [--port 7070]

# 2. Review at http://localhost:7070
#    Keyboard: j/k navigate · e exclude · p prioritize · r reset · / search
#    Filter by batch, status tab, or free-text search

# 3. When done, sync decisions to Supabase
source .env.local
python triage_app/sync.py [--dry-run]
```

### Server details

- Loads `data/news_items/discover/candidates/latest_candidates.jsonl` at startup
- Replays any existing `triage_decisions.jsonl` in-memory (idempotent restart)
- Decisions are appended to `triage_decisions.jsonl` (latest per candidate wins)
- `_orig_priority` is snapshotted before first triage so `reset` restores the original value
- All filter/sort/paginate logic is in-process — no DB reads during review

### UI features

- Stats bar: total / unreviewed / prioritized / excluded counts
- Batch dropdown: filter to a single `backfill_batch_id`
- Status tabs: All / Unreviewed / Prioritized / Excluded
- Row tints + always-visible status pill (● הוחרג / ● עדיפות / ○ לא סוקר) for clear per-row state
- Optimistic UI update after each action; toast confirmation
- Pagination (50 rows/page)

### Sync details (`sync.py`)

- Reads `triage_decisions.jsonl`, collapses to latest decision per candidate
- Sends one `PATCH /rest/v1/persistent_candidates?candidate_id=eq.{cid}` per decided candidate
- Exclude → `{candidate_status: "suppressed"}`
- Prioritize → `{candidate_status: "new", retry_priority: 100}`
- Reset → restores `candidate_status: "new"` and original `retry_priority`
- Requires `DENBUST_SUPABASE_URL` and `DENBUST_SUPABASE_SERVICE_ROLE_KEY`

## Test plan

- [x] Server starts and loads candidates correctly
- [x] Batch filter, status tabs, and search work
- [x] Exclude/prioritize/reset update row tint + badge immediately
- [x] Decisions persist across server restarts (replayed from JSONL)
- [x] `sync.py --dry-run` prints correct patches without writing
- [x] All existing unit/integration tests pass (no production code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)