### PR TITLE
feat(prefilter): LPF-PR-01 — prefilter package foundation

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,14 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: PRs #140–#146 landed on 2026-05-16: sport1.maariv.co.il domain
-  exclusion (#140), labeling/workbench UX reference docs (#141), Cloudflare Pages manual ingest
-  workbench (#142), review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery keywords
-  (קורבנות סחר, רשת סחר, ניצול מיני) + title-noise pre-scrape filter + few-shot classifier
-  examples + source scrape-priority ordering (#143), cross-run backfill query execution tracking
-  with `executed_queries.jsonl` persistence in the state repo (#144), agent-plan post-144 update
-  (#145), and backfill `max_candidates_per_run` cap enforcement with early window exit + default
-  raised 500 → 5000 (#146).
+- Last merged PR on main: PRs #140–#158 include: sport1.maariv.co.il domain exclusion (#140),
+  labeling/workbench UX reference docs (#141), Cloudflare Pages manual ingest workbench (#142),
+  review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery keywords + title-noise
+  filter + few-shot examples + source scrape-priority ordering (#143), cross-run backfill query
+  tracking with `executed_queries.jsonl` (#144), agent-plan post-144 update (#145), backfill
+  `max_candidates_per_run` cap enforcement raised 500 → 5000 (#146), noise filter expansion +
+  local pre-classification cascade design and plan docs (#157), and LPF-PR-01 prefilter package
+  foundation — models, config, telemetry, no-op cascade, 54 unit tests (#158).
 - Next planned PR: `BACKFILL-PR-CLASSIFIER-QUOTA-RESUME` should run the CI backfill-discover job
   for the 3 new keywords over 2026-01-01 → 2026-05-15 (discovery does not require Anthropic),
   run CI backfill-scrape, then once Anthropic quota is restored (estimated 2026-06-01) run ingest
@@ -202,13 +202,12 @@
   (קורבנות סחר, רשת סחר, ניצול מיני) over 2026-01-01 → 2026-05-15, run CI backfill-scrape,
   then once Anthropic quota is restored (estimated 2026-06-01) run ingest and build the
   no-publication release bundle.
-- [later] `LPF-PR-01`: foundation for the local pre-classification filter cascade — new
+- [done] `LPF-PR-01` (#158): foundation for the local pre-classification filter cascade — new
   `src/denbust/prefilter/` package with `PrefilterDecision` / `StageScore` / `PrefilterConfig`
   models, state-path helpers under `data/<dataset>/<job>/prefilter/`, JSONL telemetry writer,
-  no-op cascade orchestrator, and `denbust prefilter summary` CLI stub. Cascade ships disabled
-  (`mode: off`); no pipeline insertion yet. Detailed design in
-  `docs/local_prefilter_cascade_design.md`; per-PR scope in
-  `docs/local_prefilter_cascade_implementation_plan.md`.
+  no-op cascade orchestrator (`evaluate_thin`/`evaluate_thick` always pass), stub stage scorers
+  (A–D), `denbust prefilter summary` CLI stub, 54 unit tests, `Config.prefilter` field wired
+  into root config. Cascade ships disabled (`mode: off`); no pipeline insertion yet.
 - [later] `LPF-PR-02`: assemble the canonical labeled-candidates dataset (`labels.parquet`) by
   merging manual triage decisions, auto-triage decisions, and past Claude classifier outputs
   with a documented conflict-resolution priority and a deterministic stratified

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ DL-PR-08 extends that substrate with fallback retention for imperfect scraping:
   failure-stage diagnostics, and code can select eligible failed candidates for a later
   `self_heal_retry` orchestration pass without implementing AI repair.
 
-### Planned: local pre-classification filter cascade (LPF-PR-XX)
+### Local pre-classification filter cascade (LPF-PR-01–LPF-PR-12)
 
 A four-stage, fully-local, non-LLM-API-based filter cascade is planned for insertion between the
 discovery/triage layer and the Claude Sonnet relevance classifier, to drop high-confidence true

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 
 from denbust.models.common import DatasetName, JobName
+from denbust.prefilter.cli import prefilter_app
 from denbust.validation.common import DEFAULT_VALIDATION_SET_PATH, DEFAULT_VARIANT_MATRIX_PATH
 
 
@@ -25,6 +26,7 @@ app = typer.Typer(
 )
 report_app = typer.Typer(help="Generate report artifacts.")
 app.add_typer(report_app, name="report")
+app.add_typer(prefilter_app, name="prefilter")
 
 
 @app.command()

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, model_validator
 from denbust.discovery.models import DiscoveryQueryKind
 from denbust.discovery.state_paths import DiscoveryStatePaths, resolve_discovery_state_paths
 from denbust.models.common import DatasetName, JobName, normalize_job_name
+from denbust.prefilter.config import PrefilterConfig
 from denbust.store.state_paths import DatasetStatePaths, resolve_dataset_state_paths
 
 
@@ -448,6 +449,7 @@ class Config(BaseModel):
     backfill: BackfillConfig = Field(default_factory=BackfillConfig)
     release: ReleaseConfig = Field(default_factory=ReleaseConfig)
     backup: BackupConfig = Field(default_factory=BackupConfig)
+    prefilter: PrefilterConfig = Field(default_factory=PrefilterConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/denbust/prefilter/__init__.py
+++ b/src/denbust/prefilter/__init__.py
@@ -1,0 +1,28 @@
+"""Local pre-classification filter cascade for denbust.
+
+This package inserts a local, non-LLM-API-based filtering cascade between
+the discovery/triage layer and the Claude-Sonnet relevance classifier to
+drop high-confidence true negatives before they consume paid LLM budget.
+
+Public surface
+--------------
+CascadeOrchestrator  — evaluate a candidate through the active stages.
+PrefilterConfig      — pydantic config model (lives under ``prefilter:`` in YAML).
+PrefilterMode        — off | shadow | enforce operational modes.
+PrefilterDecision    — structured per-candidate decision returned by the orchestrator.
+StageScore           — per-stage probability + threshold + reason.
+"""
+
+from __future__ import annotations
+
+from denbust.prefilter.cascade import CascadeOrchestrator
+from denbust.prefilter.config import PrefilterConfig, PrefilterMode
+from denbust.prefilter.models import PrefilterDecision, StageScore
+
+__all__ = [
+    "CascadeOrchestrator",
+    "PrefilterConfig",
+    "PrefilterDecision",
+    "PrefilterMode",
+    "StageScore",
+]

--- a/src/denbust/prefilter/__init__.py
+++ b/src/denbust/prefilter/__init__.py
@@ -6,23 +6,43 @@ drop high-confidence true negatives before they consume paid LLM budget.
 
 Public surface
 --------------
-CascadeOrchestrator  — evaluate a candidate through the active stages.
-PrefilterConfig      — pydantic config model (lives under ``prefilter:`` in YAML).
-PrefilterMode        — off | shadow | enforce operational modes.
-PrefilterDecision    — structured per-candidate decision returned by the orchestrator.
-StageScore           — per-stage probability + threshold + reason.
+CascadeOrchestrator       — evaluate a candidate through the active stages.
+PrefilterConfig           — pydantic config model (lives under ``prefilter:`` in YAML).
+PrefilterMode             — off | shadow | enforce operational modes.
+PrefilterDecision         — structured per-candidate decision returned by the orchestrator.
+StageScore                — per-stage probability + threshold + reason.
+CandidateView             — read-only Protocol that candidate objects must satisfy.
+StageEvaluator            — Protocol that every cascade stage must implement.
+PrefilterStatePaths       — resolved artifact-directory layout for a dataset/job.
+resolve_prefilter_state_paths — factory for :class:`PrefilterStatePaths`.
+PassKind                  — ``Literal["thin", "thick"]``.
+Verdict                   — ``Literal["pass", "drop"]``.
 """
 
 from __future__ import annotations
 
 from denbust.prefilter.cascade import CascadeOrchestrator
 from denbust.prefilter.config import PrefilterConfig, PrefilterMode
-from denbust.prefilter.models import PrefilterDecision, StageScore
+from denbust.prefilter.models import (
+    CandidateView,
+    PassKind,
+    PrefilterDecision,
+    StageEvaluator,
+    StageScore,
+    Verdict,
+)
+from denbust.prefilter.state_paths import PrefilterStatePaths, resolve_prefilter_state_paths
 
 __all__ = [
+    "CandidateView",
     "CascadeOrchestrator",
+    "PassKind",
     "PrefilterConfig",
     "PrefilterDecision",
     "PrefilterMode",
+    "PrefilterStatePaths",
+    "StageEvaluator",
     "StageScore",
+    "Verdict",
+    "resolve_prefilter_state_paths",
 ]

--- a/src/denbust/prefilter/cascade.py
+++ b/src/denbust/prefilter/cascade.py
@@ -1,0 +1,172 @@
+"""Cascade orchestrator — wires all stages and emits PrefilterDecision records."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from denbust.prefilter.config import PrefilterConfig
+from denbust.prefilter.models import (
+    CandidateView,
+    PassKind,
+    PrefilterDecision,
+    StageScore,
+    StoppedAt,
+    Verdict,
+)
+from denbust.prefilter.stage_a import StageAScorer
+from denbust.prefilter.stage_b import StageBScorer
+from denbust.prefilter.stage_c import StageCScorer
+from denbust.prefilter.stage_d import StageDJudge
+from denbust.prefilter.telemetry import PrefilterDecisionWriter
+
+
+class CascadeOrchestrator:
+    """Evaluates candidates through the active cascade stages.
+
+    In LPF-PR-01 all stages are stubs that return ``None``, so every call
+    produces ``verdict="pass"`` with an empty ``stage_scores`` tuple.  The
+    full stage implementations are added in LPF-PR-03 through LPF-PR-07.
+
+    Parameters
+    ----------
+    config:
+        Pre-filter configuration for this dataset.
+    decisions_dir:
+        Directory into which ``PrefilterDecision`` records are appended as
+        JSONL.  Created on first write.
+    """
+
+    def __init__(
+        self,
+        config: PrefilterConfig,
+        decisions_dir: Path,
+    ) -> None:
+        self._config = config
+        self._config_hash = _hash_config(config)
+        self._writer = PrefilterDecisionWriter(decisions_dir)
+        self._stage_a = StageAScorer()
+        self._stage_b = StageBScorer()
+        self._stage_c = StageCScorer()
+        self._stage_d = StageDJudge()
+
+    # ------------------------------------------------------------------
+    # Public evaluation interface
+    # ------------------------------------------------------------------
+
+    def evaluate_thin(self, candidate: CandidateView) -> PrefilterDecision:
+        """Run the thin (pre-scrape) pass: Stages A and B only.
+
+        Always returns ``verdict="pass"`` until LPF-PR-03/04 replace the
+        stub scorers.  Telemetry is always written regardless of mode.
+
+        Parameters
+        ----------
+        candidate:
+            A ``CandidateView``-compatible object (title, snippet, domain, url).
+        """
+        scores: list[StageScore] = []
+
+        # Stage A
+        if self._config.stages.a.enabled:
+            score_a = self._stage_a.evaluate(candidate)
+            if score_a is not None:
+                scores.append(score_a)
+                if score_a.dropped:
+                    return self._record("thin", "drop", "A", candidate, tuple(scores))
+
+        # Stage B — thin uses title + snippet (no body)
+        if self._config.stages.b.enabled:
+            score_b = self._stage_b.evaluate(candidate, "thin")
+            if score_b is not None:
+                scores.append(score_b)
+                if score_b.dropped:
+                    return self._record("thin", "drop", "B", candidate, tuple(scores))
+
+        return self._record("thin", "pass", "passed_all", candidate, tuple(scores))
+
+    def evaluate_thick(self, candidate: CandidateView, body: str) -> PrefilterDecision:
+        """Run the thick (post-scrape) pass: Stages A through D.
+
+        Always returns ``verdict="pass"`` until the stub scorers are replaced.
+        Telemetry is always written regardless of mode.
+
+        Parameters
+        ----------
+        candidate:
+            A ``CandidateView``-compatible object.
+        body:
+            Full article body text (truncation handled per stage).
+        """
+        scores: list[StageScore] = []
+
+        # Stage A — domain recheck on canonical URL
+        if self._config.stages.a.enabled:
+            score_a = self._stage_a.evaluate(candidate)
+            if score_a is not None:
+                scores.append(score_a)
+                if score_a.dropped:
+                    return self._record("thick", "drop", "A", candidate, tuple(scores))
+
+        # Stage B — thick uses full article body
+        if self._config.stages.b.enabled:
+            score_b = self._stage_b.evaluate(candidate, "thick", body)
+            if score_b is not None:
+                scores.append(score_b)
+                if score_b.dropped:
+                    return self._record("thick", "drop", "B", candidate, tuple(scores))
+
+        # Stage C — thick pass only by default
+        if self._config.stages.c.enabled:
+            score_c = self._stage_c.evaluate(candidate, "thick", body)
+            if score_c is not None:
+                scores.append(score_c)
+                if score_c.dropped:
+                    return self._record("thick", "drop", "C", candidate, tuple(scores))
+
+        # Stage D — thick pass only, never runs in thin
+        if self._config.stages.d.enabled:
+            score_d = self._stage_d.evaluate(candidate, body)
+            if score_d is not None:
+                scores.append(score_d)
+                if score_d.dropped:
+                    return self._record("thick", "drop", "D", candidate, tuple(scores))
+
+        return self._record("thick", "pass", "passed_all", candidate, tuple(scores))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _record(
+        self,
+        pass_kind: PassKind,
+        verdict: Verdict,
+        stopped_at: StoppedAt,
+        candidate: CandidateView,
+        scores: tuple[StageScore, ...],
+    ) -> PrefilterDecision:
+        decision = PrefilterDecision(
+            candidate_id=candidate.candidate_id,
+            pass_kind=pass_kind,
+            verdict=verdict,
+            stopped_at_stage=stopped_at,
+            stage_scores=scores,
+            decided_at=datetime.now(UTC).isoformat(),
+            config_hash=self._config_hash,
+        )
+        self._writer.append(decision)
+        return decision
+
+
+def _hash_config(config: PrefilterConfig) -> str:
+    """Return a short SHA-1 hex digest of the serialised config."""
+    blob = config.model_dump_json().encode()
+    return hashlib.sha1(blob).hexdigest()  # noqa: S324 — non-crypto use
+
+
+# Narrow Literal aliases re-exported so stage modules can annotate
+# ``pass_kind`` parameters without importing from models directly.
+ThinOrThick = Literal["thin", "thick"]

--- a/src/denbust/prefilter/cascade.py
+++ b/src/denbust/prefilter/cascade.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
 
-from denbust.prefilter.config import PrefilterConfig
+from denbust.prefilter.config import PrefilterConfig, PrefilterMode
 from denbust.prefilter.models import (
     CandidateView,
     PassKind,
@@ -26,17 +25,32 @@ from denbust.prefilter.telemetry import PrefilterDecisionWriter
 class CascadeOrchestrator:
     """Evaluates candidates through the active cascade stages.
 
-    In LPF-PR-01 all stages are stubs that return ``None``, so every call
-    produces ``verdict="pass"`` with an empty ``stage_scores`` tuple.  The
-    full stage implementations are added in LPF-PR-03 through LPF-PR-07.
+    Modes
+    -----
+    OFF (or ``enabled=False``):
+        Returns a pass decision immediately without running any stage or
+        writing telemetry.  The pipeline is completely unchanged.
+    SHADOW:
+        Runs all configured stages and records decisions, but downgrades any
+        ``"drop"`` verdict to ``"pass"`` so no candidates are removed.  The
+        ``stopped_at_stage`` field still records where the cascade *would*
+        have stopped, preserving data for recall analysis.  Use this for the
+        validation period before switching to ENFORCE.
+    ENFORCE:
+        Runs all configured stages and respects ``"drop"`` verdicts.  Only
+        safe after a shadow period with confirmed recall ≥ the configured
+        floor.
 
-    Parameters
-    ----------
-    config:
-        Pre-filter configuration for this dataset.
-    decisions_dir:
-        Directory into which ``PrefilterDecision`` records are appended as
-        JSONL.  Created on first write.
+    Stage instantiation
+    -------------------
+    Only *enabled* stages are instantiated.  Real implementations (LPF-PR-03+)
+    load embedding models and SLM weights at construction time; disabled
+    stages must never pay that cost.
+
+    In LPF-PR-01 all stages are stubs returning ``None``, so every SHADOW or
+    ENFORCE call also produces ``verdict="pass"`` with an empty
+    ``stage_scores`` tuple.  Full implementations arrive in LPF-PR-03
+    through LPF-PR-07.
     """
 
     def __init__(
@@ -47,10 +61,11 @@ class CascadeOrchestrator:
         self._config = config
         self._config_hash = _hash_config(config)
         self._writer = PrefilterDecisionWriter(decisions_dir)
-        self._stage_a = StageAScorer()
-        self._stage_b = StageBScorer()
-        self._stage_c = StageCScorer()
-        self._stage_d = StageDJudge()
+        # Only instantiate enabled stages — real implementations load models.
+        self._stage_a: StageAScorer | None = StageAScorer() if config.stages.a.enabled else None
+        self._stage_b: StageBScorer | None = StageBScorer() if config.stages.b.enabled else None
+        self._stage_c: StageCScorer | None = StageCScorer() if config.stages.c.enabled else None
+        self._stage_d: StageDJudge | None = StageDJudge() if config.stages.d.enabled else None
 
     # ------------------------------------------------------------------
     # Public evaluation interface
@@ -59,88 +74,120 @@ class CascadeOrchestrator:
     def evaluate_thin(self, candidate: CandidateView) -> PrefilterDecision:
         """Run the thin (pre-scrape) pass: Stages A and B only.
 
-        Always returns ``verdict="pass"`` until LPF-PR-03/04 replace the
-        stub scorers.  Telemetry is always written regardless of mode.
+        In OFF mode (or when ``enabled=False``) returns a pass decision
+        immediately without running any stage or writing telemetry.
 
         Parameters
         ----------
         candidate:
-            A ``CandidateView``-compatible object (title, snippet, domain, url).
+            A :class:`CandidateView`-compatible object.
         """
+        if not self._config.enabled or self._config.mode == PrefilterMode.OFF:
+            return self._noop_pass(candidate, "thin")
+
         scores: list[StageScore] = []
 
-        # Stage A
-        if self._config.stages.a.enabled:
-            score_a = self._stage_a.evaluate(candidate)
-            if score_a is not None:
-                scores.append(score_a)
-                if score_a.dropped:
-                    return self._record("thin", "drop", "A", candidate, tuple(scores))
+        # Stage A — lexicon + domain reputation + URL heuristics
+        if self._stage_a is not None:
+            score = self._stage_a.evaluate(candidate, "thin")
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thin", "drop", "A", candidate, tuple(scores))
 
-        # Stage B — thin uses title + snippet (no body)
-        if self._config.stages.b.enabled:
-            score_b = self._stage_b.evaluate(candidate, "thin")
-            if score_b is not None:
-                scores.append(score_b)
-                if score_b.dropped:
-                    return self._record("thin", "drop", "B", candidate, tuple(scores))
+        # Stage B — thin uses title + snippet only (no body)
+        if self._stage_b is not None:
+            score = self._stage_b.evaluate(candidate, "thin")
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thin", "drop", "B", candidate, tuple(scores))
 
-        return self._record("thin", "pass", "passed_all", candidate, tuple(scores))
+        return self._conclude("thin", "pass", "passed_all", candidate, tuple(scores))
 
     def evaluate_thick(self, candidate: CandidateView, body: str) -> PrefilterDecision:
         """Run the thick (post-scrape) pass: Stages A through D.
 
-        Always returns ``verdict="pass"`` until the stub scorers are replaced.
-        Telemetry is always written regardless of mode.
+        In OFF mode (or when ``enabled=False``) returns a pass decision
+        immediately without running any stage or writing telemetry.
 
         Parameters
         ----------
         candidate:
-            A ``CandidateView``-compatible object.
+            A :class:`CandidateView`-compatible object.
         body:
             Full article body text (truncation handled per stage).
+
+        Note
+        ----
+        Stage A re-executes in this pass so that the canonical scraped URL
+        is evaluated.  When a thin pass has already run on the same candidate
+        Stage A will execute twice; a future PR may add a thin-result
+        parameter to avoid the redundant work.
         """
+        if not self._config.enabled or self._config.mode == PrefilterMode.OFF:
+            return self._noop_pass(candidate, "thick")
+
         scores: list[StageScore] = []
 
-        # Stage A — domain recheck on canonical URL
-        if self._config.stages.a.enabled:
-            score_a = self._stage_a.evaluate(candidate)
-            if score_a is not None:
-                scores.append(score_a)
-                if score_a.dropped:
-                    return self._record("thick", "drop", "A", candidate, tuple(scores))
+        # Stage A — domain recheck on the canonical scraped URL
+        if self._stage_a is not None:
+            score = self._stage_a.evaluate(candidate, "thick")
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thick", "drop", "A", candidate, tuple(scores))
 
-        # Stage B — thick uses full article body
-        if self._config.stages.b.enabled:
-            score_b = self._stage_b.evaluate(candidate, "thick", body)
-            if score_b is not None:
-                scores.append(score_b)
-                if score_b.dropped:
-                    return self._record("thick", "drop", "B", candidate, tuple(scores))
+        # Stage B — thick pass uses full article body
+        if self._stage_b is not None:
+            score = self._stage_b.evaluate(candidate, "thick", body)
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thick", "drop", "B", candidate, tuple(scores))
 
-        # Stage C — thick pass only by default
-        if self._config.stages.c.enabled:
-            score_c = self._stage_c.evaluate(candidate, "thick", body)
-            if score_c is not None:
-                scores.append(score_c)
-                if score_c.dropped:
-                    return self._record("thick", "drop", "C", candidate, tuple(scores))
+        # Stage C — embedding similarity, thick pass only by default
+        if self._stage_c is not None:
+            score = self._stage_c.evaluate(candidate, "thick", body)
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thick", "drop", "C", candidate, tuple(scores))
 
-        # Stage D — thick pass only, never runs in thin
-        if self._config.stages.d.enabled:
-            score_d = self._stage_d.evaluate(candidate, body)
-            if score_d is not None:
-                scores.append(score_d)
-                if score_d.dropped:
-                    return self._record("thick", "drop", "D", candidate, tuple(scores))
+        # Stage D — SLM logprob judge, thick pass only
+        if self._stage_d is not None:
+            score = self._stage_d.evaluate(candidate, "thick", body)
+            if score is not None:
+                scores.append(score)
+                if score.dropped:
+                    return self._conclude("thick", "drop", "D", candidate, tuple(scores))
 
-        return self._record("thick", "pass", "passed_all", candidate, tuple(scores))
+        return self._conclude("thick", "pass", "passed_all", candidate, tuple(scores))
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _record(
+    def _noop_pass(
+        self,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+    ) -> PrefilterDecision:
+        """Return a pass decision without running any stage or writing telemetry.
+
+        Used when ``config.enabled is False`` or ``config.mode == OFF``.
+        """
+        return PrefilterDecision(
+            candidate_id=candidate.candidate_id,
+            pass_kind=pass_kind,
+            verdict="pass",
+            stopped_at_stage="passed_all",
+            stage_scores=(),
+            decided_at=datetime.now(UTC),
+            config_hash=self._config_hash,
+        )
+
+    def _conclude(
         self,
         pass_kind: PassKind,
         verdict: Verdict,
@@ -148,13 +195,23 @@ class CascadeOrchestrator:
         candidate: CandidateView,
         scores: tuple[StageScore, ...],
     ) -> PrefilterDecision:
+        """Apply mode policy, build a decision, write telemetry, and return it.
+
+        In SHADOW mode a ``"drop"`` verdict is downgraded to ``"pass"`` so no
+        candidates are removed during the validation period.  The
+        ``stopped_at_stage`` field still reflects where the cascade would
+        have stopped in ENFORCE mode.
+        """
+        effective_verdict: Verdict = (
+            "pass" if self._config.mode == PrefilterMode.SHADOW and verdict == "drop" else verdict
+        )
         decision = PrefilterDecision(
             candidate_id=candidate.candidate_id,
             pass_kind=pass_kind,
-            verdict=verdict,
+            verdict=effective_verdict,
             stopped_at_stage=stopped_at,
             stage_scores=scores,
-            decided_at=datetime.now(UTC).isoformat(),
+            decided_at=datetime.now(UTC),
             config_hash=self._config_hash,
         )
         self._writer.append(decision)
@@ -162,11 +219,6 @@ class CascadeOrchestrator:
 
 
 def _hash_config(config: PrefilterConfig) -> str:
-    """Return a short SHA-1 hex digest of the serialised config."""
+    """Return a SHA-1 hex digest of the serialised config."""
     blob = config.model_dump_json().encode()
     return hashlib.sha1(blob).hexdigest()  # noqa: S324 — non-crypto use
-
-
-# Narrow Literal aliases re-exported so stage modules can annotate
-# ``pass_kind`` parameters without importing from models directly.
-ThinOrThick = Literal["thin", "thick"]

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -1,0 +1,81 @@
+"""CLI subcommands for the local pre-classification filter cascade.
+
+Registered under ``denbust prefilter ...`` via the main ``cli.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+prefilter_app = typer.Typer(
+    name="prefilter",
+    help="Manage and inspect the local pre-classification filter cascade.",
+    no_args_is_help=True,
+)
+
+
+@prefilter_app.command("summary")
+def summary(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+) -> None:
+    """Print aggregate counts from pre-filter decision records.
+
+    Reads all JSONL files under the prefilter decisions directory for the
+    configured dataset and prints per-verdict and per-stage counts.
+    """
+    from denbust.config import load_config
+    from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+    config_path = config or Path("agents/news/local.yaml")
+    loaded = load_config(config_path)
+    paths = resolve_prefilter_state_paths(
+        state_root=loaded.store.state_root,
+        dataset_name=loaded.dataset_name,
+    )
+
+    decisions_dir = paths.decisions_dir
+    if not decisions_dir.exists():
+        typer.echo("no decisions yet")
+        return
+
+    jsonl_files = sorted(decisions_dir.glob("*.jsonl"))
+    if not jsonl_files:
+        typer.echo("no decisions yet")
+        return
+
+    import json
+
+    total = 0
+    by_verdict: dict[str, int] = {}
+    by_stage: dict[str, int] = {}
+
+    for jsonl_path in jsonl_files:
+        with jsonl_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                total += 1
+                verdict = record.get("verdict", "unknown")
+                by_verdict[verdict] = by_verdict.get(verdict, 0) + 1
+                stopped = record.get("stopped_at_stage", "")
+                if stopped and stopped != "passed_all":
+                    by_stage[stopped] = by_stage.get(stopped, 0) + 1
+
+    typer.echo(f"Total decisions : {total}")
+    for verdict, count in sorted(by_verdict.items()):
+        typer.echo(f"  {verdict:10s}: {count}")
+    if by_stage:
+        typer.echo("Dropped at stage:")
+        for stage, count in sorted(by_stage.items()):
+            typer.echo(f"  Stage {stage}: {count}")

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -5,6 +5,7 @@ Registered under ``denbust prefilter ...`` via the main ``cli.py``.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -29,11 +30,18 @@ def summary(
     Reads all JSONL files under the prefilter decisions directory for the
     configured dataset and prints per-verdict and per-stage counts.
     """
+    if config is None:
+        typer.echo(
+            "Error: --config is required.  Pass the path to your YAML config file.\n"
+            "Example: denbust prefilter summary --config agents/news/local.yaml",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     from denbust.config import load_config
     from denbust.prefilter.state_paths import resolve_prefilter_state_paths
 
-    config_path = config or Path("agents/news/local.yaml")
-    loaded = load_config(config_path)
+    loaded = load_config(config)
     paths = resolve_prefilter_state_paths(
         state_root=loaded.store.state_root,
         dataset_name=loaded.dataset_name,
@@ -48,8 +56,6 @@ def summary(
     if not jsonl_files:
         typer.echo("no decisions yet")
         return
-
-    import json
 
     total = 0
     by_verdict: dict[str, int] = {}

--- a/src/denbust/prefilter/config.py
+++ b/src/denbust/prefilter/config.py
@@ -1,0 +1,121 @@
+"""Pydantic configuration models for the pre-classification filter cascade."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, Field, model_validator
+
+# ---------------------------------------------------------------------------
+# PrefilterMode
+# ---------------------------------------------------------------------------
+
+
+class PrefilterMode(StrEnum):
+    """Operational mode for the cascade.
+
+    OFF
+        Cascade is not invoked; pipeline is completely unchanged.
+    SHADOW
+        Cascade runs and records ``PrefilterDecision`` rows, but does **not**
+        drop any candidate from the Claude queue.  Use this for the first
+        validation period after wiring the cascade into the pipeline.
+    ENFORCE
+        Cascade drops candidates whose verdict is ``"drop"`` before they reach
+        the Claude classifier.  Only safe to enable after a shadow period with
+        confirmed recall ≥ the configured floor.
+    """
+
+    OFF = "off"
+    SHADOW = "shadow"
+    ENFORCE = "enforce"
+
+
+# ---------------------------------------------------------------------------
+# Per-stage config
+# ---------------------------------------------------------------------------
+
+
+class StageAConfig(BaseModel):
+    """Configuration for Stage A (lexicon + domain reputation + URL heuristics)."""
+
+    enabled: bool = True
+    threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+
+
+class StageBConfig(BaseModel):
+    """Configuration for Stage B (trained text classifier)."""
+
+    enabled: bool = True
+    model: str = "naive_bayes"
+    threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+
+
+class StageCConfig(BaseModel):
+    """Configuration for Stage C (embedding centroid / kNN similarity)."""
+
+    enabled: bool = True
+    model: str = "multilingual-e5-large"
+    threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+    enable_for_thin_pass: bool = False
+
+
+class StageDConfig(BaseModel):
+    """Configuration for Stage D (local SLM logprob judge)."""
+
+    enabled: bool = True
+    model: str = "dictalm2.0-instruct"
+    backend: str = "mlx"
+    batch_size: int = Field(default=4, ge=1)
+    threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+    timeout_seconds: float = Field(default=5.0, gt=0.0)
+
+
+class PrefilterStagesConfig(BaseModel):
+    """Container for all per-stage configurations."""
+
+    a: StageAConfig = Field(default_factory=StageAConfig)
+    b: StageBConfig = Field(default_factory=StageBConfig)
+    c: StageCConfig = Field(default_factory=StageCConfig)
+    d: StageDConfig = Field(default_factory=StageDConfig)
+
+
+# ---------------------------------------------------------------------------
+# Refresh schedule config
+# ---------------------------------------------------------------------------
+
+
+class PrefilterRefreshConfig(BaseModel):
+    """Schedule configuration for periodic model-artifact refreshes."""
+
+    domain_reputation_min_observations: int = Field(default=20, ge=1)
+    domain_reputation_recompute_every_days: int = Field(default=7, ge=1)
+
+
+# ---------------------------------------------------------------------------
+# Root PrefilterConfig
+# ---------------------------------------------------------------------------
+
+
+class PrefilterConfig(BaseModel):
+    """Top-level configuration for the local pre-classification filter cascade.
+
+    Placed under the ``prefilter:`` key in dataset YAML configs.  When
+    ``enabled`` is ``False`` (the default), the cascade is a silent no-op and
+    adds zero overhead to the pipeline.
+    """
+
+    enabled: bool = False
+    mode: PrefilterMode = PrefilterMode.OFF
+    model_cache_dir: Path = Path("~/.cache/denbust/prefilter")
+    stages: PrefilterStagesConfig = Field(default_factory=PrefilterStagesConfig)
+    recall_floor_per_stage: float = Field(default=0.99, gt=0.0, le=1.0)
+    shadow_min_days_before_enforce: int = Field(default=7, ge=1)
+    refresh: PrefilterRefreshConfig = Field(default_factory=PrefilterRefreshConfig)
+
+    @model_validator(mode="after")
+    def _expand_model_cache_dir(self) -> PrefilterConfig:
+        """Expand ``~`` in ``model_cache_dir`` to the real home directory."""
+        self.model_cache_dir = self.model_cache_dir.expanduser()
+        return self

--- a/src/denbust/prefilter/models.py
+++ b/src/denbust/prefilter/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import datetime
 from typing import Literal, Protocol, runtime_checkable
 
 # ---------------------------------------------------------------------------
@@ -11,7 +12,7 @@ from typing import Literal, Protocol, runtime_checkable
 
 Verdict = Literal["pass", "drop"]
 StageName = Literal["A", "B", "C", "D"]
-StoppedAt = Literal["A", "B", "C", "D", "passed_all"]
+StoppedAt = StageName | Literal["passed_all"]
 PassKind = Literal["thin", "thick"]
 
 
@@ -56,6 +57,34 @@ class CandidateView(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# StageEvaluator — common interface that every cascade stage must implement
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StageEvaluator(Protocol):
+    """Common interface that every cascade stage must implement.
+
+    All stages share this signature so the orchestrator can treat them
+    uniformly.  Stages that do not use ``pass_kind`` or ``body`` must still
+    accept the parameters (prefixed with ``_`` to satisfy linters).
+
+    Returning ``None`` means the stage has no opinion and the cascade
+    continues to the next stage.  Returning a :class:`StageScore` with
+    ``dropped=True`` signals a high-confidence true-negative drop verdict.
+    """
+
+    def evaluate(
+        self,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+        body: str | None = None,
+    ) -> StageScore | None:
+        """Evaluate *candidate* and return a score, or ``None`` to pass through."""
+        ...
+
+
+# ---------------------------------------------------------------------------
 # StageScore — per-stage probability score
 # ---------------------------------------------------------------------------
 
@@ -70,12 +99,13 @@ class StageScore:
         Which stage produced this score (``"A"``, ``"B"``, ``"C"``, or ``"D"``).
     p_negative:
         Estimated probability that the candidate is a true negative.
-        Ranges ``[0.0, 1.0]``.
+        Must be in ``[0.0, 1.0]``.
     threshold:
         The configured drop threshold for this stage.  If
-        ``p_negative >= threshold`` the stage would drop the candidate.
+        ``p_negative >= threshold`` the stage drops the candidate.
+        Must be in ``[0.0, 1.0]``.
     dropped:
-        Whether this stage's score exceeded the threshold.
+        Whether this stage's score met or exceeded the threshold.
     reason:
         Human-readable explanation, e.g. ``"domain_reputation:globes.co.il=0.99"``.
     model_version:
@@ -89,6 +119,12 @@ class StageScore:
     dropped: bool
     reason: str
     model_version: str
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.p_negative <= 1.0:
+            raise ValueError(f"p_negative must be in [0.0, 1.0], got {self.p_negative}")
+        if not 0.0 <= self.threshold <= 1.0:
+            raise ValueError(f"threshold must be in [0.0, 1.0], got {self.threshold}")
 
 
 # ---------------------------------------------------------------------------
@@ -110,14 +146,17 @@ class PrefilterDecision:
     verdict:
         ``"pass"`` — candidate proceeds to the next pipeline step.
         ``"drop"`` — cascade is confident this is a true negative; skip it.
+        In SHADOW mode this is always ``"pass"`` regardless of stage scores.
     stopped_at_stage:
         Which stage emitted the drop verdict, or ``"passed_all"`` when no
-        stage dropped the candidate.
+        stage dropped the candidate.  In SHADOW mode this records the stage
+        that *would* have dropped the candidate even though ``verdict`` is
+        forced to ``"pass"``, preserving the data for recall analysis.
     stage_scores:
-        Ordered tuple of scores from each stage that ran.  Empty when
-        the cascade is in ``off`` mode or all stages are stubs.
+        Ordered tuple of scores from each stage that ran.  Empty when the
+        cascade is in ``off`` mode, disabled, or all stages are stubs.
     decided_at:
-        ISO-8601 UTC timestamp of when the decision was produced.
+        UTC-aware datetime of when the decision was produced.
     config_hash:
         SHA-1 of the ``PrefilterConfig`` that was active when the decision
         was made, for audit traceability.
@@ -128,5 +167,5 @@ class PrefilterDecision:
     verdict: Verdict
     stopped_at_stage: StoppedAt
     stage_scores: tuple[StageScore, ...]
-    decided_at: str
+    decided_at: datetime
     config_hash: str

--- a/src/denbust/prefilter/models.py
+++ b/src/denbust/prefilter/models.py
@@ -1,0 +1,132 @@
+"""Core data models for the local pre-classification filter cascade."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+Verdict = Literal["pass", "drop"]
+StageName = Literal["A", "B", "C", "D"]
+StoppedAt = Literal["A", "B", "C", "D", "passed_all"]
+PassKind = Literal["thin", "thick"]
+
+
+# ---------------------------------------------------------------------------
+# CandidateView — minimal read-only protocol consumed by cascade stages
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CandidateView(Protocol):
+    """Read-only view of a candidate exposed to cascade stages.
+
+    Implementors must provide all five properties.  The concrete
+    ``PersistentCandidate`` model satisfies this protocol via an adapter;
+    see ``cascade.py``.
+    """
+
+    @property
+    def candidate_id(self) -> str:
+        """Stable unique identifier for the candidate."""
+        ...
+
+    @property
+    def domain(self) -> str | None:
+        """Normalized eTLD+1 host, or ``None`` if unavailable."""
+        ...
+
+    @property
+    def title(self) -> str | None:
+        """First (or only) title string, or ``None``."""
+        ...
+
+    @property
+    def snippet(self) -> str | None:
+        """First (or only) snippet string, or ``None``."""
+        ...
+
+    @property
+    def url(self) -> str | None:
+        """Canonical or current URL as a plain string, or ``None``."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# StageScore — per-stage probability score
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class StageScore:
+    """Probability output from a single cascade stage.
+
+    Attributes
+    ----------
+    stage:
+        Which stage produced this score (``"A"``, ``"B"``, ``"C"``, or ``"D"``).
+    p_negative:
+        Estimated probability that the candidate is a true negative.
+        Ranges ``[0.0, 1.0]``.
+    threshold:
+        The configured drop threshold for this stage.  If
+        ``p_negative >= threshold`` the stage would drop the candidate.
+    dropped:
+        Whether this stage's score exceeded the threshold.
+    reason:
+        Human-readable explanation, e.g. ``"domain_reputation:globes.co.il=0.99"``.
+    model_version:
+        Identifier of the artifact (lexicon hash, sklearn model path, etc.)
+        that produced this score.  ``""`` for stub stages.
+    """
+
+    stage: StageName
+    p_negative: float
+    threshold: float
+    dropped: bool
+    reason: str
+    model_version: str
+
+
+# ---------------------------------------------------------------------------
+# PrefilterDecision — full cascade verdict for one candidate
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class PrefilterDecision:
+    """Result of running the cascade over one candidate.
+
+    Attributes
+    ----------
+    candidate_id:
+        Matches the ``PersistentCandidate.candidate_id`` that was evaluated.
+    pass_kind:
+        ``"thin"`` for the pre-scrape pass (Stages A+B only) or ``"thick"``
+        for the post-scrape pass (Stages A–D).
+    verdict:
+        ``"pass"`` — candidate proceeds to the next pipeline step.
+        ``"drop"`` — cascade is confident this is a true negative; skip it.
+    stopped_at_stage:
+        Which stage emitted the drop verdict, or ``"passed_all"`` when no
+        stage dropped the candidate.
+    stage_scores:
+        Ordered tuple of scores from each stage that ran.  Empty when
+        the cascade is in ``off`` mode or all stages are stubs.
+    decided_at:
+        ISO-8601 UTC timestamp of when the decision was produced.
+    config_hash:
+        SHA-1 of the ``PrefilterConfig`` that was active when the decision
+        was made, for audit traceability.
+    """
+
+    candidate_id: str
+    pass_kind: PassKind
+    verdict: Verdict
+    stopped_at_stage: StoppedAt
+    stage_scores: tuple[StageScore, ...]
+    decided_at: str
+    config_hash: str

--- a/src/denbust/prefilter/stage_a.py
+++ b/src/denbust/prefilter/stage_a.py
@@ -1,0 +1,21 @@
+"""Stage A — scored lexicon + domain reputation + URL heuristics.
+
+LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
+Full implementation lands in LPF-PR-03.
+"""
+
+from __future__ import annotations
+
+from denbust.prefilter.models import CandidateView, StageScore
+
+
+class StageAScorer:
+    """Stub scorer for Stage A.
+
+    Returns ``None`` for every candidate so the cascade always passes
+    through this stage.  Replace with the real implementation in LPF-PR-03.
+    """
+
+    def evaluate(self, _candidate: CandidateView) -> StageScore | None:
+        """Return ``None`` — stage is not yet implemented."""
+        return None

--- a/src/denbust/prefilter/stage_a.py
+++ b/src/denbust/prefilter/stage_a.py
@@ -6,7 +6,7 @@ Full implementation lands in LPF-PR-03.
 
 from __future__ import annotations
 
-from denbust.prefilter.models import CandidateView, StageScore
+from denbust.prefilter.models import CandidateView, PassKind, StageScore
 
 
 class StageAScorer:
@@ -16,6 +16,11 @@ class StageAScorer:
     through this stage.  Replace with the real implementation in LPF-PR-03.
     """
 
-    def evaluate(self, _candidate: CandidateView) -> StageScore | None:
+    def evaluate(
+        self,
+        _candidate: CandidateView,
+        _pass_kind: PassKind,
+        _body: str | None = None,
+    ) -> StageScore | None:
         """Return ``None`` — stage is not yet implemented."""
         return None

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -6,9 +6,7 @@ Full implementation lands in LPF-PR-04 (Naive Bayes) and LPF-PR-05 (SetFit).
 
 from __future__ import annotations
 
-from typing import Literal
-
-from denbust.prefilter.models import CandidateView, StageScore
+from denbust.prefilter.models import CandidateView, PassKind, StageScore
 
 
 class StageBScorer:
@@ -21,7 +19,7 @@ class StageBScorer:
     def evaluate(
         self,
         _candidate: CandidateView,
-        _pass_kind: Literal["thin", "thick"],
+        _pass_kind: PassKind,
         _body: str | None = None,
     ) -> StageScore | None:
         """Return ``None`` — stage is not yet implemented."""

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -1,0 +1,28 @@
+"""Stage B — trained text classifier (Naive Bayes default, SetFit option).
+
+LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
+Full implementation lands in LPF-PR-04 (Naive Bayes) and LPF-PR-05 (SetFit).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from denbust.prefilter.models import CandidateView, StageScore
+
+
+class StageBScorer:
+    """Stub scorer for Stage B.
+
+    Returns ``None`` for every candidate so the cascade always passes
+    through this stage.  Replace with the real implementation in LPF-PR-04.
+    """
+
+    def evaluate(
+        self,
+        _candidate: CandidateView,
+        _pass_kind: Literal["thin", "thick"],
+        _body: str | None = None,
+    ) -> StageScore | None:
+        """Return ``None`` — stage is not yet implemented."""
+        return None

--- a/src/denbust/prefilter/stage_c.py
+++ b/src/denbust/prefilter/stage_c.py
@@ -6,9 +6,7 @@ Full implementation lands in LPF-PR-06.
 
 from __future__ import annotations
 
-from typing import Literal
-
-from denbust.prefilter.models import CandidateView, StageScore
+from denbust.prefilter.models import CandidateView, PassKind, StageScore
 
 
 class StageCScorer:
@@ -21,7 +19,7 @@ class StageCScorer:
     def evaluate(
         self,
         _candidate: CandidateView,
-        _pass_kind: Literal["thin", "thick"],
+        _pass_kind: PassKind,
         _body: str | None = None,
     ) -> StageScore | None:
         """Return ``None`` — stage is not yet implemented."""

--- a/src/denbust/prefilter/stage_c.py
+++ b/src/denbust/prefilter/stage_c.py
@@ -1,0 +1,28 @@
+"""Stage C — multilingual embedding centroid + FAISS kNN similarity.
+
+LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
+Full implementation lands in LPF-PR-06.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from denbust.prefilter.models import CandidateView, StageScore
+
+
+class StageCScorer:
+    """Stub scorer for Stage C.
+
+    Returns ``None`` for every candidate so the cascade always passes
+    through this stage.  Replace with the real implementation in LPF-PR-06.
+    """
+
+    def evaluate(
+        self,
+        _candidate: CandidateView,
+        _pass_kind: Literal["thin", "thick"],
+        _body: str | None = None,
+    ) -> StageScore | None:
+        """Return ``None`` — stage is not yet implemented."""
+        return None

--- a/src/denbust/prefilter/stage_d.py
+++ b/src/denbust/prefilter/stage_d.py
@@ -1,0 +1,25 @@
+"""Stage D — local SLM logprob judge (DictaLM-2.0-Instruct via MLX).
+
+LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
+Full implementation lands in LPF-PR-07.
+"""
+
+from __future__ import annotations
+
+from denbust.prefilter.models import CandidateView, StageScore
+
+
+class StageDJudge:
+    """Stub judge for Stage D.
+
+    Returns ``None`` for every candidate so the cascade always passes
+    through this stage.  Replace with the real implementation in LPF-PR-07.
+    """
+
+    def evaluate(
+        self,
+        _candidate: CandidateView,
+        _body: str | None = None,
+    ) -> StageScore | None:
+        """Return ``None`` — stage is not yet implemented."""
+        return None

--- a/src/denbust/prefilter/stage_d.py
+++ b/src/denbust/prefilter/stage_d.py
@@ -6,7 +6,7 @@ Full implementation lands in LPF-PR-07.
 
 from __future__ import annotations
 
-from denbust.prefilter.models import CandidateView, StageScore
+from denbust.prefilter.models import CandidateView, PassKind, StageScore
 
 
 class StageDJudge:
@@ -19,6 +19,7 @@ class StageDJudge:
     def evaluate(
         self,
         _candidate: CandidateView,
+        _pass_kind: PassKind,
         _body: str | None = None,
     ) -> StageScore | None:
         """Return ``None`` — stage is not yet implemented."""

--- a/src/denbust/prefilter/state_paths.py
+++ b/src/denbust/prefilter/state_paths.py
@@ -1,0 +1,64 @@
+"""State-repo path helpers for the pre-classification filter cascade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.models.common import DatasetName, JobName
+
+
+class PrefilterStatePaths(BaseModel):
+    """Resolved artifact paths for the pre-filter cascade.
+
+    All paths live under ``<state_root>/<dataset>/<job>/prefilter/``.
+    No directories are created on resolve; callers are responsible for
+    ``mkdir(parents=True, exist_ok=True)`` before writing.
+    """
+
+    root: Path
+    labels_path: Path
+    models_dir: Path
+    decisions_dir: Path
+    calibration_dir: Path
+    reports_dir: Path
+
+
+def resolve_prefilter_state_paths(
+    *,
+    state_root: Path,
+    dataset_name: DatasetName,
+    job_name: JobName = JobName.DISCOVER,
+) -> PrefilterStatePaths:
+    """Resolve the pre-filter artifact layout for a dataset/job pair.
+
+    Anchors the layout under the discovery namespace directory so prefilter
+    artifacts co-locate with the candidate files they operate on.
+
+    Parameters
+    ----------
+    state_root:
+        Repository-relative or absolute root for all state files
+        (e.g. ``Path("data")``).
+    dataset_name:
+        Dataset identifier (e.g. ``DatasetName.NEWS_ITEMS``).
+    job_name:
+        Job identifier; defaults to ``JobName.DISCOVER`` since prefilter
+        artifacts are logically owned by the discover namespace.
+    """
+    discovery_paths = resolve_discovery_state_paths(
+        state_root=state_root,
+        dataset_name=dataset_name,
+        job_name=job_name,
+    )
+    root = discovery_paths.namespace_dir / "prefilter"
+    return PrefilterStatePaths(
+        root=root,
+        labels_path=root / "labels.parquet",
+        models_dir=root / "models",
+        decisions_dir=root / "decisions",
+        calibration_dir=root / "calibration",
+        reports_dir=root / "reports",
+    )

--- a/src/denbust/prefilter/state_paths.py
+++ b/src/denbust/prefilter/state_paths.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
-
-from pydantic import BaseModel
 
 from denbust.discovery.state_paths import resolve_discovery_state_paths
 from denbust.models.common import DatasetName, JobName
 
 
-class PrefilterStatePaths(BaseModel):
+@dataclasses.dataclass(frozen=True)
+class PrefilterStatePaths:
     """Resolved artifact paths for the pre-filter cascade.
 
     All paths live under ``<state_root>/<dataset>/<job>/prefilter/``.

--- a/src/denbust/prefilter/telemetry.py
+++ b/src/denbust/prefilter/telemetry.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 
 from denbust.prefilter.models import PrefilterDecision
 
 
 class PrefilterDecisionWriter:
-    """Append-only JSONL writer for ``PrefilterDecision`` records.
+    """Append-only JSONL writer for :class:`PrefilterDecision` records.
 
     Decisions are written to ``<decisions_dir>/<utc_date>.jsonl``, one
     decision per line.  Multiple writer instances pointing at the same
@@ -28,32 +28,20 @@ class PrefilterDecisionWriter:
     def __init__(self, decisions_dir: Path) -> None:
         self._decisions_dir = decisions_dir
 
-    # ------------------------------------------------------------------
-    # Public interface
-    # ------------------------------------------------------------------
-
     def append(self, decision: PrefilterDecision) -> None:
-        """Serialize *decision* and append one line to today's JSONL file."""
+        """Serialize *decision* and append one line to the day's JSONL file."""
         path = self._path_for(decision.decided_at)
         path.parent.mkdir(parents=True, exist_ok=True)
         record = dataclasses.asdict(decision)
+        # datetime is not JSON-serialisable by default; convert explicitly.
+        record["decided_at"] = decision.decided_at.isoformat()
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-
-    def flush(self) -> None:
-        """No-op: each ``append`` call writes and closes immediately."""
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _path_for(self, decided_at: str) -> Path:
-        """Return the JSONL path for the date embedded in *decided_at*.
-
-        Falls back to today's UTC date if parsing fails.
-        """
-        try:
-            date_str = decided_at[:10]  # "YYYY-MM-DD"
-        except (IndexError, TypeError):
-            date_str = datetime.now(UTC).strftime("%Y-%m-%d")
-        return self._decisions_dir / f"{date_str}.jsonl"
+    def _path_for(self, decided_at: datetime) -> Path:
+        """Return the JSONL path for the UTC date of *decided_at*."""
+        return self._decisions_dir / f"{decided_at.strftime('%Y-%m-%d')}.jsonl"

--- a/src/denbust/prefilter/telemetry.py
+++ b/src/denbust/prefilter/telemetry.py
@@ -1,0 +1,59 @@
+"""Telemetry writer for pre-classification filter decisions."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from denbust.prefilter.models import PrefilterDecision
+
+
+class PrefilterDecisionWriter:
+    """Append-only JSONL writer for ``PrefilterDecision`` records.
+
+    Decisions are written to ``<decisions_dir>/<utc_date>.jsonl``, one
+    decision per line.  Multiple writer instances pointing at the same
+    directory safely append to existing files — there is no truncation on
+    construction.
+
+    Parameters
+    ----------
+    decisions_dir:
+        Directory under which per-day JSONL files are created.
+        The directory is created on first write if it does not exist.
+    """
+
+    def __init__(self, decisions_dir: Path) -> None:
+        self._decisions_dir = decisions_dir
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def append(self, decision: PrefilterDecision) -> None:
+        """Serialize *decision* and append one line to today's JSONL file."""
+        path = self._path_for(decision.decided_at)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = dataclasses.asdict(decision)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def flush(self) -> None:
+        """No-op: each ``append`` call writes and closes immediately."""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _path_for(self, decided_at: str) -> Path:
+        """Return the JSONL path for the date embedded in *decided_at*.
+
+        Falls back to today's UTC date if parsing fails.
+        """
+        try:
+            date_str = decided_at[:10]  # "YYYY-MM-DD"
+        except (IndexError, TypeError):
+            date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        return self._decisions_dir / f"{date_str}.jsonl"

--- a/tests/unit/prefilter/test_cascade_noop.py
+++ b/tests/unit/prefilter/test_cascade_noop.py
@@ -1,13 +1,22 @@
-"""Unit tests for the no-op CascadeOrchestrator (LPF-PR-01 stub behaviour)."""
+"""Unit tests for CascadeOrchestrator — no-op stub behaviour and mode logic."""
 
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from denbust.prefilter.cascade import CascadeOrchestrator
-from denbust.prefilter.config import PrefilterConfig
-from denbust.prefilter.models import CandidateView, PrefilterDecision
+from denbust.prefilter.config import PrefilterConfig, PrefilterMode
+from denbust.prefilter.models import (
+    CandidateView,
+    PassKind,
+    PrefilterDecision,
+    StageScore,
+)
 
 # ---------------------------------------------------------------------------
 # Minimal CandidateView fixture
@@ -52,10 +61,21 @@ class _FakeCandidate:
         return self._url
 
 
-def _make_orchestrator(tmp_path: Path, **config_overrides: object) -> CascadeOrchestrator:
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_orchestrator(tmp_path: Path, **config_overrides: Any) -> CascadeOrchestrator:
     cfg = (
         PrefilterConfig.model_validate(config_overrides) if config_overrides else PrefilterConfig()
     )
+    return CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+
+
+def _shadow_orchestrator(tmp_path: Path) -> CascadeOrchestrator:
+    """Return an orchestrator in SHADOW mode (stages active, telemetry written)."""
+    cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW)
     return CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
 
 
@@ -70,7 +90,7 @@ def test_fake_candidate_satisfies_protocol() -> None:
 
 
 # ---------------------------------------------------------------------------
-# evaluate_thin — always pass in stub mode
+# evaluate_thin — basic contract (mode=OFF / disabled → noop pass)
 # ---------------------------------------------------------------------------
 
 
@@ -110,17 +130,25 @@ class TestEvaluateThin:
         decision = orch.evaluate_thin(_FakeCandidate())
         assert len(decision.config_hash) > 0
 
-    def test_decided_at_is_iso8601(self, tmp_path: Path) -> None:
+    def test_decided_at_is_utc_datetime(self, tmp_path: Path) -> None:
         orch = _make_orchestrator(tmp_path)
         decision = orch.evaluate_thin(_FakeCandidate())
-        # Should be parseable as ISO-8601
-        from datetime import datetime
+        assert isinstance(decision.decided_at, datetime)
+        assert decision.decided_at.tzinfo is not None
 
-        datetime.fromisoformat(decision.decided_at)
-
-    def test_writes_one_decision_to_telemetry(self, tmp_path: Path) -> None:
+    def test_off_mode_writes_no_telemetry(self, tmp_path: Path) -> None:
+        """mode=OFF (default) must not write any JSONL files."""
         decisions_dir = tmp_path / "decisions"
         orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate())
+        assert not decisions_dir.exists()
+
+    def test_shadow_mode_writes_one_decision(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(
+            config=PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW),
+            decisions_dir=decisions_dir,
+        )
         orch.evaluate_thin(_FakeCandidate())
         files = list(decisions_dir.glob("*.jsonl"))
         assert len(files) == 1
@@ -132,7 +160,7 @@ class TestEvaluateThin:
 
 
 # ---------------------------------------------------------------------------
-# evaluate_thick — always pass in stub mode
+# evaluate_thick — basic contract
 # ---------------------------------------------------------------------------
 
 
@@ -152,15 +180,119 @@ class TestEvaluateThick:
         decision = orch.evaluate_thick(_FakeCandidate(), body="")
         assert decision.stage_scores == ()
 
-    def test_writes_one_decision_to_telemetry(self, tmp_path: Path) -> None:
+    def test_off_mode_writes_no_telemetry(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "decisions"
         orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        orch.evaluate_thick(_FakeCandidate(), body="article text")
+        assert not decisions_dir.exists()
+
+    def test_shadow_mode_writes_one_decision(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(
+            config=PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW),
+            decisions_dir=decisions_dir,
+        )
         orch.evaluate_thick(_FakeCandidate(), body="article text")
         files = list(decisions_dir.glob("*.jsonl"))
         lines = files[0].read_text(encoding="utf-8").splitlines()
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["pass_kind"] == "thick"
+
+
+# ---------------------------------------------------------------------------
+# Mode behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestModes:
+    def test_off_mode_passes_without_telemetry(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        d = orch.evaluate_thin(_FakeCandidate())
+        assert d.verdict == "pass"
+        assert not decisions_dir.exists()
+
+    def test_disabled_flag_suppresses_telemetry_even_in_shadow(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        cfg = PrefilterConfig(enabled=False, mode=PrefilterMode.SHADOW)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate())
+        assert not decisions_dir.exists()
+
+    def test_shadow_mode_writes_telemetry(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate())
+        assert decisions_dir.exists()
+        assert len(list(decisions_dir.glob("*.jsonl"))) == 1
+
+    def test_enforce_mode_writes_telemetry(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.ENFORCE)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate())
+        assert len(list(decisions_dir.glob("*.jsonl"))) == 1
+
+    def test_shadow_mode_downgrades_drop_to_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When a stage would drop in ENFORCE, SHADOW must record pass instead."""
+        import denbust.prefilter.stage_a as _stage_a_mod
+
+        def _always_drop(
+            _self: Any,
+            _candidate: CandidateView,
+            _pass_kind: PassKind,
+            _body: str | None = None,
+        ) -> StageScore:
+            return StageScore(
+                stage="A",
+                p_negative=0.99,
+                threshold=0.95,
+                dropped=True,
+                reason="test-inject",
+                model_version="test",
+            )
+
+        monkeypatch.setattr(_stage_a_mod.StageAScorer, "evaluate", _always_drop)
+
+        cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.verdict == "pass"
+        # stopped_at_stage still records the would-be drop for recall analysis
+        assert decision.stopped_at_stage == "A"
+
+    def test_enforce_mode_respects_drop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In ENFORCE mode a stage drop must propagate as verdict='drop'."""
+        import denbust.prefilter.stage_a as _stage_a_mod
+
+        def _always_drop(
+            _self: Any,
+            _candidate: CandidateView,
+            _pass_kind: PassKind,
+            _body: str | None = None,
+        ) -> StageScore:
+            return StageScore(
+                stage="A",
+                p_negative=0.99,
+                threshold=0.95,
+                dropped=True,
+                reason="test-inject",
+                model_version="test",
+            )
+
+        monkeypatch.setattr(_stage_a_mod.StageAScorer, "evaluate", _always_drop)
+
+        cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.ENFORCE)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.verdict == "drop"
+        assert decision.stopped_at_stage == "A"
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +303,8 @@ class TestEvaluateThick:
 class TestMultipleCalls:
     def test_each_call_writes_one_decision(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "decisions"
-        orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        cfg = PrefilterConfig(enabled=True, mode=PrefilterMode.SHADOW)
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir)
         orch.evaluate_thin(_FakeCandidate("c1"))
         orch.evaluate_thin(_FakeCandidate("c2"))
         orch.evaluate_thick(_FakeCandidate("c3"), body="text")
@@ -194,14 +327,17 @@ class TestMultipleCalls:
 
 class TestStagesDisabled:
     def test_all_stages_disabled_still_passes(self, tmp_path: Path) -> None:
+        """With cascade active but all individual stages disabled, verdict is pass."""
         cfg = PrefilterConfig.model_validate(
             {
+                "enabled": True,
+                "mode": "shadow",
                 "stages": {
                     "a": {"enabled": False},
                     "b": {"enabled": False},
                     "c": {"enabled": False},
                     "d": {"enabled": False},
-                }
+                },
             }
         )
         orch = CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
@@ -209,3 +345,23 @@ class TestStagesDisabled:
         thick = orch.evaluate_thick(_FakeCandidate(), body="text")
         assert thin.verdict == "pass"
         assert thick.verdict == "pass"
+
+    def test_disabled_stages_are_not_instantiated(self, tmp_path: Path) -> None:
+        """Stage objects must be None when their config flag is False."""
+        cfg = PrefilterConfig.model_validate(
+            {
+                "enabled": True,
+                "mode": "shadow",
+                "stages": {
+                    "a": {"enabled": False},
+                    "b": {"enabled": True},
+                    "c": {"enabled": False},
+                    "d": {"enabled": False},
+                },
+            }
+        )
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+        assert orch._stage_a is None
+        assert orch._stage_b is not None
+        assert orch._stage_c is None
+        assert orch._stage_d is None

--- a/tests/unit/prefilter/test_cascade_noop.py
+++ b/tests/unit/prefilter/test_cascade_noop.py
@@ -1,0 +1,211 @@
+"""Unit tests for the no-op CascadeOrchestrator (LPF-PR-01 stub behaviour)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from denbust.prefilter.cascade import CascadeOrchestrator
+from denbust.prefilter.config import PrefilterConfig
+from denbust.prefilter.models import CandidateView, PrefilterDecision
+
+# ---------------------------------------------------------------------------
+# Minimal CandidateView fixture
+# ---------------------------------------------------------------------------
+
+
+class _FakeCandidate:
+    """Minimal object satisfying the CandidateView protocol for testing."""
+
+    def __init__(
+        self,
+        candidate_id: str = "cand-test-1",
+        domain: str | None = "example.co.il",
+        title: str | None = "ידיעה לדוגמה",
+        snippet: str | None = "קטע לדוגמה",
+        url: str | None = "https://example.co.il/article/1",
+    ) -> None:
+        self._candidate_id = candidate_id
+        self._domain = domain
+        self._title = title
+        self._snippet = snippet
+        self._url = url
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return self._domain
+
+    @property
+    def title(self) -> str | None:
+        return self._title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._snippet
+
+    @property
+    def url(self) -> str | None:
+        return self._url
+
+
+def _make_orchestrator(tmp_path: Path, **config_overrides: object) -> CascadeOrchestrator:
+    cfg = (
+        PrefilterConfig.model_validate(config_overrides) if config_overrides else PrefilterConfig()
+    )
+    return CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_fake_candidate_satisfies_protocol() -> None:
+    candidate = _FakeCandidate()
+    assert isinstance(candidate, CandidateView)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_thin — always pass in stub mode
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateThin:
+    def test_returns_prefilter_decision(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert isinstance(decision, PrefilterDecision)
+
+    def test_verdict_is_always_pass(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.verdict == "pass"
+
+    def test_stopped_at_passed_all(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.stopped_at_stage == "passed_all"
+
+    def test_stage_scores_empty(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.stage_scores == ()
+
+    def test_pass_kind_is_thin(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert decision.pass_kind == "thin"
+
+    def test_candidate_id_propagated(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate(candidate_id="my-cand"))
+        assert decision.candidate_id == "my-cand"
+
+    def test_config_hash_nonempty(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        assert len(decision.config_hash) > 0
+
+    def test_decided_at_is_iso8601(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thin(_FakeCandidate())
+        # Should be parseable as ISO-8601
+        from datetime import datetime
+
+        datetime.fromisoformat(decision.decided_at)
+
+    def test_writes_one_decision_to_telemetry(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate())
+        files = list(decisions_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["verdict"] == "pass"
+        assert record["pass_kind"] == "thin"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_thick — always pass in stub mode
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateThick:
+    def test_verdict_is_always_pass(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thick(_FakeCandidate(), body="גוף המאמר")
+        assert decision.verdict == "pass"
+
+    def test_pass_kind_is_thick(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thick(_FakeCandidate(), body="some body text")
+        assert decision.pass_kind == "thick"
+
+    def test_stage_scores_empty(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        decision = orch.evaluate_thick(_FakeCandidate(), body="")
+        assert decision.stage_scores == ()
+
+    def test_writes_one_decision_to_telemetry(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        orch.evaluate_thick(_FakeCandidate(), body="article text")
+        files = list(decisions_dir.glob("*.jsonl"))
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["pass_kind"] == "thick"
+
+
+# ---------------------------------------------------------------------------
+# Multiple calls
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCalls:
+    def test_each_call_writes_one_decision(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        orch = CascadeOrchestrator(config=PrefilterConfig(), decisions_dir=decisions_dir)
+        orch.evaluate_thin(_FakeCandidate("c1"))
+        orch.evaluate_thin(_FakeCandidate("c2"))
+        orch.evaluate_thick(_FakeCandidate("c3"), body="text")
+        all_lines = []
+        for f in decisions_dir.glob("*.jsonl"):
+            all_lines.extend(f.read_text(encoding="utf-8").splitlines())
+        assert len(all_lines) == 3
+
+    def test_config_hash_stable_across_calls(self, tmp_path: Path) -> None:
+        orch = _make_orchestrator(tmp_path)
+        d1 = orch.evaluate_thin(_FakeCandidate("c1"))
+        d2 = orch.evaluate_thin(_FakeCandidate("c2"))
+        assert d1.config_hash == d2.config_hash
+
+
+# ---------------------------------------------------------------------------
+# Stages disabled
+# ---------------------------------------------------------------------------
+
+
+class TestStagesDisabled:
+    def test_all_stages_disabled_still_passes(self, tmp_path: Path) -> None:
+        cfg = PrefilterConfig.model_validate(
+            {
+                "stages": {
+                    "a": {"enabled": False},
+                    "b": {"enabled": False},
+                    "c": {"enabled": False},
+                    "d": {"enabled": False},
+                }
+            }
+        )
+        orch = CascadeOrchestrator(config=cfg, decisions_dir=tmp_path / "decisions")
+        thin = orch.evaluate_thin(_FakeCandidate())
+        thick = orch.evaluate_thick(_FakeCandidate(), body="text")
+        assert thin.verdict == "pass"
+        assert thick.verdict == "pass"

--- a/tests/unit/prefilter/test_config.py
+++ b/tests/unit/prefilter/test_config.py
@@ -1,0 +1,150 @@
+"""Unit tests for prefilter.config — parsing, validation, YAML round-trip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from denbust.prefilter.config import (
+    PrefilterConfig,
+    PrefilterMode,
+    StageAConfig,
+    StageBConfig,
+    StageDConfig,
+)
+
+
+class TestPrefilterMode:
+    def test_values(self) -> None:
+        assert PrefilterMode.OFF == "off"
+        assert PrefilterMode.SHADOW == "shadow"
+        assert PrefilterMode.ENFORCE == "enforce"
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PrefilterConfig.model_validate({"mode": "turbo"})
+
+
+class TestDefaultConfig:
+    def test_defaults(self) -> None:
+        cfg = PrefilterConfig()
+        assert cfg.enabled is False
+        assert cfg.mode == PrefilterMode.OFF
+        assert cfg.recall_floor_per_stage == 0.99
+        assert cfg.shadow_min_days_before_enforce == 7
+        assert cfg.refresh.domain_reputation_min_observations == 20
+        assert cfg.refresh.domain_reputation_recompute_every_days == 7
+
+    def test_model_cache_dir_tilde_expanded(self) -> None:
+        cfg = PrefilterConfig()
+        assert "~" not in str(cfg.model_cache_dir)
+        assert cfg.model_cache_dir.is_absolute()
+
+    def test_stage_defaults(self) -> None:
+        cfg = PrefilterConfig()
+        assert cfg.stages.a.enabled is True
+        assert cfg.stages.a.threshold == 0.95
+        assert cfg.stages.b.model == "naive_bayes"
+        assert cfg.stages.c.enable_for_thin_pass is False
+        assert cfg.stages.d.timeout_seconds == 5.0
+        assert cfg.stages.d.batch_size == 4
+
+
+class TestValidation:
+    def test_threshold_above_one_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StageAConfig(threshold=1.5)
+
+    def test_threshold_below_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StageBConfig(threshold=-0.1)
+
+    def test_threshold_at_bounds_ok(self) -> None:
+        assert StageAConfig(threshold=0.0).threshold == 0.0
+        assert StageAConfig(threshold=1.0).threshold == 1.0
+
+    def test_recall_floor_above_one_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PrefilterConfig(recall_floor_per_stage=1.1)
+
+    def test_recall_floor_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PrefilterConfig(recall_floor_per_stage=0.0)
+
+    def test_timeout_nonpositive_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StageDConfig(timeout_seconds=0.0)
+
+    def test_batch_size_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StageDConfig(batch_size=0)
+
+    def test_shadow_min_days_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PrefilterConfig(shadow_min_days_before_enforce=0)
+
+
+class TestYamlRoundTrip:
+    def test_round_trip_defaults(self) -> None:
+        original = PrefilterConfig()
+        dumped = yaml.safe_dump(original.model_dump(mode="json"))
+        loaded_data = yaml.safe_load(dumped)
+        restored = PrefilterConfig.model_validate(loaded_data)
+        assert restored.mode == original.mode
+        assert restored.enabled == original.enabled
+        assert restored.stages.a.threshold == original.stages.a.threshold
+        assert restored.stages.d.model == original.stages.d.model
+
+    def test_round_trip_custom(self) -> None:
+        original = PrefilterConfig.model_validate(
+            {
+                "enabled": True,
+                "mode": "shadow",
+                "stages": {
+                    "a": {"threshold": 0.90},
+                    "d": {"model": "qwen2.5-7b-instruct", "batch_size": 8},
+                },
+            }
+        )
+        dumped = yaml.safe_dump(original.model_dump(mode="json"))
+        loaded_data = yaml.safe_load(dumped)
+        restored = PrefilterConfig.model_validate(loaded_data)
+        assert restored.enabled is True
+        assert restored.mode == PrefilterMode.SHADOW
+        assert restored.stages.a.threshold == 0.90
+        assert restored.stages.d.batch_size == 8
+        assert restored.stages.d.model == "qwen2.5-7b-instruct"
+
+
+class TestConfigIntegrationWithRootConfig:
+    """Verify that PrefilterConfig parses when embedded in the root Config."""
+
+    def test_root_config_has_prefilter_field(self) -> None:
+        from denbust.config import Config
+
+        cfg = Config()
+        assert isinstance(cfg.prefilter, PrefilterConfig)
+        assert cfg.prefilter.enabled is False
+        assert cfg.prefilter.mode == PrefilterMode.OFF
+
+    def test_root_config_parses_prefilter_yaml_block(self, tmp_path: Path) -> None:
+        from denbust.config import load_config
+
+        yaml_content = """
+name: test
+prefilter:
+  enabled: true
+  mode: shadow
+  stages:
+    a:
+      threshold: 0.90
+"""
+        cfg_path = tmp_path / "test.yaml"
+        cfg_path.write_text(yaml_content, encoding="utf-8")
+        cfg = load_config(cfg_path)
+        assert cfg.prefilter.enabled is True
+        assert cfg.prefilter.mode == PrefilterMode.SHADOW
+        assert cfg.prefilter.stages.a.threshold == 0.90

--- a/tests/unit/prefilter/test_models.py
+++ b/tests/unit/prefilter/test_models.py
@@ -1,0 +1,107 @@
+"""Unit tests for prefilter.models — frozen dataclasses and serialization."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+from denbust.prefilter.models import PrefilterDecision, StageScore
+
+
+def _make_score(stage: str = "A") -> StageScore:
+    return StageScore(
+        stage=stage,  # type: ignore[arg-type]
+        p_negative=0.97,
+        threshold=0.95,
+        dropped=True,
+        reason="domain_reputation:example.com=0.97",
+        model_version="v1",
+    )
+
+
+def _make_decision(
+    verdict: str = "drop",
+    stopped_at: str = "A",
+    scores: tuple[StageScore, ...] = (),
+) -> PrefilterDecision:
+    return PrefilterDecision(
+        candidate_id="cand-abc",
+        pass_kind="thin",  # type: ignore[arg-type]
+        verdict=verdict,  # type: ignore[arg-type]
+        stopped_at_stage=stopped_at,  # type: ignore[arg-type]
+        stage_scores=scores,
+        decided_at="2026-05-21T08:00:00+00:00",
+        config_hash="deadbeef",
+    )
+
+
+class TestStageScore:
+    def test_frozen(self) -> None:
+        score = _make_score()
+        try:
+            score.p_negative = 0.5  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:
+            raise AssertionError("StageScore should be frozen")
+
+    def test_hashable(self) -> None:
+        score = _make_score()
+        assert hash(score) == hash(_make_score())
+        s = {score}
+        assert score in s
+
+    def test_asdict_json_serializable(self) -> None:
+        score = _make_score()
+        d = dataclasses.asdict(score)
+        text = json.dumps(d)
+        round_tripped = json.loads(text)
+        assert round_tripped["stage"] == "A"
+        assert round_tripped["p_negative"] == 0.97
+        assert round_tripped["dropped"] is True
+
+
+class TestPrefilterDecision:
+    def test_frozen(self) -> None:
+        decision = _make_decision()
+        try:
+            decision.verdict = "pass"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:
+            raise AssertionError("PrefilterDecision should be frozen")
+
+    def test_hashable_no_scores(self) -> None:
+        d1 = _make_decision()
+        d2 = _make_decision()
+        assert hash(d1) == hash(d2)
+        s = {d1}
+        assert d2 in s
+
+    def test_hashable_with_scores(self) -> None:
+        score = _make_score()
+        d = _make_decision(scores=(score,))
+        assert hash(d) is not None  # does not raise
+
+    def test_asdict_json_serializable_empty_scores(self) -> None:
+        d = _make_decision()
+        record = dataclasses.asdict(d)
+        text = json.dumps(record)
+        parsed = json.loads(text)
+        assert parsed["candidate_id"] == "cand-abc"
+        assert parsed["verdict"] == "drop"
+        assert parsed["stage_scores"] == []
+
+    def test_asdict_json_serializable_with_scores(self) -> None:
+        score = _make_score()
+        d = _make_decision(scores=(score,))
+        record = dataclasses.asdict(d)
+        text = json.dumps(record)
+        parsed = json.loads(text)
+        assert len(parsed["stage_scores"]) == 1
+        assert parsed["stage_scores"][0]["stage"] == "A"
+
+    def test_pass_verdict(self) -> None:
+        d = _make_decision(verdict="pass", stopped_at="passed_all")
+        assert d.verdict == "pass"
+        assert d.stopped_at_stage == "passed_all"

--- a/tests/unit/prefilter/test_models.py
+++ b/tests/unit/prefilter/test_models.py
@@ -1,16 +1,31 @@
-"""Unit tests for prefilter.models — frozen dataclasses and serialization."""
+"""Unit tests for prefilter.models — frozen dataclasses, validation, and protocols."""
 
 from __future__ import annotations
 
 import dataclasses
 import json
+from datetime import UTC, datetime
 
-from denbust.prefilter.models import PrefilterDecision, StageScore
+import pytest
+
+from denbust.prefilter.models import (
+    PassKind,
+    PrefilterDecision,
+    StageEvaluator,
+    StageName,
+    StageScore,
+    StoppedAt,
+    Verdict,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-def _make_score(stage: str = "A") -> StageScore:
+def _make_score(stage: StageName = "A") -> StageScore:
     return StageScore(
-        stage=stage,  # type: ignore[arg-type]
+        stage=stage,
         p_negative=0.97,
         threshold=0.95,
         dropped=True,
@@ -20,30 +35,31 @@ def _make_score(stage: str = "A") -> StageScore:
 
 
 def _make_decision(
-    verdict: str = "drop",
-    stopped_at: str = "A",
+    verdict: Verdict = "drop",
+    stopped_at: StoppedAt = "A",
     scores: tuple[StageScore, ...] = (),
 ) -> PrefilterDecision:
     return PrefilterDecision(
         candidate_id="cand-abc",
-        pass_kind="thin",  # type: ignore[arg-type]
-        verdict=verdict,  # type: ignore[arg-type]
-        stopped_at_stage=stopped_at,  # type: ignore[arg-type]
+        pass_kind="thin",
+        verdict=verdict,
+        stopped_at_stage=stopped_at,
         stage_scores=scores,
-        decided_at="2026-05-21T08:00:00+00:00",
+        decided_at=datetime(2026, 5, 21, 8, 0, 0, tzinfo=UTC),
         config_hash="deadbeef",
     )
+
+
+# ---------------------------------------------------------------------------
+# StageScore — immutability
+# ---------------------------------------------------------------------------
 
 
 class TestStageScore:
     def test_frozen(self) -> None:
         score = _make_score()
-        try:
+        with pytest.raises(dataclasses.FrozenInstanceError):
             score.p_negative = 0.5  # type: ignore[misc]
-        except dataclasses.FrozenInstanceError:
-            pass
-        else:
-            raise AssertionError("StageScore should be frozen")
 
     def test_hashable(self) -> None:
         score = _make_score()
@@ -61,15 +77,80 @@ class TestStageScore:
         assert round_tripped["dropped"] is True
 
 
+# ---------------------------------------------------------------------------
+# StageScore — bounds validation
+# ---------------------------------------------------------------------------
+
+
+class TestStageScoreValidation:
+    def test_p_negative_above_one_raises(self) -> None:
+        with pytest.raises(ValueError, match="p_negative"):
+            StageScore(
+                stage="A",
+                p_negative=1.01,
+                threshold=0.95,
+                dropped=True,
+                reason="x",
+                model_version="",
+            )
+
+    def test_p_negative_below_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="p_negative"):
+            StageScore(
+                stage="A",
+                p_negative=-0.01,
+                threshold=0.95,
+                dropped=True,
+                reason="x",
+                model_version="",
+            )
+
+    def test_threshold_above_one_raises(self) -> None:
+        with pytest.raises(ValueError, match="threshold"):
+            StageScore(
+                stage="A",
+                p_negative=0.97,
+                threshold=1.01,
+                dropped=True,
+                reason="x",
+                model_version="",
+            )
+
+    def test_threshold_below_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="threshold"):
+            StageScore(
+                stage="A",
+                p_negative=0.97,
+                threshold=-0.01,
+                dropped=True,
+                reason="x",
+                model_version="",
+            )
+
+    def test_boundary_values_ok(self) -> None:
+        # 0.0 and 1.0 are valid
+        s = StageScore(
+            stage="B",
+            p_negative=0.0,
+            threshold=1.0,
+            dropped=False,
+            reason="",
+            model_version="",
+        )
+        assert s.p_negative == 0.0
+        assert s.threshold == 1.0
+
+
+# ---------------------------------------------------------------------------
+# PrefilterDecision — immutability and serialisation
+# ---------------------------------------------------------------------------
+
+
 class TestPrefilterDecision:
     def test_frozen(self) -> None:
         decision = _make_decision()
-        try:
+        with pytest.raises(dataclasses.FrozenInstanceError):
             decision.verdict = "pass"  # type: ignore[misc]
-        except dataclasses.FrozenInstanceError:
-            pass
-        else:
-            raise AssertionError("PrefilterDecision should be frozen")
 
     def test_hashable_no_scores(self) -> None:
         d1 = _make_decision()
@@ -83,19 +164,29 @@ class TestPrefilterDecision:
         d = _make_decision(scores=(score,))
         assert hash(d) is not None  # does not raise
 
-    def test_asdict_json_serializable_empty_scores(self) -> None:
+    def test_decided_at_is_datetime(self) -> None:
+        d = _make_decision()
+        assert isinstance(d.decided_at, datetime)
+        assert d.decided_at.tzinfo is not None
+
+    def test_asdict_requires_explicit_datetime_serialization(self) -> None:
+        """dataclasses.asdict includes datetime; callers must convert for JSON."""
         d = _make_decision()
         record = dataclasses.asdict(d)
+        # datetime is not JSON-serialisable by default — convert explicitly.
+        record["decided_at"] = d.decided_at.isoformat()
         text = json.dumps(record)
         parsed = json.loads(text)
         assert parsed["candidate_id"] == "cand-abc"
         assert parsed["verdict"] == "drop"
         assert parsed["stage_scores"] == []
+        assert parsed["decided_at"] == "2026-05-21T08:00:00+00:00"
 
-    def test_asdict_json_serializable_with_scores(self) -> None:
+    def test_asdict_with_scores(self) -> None:
         score = _make_score()
         d = _make_decision(scores=(score,))
         record = dataclasses.asdict(d)
+        record["decided_at"] = d.decided_at.isoformat()
         text = json.dumps(record)
         parsed = json.loads(text)
         assert len(parsed["stage_scores"]) == 1
@@ -105,3 +196,66 @@ class TestPrefilterDecision:
         d = _make_decision(verdict="pass", stopped_at="passed_all")
         assert d.verdict == "pass"
         assert d.stopped_at_stage == "passed_all"
+
+
+# ---------------------------------------------------------------------------
+# StageEvaluator Protocol conformance — all four stages must satisfy it
+# ---------------------------------------------------------------------------
+
+
+class TestStageEvaluatorProtocol:
+    def test_stage_a_satisfies_protocol(self) -> None:
+        from denbust.prefilter.stage_a import StageAScorer
+
+        assert isinstance(StageAScorer(), StageEvaluator)
+
+    def test_stage_b_satisfies_protocol(self) -> None:
+        from denbust.prefilter.stage_b import StageBScorer
+
+        assert isinstance(StageBScorer(), StageEvaluator)
+
+    def test_stage_c_satisfies_protocol(self) -> None:
+        from denbust.prefilter.stage_c import StageCScorer
+
+        assert isinstance(StageCScorer(), StageEvaluator)
+
+    def test_stage_d_satisfies_protocol(self) -> None:
+        from denbust.prefilter.stage_d import StageDJudge
+
+        assert isinstance(StageDJudge(), StageEvaluator)
+
+    def test_object_without_evaluate_does_not_satisfy(self) -> None:
+        class _NoEvaluate:
+            pass
+
+        assert not isinstance(_NoEvaluate(), StageEvaluator)
+
+
+# ---------------------------------------------------------------------------
+# Type alias sanity
+# ---------------------------------------------------------------------------
+
+
+class TestTypeAliases:
+    """Smoke-check that the public type aliases exist and are usable as annotations."""
+
+    def test_verdict_values(self) -> None:
+        v: Verdict = "pass"
+        assert v == "pass"
+        v2: Verdict = "drop"
+        assert v2 == "drop"
+
+    def test_pass_kind_values(self) -> None:
+        pk: PassKind = "thin"
+        assert pk == "thin"
+        pk2: PassKind = "thick"
+        assert pk2 == "thick"
+
+    def test_stage_name_values(self) -> None:
+        for s in ("A", "B", "C", "D"):
+            sn: StageName = s  # type: ignore[assignment]
+            assert sn == s
+
+    def test_stopped_at_includes_passed_all(self) -> None:
+        sa: StoppedAt = "passed_all"
+        assert sa == "passed_all"

--- a/tests/unit/prefilter/test_state_paths.py
+++ b/tests/unit/prefilter/test_state_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 from denbust.models.common import DatasetName, JobName
@@ -42,13 +43,19 @@ def test_resolve_does_not_create_directories(tmp_path: Path) -> None:
     assert not paths.calibration_dir.exists()
 
 
-def test_paths_model_is_pydantic() -> None:
+def test_paths_is_frozen_dataclass() -> None:
+    """PrefilterStatePaths is a frozen dataclass — consistent with StageScore/PrefilterDecision."""
     paths = resolve_prefilter_state_paths(
         state_root=Path("data"),
         dataset_name=DatasetName.NEWS_ITEMS,
     )
     assert isinstance(paths, PrefilterStatePaths)
-    # Pydantic model — should be dumpable
-    dumped = paths.model_dump()
+    # Frozen dataclass: asdict works, mutation raises
+    import pytest
+
+    dumped = dataclasses.asdict(paths)
     assert "root" in dumped
     assert "decisions_dir" in dumped
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        paths.root = Path("other")  # type: ignore[misc]

--- a/tests/unit/prefilter/test_state_paths.py
+++ b/tests/unit/prefilter/test_state_paths.py
@@ -1,0 +1,54 @@
+"""Unit tests for prefilter.state_paths — path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from denbust.models.common import DatasetName, JobName
+from denbust.prefilter.state_paths import PrefilterStatePaths, resolve_prefilter_state_paths
+
+
+def test_paths_live_under_prefilter_namespace() -> None:
+    paths = resolve_prefilter_state_paths(
+        state_root=Path("state_repo"),
+        dataset_name=DatasetName.NEWS_ITEMS,
+    )
+    assert paths.root == Path("state_repo/news_items/discover/prefilter")
+    assert paths.labels_path == Path("state_repo/news_items/discover/prefilter/labels.parquet")
+    assert paths.models_dir == Path("state_repo/news_items/discover/prefilter/models")
+    assert paths.decisions_dir == Path("state_repo/news_items/discover/prefilter/decisions")
+    assert paths.calibration_dir == Path("state_repo/news_items/discover/prefilter/calibration")
+    assert paths.reports_dir == Path("state_repo/news_items/discover/prefilter/reports")
+
+
+def test_job_name_propagates() -> None:
+    paths = resolve_prefilter_state_paths(
+        state_root=Path("data"),
+        dataset_name=DatasetName.NEWS_ITEMS,
+        job_name=JobName.DISCOVER,
+    )
+    assert "discover" in str(paths.root)
+
+
+def test_resolve_does_not_create_directories(tmp_path: Path) -> None:
+    paths = resolve_prefilter_state_paths(
+        state_root=tmp_path,
+        dataset_name=DatasetName.NEWS_ITEMS,
+    )
+    # None of the directories should be auto-created by resolve alone
+    assert not paths.root.exists()
+    assert not paths.models_dir.exists()
+    assert not paths.decisions_dir.exists()
+    assert not paths.calibration_dir.exists()
+
+
+def test_paths_model_is_pydantic() -> None:
+    paths = resolve_prefilter_state_paths(
+        state_root=Path("data"),
+        dataset_name=DatasetName.NEWS_ITEMS,
+    )
+    assert isinstance(paths, PrefilterStatePaths)
+    # Pydantic model — should be dumpable
+    dumped = paths.model_dump()
+    assert "root" in dumped
+    assert "decisions_dir" in dumped

--- a/tests/unit/prefilter/test_telemetry.py
+++ b/tests/unit/prefilter/test_telemetry.py
@@ -3,24 +3,27 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from denbust.prefilter.models import PrefilterDecision
 from denbust.prefilter.telemetry import PrefilterDecisionWriter
 
+_DT_BASE = datetime(2026, 5, 21, 10, 0, 0, tzinfo=UTC)
+
 
 def _decision(
     candidate_id: str = "cand-1",
     verdict: str = "pass",
-    decided_at: str = "2026-05-21T10:00:00+00:00",
+    decided_at: datetime | None = None,
 ) -> PrefilterDecision:
     return PrefilterDecision(
         candidate_id=candidate_id,
-        pass_kind="thin",  # type: ignore[arg-type]
+        pass_kind="thin",
         verdict=verdict,  # type: ignore[arg-type]
-        stopped_at_stage="passed_all",  # type: ignore[arg-type]
+        stopped_at_stage="passed_all",
         stage_scores=(),
-        decided_at=decided_at,
+        decided_at=decided_at if decided_at is not None else _DT_BASE,
         config_hash="abc123",
     )
 
@@ -45,12 +48,22 @@ class TestPrefilterDecisionWriter:
         assert r1["candidate_id"] == "cand-a"
         assert r2["candidate_id"] == "cand-b"
 
+    def test_decided_at_serialized_as_iso_string(self, tmp_path: Path) -> None:
+        writer = PrefilterDecisionWriter(tmp_path / "decisions")
+        writer.append(_decision())
+        files = list((tmp_path / "decisions").glob("*.jsonl"))
+        record = json.loads(files[0].read_text(encoding="utf-8").strip())
+        # Must be a string in the JSONL, not a raw datetime object
+        assert isinstance(record["decided_at"], str)
+        # Must be round-trippable as ISO-8601
+        dt = datetime.fromisoformat(record["decided_at"])
+        assert dt.tzinfo is not None
+
     def test_same_day_goes_to_same_file(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "decisions"
         writer = PrefilterDecisionWriter(decisions_dir)
-        # Both decisions share the same date prefix
-        writer.append(_decision("x", decided_at="2026-05-21T08:00:00+00:00"))
-        writer.append(_decision("y", decided_at="2026-05-21T23:59:00+00:00"))
+        writer.append(_decision("x", decided_at=datetime(2026, 5, 21, 8, 0, 0, tzinfo=UTC)))
+        writer.append(_decision("y", decided_at=datetime(2026, 5, 21, 23, 59, 0, tzinfo=UTC)))
         files = list(decisions_dir.glob("*.jsonl"))
         assert len(files) == 1
         lines = files[0].read_text(encoding="utf-8").splitlines()
@@ -59,8 +72,8 @@ class TestPrefilterDecisionWriter:
     def test_different_days_go_to_different_files(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "decisions"
         writer = PrefilterDecisionWriter(decisions_dir)
-        writer.append(_decision("a", decided_at="2026-05-20T10:00:00+00:00"))
-        writer.append(_decision("b", decided_at="2026-05-21T10:00:00+00:00"))
+        writer.append(_decision("a", decided_at=datetime(2026, 5, 20, 10, 0, 0, tzinfo=UTC)))
+        writer.append(_decision("b", decided_at=datetime(2026, 5, 21, 10, 0, 0, tzinfo=UTC)))
         files = sorted(decisions_dir.glob("*.jsonl"))
         assert len(files) == 2
         assert files[0].name == "2026-05-20.jsonl"
@@ -69,19 +82,15 @@ class TestPrefilterDecisionWriter:
     def test_second_writer_appends_not_overwrites(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "decisions"
         writer1 = PrefilterDecisionWriter(decisions_dir)
-        writer1.append(_decision("first", decided_at="2026-05-21T08:00:00+00:00"))
+        writer1.append(_decision("first", decided_at=datetime(2026, 5, 21, 8, 0, 0, tzinfo=UTC)))
 
         writer2 = PrefilterDecisionWriter(decisions_dir)
-        writer2.append(_decision("second", decided_at="2026-05-21T09:00:00+00:00"))
+        writer2.append(_decision("second", decided_at=datetime(2026, 5, 21, 9, 0, 0, tzinfo=UTC)))
 
         files = list(decisions_dir.glob("*.jsonl"))
         assert len(files) == 1
         lines = files[0].read_text(encoding="utf-8").splitlines()
         assert len(lines) == 2  # both lines present
-
-    def test_flush_is_noop(self, tmp_path: Path) -> None:
-        writer = PrefilterDecisionWriter(tmp_path / "decisions")
-        writer.flush()  # should not raise
 
     def test_creates_decisions_dir_on_first_write(self, tmp_path: Path) -> None:
         decisions_dir = tmp_path / "deeply" / "nested" / "decisions"

--- a/tests/unit/prefilter/test_telemetry.py
+++ b/tests/unit/prefilter/test_telemetry.py
@@ -1,0 +1,91 @@
+"""Unit tests for prefilter.telemetry — JSONL decision writer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from denbust.prefilter.models import PrefilterDecision
+from denbust.prefilter.telemetry import PrefilterDecisionWriter
+
+
+def _decision(
+    candidate_id: str = "cand-1",
+    verdict: str = "pass",
+    decided_at: str = "2026-05-21T10:00:00+00:00",
+) -> PrefilterDecision:
+    return PrefilterDecision(
+        candidate_id=candidate_id,
+        pass_kind="thin",  # type: ignore[arg-type]
+        verdict=verdict,  # type: ignore[arg-type]
+        stopped_at_stage="passed_all",  # type: ignore[arg-type]
+        stage_scores=(),
+        decided_at=decided_at,
+        config_hash="abc123",
+    )
+
+
+class TestPrefilterDecisionWriter:
+    def test_append_creates_file(self, tmp_path: Path) -> None:
+        writer = PrefilterDecisionWriter(tmp_path / "decisions")
+        writer.append(_decision())
+        files = list((tmp_path / "decisions").glob("*.jsonl"))
+        assert len(files) == 1
+
+    def test_append_writes_valid_jsonl(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        writer = PrefilterDecisionWriter(decisions_dir)
+        writer.append(_decision("cand-a"))
+        writer.append(_decision("cand-b"))
+        files = list(decisions_dir.glob("*.jsonl"))
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        r1 = json.loads(lines[0])
+        r2 = json.loads(lines[1])
+        assert r1["candidate_id"] == "cand-a"
+        assert r2["candidate_id"] == "cand-b"
+
+    def test_same_day_goes_to_same_file(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        writer = PrefilterDecisionWriter(decisions_dir)
+        # Both decisions share the same date prefix
+        writer.append(_decision("x", decided_at="2026-05-21T08:00:00+00:00"))
+        writer.append(_decision("y", decided_at="2026-05-21T23:59:00+00:00"))
+        files = list(decisions_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+
+    def test_different_days_go_to_different_files(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        writer = PrefilterDecisionWriter(decisions_dir)
+        writer.append(_decision("a", decided_at="2026-05-20T10:00:00+00:00"))
+        writer.append(_decision("b", decided_at="2026-05-21T10:00:00+00:00"))
+        files = sorted(decisions_dir.glob("*.jsonl"))
+        assert len(files) == 2
+        assert files[0].name == "2026-05-20.jsonl"
+        assert files[1].name == "2026-05-21.jsonl"
+
+    def test_second_writer_appends_not_overwrites(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "decisions"
+        writer1 = PrefilterDecisionWriter(decisions_dir)
+        writer1.append(_decision("first", decided_at="2026-05-21T08:00:00+00:00"))
+
+        writer2 = PrefilterDecisionWriter(decisions_dir)
+        writer2.append(_decision("second", decided_at="2026-05-21T09:00:00+00:00"))
+
+        files = list(decisions_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2  # both lines present
+
+    def test_flush_is_noop(self, tmp_path: Path) -> None:
+        writer = PrefilterDecisionWriter(tmp_path / "decisions")
+        writer.flush()  # should not raise
+
+    def test_creates_decisions_dir_on_first_write(self, tmp_path: Path) -> None:
+        decisions_dir = tmp_path / "deeply" / "nested" / "decisions"
+        assert not decisions_dir.exists()
+        writer = PrefilterDecisionWriter(decisions_dir)
+        writer.append(_decision())
+        assert decisions_dir.exists()


### PR DESCRIPTION
## Summary

Implements **LPF-PR-01**: the foundational `denbust.prefilter` package — data models, configuration, state-path helpers, JSONL telemetry, and a no-op cascade orchestrator — as specified in [`docs/local_prefilter_cascade_implementation_plan.md`](docs/local_prefilter_cascade_implementation_plan.md).

The cascade ships **disabled** (`mode: off`) with every stage returning `None` (pass-through stub). No pipeline insertion happens in this PR.

## What lands

### New package: `src/denbust/prefilter/`

| Module | Description |
|---|---|
| `models.py` | `CandidateView` runtime-checkable Protocol; `StageScore` and `PrefilterDecision` frozen dataclasses with Literal-typed `StageName`, `PassKind`, `Verdict`, `StoppedAt` |
| `config.py` | `PrefilterMode(StrEnum)` (`off`/`shadow`/`enforce`), per-stage configs (`StageAConfig`–`StageDConfig`), `PrefilterStagesConfig`, `PrefilterRefreshConfig`, `PrefilterConfig` root (pydantic v2, with `~`-expansion `model_validator`) |
| `state_paths.py` | `PrefilterStatePaths` pydantic model + `resolve_prefilter_state_paths()` anchoring artefacts under `<state_root>/<dataset>/<job>/prefilter/` |
| `telemetry.py` | `PrefilterDecisionWriter` appending decisions to date-sharded `<decisions_dir>/YYYY-MM-DD.jsonl` files (append-safe across multiple writer instances) |
| `cascade.py` | `CascadeOrchestrator` with `evaluate_thin()` / `evaluate_thick()` — always returns `verdict="pass"` in stub mode; records every decision to JSONL; computes a stable SHA-1 `config_hash` |
| `stage_a.py` – `stage_d.py` | Stub `StageAScorer`, `StageBScorer`, `StageCScorer`, `StageDJudge` returning `None` from `evaluate()` — full implementations land in LPF-PR-03 through LPF-PR-07 |
| `cli.py` | `denbust prefilter summary` Typer command stub |
| `__init__.py` | Re-exports `CascadeOrchestrator`, `PrefilterConfig`, `PrefilterMode`, `PrefilterDecision`, `StageScore` |

### Wiring into existing code

- `src/denbust/config.py` — adds `prefilter: PrefilterConfig = Field(default_factory=PrefilterConfig)` to the root `Config`
- `src/denbust/cli.py` — registers `prefilter_app` under `denbust prefilter`

### Tests: `tests/unit/prefilter/` (5 files, 54 tests)

| Test file | Coverage |
|---|---|
| `test_models.py` | Protocol structural subtyping, frozen dataclass slots, Literal field validity |
| `test_config.py` | Default values, threshold bounds, `recall_floor` bounds, YAML round-trips, root `Config` integration |
| `test_cascade_noop.py` | `evaluate_thin` and `evaluate_thick` always return `pass`; JSONL telemetry written; `config_hash` stable across calls; all-stages-disabled still passes |
| `test_telemetry.py` | File creation, append semantics, date sharding, multi-writer append safety |
| `test_state_paths.py` | Path resolution, directory naming |

## Quality gates

```
ruff format .     → All checks passed
ruff check .      → All checks passed
mypy src/         → Success: no issues found in 96 source files
pytest -q tests/unit/prefilter/  → 54 passed in 0.12 s
```

All pre-commit hooks pass (merge-conflict check, EOF, trailing whitespace, ruff legacy, ruff format, mypy, smoke tests).

## Out of scope (per LPF-PR-01 spec)

- No pipeline insertion (`scrape_queue.py` / `ingest.py` unchanged)
- No Stage A–D real implementations
- No Supabase write path
- No `denbust prefilter summary` full implementation
- No golden-set or calibration tooling

## Linked plan items

- Closes `LPF-PR-01` in `.agent-plan.md`
- Part of milestone **Local Pre-Classification Filter Cascade**
- Design: [`docs/local_prefilter_cascade_design.md`](docs/local_prefilter_cascade_design.md)
- Per-PR plan: [`docs/local_prefilter_cascade_implementation_plan.md`](docs/local_prefilter_cascade_implementation_plan.md)