### PR TITLE
feat(prefilter): LPF-PR-04 — Stage B calibrated ComplementNB classifier

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -32,10 +32,6 @@
   the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
   disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
   returns `403 PERMISSION_DENIED`.
-- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
-  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
-  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
-  returns `403 PERMISSION_DENIED`.
 
 ## Task Ledger
 

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -16,14 +16,22 @@
   foundation — models, config, telemetry, no-op cascade, 54 unit tests (#158), LPF-PR-02
   labeled-candidates dataset assembly with `LabeledCandidate`, `assemble_labels()`,
   `write_labels_parquet()`, `denbust prefilter assemble-labels` CLI, 57 unit tests (#159),
-  and LPF-PR-03 Stage A scorer — `LexiconScorer` with chi-squared weighted terms + default
+  LPF-PR-03 Stage A scorer — `LexiconScorer` with chi-squared weighted terms + default
   lexicon from `_EXCLUDED_TITLE_TERMS`, `DomainReputationScorer` with Beta-Binomial posterior,
   `UrlHeuristicScorer`, independence-formula blend, `StageAScorer.evaluate()` returning
   `StageScore`, `build_stage_a_artifacts()` retrain function, `denbust prefilter retrain
-  --stage a` CLI, and 56 unit tests covering all sub-scorers and the blend.
-- Next planned PR: `LPF-PR-04` — Stage B default: Multinomial Naive Bayes (ComplementNB) on
-  character n-grams (3–5) over title+snippet (thin pass) and article body (thick pass),
-  Platt-calibrated, trained via `denbust prefilter retrain --stage b`. Cascade remains disabled.
+  --stage a` CLI, and 56 unit tests covering all sub-scorers and the blend (#160), and
+  LPF-PR-04 Stage B calibrated ComplementNB — `StageBScorer` loading thin and thick joblib
+  artifacts, `StageBModelMeta` provenance dataclass, `train_naive_bayes()` retrain function,
+  `denbust prefilter retrain --stage b` CLI, scikit-learn/joblib dependencies, and 47 unit
+  tests covering training, inference, calibration, and cascade integration.
+- Next planned PR: `LPF-PR-05` — Stage B alternative: SetFit on `intfloat/multilingual-e5-large`,
+  with an A/B harness in `denbust prefilter evaluate --compare-b naive_bayes,setfit`. Introduces
+  the optional `[prefilter]` extras group.
+- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
+  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
+  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
+  returns `403 PERMISSION_DENIED`.
 - Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
   the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
   disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
@@ -224,10 +232,14 @@
   upper-95 bound, `UrlHeuristicScorer` (path/extension/query heuristics), independence-formula
   blend in `StageAScorer.evaluate()`, `build_stage_a_artifacts()` retrain function,
   `denbust prefilter retrain --stage a` CLI, and 56 unit tests. Cascade still disabled.
-- [next] `LPF-PR-04`: Stage B default — Multinomial Naive Bayes (ComplementNB) on character
-  n-grams (3–5) over title+snippet (thin) and article body (thick), Platt-calibrated, trained
-  via `denbust prefilter retrain --stage b`.
-- [later] `LPF-PR-05`: Stage B alternative — SetFit on `intfloat/multilingual-e5-large`, with
+- [done] `LPF-PR-04`: Stage B default — calibrated `ComplementNB` on character n-grams (3–5)
+  via `TfidfVectorizer`, Platt-calibrated with `CalibratedClassifierCV(method="sigmoid")`.
+  `StageBScorer` loads thin/thick joblib artifacts; `StageBModelMeta` frozen dataclass; SHA-1
+  12-char `model_version`; `train_naive_bayes()` retrain function; `denbust prefilter retrain
+  --stage b` CLI; `scikit-learn>=1.5` and `joblib>=1.4` added to dependencies; 47 unit tests
+  across training, inference, Brier-score calibration, and cascade integration. Cascade still
+  disabled.
+- [next] `LPF-PR-05`: Stage B alternative — SetFit on `intfloat/multilingual-e5-large`, with
   an A/B harness in `denbust prefilter evaluate --compare-b naive_bayes,setfit`. Introduces the
   optional `[prefilter]` extras group (`sentence-transformers`, `setfit`, `torch`, `faiss-cpu`,
   `mlx-lm`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "google-api-python-client>=2.154.0",
     "google-auth>=2.36.0",
     "boto3>=1.36.0",
+    "scikit-learn>=1.5",
+    "joblib>=1.4",
 ]
 
 [project.optional-dependencies]
@@ -100,9 +102,11 @@ module = [
     "google.*",
     "googleapiclient.*",
     "huggingface_hub.*",
+    "joblib.*",
     "kaggle.*",
     "pyarrow.*",
     "playwright.*",
+    "sklearn.*",
 ]
 ignore_missing_imports = true
 

--- a/src/denbust/prefilter/cascade.py
+++ b/src/denbust/prefilter/cascade.py
@@ -47,10 +47,9 @@ class CascadeOrchestrator:
     load embedding models and SLM weights at construction time; disabled
     stages must never pay that cost.
 
-    In LPF-PR-01 all stages are stubs returning ``None``, so every SHADOW or
-    ENFORCE call also produces ``verdict="pass"`` with an empty
-    ``stage_scores`` tuple.  Full implementations arrive in LPF-PR-03
-    through LPF-PR-07.
+    Stage A (LPF-PR-03) and Stage B (LPF-PR-04) are fully implemented.
+    Stages C and D remain stubs returning ``None``; full implementations
+    arrive in LPF-PR-06 and LPF-PR-07.
     """
 
     def __init__(
@@ -68,7 +67,11 @@ class CascadeOrchestrator:
             if config.stages.a.enabled
             else None
         )
-        self._stage_b: StageBScorer | None = StageBScorer() if config.stages.b.enabled else None
+        self._stage_b: StageBScorer | None = (
+            StageBScorer(models_dir=models_dir, threshold=config.stages.b.threshold)
+            if config.stages.b.enabled
+            else None
+        )
         self._stage_c: StageCScorer | None = StageCScorer() if config.stages.c.enabled else None
         self._stage_d: StageDJudge | None = StageDJudge() if config.stages.d.enabled else None
 

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -92,39 +92,40 @@ def summary(
 def retrain_cmd(
     stage: Annotated[
         str,
-        typer.Option("--stage", "-s", help="Stage to retrain: a"),
+        typer.Option("--stage", "-s", help="Stage to retrain: a, b"),
     ],
     config: Annotated[
         Path | None,
         typer.Option("--config", "-c", help="Path to YAML config file"),
     ] = None,
 ) -> None:
-    """Rebuild Stage-A artifacts (lexicon + domain reputation) from labels.parquet.
+    """Rebuild stage artifacts from labels.parquet.
 
-    Reads the labeled-candidates parquet from the prefilter state path and writes
-    updated Stage-A artifacts to ``models/stage_a/`` under the same state root.
+    Reads the labeled-candidates parquet from the prefilter state path and
+    writes updated artifacts under ``models/<stage>/`` in the same state root.
 
-    Only ``--stage a`` is supported in this release; other stages are planned
-    for future PRs.
+    Supported stages
+    ----------------
+    a   Lexicon (chi-squared weighted terms) + domain reputation parquet.
+    b   Calibrated ComplementNB thin and thick models (scikit-learn joblib).
     """
     if config is None:
         typer.echo(
             "Error: --config is required.  Pass the path to your YAML config file.\n"
-            "Example: denbust prefilter retrain --stage a --config agents/news/local.yaml",
+            "Example: denbust prefilter retrain --stage b --config agents/news/local.yaml",
             err=True,
         )
         raise typer.Exit(1)
 
     stage = stage.lower().strip()
-    if stage != "a":
+    if stage not in {"a", "b"}:
         typer.echo(
-            f"Error: --stage {stage!r} is not yet supported.  Only 'a' is available.",
+            f"Error: --stage {stage!r} is not supported.  Choose 'a' or 'b'.",
             err=True,
         )
         raise typer.Exit(1)
 
     from denbust.config import load_config
-    from denbust.prefilter.stage_a import build_stage_a_artifacts
     from denbust.prefilter.state_paths import resolve_prefilter_state_paths
 
     loaded = load_config(config)
@@ -141,14 +142,31 @@ def retrain_cmd(
         )
         raise typer.Exit(1)
 
-    typer.echo(f"Retraining Stage A from {prefilter_paths.labels_path} ...")
-    lex_path, dom_path = build_stage_a_artifacts(
-        labels_path=prefilter_paths.labels_path,
-        out_dir=prefilter_paths.models_dir,
-    )
-    typer.echo(f"  lexicon          -> {lex_path}")
-    typer.echo(f"  domain_reputation -> {dom_path}")
-    typer.echo("Stage A retrain complete.")
+    if stage == "a":
+        from denbust.prefilter.stage_a import build_stage_a_artifacts
+
+        typer.echo(f"Retraining Stage A from {prefilter_paths.labels_path} ...")
+        lex_path, dom_path = build_stage_a_artifacts(
+            labels_path=prefilter_paths.labels_path,
+            out_dir=prefilter_paths.models_dir,
+        )
+        typer.echo(f"  lexicon           -> {lex_path}")
+        typer.echo(f"  domain_reputation -> {dom_path}")
+        typer.echo("Stage A retrain complete.")
+
+    else:  # stage == "b"
+        from denbust.prefilter.stage_b import train_naive_bayes
+
+        typer.echo(f"Retraining Stage B from {prefilter_paths.labels_path} ...")
+        meta = train_naive_bayes(
+            labels_path=prefilter_paths.labels_path,
+            out_dir=prefilter_paths.models_dir,
+        )
+        stage_dir = prefilter_paths.models_dir / "stage_b"
+        typer.echo(f"  thin_model        -> {stage_dir / 'thin_model.joblib'}")
+        typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
+        typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
+        typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
 
 
 @prefilter_app.command("assemble-labels")

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -158,11 +158,10 @@ def retrain_cmd(
         from denbust.prefilter.stage_b import train_naive_bayes
 
         typer.echo(f"Retraining Stage B from {prefilter_paths.labels_path} ...")
-        meta = train_naive_bayes(
+        meta, stage_dir = train_naive_bayes(
             labels_path=prefilter_paths.labels_path,
             out_dir=prefilter_paths.models_dir,
         )
-        stage_dir = prefilter_paths.models_dir / "stage_b"
         typer.echo(f"  thin_model        -> {stage_dir / 'thin_model.joblib'}")
         typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
         typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -1,26 +1,317 @@
-"""Stage B — trained text classifier (Naive Bayes default, SetFit option).
+"""Stage B — trained text classifier (Naive Bayes default).
 
-LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
-Full implementation lands in LPF-PR-04 (Naive Bayes) and LPF-PR-05 (SetFit).
+Implements Stage B as a calibrated Complement Naive Bayes on character
+n-grams (3–5).  Two separate model artifacts are trained and persisted:
+
+thin_model.joblib
+    Applied to ``title + " " + snippet`` in the thin (pre-scrape) pass.
+thick_model.joblib
+    Applied to ``article_body`` text in the thick (post-scrape) pass,
+    falling back to title+snippet when body is absent or empty.
+meta.json
+    :class:`StageBModelMeta` — artifact provenance metadata.
+
+Both models use the labeled-candidates parquet produced by LPF-PR-02.
+The thin model is trained on title+snippet.  The thick model is trained on
+``article_body`` when available and on title+snippet otherwise — so the
+thick model improves automatically as more scraped labels accumulate.
+
+When no trained artifacts exist the scorer returns ``None``, preserving the
+stub behaviour so the cascade continues to Stage C unimpeded.
+
+Full SetFit alternative lands in LPF-PR-05.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
 from denbust.prefilter.models import CandidateView, PassKind, StageScore
+
+# ---------------------------------------------------------------------------
+# Artifact path constants
+# ---------------------------------------------------------------------------
+
+_STAGE_B_SUBDIR = "stage_b"
+_THIN_MODEL_FILE = "thin_model.joblib"
+_THICK_MODEL_FILE = "thick_model.joblib"
+_META_FILE = "meta.json"
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class StageBModelMeta:
+    """Provenance metadata for trained Stage B model artifacts.
+
+    Attributes
+    ----------
+    model_kind:
+        Always ``"naive_bayes"`` in LPF-PR-04.  SetFit support: LPF-PR-05.
+    model_version:
+        Short (12-char) SHA-1 of the thin model artifact file.
+    trained_at:
+        ISO-8601 UTC timestamp of when the artifacts were written.
+    n_train:
+        Number of training examples used to fit the models.
+    n_val:
+        Number of validation examples available at training time.
+    """
+
+    model_kind: Literal["naive_bayes"]
+    model_version: str
+    trained_at: str
+    n_train: int
+    n_val: int
+
+
+# ---------------------------------------------------------------------------
+# StageBScorer
+# ---------------------------------------------------------------------------
 
 
 class StageBScorer:
-    """Stub scorer for Stage B.
+    """Stage B cascade scorer: calibrated Complement Naive Bayes.
 
-    Returns ``None`` for every candidate so the cascade always passes
-    through this stage.  Replace with the real implementation in LPF-PR-04.
+    Returns ``None`` when no trained artifacts exist, preserving stub
+    behaviour so the cascade continues to Stage C unimpeded.
+
+    Parameters
+    ----------
+    models_dir:
+        Root models directory (``PrefilterStatePaths.models_dir``).
+        Artifacts expected under ``models_dir/stage_b/``.  When ``None`` or
+        the artifact files are absent, returns ``None`` for every candidate.
+    threshold:
+        Drop threshold.  Candidates whose ``p_negative >= threshold`` are
+        tagged ``dropped=True``.
     """
+
+    def __init__(
+        self,
+        *,
+        models_dir: Path | None = None,
+        threshold: float = 0.95,
+    ) -> None:
+        self._threshold = threshold
+        self._thin_model: Any = None
+        self._thick_model: Any = None
+        self._model_version: str = ""
+
+        if models_dir is None:
+            return
+
+        stage_dir = models_dir / _STAGE_B_SUBDIR
+        thin_path = stage_dir / _THIN_MODEL_FILE
+        thick_path = stage_dir / _THICK_MODEL_FILE
+        meta_path = stage_dir / _META_FILE
+
+        if not (thin_path.exists() and thick_path.exists()):
+            return
+
+        import joblib  # lazy — scikit-learn/joblib are optional at import time
+
+        _load: Any = joblib.load
+        self._thin_model = _load(thin_path)
+        self._thick_model = _load(thick_path)
+        if meta_path.exists():
+            meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
+            self._model_version = str(meta_raw.get("model_version", ""))
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
 
     def evaluate(
         self,
-        _candidate: CandidateView,
-        _pass_kind: PassKind,
-        _body: str | None = None,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+        body: str | None = None,
     ) -> StageScore | None:
-        """Return ``None`` — stage is not yet implemented."""
-        return None
+        """Evaluate *candidate* and return a :class:`StageScore`, or ``None``.
+
+        Returns ``None`` when no trained model is loaded so the cascade
+        passes Stage B without a score.
+
+        Parameters
+        ----------
+        candidate:
+            Candidate to evaluate.
+        pass_kind:
+            ``"thin"`` → thin model applied to title+snippet.
+            ``"thick"`` → thick model applied to *body*; falls back to thin
+            text when *body* is absent or empty.
+        body:
+            Full article body text; only meaningful for the thick pass.
+        """
+        if self._thin_model is None:
+            return None
+
+        title = candidate.title or ""
+        snippet = candidate.snippet or ""
+        thin_text = (title + " " + snippet).strip()
+
+        if pass_kind == "thick" and body and body.strip():
+            text = body.strip()
+            model = self._thick_model
+        else:
+            text = thin_text
+            model = self._thin_model
+
+        # CalibratedClassifierCV.predict_proba returns [[p(class_0), p(class_1)]].
+        # Classes are sorted by integer label: y=0 → "negative", y=1 → "positive".
+        # Therefore proba[0][0] == p("negative") == p_negative.
+        proba: Any = model.predict_proba([text])
+        p_negative = float(proba[0][0])
+
+        dropped = p_negative >= self._threshold
+        return StageScore(
+            stage="B",
+            p_negative=p_negative,
+            threshold=self._threshold,
+            dropped=dropped,
+            reason=f"nb={p_negative:.3f}",
+            model_version=self._model_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Artifact builder (used by CLI retrain command)
+# ---------------------------------------------------------------------------
+
+
+def train_naive_bayes(
+    labels_path: Path,
+    out_dir: Path,
+    *,
+    seed: int = 20260521,
+) -> StageBModelMeta:
+    """Train calibrated ComplementNB classifiers and write Stage B artifacts.
+
+    Reads *labels_path*, restricts to the ``"train"`` split, then trains:
+
+    - **thin model** on ``title + " " + snippet`` (all train rows)
+    - **thick model** on ``article_body`` when present, else title+snippet
+
+    Artifacts written to ``out_dir/stage_b/``:
+
+    - ``thin_model.joblib``
+    - ``thick_model.joblib``
+    - ``meta.json``
+
+    Parameters
+    ----------
+    labels_path:
+        Path to a ``labels.parquet`` from :mod:`denbust.prefilter.labels`.
+    out_dir:
+        Parent directory for ``stage_b/`` artifacts.
+    seed:
+        Random seed for :class:`~sklearn.calibration.CalibratedClassifierCV`
+        to make cross-validation fold assignment reproducible.
+
+    Returns
+    -------
+    StageBModelMeta
+        Provenance metadata for the written artifacts.
+
+    Raises
+    ------
+    ValueError
+        When the training split is empty or contains only one label class.
+    ImportError
+        When ``scikit-learn`` or ``joblib`` are not installed.
+    """
+    import joblib
+    from sklearn.calibration import CalibratedClassifierCV
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.model_selection import StratifiedKFold
+    from sklearn.naive_bayes import ComplementNB
+    from sklearn.pipeline import Pipeline
+
+    from denbust.prefilter.labels import read_labels_parquet
+
+    rows = read_labels_parquet(labels_path)
+    train_rows = [r for r in rows if r.split == "train"]
+    val_rows = [r for r in rows if r.split == "val"]
+
+    if not train_rows:
+        raise ValueError(f"No training rows found in {labels_path}")
+
+    classes = {r.label for r in train_rows}
+    if len(classes) < 2:
+        raise ValueError(
+            f"Training data contains only one label class ({classes}); "
+            "both 'positive' and 'negative' labels are required."
+        )
+
+    # Label mapping: y=0 → "negative", y=1 → "positive".
+    # sklearn sorts unique integer labels, so predict_proba columns are ordered
+    # [p(class=0), p(class=1)] = [p_negative, p_positive].
+    label_to_int = {"negative": 0, "positive": 1}
+
+    thin_texts = [(r.title + " " + r.snippet).strip() for r in train_rows]
+    # Thick model: use article_body when available, fall back to title+snippet.
+    thick_texts = [(r.article_body or (r.title + " " + r.snippet)).strip() for r in train_rows]
+    y_train = [label_to_int[r.label] for r in train_rows]
+
+    def _build_pipeline() -> Any:
+        vec = TfidfVectorizer(
+            analyzer="char_wb",
+            ngram_range=(3, 5),
+            min_df=2,
+            sublinear_tf=True,
+        )
+        base: Any = Pipeline([("vec", vec), ("clf", ComplementNB())])
+        cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=seed)
+        return CalibratedClassifierCV(base, method="sigmoid", cv=cv)
+
+    thin_model = _build_pipeline()
+    thin_model.fit(thin_texts, y_train)
+
+    thick_model = _build_pipeline()
+    thick_model.fit(thick_texts, y_train)
+
+    stage_dir = out_dir / _STAGE_B_SUBDIR
+    stage_dir.mkdir(parents=True, exist_ok=True)
+
+    thin_path = stage_dir / _THIN_MODEL_FILE
+    thick_path = stage_dir / _THICK_MODEL_FILE
+    meta_path = stage_dir / _META_FILE
+
+    _dump: Any = joblib.dump
+    _dump(thin_model, thin_path)
+    _dump(thick_model, thick_path)
+
+    model_version = _sha1_file(thin_path)[:12]
+
+    meta = StageBModelMeta(
+        model_kind="naive_bayes",
+        model_version=model_version,
+        trained_at=datetime.now(UTC).isoformat(),
+        n_train=len(train_rows),
+        n_val=len(val_rows),
+    )
+    meta_path.write_text(
+        json.dumps(dataclasses.asdict(meta), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha1_file(path: Path) -> str:
+    """Return the full SHA-1 hex digest of *path*'s content."""
+    return hashlib.sha1(path.read_bytes()).hexdigest()  # noqa: S324

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -27,11 +27,16 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import logging
+import shutil
+import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
 from denbust.prefilter.models import CandidateView, PassKind, StageScore
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Artifact path constants
@@ -64,6 +69,10 @@ class StageBModelMeta:
         Number of training examples used to fit the models.
     n_val:
         Number of validation examples available at training time.
+    n_thick_with_body:
+        Train rows where the thick model used a real ``article_body`` rather
+        than falling back to title+snippet.  Zero means thick == thin model
+        at training time; increases as more scraped labels accumulate.
     """
 
     model_kind: Literal["naive_bayes"]
@@ -71,6 +80,42 @@ class StageBModelMeta:
     trained_at: str
     n_train: int
     n_val: int
+    n_thick_with_body: int
+
+
+# ---------------------------------------------------------------------------
+# Pipeline builder (module-level so it can be imported and tested directly)
+# ---------------------------------------------------------------------------
+
+
+def _build_nb_pipeline(seed: int) -> Any:
+    """Build a fresh calibrated ComplementNB pipeline.
+
+    Uses lazy sklearn imports so the module stays importable without
+    scikit-learn installed (the scorer falls back to stub mode in that case).
+
+    Parameters
+    ----------
+    seed:
+        Random state for :class:`~sklearn.model_selection.StratifiedKFold`
+        inside :class:`~sklearn.calibration.CalibratedClassifierCV` to make
+        cross-validation fold assignment reproducible.
+    """
+    from sklearn.calibration import CalibratedClassifierCV
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.model_selection import StratifiedKFold
+    from sklearn.naive_bayes import ComplementNB
+    from sklearn.pipeline import Pipeline
+
+    vec = TfidfVectorizer(
+        analyzer="char_wb",
+        ngram_range=(3, 5),
+        min_df=2,
+        sublinear_tf=True,
+    )
+    base: Any = Pipeline([("vec", vec), ("clf", ComplementNB())])
+    cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=seed)
+    return CalibratedClassifierCV(base, method="sigmoid", cv=cv)
 
 
 # ---------------------------------------------------------------------------
@@ -119,12 +164,17 @@ class StageBScorer:
 
         import joblib  # lazy — scikit-learn/joblib are optional at import time
 
-        _load: Any = joblib.load
-        self._thin_model = _load(thin_path)
-        self._thick_model = _load(thick_path)
+        self._thin_model = joblib.load(thin_path)
+        self._thick_model = joblib.load(thick_path)
         if meta_path.exists():
             meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
             self._model_version = str(meta_raw.get("model_version", ""))
+        else:
+            logger.warning(
+                "Stage B: meta.json missing from %s; model_version will be empty "
+                "in telemetry.  Re-run `denbust prefilter retrain --stage b` to fix.",
+                stage_dir,
+            )
 
     # ------------------------------------------------------------------
     # Evaluation
@@ -178,7 +228,7 @@ class StageBScorer:
             p_negative=p_negative,
             threshold=self._threshold,
             dropped=dropped,
-            reason=f"nb={p_negative:.3f}",
+            reason=f"nb/{pass_kind}={p_negative:.3f}",
             model_version=self._model_version,
         )
 
@@ -193,7 +243,7 @@ def train_naive_bayes(
     out_dir: Path,
     *,
     seed: int = 20260521,
-) -> StageBModelMeta:
+) -> tuple[StageBModelMeta, Path]:
     """Train calibrated ComplementNB classifiers and write Stage B artifacts.
 
     Reads *labels_path*, restricts to the ``"train"`` split, then trains:
@@ -201,11 +251,15 @@ def train_naive_bayes(
     - **thin model** on ``title + " " + snippet`` (all train rows)
     - **thick model** on ``article_body`` when present, else title+snippet
 
-    Artifacts written to ``out_dir/stage_b/``:
+    Artifacts written atomically to ``out_dir/stage_b/``:
 
     - ``thin_model.joblib``
     - ``thick_model.joblib``
     - ``meta.json``
+
+    All three files are first written to a temporary sibling directory and
+    then renamed into place as a unit, so a crash mid-write never leaves the
+    ``stage_b/`` directory in a partially-written state.
 
     Parameters
     ----------
@@ -214,13 +268,15 @@ def train_naive_bayes(
     out_dir:
         Parent directory for ``stage_b/`` artifacts.
     seed:
-        Random seed for :class:`~sklearn.calibration.CalibratedClassifierCV`
-        to make cross-validation fold assignment reproducible.
+        Random seed passed to :func:`_build_nb_pipeline` for reproducible
+        cross-validation fold assignment.
 
     Returns
     -------
-    StageBModelMeta
-        Provenance metadata for the written artifacts.
+    tuple[StageBModelMeta, Path]
+        ``(meta, stage_dir)`` — provenance metadata and the path of the
+        written artifact directory.  The caller can use ``stage_dir`` to
+        report artifact locations without re-computing the path.
 
     Raises
     ------
@@ -230,11 +286,6 @@ def train_naive_bayes(
         When ``scikit-learn`` or ``joblib`` are not installed.
     """
     import joblib
-    from sklearn.calibration import CalibratedClassifierCV
-    from sklearn.feature_extraction.text import TfidfVectorizer
-    from sklearn.model_selection import StratifiedKFold
-    from sklearn.naive_bayes import ComplementNB
-    from sklearn.pipeline import Pipeline
 
     from denbust.prefilter.labels import read_labels_parquet
 
@@ -258,53 +309,76 @@ def train_naive_bayes(
     label_to_int = {"negative": 0, "positive": 1}
 
     thin_texts = [(r.title + " " + r.snippet).strip() for r in train_rows]
+
     # Thick model: use article_body when available, fall back to title+snippet.
+    # Track how many rows actually have a real body — zero means thick == thin.
+    n_thick_with_body = sum(1 for r in train_rows if r.article_body is not None)
+    if n_thick_with_body == 0:
+        warnings.warn(
+            f"All {len(train_rows)} train rows have article_body=None; "
+            "the thick model is identical to the thin model at this training. "
+            "Scrape articles and retrain to improve thick-pass accuracy.",
+            UserWarning,
+            stacklevel=2,
+        )
     thick_texts = [(r.article_body or (r.title + " " + r.snippet)).strip() for r in train_rows]
     y_train = [label_to_int[r.label] for r in train_rows]
 
-    def _build_pipeline() -> Any:
-        vec = TfidfVectorizer(
-            analyzer="char_wb",
-            ngram_range=(3, 5),
-            min_df=2,
-            sublinear_tf=True,
-        )
-        base: Any = Pipeline([("vec", vec), ("clf", ComplementNB())])
-        cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=seed)
-        return CalibratedClassifierCV(base, method="sigmoid", cv=cv)
-
-    thin_model = _build_pipeline()
+    thin_model = _build_nb_pipeline(seed)
     thin_model.fit(thin_texts, y_train)
 
-    thick_model = _build_pipeline()
+    thick_model = _build_nb_pipeline(seed)
     thick_model.fit(thick_texts, y_train)
 
-    stage_dir = out_dir / _STAGE_B_SUBDIR
-    stage_dir.mkdir(parents=True, exist_ok=True)
+    # Atomic write: write all artifacts to a temp sibling directory, then
+    # rename it into place.  This ensures the stage_b/ directory is either
+    # fully written or the old version survives intact.
+    out_dir.mkdir(parents=True, exist_ok=True)
+    import tempfile
 
-    thin_path = stage_dir / _THIN_MODEL_FILE
-    thick_path = stage_dir / _THICK_MODEL_FILE
-    meta_path = stage_dir / _META_FILE
+    tmp_dir = Path(tempfile.mkdtemp(dir=out_dir, prefix=f"{_STAGE_B_SUBDIR}.tmp."))
+    try:
+        thin_path = tmp_dir / _THIN_MODEL_FILE
+        thick_path = tmp_dir / _THICK_MODEL_FILE
+        meta_path = tmp_dir / _META_FILE
 
-    _dump: Any = joblib.dump
-    _dump(thin_model, thin_path)
-    _dump(thick_model, thick_path)
+        joblib.dump(thin_model, thin_path)
+        joblib.dump(thick_model, thick_path)
 
-    model_version = _sha1_file(thin_path)[:12]
+        model_version = _sha1_file(thin_path)[:12]
 
-    meta = StageBModelMeta(
-        model_kind="naive_bayes",
-        model_version=model_version,
-        trained_at=datetime.now(UTC).isoformat(),
-        n_train=len(train_rows),
-        n_val=len(val_rows),
-    )
-    meta_path.write_text(
-        json.dumps(dataclasses.asdict(meta), ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+        meta = StageBModelMeta(
+            model_kind="naive_bayes",
+            model_version=model_version,
+            trained_at=datetime.now(UTC).isoformat(),
+            n_train=len(train_rows),
+            n_val=len(val_rows),
+            n_thick_with_body=n_thick_with_body,
+        )
+        # Serialize only the JSON-safe fields — exclude any future Path-typed fields.
+        meta_dict = {
+            "model_kind": meta.model_kind,
+            "model_version": meta.model_version,
+            "trained_at": meta.trained_at,
+            "n_train": meta.n_train,
+            "n_val": meta.n_val,
+            "n_thick_with_body": meta.n_thick_with_body,
+        }
+        meta_path.write_text(
+            json.dumps(meta_dict, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
 
-    return meta
+        # Atomic replace: remove old stage_b/ (if any) then rename tmp into place.
+        stage_dir = out_dir / _STAGE_B_SUBDIR
+        if stage_dir.exists():
+            shutil.rmtree(stage_dir)
+        tmp_dir.rename(stage_dir)
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    return meta, stage_dir
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/prefilter/_helpers.py
+++ b/tests/unit/prefilter/_helpers.py
@@ -1,0 +1,88 @@
+"""Shared test helpers for prefilter unit tests.
+
+Putting shared test utilities here (rather than duplicating them across test
+modules) avoids the conftest import anti-pattern while keeping each test file
+self-contained at the import level.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from denbust.prefilter.labels import LabeledCandidate
+
+# ---------------------------------------------------------------------------
+# Shared labeled-row builder
+# ---------------------------------------------------------------------------
+
+_LABELED_AT = "2026-01-01T00:00:00+00:00"
+
+
+def make_labeled_row(
+    idx: int,
+    label: Literal["positive", "negative"],
+    split: Literal["train", "val", "test"],
+    title: str,
+    snippet: str,
+    body: str | None = None,
+) -> LabeledCandidate:
+    """Build a minimal :class:`LabeledCandidate` for fixture use."""
+    return LabeledCandidate(
+        candidate_id=f"cand-{idx:04d}",
+        domain="example.co.il",
+        url=f"https://example.co.il/article/{idx}",
+        title=title,
+        snippet=snippet,
+        article_body=body,
+        label=label,
+        label_source="triage_manual",
+        split=split,
+        labeled_at=_LABELED_AT,
+        decision_hash=f"hash{idx:04d}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Minimal CandidateView for testing
+#
+# Defined here so all prefilter test files share one implementation instead
+# of copy-pasting an identical class into every module.
+# ---------------------------------------------------------------------------
+
+
+class FakeCandidate:
+    """Minimal object satisfying the CandidateView protocol for test use."""
+
+    def __init__(
+        self,
+        candidate_id: str = "cand-test",
+        domain: str | None = "example.co.il",
+        title: str | None = "עצור חשוד ברצח",
+        snippet: str | None = "המשטרה עצרה חשוד",
+        url: str | None = "https://example.co.il/article/1",
+    ) -> None:
+        self._candidate_id = candidate_id
+        self._domain = domain
+        self._title = title
+        self._snippet = snippet
+        self._url = url
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return self._domain
+
+    @property
+    def title(self) -> str | None:
+        return self._title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._snippet
+
+    @property
+    def url(self) -> str | None:
+        return self._url

--- a/tests/unit/prefilter/conftest.py
+++ b/tests/unit/prefilter/conftest.py
@@ -3,59 +3,42 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 import pytest
 
-from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
+from denbust.prefilter.labels import write_labels_parquet
 from denbust.prefilter.stage_b import train_naive_bayes
 
-# ---------------------------------------------------------------------------
-# Shared label-row builder
-# ---------------------------------------------------------------------------
-
-_LABELED_AT = "2026-01-01T00:00:00+00:00"
-
-
-def make_labeled_row(
-    idx: int,
-    label: Literal["positive", "negative"],
-    split: Literal["train", "val", "test"],
-    title: str,
-    snippet: str,
-    body: str | None = None,
-) -> LabeledCandidate:
-    """Build a minimal :class:`LabeledCandidate` for fixture use."""
-    return LabeledCandidate(
-        candidate_id=f"cand-{idx:04d}",
-        domain="example.co.il",
-        url=f"https://example.co.il/article/{idx}",
-        title=title,
-        snippet=snippet,
-        article_body=body,
-        label=label,
-        label_source="triage_manual",
-        split=split,
-        labeled_at=_LABELED_AT,
-        decision_hash=f"hash{idx:04d}",
-    )
-
+# Re-export FakeCandidate so tests can import it from one place.
+# (Importing from _helpers directly is equally valid.)
+from tests.unit.prefilter._helpers import FakeCandidate as FakeCandidate  # noqa: PLC0414
+from tests.unit.prefilter._helpers import make_labeled_row
 
 # ---------------------------------------------------------------------------
 # Shared trained Stage B fixture
+#
+# scope="module" — one training run per test MODULE, not per test function.
+# The models are read-only after setup; there is no need to retrain for each
+# of the ~35 tests that exercise the scorer.  tmp_path_factory creates a
+# directory that persists for the lifetime of the module.
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def trained_stage_b_dir(tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def trained_stage_b_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Train Stage B models on a small fixture dataset; return *models_dir*.
 
     Writes ``labels.parquet`` with 15 train rows per class (positive /
     negative) and 4 val + 4 test rows per class, then calls
     :func:`train_naive_bayes` and returns the ``models_dir`` path.
+
+    The fixture is module-scoped so a single training run is shared across
+    all tests in a module — training is idempotent and the artifacts are
+    purely read-only after setup.
     """
+    base = tmp_path_factory.mktemp("stage_b_trained")
     n_per_class = 15
-    rows: list[LabeledCandidate] = []
+    rows = []
     idx = 0
     for split, count in [("train", n_per_class), ("val", 4), ("test", 4)]:
         for _ in range(count):
@@ -82,8 +65,8 @@ def trained_stage_b_dir(tmp_path: Path) -> Path:
             )
             idx += 1
 
-    labels_path = tmp_path / "labels.parquet"
+    labels_path = base / "labels.parquet"
     write_labels_parquet(rows, labels_path)
-    models_dir = tmp_path / "models"
+    models_dir = base / "models"
     train_naive_bayes(labels_path, models_dir)
     return models_dir

--- a/tests/unit/prefilter/conftest.py
+++ b/tests/unit/prefilter/conftest.py
@@ -1,0 +1,89 @@
+"""Shared pytest fixtures for prefilter unit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
+from denbust.prefilter.stage_b import train_naive_bayes
+
+# ---------------------------------------------------------------------------
+# Shared label-row builder
+# ---------------------------------------------------------------------------
+
+_LABELED_AT = "2026-01-01T00:00:00+00:00"
+
+
+def make_labeled_row(
+    idx: int,
+    label: Literal["positive", "negative"],
+    split: Literal["train", "val", "test"],
+    title: str,
+    snippet: str,
+    body: str | None = None,
+) -> LabeledCandidate:
+    """Build a minimal :class:`LabeledCandidate` for fixture use."""
+    return LabeledCandidate(
+        candidate_id=f"cand-{idx:04d}",
+        domain="example.co.il",
+        url=f"https://example.co.il/article/{idx}",
+        title=title,
+        snippet=snippet,
+        article_body=body,
+        label=label,
+        label_source="triage_manual",
+        split=split,
+        labeled_at=_LABELED_AT,
+        decision_hash=f"hash{idx:04d}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared trained Stage B fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def trained_stage_b_dir(tmp_path: Path) -> Path:
+    """Train Stage B models on a small fixture dataset; return *models_dir*.
+
+    Writes ``labels.parquet`` with 15 train rows per class (positive /
+    negative) and 4 val + 4 test rows per class, then calls
+    :func:`train_naive_bayes` and returns the ``models_dir`` path.
+    """
+    n_per_class = 15
+    rows: list[LabeledCandidate] = []
+    idx = 0
+    for split, count in [("train", n_per_class), ("val", 4), ("test", 4)]:
+        for _ in range(count):
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "negative",
+                    split,  # type: ignore[arg-type]
+                    title="ספורט ופנאי",
+                    snippet="כדורגל ושחמט",
+                    body=("משחקי כדורגל וטניס וכדורסל הם ספורט פנאי" if split == "train" else None),
+                )
+            )
+            idx += 1
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "positive",
+                    split,  # type: ignore[arg-type]
+                    title="עצור חשוד ברצח",
+                    snippet="המשטרה עצרה חשוד",
+                    body=("החשוד נעצר לאחר חקירה ממושכת של המשטרה" if split == "train" else None),
+                )
+            )
+            idx += 1
+
+    labels_path = tmp_path / "labels.parquet"
+    write_labels_parquet(rows, labels_path)
+    models_dir = tmp_path / "models"
+    train_naive_bayes(labels_path, models_dir)
+    return models_dir

--- a/tests/unit/prefilter/test_stage_b_calibration.py
+++ b/tests/unit/prefilter/test_stage_b_calibration.py
@@ -2,8 +2,12 @@
 
 The calibrated ComplementNB should assign probability estimates that are
 better-calibrated than a naive constant-output baseline.  We evaluate on
-held-out examples drawn from the same text distribution as the training
-fixture (see conftest.py → trained_stage_b_dir).
+held-out candidates whose text is *different* from the training fixture so
+the model must generalise rather than memorise.
+
+Training negatives use "ספורט ופנאי" / "כדורגל ושחמט".
+Training positives use "עצור חשוד ברצח" / "המשטרה עצרה חשוד".
+Val candidates below deliberately use different phrasings.
 """
 
 from __future__ import annotations
@@ -11,44 +15,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from denbust.prefilter.stage_b import StageBScorer
+from tests.unit.prefilter._helpers import FakeCandidate
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-class _FakeCand:
-    """Minimal CandidateView for calibration evaluation."""
-
-    def __init__(
-        self,
-        candidate_id: str,
-        title: str | None,
-        snippet: str | None,
-    ) -> None:
-        self._candidate_id = candidate_id
-        self._title = title
-        self._snippet = snippet
-
-    @property
-    def candidate_id(self) -> str:
-        return self._candidate_id
-
-    @property
-    def domain(self) -> str | None:
-        return "example.co.il"
-
-    @property
-    def title(self) -> str | None:
-        return self._title
-
-    @property
-    def snippet(self) -> str | None:
-        return self._snippet
-
-    @property
-    def url(self) -> str | None:
-        return "https://example.co.il/article/1"
 
 
 def _brier_score(p_positives: list[float], labels: list[int]) -> float:
@@ -58,23 +29,64 @@ def _brier_score(p_positives: list[float], labels: list[int]) -> float:
 
 
 # ---------------------------------------------------------------------------
-# Val-split candidates (mirrors conftest._write_fixture val rows)
-# The conftest fixture trains on sports (negative) and crime (positive).
-# These val examples come from the same distribution.
-# y = 0 → negative (sports), y = 1 → positive (crime/arrest).
+# Held-out val candidates — different phrasing from the training fixture.
+#
+# y = 0 → negative (sports); y = 1 → positive (crime/arrest).
+# Text is deliberately *not* identical to training titles/snippets so the
+# model must generalise across surface forms, not just memorise exact n-grams.
 # ---------------------------------------------------------------------------
 
-_VAL_CANDIDATES: list[tuple[_FakeCand, int]] = [
-    # negatives — sports
-    (_FakeCand("v-neg-0", "ספורט ופנאי", "כדורגל ושחמט"), 0),
-    (_FakeCand("v-neg-1", "ספורט ופנאי", "כדורגל ושחמט"), 0),
-    (_FakeCand("v-neg-2", "ספורט ופנאי", "כדורגל ושחמט"), 0),
-    (_FakeCand("v-neg-3", "ספורט ופנאי", "כדורגל ושחמט"), 0),
-    # positives — crime/arrest
-    (_FakeCand("v-pos-0", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
-    (_FakeCand("v-pos-1", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
-    (_FakeCand("v-pos-2", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
-    (_FakeCand("v-pos-3", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
+_VAL_CANDIDATES: list[tuple[FakeCandidate, int]] = [
+    # negatives — sports, different words from training set
+    (
+        FakeCandidate(
+            candidate_id="v-neg-0", title="ליגת הכדורסל הלאומית", snippet="תוצאות משחקי כדורגל"
+        ),
+        0,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-neg-1", title="אליפות הטניס העולמית", snippet="טורניר כדורגל ושחמט"
+        ),
+        0,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-neg-2", title="ספורט ופנאי ובידור", snippet="ספורטאים וקבוצות"
+        ),
+        0,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-neg-3", title="תוצאות ספורט של השבוע", snippet="כדורגל וכדורסל"
+        ),
+        0,
+    ),
+    # positives — crime/arrest, different words from training set
+    (
+        FakeCandidate(
+            candidate_id="v-pos-0", title="נאשם נעצר על ידי המשטרה", snippet="חשוד ברצח נלכד"
+        ),
+        1,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-pos-1", title="מעצר חשוד בעקבות חקירה", snippet="המשטרה עצרה את החשוד"
+        ),
+        1,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-pos-2", title="חשוד בפשע נעצר הלילה", snippet="כוחות המשטרה פשטו"
+        ),
+        1,
+    ),
+    (
+        FakeCandidate(
+            candidate_id="v-pos-3", title="עצור בגין חשד לרצח", snippet="נאשם הובא לחקירה"
+        ),
+        1,
+    ),
 ]
 
 

--- a/tests/unit/prefilter/test_stage_b_calibration.py
+++ b/tests/unit/prefilter/test_stage_b_calibration.py
@@ -1,0 +1,170 @@
+"""Unit tests verifying that Stage B calibration reduces Brier score.
+
+The calibrated ComplementNB should assign probability estimates that are
+better-calibrated than a naive constant-output baseline.  We evaluate on
+held-out examples drawn from the same text distribution as the training
+fixture (see conftest.py → trained_stage_b_dir).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from denbust.prefilter.stage_b import StageBScorer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeCand:
+    """Minimal CandidateView for calibration evaluation."""
+
+    def __init__(
+        self,
+        candidate_id: str,
+        title: str | None,
+        snippet: str | None,
+    ) -> None:
+        self._candidate_id = candidate_id
+        self._title = title
+        self._snippet = snippet
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return "example.co.il"
+
+    @property
+    def title(self) -> str | None:
+        return self._title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._snippet
+
+    @property
+    def url(self) -> str | None:
+        return "https://example.co.il/article/1"
+
+
+def _brier_score(p_positives: list[float], labels: list[int]) -> float:
+    """Mean squared error between P(positive) and true labels (0=negative, 1=positive)."""
+    assert len(p_positives) == len(labels)
+    return sum((p - y) ** 2 for p, y in zip(p_positives, labels)) / len(p_positives)
+
+
+# ---------------------------------------------------------------------------
+# Val-split candidates (mirrors conftest._write_fixture val rows)
+# The conftest fixture trains on sports (negative) and crime (positive).
+# These val examples come from the same distribution.
+# y = 0 → negative (sports), y = 1 → positive (crime/arrest).
+# ---------------------------------------------------------------------------
+
+_VAL_CANDIDATES: list[tuple[_FakeCand, int]] = [
+    # negatives — sports
+    (_FakeCand("v-neg-0", "ספורט ופנאי", "כדורגל ושחמט"), 0),
+    (_FakeCand("v-neg-1", "ספורט ופנאי", "כדורגל ושחמט"), 0),
+    (_FakeCand("v-neg-2", "ספורט ופנאי", "כדורגל ושחמט"), 0),
+    (_FakeCand("v-neg-3", "ספורט ופנאי", "כדורגל ושחמט"), 0),
+    # positives — crime/arrest
+    (_FakeCand("v-pos-0", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
+    (_FakeCand("v-pos-1", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
+    (_FakeCand("v-pos-2", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
+    (_FakeCand("v-pos-3", "עצור חשוד ברצח", "המשטרה עצרה חשוד"), 1),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStageBCalibration:
+    """Calibrated model Brier score must beat the naive constant baseline."""
+
+    def test_brier_better_than_constant_05_baseline_thin(self, trained_stage_b_dir: Path) -> None:
+        """Calibrated thin model must beat always-predicting-0.5 baseline.
+
+        Brier score for a constant 0.5 predictor is always 0.25 regardless of
+        class balance.  The calibrated model should score below this.
+        """
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+
+        p_pos: list[float] = []
+        y_true: list[int] = []
+        for cand, label in _VAL_CANDIDATES:
+            result = scorer.evaluate(cand, "thin")
+            assert result is not None
+            # p_positive = 1 − p_negative; Brier score is in terms of P(positive).
+            p_pos.append(1.0 - result.p_negative)
+            y_true.append(label)
+
+        model_brier = _brier_score(p_pos, y_true)
+        # Constant 0.5 → Brier = 0.25 for any label distribution.
+        baseline_brier = _brier_score([0.5] * len(y_true), y_true)
+        assert model_brier < baseline_brier, (
+            f"Calibrated thin model Brier ({model_brier:.4f}) must beat "
+            f"constant-0.5 baseline ({baseline_brier:.4f})"
+        )
+
+    def test_brier_better_than_constant_05_baseline_thick(self, trained_stage_b_dir: Path) -> None:
+        """Calibrated thick model must beat always-predicting-0.5 baseline.
+
+        Thick model falls back to title+snippet when body is absent, which
+        is the val-set scenario (conftest sets body=None for non-train rows).
+        """
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+
+        p_pos: list[float] = []
+        y_true: list[int] = []
+        for cand, label in _VAL_CANDIDATES:
+            # body=None → falls back to title+snippet in the thick model
+            result = scorer.evaluate(cand, "thick", body=None)
+            assert result is not None
+            p_pos.append(1.0 - result.p_negative)
+            y_true.append(label)
+
+        model_brier = _brier_score(p_pos, y_true)
+        baseline_brier = _brier_score([0.5] * len(y_true), y_true)
+        assert model_brier < baseline_brier, (
+            f"Calibrated thick model Brier ({model_brier:.4f}) must beat "
+            f"constant-0.5 baseline ({baseline_brier:.4f})"
+        )
+
+    def test_all_probabilities_bounded(self, trained_stage_b_dir: Path) -> None:
+        """Every p_negative value returned by evaluate must lie in [0, 1]."""
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        for cand, _ in _VAL_CANDIDATES:
+            result = scorer.evaluate(cand, "thin")
+            assert result is not None
+            assert 0.0 <= result.p_negative <= 1.0, (
+                f"p_negative={result.p_negative} out of [0, 1] for {cand.candidate_id}"
+            )
+
+    def test_negative_class_higher_p_negative_than_positive(
+        self, trained_stage_b_dir: Path
+    ) -> None:
+        """On average, negatives should score higher p_negative than positives."""
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+
+        neg_scores = []
+        pos_scores = []
+        for cand, label in _VAL_CANDIDATES:
+            result = scorer.evaluate(cand, "thin")
+            assert result is not None
+            if label == 0:
+                neg_scores.append(result.p_negative)
+            else:
+                pos_scores.append(result.p_negative)
+
+        assert neg_scores and pos_scores
+        avg_neg = sum(neg_scores) / len(neg_scores)
+        avg_pos = sum(pos_scores) / len(pos_scores)
+        assert avg_neg > avg_pos, (
+            f"Mean p_negative for negatives ({avg_neg:.3f}) must exceed "
+            f"mean p_negative for positives ({avg_pos:.3f})"
+        )

--- a/tests/unit/prefilter/test_stage_b_integration_with_cascade.py
+++ b/tests/unit/prefilter/test_stage_b_integration_with_cascade.py
@@ -1,0 +1,282 @@
+"""Integration tests for Stage B within the CascadeOrchestrator.
+
+Verifies that:
+- When trained artifacts are present, Stage B produces a StageScore in the
+  decision's ``stage_scores`` tuple for both thin and thick passes.
+- When no artifacts are present (models_dir=None), Stage B is silently skipped
+  and the cascade continues without a B score.
+- SHADOW mode correctly downgrades a B-driven drop to a pass verdict.
+- ENFORCE mode correctly propagates a B-driven drop as a drop verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from denbust.prefilter.cascade import CascadeOrchestrator
+from denbust.prefilter.config import PrefilterConfig
+from denbust.prefilter.models import CandidateView, PassKind, StageScore
+
+# ---------------------------------------------------------------------------
+# Minimal CandidateView
+# ---------------------------------------------------------------------------
+
+
+class _FakeCand:
+    """Minimal object satisfying the CandidateView protocol."""
+
+    def __init__(
+        self,
+        candidate_id: str = "cand-test",
+        domain: str | None = "example.co.il",
+        title: str | None = "עצור חשוד ברצח",
+        snippet: str | None = "המשטרה עצרה חשוד",
+        url: str | None = "https://example.co.il/article/1",
+    ) -> None:
+        self._candidate_id = candidate_id
+        self._domain = domain
+        self._title = title
+        self._snippet = snippet
+        self._url = url
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return self._domain
+
+    @property
+    def title(self) -> str | None:
+        return self._title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._snippet
+
+    @property
+    def url(self) -> str | None:
+        return self._url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _shadow_orchestrator(
+    decisions_dir: Path,
+    models_dir: Path | None = None,
+    *,
+    disable_a: bool = True,
+    disable_c: bool = True,
+    disable_d: bool = True,
+) -> CascadeOrchestrator:
+    """Build a SHADOW-mode orchestrator with only Stage B enabled by default."""
+    cfg = PrefilterConfig.model_validate(
+        {
+            "enabled": True,
+            "mode": "shadow",
+            "stages": {
+                "a": {"enabled": not disable_a},
+                "b": {"enabled": True},
+                "c": {"enabled": not disable_c},
+                "d": {"enabled": not disable_d},
+            },
+        }
+    )
+    return CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir, models_dir=models_dir)
+
+
+def _enforce_orchestrator(
+    decisions_dir: Path,
+    models_dir: Path | None = None,
+    *,
+    disable_a: bool = True,
+    disable_c: bool = True,
+    disable_d: bool = True,
+) -> CascadeOrchestrator:
+    """Build an ENFORCE-mode orchestrator with only Stage B enabled by default."""
+    cfg = PrefilterConfig.model_validate(
+        {
+            "enabled": True,
+            "mode": "enforce",
+            "stages": {
+                "a": {"enabled": not disable_a},
+                "b": {"enabled": True},
+                "c": {"enabled": not disable_c},
+                "d": {"enabled": not disable_d},
+            },
+        }
+    )
+    return CascadeOrchestrator(config=cfg, decisions_dir=decisions_dir, models_dir=models_dir)
+
+
+# ---------------------------------------------------------------------------
+# Stub behavior — no trained artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestStageBStubInCascade:
+    """With no trained artifacts, Stage B is silently skipped."""
+
+    def test_thin_pass_no_b_score_when_no_artifacts(self, tmp_path: Path) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=None)
+        decision = orch.evaluate_thin(_FakeCand())
+        b_scores = [s for s in decision.stage_scores if s.stage == "B"]
+        assert b_scores == []
+
+    def test_thick_pass_no_b_score_when_no_artifacts(self, tmp_path: Path) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=None)
+        decision = orch.evaluate_thick(_FakeCand(), body="some article body")
+        b_scores = [s for s in decision.stage_scores if s.stage == "B"]
+        assert b_scores == []
+
+    def test_cascade_still_passes_without_b_artifacts(self, tmp_path: Path) -> None:
+        orch = _enforce_orchestrator(tmp_path / "decisions", models_dir=None)
+        decision = orch.evaluate_thin(_FakeCand())
+        assert decision.verdict == "pass"
+        assert decision.stopped_at_stage == "passed_all"
+
+
+# ---------------------------------------------------------------------------
+# Loaded model — Stage B score appears in stage_scores
+# ---------------------------------------------------------------------------
+
+
+class TestStageBScoreInCascade:
+    """With trained artifacts, Stage B emits a StageScore in the decision."""
+
+    def test_thin_pass_emits_b_score(self, trained_stage_b_dir: Path, tmp_path: Path) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thin(_FakeCand())
+        b_scores = [s for s in decision.stage_scores if s.stage == "B"]
+        assert len(b_scores) == 1
+
+    def test_thick_pass_emits_b_score(self, trained_stage_b_dir: Path, tmp_path: Path) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thick(_FakeCand(), body="החשוד נעצר לאחר חקירה ממושכת של המשטרה")
+        b_scores = [s for s in decision.stage_scores if s.stage == "B"]
+        assert len(b_scores) == 1
+
+    def test_b_score_p_negative_in_unit_interval(
+        self, trained_stage_b_dir: Path, tmp_path: Path
+    ) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thin(_FakeCand())
+        b_score = next(s for s in decision.stage_scores if s.stage == "B")
+        assert 0.0 <= b_score.p_negative <= 1.0
+
+    def test_b_score_model_version_nonempty(
+        self, trained_stage_b_dir: Path, tmp_path: Path
+    ) -> None:
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thin(_FakeCand())
+        b_score = next(s for s in decision.stage_scores if s.stage == "B")
+        assert len(b_score.model_version) > 0
+
+
+# ---------------------------------------------------------------------------
+# Mode semantics — SHADOW vs ENFORCE
+# ---------------------------------------------------------------------------
+
+
+class TestStageBModeSemanticsInCascade:
+    """SHADOW downgrades B drops; ENFORCE respects them."""
+
+    def test_shadow_downgrades_b_drop_to_pass(
+        self,
+        trained_stage_b_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When Stage B would drop in ENFORCE, SHADOW must record pass instead."""
+        import denbust.prefilter.stage_b as _stage_b_mod
+
+        def _always_drop(
+            _self: Any,
+            _candidate: CandidateView,
+            _pass_kind: PassKind,
+            _body: str | None = None,
+        ) -> StageScore:
+            return StageScore(
+                stage="B",
+                p_negative=0.99,
+                threshold=0.95,
+                dropped=True,
+                reason="test-inject",
+                model_version="test",
+            )
+
+        monkeypatch.setattr(_stage_b_mod.StageBScorer, "evaluate", _always_drop)
+
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thin(_FakeCand())
+        assert decision.verdict == "pass"
+        # stopped_at_stage records where the cascade would have stopped.
+        assert decision.stopped_at_stage == "B"
+
+    def test_enforce_respects_b_drop(
+        self,
+        trained_stage_b_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """In ENFORCE mode a B-driven drop must propagate as verdict='drop'."""
+        import denbust.prefilter.stage_b as _stage_b_mod
+
+        def _always_drop(
+            _self: Any,
+            _candidate: CandidateView,
+            _pass_kind: PassKind,
+            _body: str | None = None,
+        ) -> StageScore:
+            return StageScore(
+                stage="B",
+                p_negative=0.99,
+                threshold=0.95,
+                dropped=True,
+                reason="test-inject",
+                model_version="test",
+            )
+
+        monkeypatch.setattr(_stage_b_mod.StageBScorer, "evaluate", _always_drop)
+
+        orch = _enforce_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        decision = orch.evaluate_thin(_FakeCand())
+        assert decision.verdict == "drop"
+        assert decision.stopped_at_stage == "B"
+
+    def test_telemetry_written_in_shadow_after_b_evaluates(
+        self, trained_stage_b_dir: Path, tmp_path: Path
+    ) -> None:
+        """Stage B running must cause a telemetry record to be written."""
+        decisions_dir = tmp_path / "decisions"
+        orch = _shadow_orchestrator(decisions_dir, models_dir=trained_stage_b_dir)
+        orch.evaluate_thin(_FakeCand())
+        files = list(decisions_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+
+    def test_thick_pass_uses_body_for_b(self, trained_stage_b_dir: Path, tmp_path: Path) -> None:
+        """evaluate_thick must forward body to Stage B so the thick model runs."""
+        orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
+        # Positive title+snippet, but strongly negative body → thick model score should
+        # be higher (more negative) than thin model score.
+        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        body = "משחקי כדורגל וטניס וכדורסל הם ספורט פנאי"
+
+        decision_thin = orch.evaluate_thin(cand)
+        decision_thick = orch.evaluate_thick(cand, body=body)
+
+        b_thin = next(s for s in decision_thin.stage_scores if s.stage == "B")
+        b_thick = next(s for s in decision_thick.stage_scores if s.stage == "B")
+
+        # The thick model uses the body (strongly negative sports text) while the
+        # thin model uses the title+snippet (positive crime text).  They should differ.
+        assert b_thin.p_negative != b_thick.p_negative

--- a/tests/unit/prefilter/test_stage_b_integration_with_cascade.py
+++ b/tests/unit/prefilter/test_stage_b_integration_with_cascade.py
@@ -19,49 +19,7 @@ import pytest
 from denbust.prefilter.cascade import CascadeOrchestrator
 from denbust.prefilter.config import PrefilterConfig
 from denbust.prefilter.models import CandidateView, PassKind, StageScore
-
-# ---------------------------------------------------------------------------
-# Minimal CandidateView
-# ---------------------------------------------------------------------------
-
-
-class _FakeCand:
-    """Minimal object satisfying the CandidateView protocol."""
-
-    def __init__(
-        self,
-        candidate_id: str = "cand-test",
-        domain: str | None = "example.co.il",
-        title: str | None = "עצור חשוד ברצח",
-        snippet: str | None = "המשטרה עצרה חשוד",
-        url: str | None = "https://example.co.il/article/1",
-    ) -> None:
-        self._candidate_id = candidate_id
-        self._domain = domain
-        self._title = title
-        self._snippet = snippet
-        self._url = url
-
-    @property
-    def candidate_id(self) -> str:
-        return self._candidate_id
-
-    @property
-    def domain(self) -> str | None:
-        return self._domain
-
-    @property
-    def title(self) -> str | None:
-        return self._title
-
-    @property
-    def snippet(self) -> str | None:
-        return self._snippet
-
-    @property
-    def url(self) -> str | None:
-        return self._url
-
+from tests.unit.prefilter._helpers import FakeCandidate
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -126,19 +84,19 @@ class TestStageBStubInCascade:
 
     def test_thin_pass_no_b_score_when_no_artifacts(self, tmp_path: Path) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=None)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         b_scores = [s for s in decision.stage_scores if s.stage == "B"]
         assert b_scores == []
 
     def test_thick_pass_no_b_score_when_no_artifacts(self, tmp_path: Path) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=None)
-        decision = orch.evaluate_thick(_FakeCand(), body="some article body")
+        decision = orch.evaluate_thick(FakeCandidate(), body="some article body")
         b_scores = [s for s in decision.stage_scores if s.stage == "B"]
         assert b_scores == []
 
     def test_cascade_still_passes_without_b_artifacts(self, tmp_path: Path) -> None:
         orch = _enforce_orchestrator(tmp_path / "decisions", models_dir=None)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         assert decision.verdict == "pass"
         assert decision.stopped_at_stage == "passed_all"
 
@@ -153,13 +111,15 @@ class TestStageBScoreInCascade:
 
     def test_thin_pass_emits_b_score(self, trained_stage_b_dir: Path, tmp_path: Path) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         b_scores = [s for s in decision.stage_scores if s.stage == "B"]
         assert len(b_scores) == 1
 
     def test_thick_pass_emits_b_score(self, trained_stage_b_dir: Path, tmp_path: Path) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thick(_FakeCand(), body="החשוד נעצר לאחר חקירה ממושכת של המשטרה")
+        decision = orch.evaluate_thick(
+            FakeCandidate(), body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+        )
         b_scores = [s for s in decision.stage_scores if s.stage == "B"]
         assert len(b_scores) == 1
 
@@ -167,7 +127,7 @@ class TestStageBScoreInCascade:
         self, trained_stage_b_dir: Path, tmp_path: Path
     ) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         b_score = next(s for s in decision.stage_scores if s.stage == "B")
         assert 0.0 <= b_score.p_negative <= 1.0
 
@@ -175,7 +135,7 @@ class TestStageBScoreInCascade:
         self, trained_stage_b_dir: Path, tmp_path: Path
     ) -> None:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         b_score = next(s for s in decision.stage_scores if s.stage == "B")
         assert len(b_score.model_version) > 0
 
@@ -215,7 +175,7 @@ class TestStageBModeSemanticsInCascade:
         monkeypatch.setattr(_stage_b_mod.StageBScorer, "evaluate", _always_drop)
 
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         assert decision.verdict == "pass"
         # stopped_at_stage records where the cascade would have stopped.
         assert decision.stopped_at_stage == "B"
@@ -247,7 +207,7 @@ class TestStageBModeSemanticsInCascade:
         monkeypatch.setattr(_stage_b_mod.StageBScorer, "evaluate", _always_drop)
 
         orch = _enforce_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
-        decision = orch.evaluate_thin(_FakeCand())
+        decision = orch.evaluate_thin(FakeCandidate())
         assert decision.verdict == "drop"
         assert decision.stopped_at_stage == "B"
 
@@ -257,7 +217,7 @@ class TestStageBModeSemanticsInCascade:
         """Stage B running must cause a telemetry record to be written."""
         decisions_dir = tmp_path / "decisions"
         orch = _shadow_orchestrator(decisions_dir, models_dir=trained_stage_b_dir)
-        orch.evaluate_thin(_FakeCand())
+        orch.evaluate_thin(FakeCandidate())
         files = list(decisions_dir.glob("*.jsonl"))
         assert len(files) == 1
         lines = files[0].read_text(encoding="utf-8").splitlines()
@@ -268,7 +228,7 @@ class TestStageBModeSemanticsInCascade:
         orch = _shadow_orchestrator(tmp_path / "decisions", models_dir=trained_stage_b_dir)
         # Positive title+snippet, but strongly negative body → thick model score should
         # be higher (more negative) than thin model score.
-        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
         body = "משחקי כדורגל וטניס וכדורסל הם ספורט פנאי"
 
         decision_thin = orch.evaluate_thin(cand)

--- a/tests/unit/prefilter/test_stage_b_predict.py
+++ b/tests/unit/prefilter/test_stage_b_predict.py
@@ -1,0 +1,209 @@
+"""Unit tests for StageBScorer inference (predict path) in prefilter.stage_b."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from denbust.prefilter.models import StageScore
+from denbust.prefilter.stage_b import StageBScorer
+
+# ---------------------------------------------------------------------------
+# Minimal CandidateView for testing
+# ---------------------------------------------------------------------------
+
+
+class _FakeCand:
+    """Minimal object satisfying the CandidateView protocol."""
+
+    def __init__(
+        self,
+        candidate_id: str = "cand-test",
+        domain: str | None = "example.co.il",
+        title: str | None = "עצור חשוד ברצח",
+        snippet: str | None = "המשטרה עצרה חשוד",
+        url: str | None = "https://example.co.il/article/1",
+    ) -> None:
+        self._candidate_id = candidate_id
+        self._domain = domain
+        self._title = title
+        self._snippet = snippet
+        self._url = url
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return self._domain
+
+    @property
+    def title(self) -> str | None:
+        return self._title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._snippet
+
+    @property
+    def url(self) -> str | None:
+        return self._url
+
+
+# ---------------------------------------------------------------------------
+# Stub behaviour — no artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestStageBScorerStub:
+    """StageBScorer returns None when no trained artifacts are present."""
+
+    def test_none_models_dir_returns_none_thin(self) -> None:
+        scorer = StageBScorer(models_dir=None)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is None
+
+    def test_none_models_dir_returns_none_thick(self) -> None:
+        scorer = StageBScorer(models_dir=None)
+        result = scorer.evaluate(_FakeCand(), "thick", body="some body text")
+        assert result is None
+
+    def test_missing_dir_returns_none(self, tmp_path: Path) -> None:
+        scorer = StageBScorer(models_dir=tmp_path / "nonexistent")
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is None
+
+    def test_empty_models_dir_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "stage_b").mkdir(parents=True)
+        scorer = StageBScorer(models_dir=tmp_path)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is None
+
+    def test_partial_artifacts_returns_none(self, tmp_path: Path) -> None:
+        """Only thin_model present (no thick_model) → stub behaviour."""
+        stage_dir = tmp_path / "stage_b"
+        stage_dir.mkdir(parents=True)
+        (stage_dir / "thin_model.joblib").write_bytes(b"dummy")
+        scorer = StageBScorer(models_dir=tmp_path)
+        assert scorer.evaluate(_FakeCand(), "thin") is None
+
+
+# ---------------------------------------------------------------------------
+# Loaded model behaviour — uses trained_stage_b_dir fixture from conftest
+# ---------------------------------------------------------------------------
+
+
+class TestStageBScorerLoaded:
+    """StageBScorer loaded from trained artifacts produces valid StageScore."""
+
+    def test_thin_returns_stage_score(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert isinstance(result, StageScore)
+
+    def test_thick_with_body_returns_stage_score(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(
+            _FakeCand(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+        )
+        assert isinstance(result, StageScore)
+
+    def test_thick_without_body_falls_back_to_thin(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thick", body=None)
+        assert isinstance(result, StageScore)
+
+    def test_thick_empty_body_falls_back_to_thin(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thick", body="   ")
+        assert isinstance(result, StageScore)
+
+    def test_stage_score_has_stage_b(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert result.stage == "B"
+
+    def test_p_negative_in_unit_interval_thin(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert 0.0 <= result.p_negative <= 1.0
+
+    def test_p_negative_in_unit_interval_thick(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(
+            _FakeCand(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+        )
+        assert result is not None
+        assert 0.0 <= result.p_negative <= 1.0
+
+    def test_threshold_propagated(self, trained_stage_b_dir: Path) -> None:
+        custom_threshold = 0.7
+        scorer = StageBScorer(models_dir=trained_stage_b_dir, threshold=custom_threshold)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert result.threshold == custom_threshold
+
+    def test_dropped_flag_consistent_with_threshold(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir, threshold=0.95)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert result.dropped == (result.p_negative >= 0.95)
+
+    def test_model_version_nonempty(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert len(result.model_version) > 0
+
+    def test_model_version_is_hex(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(_FakeCand(), "thin")
+        assert result is not None
+        assert all(c in "0123456789abcdef" for c in result.model_version)
+
+    def test_deterministic_thin_same_input(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        r1 = scorer.evaluate(cand, "thin")
+        r2 = scorer.evaluate(cand, "thin")
+        assert r1 is not None and r2 is not None
+        assert r1.p_negative == r2.p_negative
+
+    def test_deterministic_thick_same_input(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        cand = _FakeCand()
+        body = "החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+        r1 = scorer.evaluate(cand, "thick", body=body)
+        r2 = scorer.evaluate(cand, "thick", body=body)
+        assert r1 is not None and r2 is not None
+        assert r1.p_negative == r2.p_negative
+
+    def test_different_inputs_may_differ(self, trained_stage_b_dir: Path) -> None:
+        """Crime text and sports text should produce different p_negative values."""
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        crime = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        sports = _FakeCand(title="ספורט ופנאי", snippet="כדורגל ושחמט")
+        r_crime = scorer.evaluate(crime, "thin")
+        r_sports = scorer.evaluate(sports, "thin")
+        assert r_crime is not None and r_sports is not None
+        # Crime is positive → lower p_negative; sports is negative → higher p_negative.
+        # At 15 examples per class the model should be directionally correct.
+        assert r_crime.p_negative < r_sports.p_negative
+
+    def test_thin_and_thick_passes_use_different_models(self, trained_stage_b_dir: Path) -> None:
+        """Thin and thick scorers are separate sklearn pipelines.
+
+        With a body that differs from title+snippet the scores should differ,
+        confirming that two distinct models are used.
+        """
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        # Pass a *negative* body → thick model should produce higher p_negative
+        # than the thin model that saw a positive title+snippet.
+        r_thin = scorer.evaluate(cand, "thin")
+        r_thick = scorer.evaluate(cand, "thick", body="משחקי כדורגל וטניס וכדורסל הם ספורט פנאי")
+        assert r_thin is not None and r_thick is not None
+        # Different models → scores must not be identical.
+        assert r_thin.p_negative != r_thick.p_negative

--- a/tests/unit/prefilter/test_stage_b_predict.py
+++ b/tests/unit/prefilter/test_stage_b_predict.py
@@ -6,49 +6,7 @@ from pathlib import Path
 
 from denbust.prefilter.models import StageScore
 from denbust.prefilter.stage_b import StageBScorer
-
-# ---------------------------------------------------------------------------
-# Minimal CandidateView for testing
-# ---------------------------------------------------------------------------
-
-
-class _FakeCand:
-    """Minimal object satisfying the CandidateView protocol."""
-
-    def __init__(
-        self,
-        candidate_id: str = "cand-test",
-        domain: str | None = "example.co.il",
-        title: str | None = "עצור חשוד ברצח",
-        snippet: str | None = "המשטרה עצרה חשוד",
-        url: str | None = "https://example.co.il/article/1",
-    ) -> None:
-        self._candidate_id = candidate_id
-        self._domain = domain
-        self._title = title
-        self._snippet = snippet
-        self._url = url
-
-    @property
-    def candidate_id(self) -> str:
-        return self._candidate_id
-
-    @property
-    def domain(self) -> str | None:
-        return self._domain
-
-    @property
-    def title(self) -> str | None:
-        return self._title
-
-    @property
-    def snippet(self) -> str | None:
-        return self._snippet
-
-    @property
-    def url(self) -> str | None:
-        return self._url
-
+from tests.unit.prefilter._helpers import FakeCandidate
 
 # ---------------------------------------------------------------------------
 # Stub behaviour — no artifacts
@@ -60,23 +18,23 @@ class TestStageBScorerStub:
 
     def test_none_models_dir_returns_none_thin(self) -> None:
         scorer = StageBScorer(models_dir=None)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is None
 
     def test_none_models_dir_returns_none_thick(self) -> None:
         scorer = StageBScorer(models_dir=None)
-        result = scorer.evaluate(_FakeCand(), "thick", body="some body text")
+        result = scorer.evaluate(FakeCandidate(), "thick", body="some body text")
         assert result is None
 
     def test_missing_dir_returns_none(self, tmp_path: Path) -> None:
         scorer = StageBScorer(models_dir=tmp_path / "nonexistent")
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is None
 
     def test_empty_models_dir_returns_none(self, tmp_path: Path) -> None:
         (tmp_path / "stage_b").mkdir(parents=True)
         scorer = StageBScorer(models_dir=tmp_path)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is None
 
     def test_partial_artifacts_returns_none(self, tmp_path: Path) -> None:
@@ -85,7 +43,7 @@ class TestStageBScorerStub:
         stage_dir.mkdir(parents=True)
         (stage_dir / "thin_model.joblib").write_bytes(b"dummy")
         scorer = StageBScorer(models_dir=tmp_path)
-        assert scorer.evaluate(_FakeCand(), "thin") is None
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
 
 
 # ---------------------------------------------------------------------------
@@ -98,42 +56,42 @@ class TestStageBScorerLoaded:
 
     def test_thin_returns_stage_score(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert isinstance(result, StageScore)
 
     def test_thick_with_body_returns_stage_score(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
         result = scorer.evaluate(
-            _FakeCand(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+            FakeCandidate(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
         )
         assert isinstance(result, StageScore)
 
     def test_thick_without_body_falls_back_to_thin(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thick", body=None)
+        result = scorer.evaluate(FakeCandidate(), "thick", body=None)
         assert isinstance(result, StageScore)
 
     def test_thick_empty_body_falls_back_to_thin(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thick", body="   ")
+        result = scorer.evaluate(FakeCandidate(), "thick", body="   ")
         assert isinstance(result, StageScore)
 
     def test_stage_score_has_stage_b(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert result.stage == "B"
 
     def test_p_negative_in_unit_interval_thin(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert 0.0 <= result.p_negative <= 1.0
 
     def test_p_negative_in_unit_interval_thick(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
         result = scorer.evaluate(
-            _FakeCand(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+            FakeCandidate(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
         )
         assert result is not None
         assert 0.0 <= result.p_negative <= 1.0
@@ -141,31 +99,45 @@ class TestStageBScorerLoaded:
     def test_threshold_propagated(self, trained_stage_b_dir: Path) -> None:
         custom_threshold = 0.7
         scorer = StageBScorer(models_dir=trained_stage_b_dir, threshold=custom_threshold)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert result.threshold == custom_threshold
 
     def test_dropped_flag_consistent_with_threshold(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir, threshold=0.95)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert result.dropped == (result.p_negative >= 0.95)
 
     def test_model_version_nonempty(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert len(result.model_version) > 0
 
     def test_model_version_is_hex(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        result = scorer.evaluate(_FakeCand(), "thin")
+        result = scorer.evaluate(FakeCandidate(), "thin")
         assert result is not None
         assert all(c in "0123456789abcdef" for c in result.model_version)
 
+    def test_reason_includes_pass_kind_thin(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.reason.startswith("nb/thin=")
+
+    def test_reason_includes_pass_kind_thick(self, trained_stage_b_dir: Path) -> None:
+        scorer = StageBScorer(models_dir=trained_stage_b_dir)
+        result = scorer.evaluate(
+            FakeCandidate(), "thick", body="החשוד נעצר לאחר חקירה ממושכת של המשטרה"
+        )
+        assert result is not None
+        assert result.reason.startswith("nb/thick=")
+
     def test_deterministic_thin_same_input(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
         r1 = scorer.evaluate(cand, "thin")
         r2 = scorer.evaluate(cand, "thin")
         assert r1 is not None and r2 is not None
@@ -173,7 +145,7 @@ class TestStageBScorerLoaded:
 
     def test_deterministic_thick_same_input(self, trained_stage_b_dir: Path) -> None:
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        cand = _FakeCand()
+        cand = FakeCandidate()
         body = "החשוד נעצר לאחר חקירה ממושכת של המשטרה"
         r1 = scorer.evaluate(cand, "thick", body=body)
         r2 = scorer.evaluate(cand, "thick", body=body)
@@ -183,8 +155,8 @@ class TestStageBScorerLoaded:
     def test_different_inputs_may_differ(self, trained_stage_b_dir: Path) -> None:
         """Crime text and sports text should produce different p_negative values."""
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        crime = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
-        sports = _FakeCand(title="ספורט ופנאי", snippet="כדורגל ושחמט")
+        crime = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        sports = FakeCandidate(title="ספורט ופנאי", snippet="כדורגל ושחמט")
         r_crime = scorer.evaluate(crime, "thin")
         r_sports = scorer.evaluate(sports, "thin")
         assert r_crime is not None and r_sports is not None
@@ -192,18 +164,22 @@ class TestStageBScorerLoaded:
         # At 15 examples per class the model should be directionally correct.
         assert r_crime.p_negative < r_sports.p_negative
 
-    def test_thin_and_thick_passes_use_different_models(self, trained_stage_b_dir: Path) -> None:
-        """Thin and thick scorers are separate sklearn pipelines.
+    def test_thick_body_produces_different_score_than_thin(self, trained_stage_b_dir: Path) -> None:
+        """Thick pass with a body that contradicts title+snippet must differ from thin.
 
-        With a body that differs from title+snippet the scores should differ,
-        confirming that two distinct models are used.
+        This verifies that two distinct model pipelines are used — if both
+        passes returned the same score, there would be no benefit to the
+        thick/thin split.
         """
         scorer = StageBScorer(models_dir=trained_stage_b_dir)
-        cand = _FakeCand(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
-        # Pass a *negative* body → thick model should produce higher p_negative
-        # than the thin model that saw a positive title+snippet.
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        # Negative-domain body fed to a positive-domain candidate:
+        # thick model was trained on body text; thin model on title+snippet.
         r_thin = scorer.evaluate(cand, "thin")
         r_thick = scorer.evaluate(cand, "thick", body="משחקי כדורגל וטניס וכדורסל הם ספורט פנאי")
         assert r_thin is not None and r_thick is not None
-        # Different models → scores must not be identical.
+        # Assert that thin and thick reason tags differ — confirms two distinct paths.
+        assert r_thin.reason.startswith("nb/thin=")
+        assert r_thick.reason.startswith("nb/thick=")
+        # And the scores should be numerically different given contradictory inputs.
         assert r_thin.p_negative != r_thick.p_negative

--- a/tests/unit/prefilter/test_stage_b_train.py
+++ b/tests/unit/prefilter/test_stage_b_train.py
@@ -3,41 +3,18 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import pytest
 
 from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
 from denbust.prefilter.stage_b import StageBModelMeta, train_naive_bayes
+from tests.unit.prefilter._helpers import make_labeled_row
 
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
-
-_LABELED_AT = "2026-01-01T00:00:00+00:00"
-
-
-def _make_row(
-    idx: int,
-    label: str,
-    split: str,
-    title: str,
-    snippet: str,
-    body: str | None = None,
-) -> LabeledCandidate:
-    return LabeledCandidate(
-        candidate_id=f"cand-{idx:04d}",
-        domain="example.co.il",
-        url=f"https://example.co.il/article/{idx}",
-        title=title,
-        snippet=snippet,
-        article_body=body,
-        label=label,  # type: ignore[arg-type]
-        label_source="triage_manual",
-        split=split,  # type: ignore[arg-type]
-        labeled_at=_LABELED_AT,
-        decision_hash=f"hash{idx:04d}",
-    )
 
 
 def _write_fixture(tmp_path: Path, n_per_class: int = 15) -> Path:
@@ -47,10 +24,10 @@ def _write_fixture(tmp_path: Path, n_per_class: int = 15) -> Path:
     for split, count in [("train", n_per_class), ("val", 4), ("test", 4)]:
         for _ in range(count):
             rows.append(
-                _make_row(
+                make_labeled_row(
                     idx,
                     "negative",
-                    split,
+                    split,  # type: ignore[arg-type]
                     title="ספורט ופנאי",
                     snippet="כדורגל ושחמט",
                     body="משחקי כדורגל וטניס וכדורסל הם ספורט פנאי" if split == "train" else None,
@@ -58,10 +35,10 @@ def _write_fixture(tmp_path: Path, n_per_class: int = 15) -> Path:
             )
             idx += 1
             rows.append(
-                _make_row(
+                make_labeled_row(
                     idx,
                     "positive",
-                    split,
+                    split,  # type: ignore[arg-type]
                     title="עצור חשוד ברצח",
                     snippet="המשטרה עצרה חשוד",
                     body="החשוד נעצר לאחר חקירה ממושכת של המשטרה" if split == "train" else None,
@@ -82,70 +59,122 @@ def _write_fixture(tmp_path: Path, n_per_class: int = 15) -> Path:
 class TestTrainNaiveBayes:
     def test_returns_meta(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
-        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
         assert isinstance(meta, StageBModelMeta)
+
+    def test_returns_stage_dir(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_naive_bayes(labels_path, tmp_path / "models")
+        assert stage_dir.is_dir()
 
     def test_meta_model_kind(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
-        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
         assert meta.model_kind == "naive_bayes"
 
     def test_meta_n_train_matches_split(self, tmp_path: Path) -> None:
         n = 15
         labels_path = _write_fixture(tmp_path, n_per_class=n)
-        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
         assert meta.n_train == n * 2  # n positive + n negative
 
     def test_meta_n_val_matches_split(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
-        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
         assert meta.n_val == 8  # 4 positive + 4 negative
+
+    def test_meta_n_thick_with_body_counts_non_none_bodies(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path, n_per_class=15)
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
+        # _write_fixture gives body to all 15*2=30 train rows
+        assert meta.n_thick_with_body == 30
+
+    def test_meta_n_thick_with_body_zero_when_no_bodies(self, tmp_path: Path) -> None:
+        rows: list[LabeledCandidate] = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        rows += [
+            make_labeled_row(i + 10, "positive", "train", "עצור", "חשוד")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
+        assert meta.n_thick_with_body == 0
 
     def test_thin_model_artifact_created(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
         models_dir = tmp_path / "models"
-        train_naive_bayes(labels_path, models_dir)
-        assert (models_dir / "stage_b" / "thin_model.joblib").exists()
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        assert (stage_dir / "thin_model.joblib").exists()
 
     def test_thick_model_artifact_created(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
         models_dir = tmp_path / "models"
-        train_naive_bayes(labels_path, models_dir)
-        assert (models_dir / "stage_b" / "thick_model.joblib").exists()
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        assert (stage_dir / "thick_model.joblib").exists()
 
     def test_meta_json_artifact_created(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
         models_dir = tmp_path / "models"
-        train_naive_bayes(labels_path, models_dir)
-        assert (models_dir / "stage_b" / "meta.json").exists()
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        assert (stage_dir / "meta.json").exists()
+
+    def test_stage_dir_matches_returned_path(self, tmp_path: Path) -> None:
+        """The returned stage_dir is the actual artifact directory."""
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        assert stage_dir == models_dir / "stage_b"
 
     def test_meta_json_is_valid(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
         models_dir = tmp_path / "models"
-        train_naive_bayes(labels_path, models_dir)
-        raw = json.loads((models_dir / "stage_b" / "meta.json").read_text(encoding="utf-8"))
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
         assert raw["model_kind"] == "naive_bayes"
         assert len(raw["model_version"]) == 12
         assert isinstance(raw["n_train"], int)
         assert isinstance(raw["n_val"], int)
+        assert isinstance(raw["n_thick_with_body"], int)
 
     def test_model_version_is_12_char_sha1(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
-        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        meta, _ = train_naive_bayes(labels_path, tmp_path / "models")
         assert len(meta.model_version) == 12
         assert all(c in "0123456789abcdef" for c in meta.model_version)
 
     def test_creates_stage_b_subdir(self, tmp_path: Path) -> None:
         labels_path = _write_fixture(tmp_path)
         models_dir = tmp_path / "deep" / "nested" / "models"
+        _, stage_dir = train_naive_bayes(labels_path, models_dir)
+        assert stage_dir.is_dir()
+
+    def test_atomic_write_no_tmp_dir_left_on_success(self, tmp_path: Path) -> None:
+        """After a successful retrain, no temp directory should remain."""
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
         train_naive_bayes(labels_path, models_dir)
-        assert (models_dir / "stage_b").is_dir()
+        tmp_dirs = list(models_dir.glob("stage_b.tmp.*"))
+        assert tmp_dirs == [], f"Stale tmp dirs: {tmp_dirs}"
+
+    def test_second_retrain_replaces_artifacts(self, tmp_path: Path) -> None:
+        """Calling train_naive_bayes twice should overwrite the artifacts cleanly."""
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        meta1, stage_dir1 = train_naive_bayes(labels_path, models_dir)
+        meta2, stage_dir2 = train_naive_bayes(labels_path, models_dir)
+        assert stage_dir1 == stage_dir2
+        assert meta1.model_kind == meta2.model_kind
 
     def test_raises_on_empty_training_split(self, tmp_path: Path) -> None:
         """ValueError when no 'train' rows exist."""
         rows = [
-            _make_row(0, "negative", "val", "ספורט", "כדורגל"),
-            _make_row(1, "positive", "val", "עצור", "חשוד"),
+            make_labeled_row(0, "negative", "val", "ספורט", "כדורגל"),  # type: ignore[arg-type]
+            make_labeled_row(1, "positive", "val", "עצור", "חשוד"),  # type: ignore[arg-type]
         ]
         labels_path = tmp_path / "labels.parquet"
         write_labels_parquet(rows, labels_path)
@@ -154,8 +183,26 @@ class TestTrainNaiveBayes:
 
     def test_raises_on_single_class_training(self, tmp_path: Path) -> None:
         """ValueError when only one label class is present in the train split."""
-        rows = [_make_row(i, "negative", "train", "ספורט", "כדורגל") for i in range(10)]
+        rows = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
         labels_path = tmp_path / "labels.parquet"
         write_labels_parquet(rows, labels_path)
         with pytest.raises(ValueError, match="only one label class"):
+            train_naive_bayes(labels_path, tmp_path / "models")
+
+    def test_warns_when_all_bodies_none(self, tmp_path: Path) -> None:
+        """UserWarning emitted when thick model falls back to thin at training."""
+        rows: list[LabeledCandidate] = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        rows += [
+            make_labeled_row(i + 10, "positive", "train", "עצור", "חשוד")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.warns(UserWarning, match="identical to the thin model"):
             train_naive_bayes(labels_path, tmp_path / "models")

--- a/tests/unit/prefilter/test_stage_b_train.py
+++ b/tests/unit/prefilter/test_stage_b_train.py
@@ -1,0 +1,161 @@
+"""Unit tests for train_naive_bayes() in prefilter.stage_b."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
+from denbust.prefilter.stage_b import StageBModelMeta, train_naive_bayes
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_LABELED_AT = "2026-01-01T00:00:00+00:00"
+
+
+def _make_row(
+    idx: int,
+    label: str,
+    split: str,
+    title: str,
+    snippet: str,
+    body: str | None = None,
+) -> LabeledCandidate:
+    return LabeledCandidate(
+        candidate_id=f"cand-{idx:04d}",
+        domain="example.co.il",
+        url=f"https://example.co.il/article/{idx}",
+        title=title,
+        snippet=snippet,
+        article_body=body,
+        label=label,  # type: ignore[arg-type]
+        label_source="triage_manual",
+        split=split,  # type: ignore[arg-type]
+        labeled_at=_LABELED_AT,
+        decision_hash=f"hash{idx:04d}",
+    )
+
+
+def _write_fixture(tmp_path: Path, n_per_class: int = 15) -> Path:
+    """Write a minimal labels.parquet with *n_per_class* examples per label."""
+    rows: list[LabeledCandidate] = []
+    idx = 0
+    for split, count in [("train", n_per_class), ("val", 4), ("test", 4)]:
+        for _ in range(count):
+            rows.append(
+                _make_row(
+                    idx,
+                    "negative",
+                    split,
+                    title="ספורט ופנאי",
+                    snippet="כדורגל ושחמט",
+                    body="משחקי כדורגל וטניס וכדורסל הם ספורט פנאי" if split == "train" else None,
+                )
+            )
+            idx += 1
+            rows.append(
+                _make_row(
+                    idx,
+                    "positive",
+                    split,
+                    title="עצור חשוד ברצח",
+                    snippet="המשטרה עצרה חשוד",
+                    body="החשוד נעצר לאחר חקירה ממושכת של המשטרה" if split == "train" else None,
+                )
+            )
+            idx += 1
+
+    labels_path = tmp_path / "labels.parquet"
+    write_labels_parquet(rows, labels_path)
+    return labels_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrainNaiveBayes:
+    def test_returns_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        assert isinstance(meta, StageBModelMeta)
+
+    def test_meta_model_kind(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        assert meta.model_kind == "naive_bayes"
+
+    def test_meta_n_train_matches_split(self, tmp_path: Path) -> None:
+        n = 15
+        labels_path = _write_fixture(tmp_path, n_per_class=n)
+        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        assert meta.n_train == n * 2  # n positive + n negative
+
+    def test_meta_n_val_matches_split(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        assert meta.n_val == 8  # 4 positive + 4 negative
+
+    def test_thin_model_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_naive_bayes(labels_path, models_dir)
+        assert (models_dir / "stage_b" / "thin_model.joblib").exists()
+
+    def test_thick_model_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_naive_bayes(labels_path, models_dir)
+        assert (models_dir / "stage_b" / "thick_model.joblib").exists()
+
+    def test_meta_json_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_naive_bayes(labels_path, models_dir)
+        assert (models_dir / "stage_b" / "meta.json").exists()
+
+    def test_meta_json_is_valid(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_naive_bayes(labels_path, models_dir)
+        raw = json.loads((models_dir / "stage_b" / "meta.json").read_text(encoding="utf-8"))
+        assert raw["model_kind"] == "naive_bayes"
+        assert len(raw["model_version"]) == 12
+        assert isinstance(raw["n_train"], int)
+        assert isinstance(raw["n_val"], int)
+
+    def test_model_version_is_12_char_sha1(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta = train_naive_bayes(labels_path, tmp_path / "models")
+        assert len(meta.model_version) == 12
+        assert all(c in "0123456789abcdef" for c in meta.model_version)
+
+    def test_creates_stage_b_subdir(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "deep" / "nested" / "models"
+        train_naive_bayes(labels_path, models_dir)
+        assert (models_dir / "stage_b").is_dir()
+
+    def test_raises_on_empty_training_split(self, tmp_path: Path) -> None:
+        """ValueError when no 'train' rows exist."""
+        rows = [
+            _make_row(0, "negative", "val", "ספורט", "כדורגל"),
+            _make_row(1, "positive", "val", "עצור", "חשוד"),
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.raises(ValueError, match="No training rows"):
+            train_naive_bayes(labels_path, tmp_path / "models")
+
+    def test_raises_on_single_class_training(self, tmp_path: Path) -> None:
+        """ValueError when only one label class is present in the train split."""
+        rows = [_make_row(i, "negative", "train", "ספורט", "כדורגל") for i in range(10)]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.raises(ValueError, match="only one label class"):
+            train_naive_bayes(labels_path, tmp_path / "models")


### PR DESCRIPTION
## Summary

Implements Stage B of the local pre-classification filter cascade as a calibrated Complement Naive Bayes classifier on character n-grams (3–5), as specified in [LPF-PR-04](docs/local_prefilter_cascade_implementation_plan.md).

**New components:**

- **`StageBScorer`** (`src/denbust/prefilter/stage_b.py`): Loads pre-trained thin/thick `joblib` artifacts from `models_dir/stage_b/`. Returns a `StageScore(stage="B", p_negative=..., ...)` for every candidate, or `None` when no artifacts are present — preserving the stub-pass-through behaviour so the cascade continues to Stage C unimpeded. Class-ordered probabilities (`proba[0][0] = p(class=0="negative")`) are used directly.

- **`StageBModelMeta`**: Frozen dataclass capturing `model_kind="naive_bayes"`, `model_version` (first 12 hex chars of the thin-model file's SHA-1), `trained_at` (UTC ISO-8601), `n_train`, `n_val`.

- **`train_naive_bayes(labels_path, out_dir, *, seed=20260521)`**: Trains two separate sklearn pipelines:
  - **thin model** on `(title + " " + snippet).strip()` — for the pre-scrape pass
  - **thick model** on `article_body` when present, else title+snippet — improves automatically as scraped labels accumulate
  - Pipeline: `TfidfVectorizer(analyzer="char_wb", ngram_range=(3,5), min_df=2, sublinear_tf=True)` → `ComplementNB()` → `CalibratedClassifierCV(method="sigmoid", cv=StratifiedKFold(n_splits=5, shuffle=True, random_state=seed))`
  - Writes `thin_model.joblib`, `thick_model.joblib`, `meta.json` to `out_dir/stage_b/`
  - Raises `ValueError` on empty or single-class train split

**Modified components:**

- **`CascadeOrchestrator`** (`cascade.py`): `StageBScorer` instantiation now passes `models_dir` and `threshold` from config (was passing nothing — a bug from the stub).
- **`retrain_cmd`** (`cli.py`): `--stage b` branch calls `train_naive_bayes`, prints three artifact paths and `model_version`. Stage validation updated to `{"a", "b"}`.
- **`pyproject.toml`**: Adds `scikit-learn>=1.5` and `joblib>=1.4` to runtime dependencies; adds `joblib.*` and `sklearn.*` to mypy `ignore_missing_imports` overrides.

## Test coverage (47 new tests)

| File | Tests | Coverage |
|---|---|---|
| `test_stage_b_train.py` | 12 | `train_naive_bayes()` — meta fields, artifact creation, error paths |
| `test_stage_b_predict.py` | 18 | `StageBScorer` — stub/loaded, unit interval, determinism, thin vs thick model separation |
| `test_stage_b_calibration.py` | 4 | Brier score beats constant-0.5 baseline (thin + thick); all probs in [0,1]; neg class > pos class p_negative |
| `test_stage_b_integration_with_cascade.py` | 13 | `CascadeOrchestrator` with B enabled: SHADOW downgrade, ENFORCE drop, stub pass-through, telemetry write |
| `conftest.py` | — | Shared `trained_stage_b_dir` fixture + `make_labeled_row` helper |

## Architecture notes

- Cascade remains **disabled** (`mode: off`) — no pipeline insertion yet (LPF-PR-08).
- Mypy strict mode maintained: sklearn/joblib are `ignore_missing_imports`; runtime types use the `Any` pattern from Stage A.
- `model_version` is the SHA-1 of the thin-model binary (first 12 hex chars), giving a unique version string per retrain that can be correlated with telemetry records.

## Test plan

- [x] All 1322 tests pass (`pytest -q`)
- [x] `ruff format . && ruff check .` — no issues
- [x] `mypy src/` — no issues (97 source files)
- [x] Stage B scorer returns `None` (stub) when `models_dir=None`
- [x] Stage B scorer returns `StageScore` in `[0,1]` when artifacts are present
- [x] Brier score of calibrated model beats constant-0.5 baseline on held-out val candidates
- [x] `CascadeOrchestrator` in SHADOW mode downgrades B-driven drop to pass verdict
- [x] `CascadeOrchestrator` in ENFORCE mode propagates B-driven drop as `verdict="drop"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)