### PR TITLE
feat(prefilter): LPF-PR-05 — Stage B SetFit alternative scorer and evaluate CLI

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -20,14 +20,23 @@
   lexicon from `_EXCLUDED_TITLE_TERMS`, `DomainReputationScorer` with Beta-Binomial posterior,
   `UrlHeuristicScorer`, independence-formula blend, `StageAScorer.evaluate()` returning
   `StageScore`, `build_stage_a_artifacts()` retrain function, `denbust prefilter retrain
-  --stage a` CLI, and 56 unit tests covering all sub-scorers and the blend (#160), and
+  --stage a` CLI, and 56 unit tests covering all sub-scorers and the blend (#160),
   LPF-PR-04 Stage B calibrated ComplementNB — `StageBScorer` loading thin and thick joblib
   artifacts, `StageBModelMeta` provenance dataclass, `train_naive_bayes()` retrain function,
   `denbust prefilter retrain --stage b` CLI, scikit-learn/joblib dependencies, and 47 unit
-  tests covering training, inference, calibration, and cascade integration.
-- Next planned PR: `LPF-PR-05` — Stage B alternative: SetFit on `intfloat/multilingual-e5-large`,
-  with an A/B harness in `denbust prefilter evaluate --compare-b naive_bayes,setfit`. Introduces
-  the optional `[prefilter]` extras group.
+  tests covering training, inference, calibration, and cascade integration (#161), and
+  LPF-PR-05 Stage B SetFit alternative — `StageBSetFitScorer` + `train_setfit()` using
+  `intfloat/multilingual-e5-large`, A/B evaluation harness via `denbust prefilter evaluate
+  --compare-b naive_bayes,setfit`, `[prefilter]` optional extras group (setfit, sentence-
+  transformers, torch, faiss-cpu, mlx-lm, datasets), mypy overrides for all heavy deps,
+  `slow` pytest marker registration, and 37 unit tests (all mocked, no network access).
+- Next planned PR: `LPF-PR-06` — Stage C embedding similarity using
+  `intfloat/multilingual-e5-large` with centroid-cosine and FAISS-HNSW kNN-max-cosine signals,
+  sigmoid-calibrated on validation pairs, thick pass only by default.
+- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
+  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
+  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
+  returns `403 PERMISSION_DENIED`.
 - Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
   the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
   disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
@@ -235,11 +244,11 @@
   --stage b` CLI; `scikit-learn>=1.5` and `joblib>=1.4` added to dependencies; 47 unit tests
   across training, inference, Brier-score calibration, and cascade integration. Cascade still
   disabled.
-- [next] `LPF-PR-05`: Stage B alternative — SetFit on `intfloat/multilingual-e5-large`, with
+- [done] `LPF-PR-05`: Stage B alternative — SetFit on `intfloat/multilingual-e5-large`, with
   an A/B harness in `denbust prefilter evaluate --compare-b naive_bayes,setfit`. Introduces the
   optional `[prefilter]` extras group (`sentence-transformers`, `setfit`, `torch`, `faiss-cpu`,
-  `mlx-lm`).
-- [later] `LPF-PR-06`: Stage C — embedding similarity using `multilingual-e5-large` with both
+  `mlx-lm`, `datasets`).
+- [next] `LPF-PR-06`: Stage C — embedding similarity using `multilingual-e5-large` with both
   centroid-cosine and FAISS-HNSW kNN-max-cosine signals, sigmoid-calibrated on validation pairs.
   Thick-pass only by default.
 - [later] `LPF-PR-07`: Stage D — local SLM judge via MLX (`dicta-il/dictalm2.0-instruct` default,

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -37,10 +37,6 @@
   the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
   disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
   returns `403 PERMISSION_DENIED`.
-- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
-  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
-  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
-  returns `403 PERMISSION_DENIED`.
 
 ## Task Ledger
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,13 @@
 pip install -e ".[dev]"
 ```
 
+- Install the optional prefilter extras (SetFit, sentence-transformers, torch,
+  faiss-cpu, mlx-lm) needed for Stage B SetFit and future Stage C / D:
+
+```bash
+pip install -e ".[dev,prefilter]"
+```
+
 - Install browser runtime before live Mako runs:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,14 @@ dev = [
     "types-beautifulsoup4>=4.12.0",
     "types-pyyaml>=6.0.0",
 ]
+prefilter = [
+    "setfit>=1.0",
+    "sentence-transformers>=3.0",
+    "torch>=2.3",
+    "faiss-cpu>=1.8",
+    "mlx-lm>=0.18 ; sys_platform == 'darwin'",
+    "datasets>=2.20",
+]
 
 [project.scripts]
 denbust = "denbust.cli:app"
@@ -79,6 +87,10 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["denbust"]
 
+[tool.ruff.lint.per-file-ignores]
+# importorskip must precede application imports; E402 is expected here.
+"tests/unit/prefilter/test_stage_b_setfit_*.py" = ["E402"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true
@@ -98,15 +110,21 @@ module = [
     "anthropic.*",
     "boto3.*",
     "bs4.*",
+    "datasets.*",
+    "faiss.*",
     "feedparser.*",
     "google.*",
     "googleapiclient.*",
     "huggingface_hub.*",
     "joblib.*",
     "kaggle.*",
+    "mlx_lm.*",
     "pyarrow.*",
     "playwright.*",
+    "sentence_transformers.*",
+    "setfit.*",
     "sklearn.*",
+    "torch.*",
 ]
 ignore_missing_imports = true
 
@@ -114,6 +132,9 @@ ignore_missing_imports = true
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "-v"
+markers = [
+    "slow: marks tests as slow (requires trained models or heavy computation; deselect with -m 'not slow')",
+]
 
 [tool.coverage.run]
 relative_files = true

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -191,10 +191,10 @@ def retrain_cmd(
         typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
 
     else:  # setfit
-        from denbust.prefilter.stage_b import train_setfit
+        from denbust.prefilter.stage_b import _DEFAULT_SETFIT_BASE_MODEL, train_setfit
 
         typer.echo(f"Retraining Stage B (setfit) from {prefilter_paths.labels_path} ...")
-        typer.echo("  base model: intfloat/multilingual-e5-large  (download may take a while)")
+        typer.echo(f"  base model: {_DEFAULT_SETFIT_BASE_MODEL}  (download may take a while)")
         meta, stage_dir = train_setfit(
             labels_path=prefilter_paths.labels_path,
             out_dir=prefilter_paths.models_dir,
@@ -216,15 +216,15 @@ def evaluate_cmd(
         typer.Option("--split", help="Labeled split to evaluate on: val or test"),
     ] = "val",
     compare_b: Annotated[
-        str | None,
+        str,
         typer.Option(
             "--compare-b",
             help=(
-                "Comma-separated Stage B model kinds to compare, e.g. "
-                "'naive_bayes,setfit'.  Both must be trained first."
+                "Comma-separated Stage B model kinds to evaluate, e.g. "
+                "'naive_bayes' or 'naive_bayes,setfit'.  All must be trained first."
             ),
         ),
-    ] = None,
+    ] = "naive_bayes",
     recall_floor: Annotated[
         float,
         typer.Option(
@@ -237,14 +237,15 @@ def evaluate_cmd(
         typer.Option("--report-path", "-r", help="Write a markdown report to this path."),
     ] = None,
 ) -> None:
-    """Compare Stage B model variants on a labeled evaluation split.
+    """Evaluate Stage B model variants on a labeled split.
 
     Loads each model from the configured models directory, scores every
     candidate in the chosen split using the thin pass (title + snippet), and
     prints precision / recall / Brier score for each at the threshold that
-    achieves ``--recall-floor`` on that same split.
+    achieves ``--recall-floor`` on that same split.  Unscored candidates
+    (scorer returned ``None``) are excluded from metric calculations.
 
-    Both models must be trained before running this command:
+    Models must be trained before running this command:
 
     \\b
         denbust prefilter retrain --stage b --model naive_bayes --config CFG
@@ -265,13 +266,6 @@ def evaluate_cmd(
         )
         raise typer.Exit(1)
 
-    if compare_b is None:
-        typer.echo(
-            "Error: --compare-b is required (e.g. --compare-b naive_bayes,setfit).",
-            err=True,
-        )
-        raise typer.Exit(1)
-
     model_kinds = [k.strip() for k in compare_b.split(",") if k.strip()]
     valid_kinds = {"naive_bayes", "setfit"}
     unknown = set(model_kinds) - valid_kinds
@@ -285,7 +279,7 @@ def evaluate_cmd(
 
     from denbust.config import load_config
     from denbust.prefilter.labels import read_labels_parquet
-    from denbust.prefilter.stage_b import StageBScorer, StageBSetFitScorer
+    from denbust.prefilter.stage_b import StageBScorer, StageBScorerProtocol, StageBSetFitScorer
     from denbust.prefilter.state_paths import resolve_prefilter_state_paths
 
     loaded = load_config(config)
@@ -319,72 +313,67 @@ def evaluate_cmd(
     results: list[dict[str, Any]] = []
 
     for kind in model_kinds:
+        scorer: StageBScorerProtocol
         if kind == "naive_bayes":
-            scorer: StageBScorer | StageBSetFitScorer = StageBScorer(
-                models_dir=prefilter_paths.models_dir
-            )
+            scorer = StageBScorer(models_dir=prefilter_paths.models_dir)
         else:
             scorer = StageBSetFitScorer(models_dir=prefilter_paths.models_dir)
 
-        p_negatives: list[float] = []
+        # Collect scores only for rows the scorer can actually handle.
+        # Rows returning None pass through the filter — they must NOT be
+        # imputed with a fake probability or they corrupt every metric.
+        scored_p: list[float] = []
+        scored_y: list[int] = []
         n_skipped = 0
-        for row in eval_rows:
+        for row, y in zip(eval_rows, y_true):
             score = scorer.evaluate(row, "thin")
             if score is None:
                 n_skipped += 1
-                p_negatives.append(0.5)  # no-info fallback: neutral probability
             else:
-                p_negatives.append(score.p_negative)
+                scored_p.append(score.p_negative)
+                scored_y.append(y)
 
-        if n_skipped == len(eval_rows):
+        if not scored_p:
             typer.echo(
                 f"  {kind}: scorer returned None for all candidates "
                 "(artifacts missing or package not installed) — skipping.\n"
             )
             continue
 
-        threshold = _threshold_at_recall_floor(p_negatives, y_true, recall_floor)
-
-        dropped = [p >= threshold for p in p_negatives]
-        true_drops = sum(1 for d, y in zip(dropped, y_true) if d and y == 0)
-        false_drops = sum(1 for d, y in zip(dropped, y_true) if d and y == 1)
-        total_dropped = sum(dropped)
-
-        recall = (n_pos - false_drops) / n_pos if n_pos > 0 else 1.0
-        drop_precision = true_drops / total_dropped if total_dropped > 0 else 0.0
-        drop_rate = total_dropped / len(y_true)
-        # Brier score: MSE between p_positive = (1 - p_negative) and y ∈ {0, 1}
-        brier = sum((1.0 - p - y) ** 2 for p, y in zip(p_negatives, y_true)) / len(y_true)
+        metrics = _compute_stage_b_metrics(
+            scored_p=scored_p,
+            scored_y=scored_y,
+            n_pos_total=n_pos,
+            n_total=len(y_true),
+            recall_floor=recall_floor,
+        )
 
         version = scorer.model_version or "(unknown)"
         typer.echo(f"  {kind}  [version: {version}]")
-        typer.echo(f"    threshold      : {threshold:.4f}")
-        typer.echo(f"    recall         : {recall:.4f}  (target ≥ {recall_floor:.4f})")
-        typer.echo(f"    drop_precision : {drop_precision:.4f}  (true_neg / total_dropped)")
-        typer.echo(f"    drop_rate      : {drop_rate:.4f}")
-        typer.echo(f"    brier_score    : {brier:.4f}")
+        typer.echo(f"    threshold      : {metrics['threshold']:.4f}")
+        typer.echo(f"    recall         : {metrics['recall']:.4f}  (target ≥ {recall_floor:.4f})")
+        typer.echo(
+            f"    drop_precision : {metrics['drop_precision']:.4f}  (true_neg / total_dropped)"
+        )
+        typer.echo(f"    drop_rate      : {metrics['drop_rate']:.4f}")
+        typer.echo(f"    brier_score    : {metrics['brier_score']:.4f}")
         if n_skipped:
-            typer.echo(f"    no-score rows  : {n_skipped} (treated as p_negative=0.5)")
+            typer.echo(
+                f"    no-score rows  : {n_skipped} (excluded from metrics; "
+                "treated as pass-through in production)"
+            )
         typer.echo("")
 
-        results.append(
-            {
-                "kind": kind,
-                "version": version,
-                "threshold": threshold,
-                "recall": recall,
-                "drop_precision": drop_precision,
-                "drop_rate": drop_rate,
-                "brier_score": brier,
-            }
-        )
+        results.append({"kind": kind, "version": version, **metrics})
 
     if len(results) >= 2:
-        # Prefer higher drop_rate (more negatives filtered); break ties by lower Brier.
-        best = max(results, key=lambda r: (r["drop_rate"], -r["brier_score"]))
+        # Prefer the model with the best calibration (lower Brier score).
+        # Break ties by drop rate — a higher rate means more noise is filtered
+        # at the same quality level.
+        best = min(results, key=lambda r: (r["brier_score"], -r["drop_rate"]))
         typer.echo(
-            f"Recommendation: '{best['kind']}' achieves the highest drop rate "
-            f"({best['drop_rate']:.1%}) at the given recall floor."
+            f"Recommendation: '{best['kind']}' has the best calibration "
+            f"(Brier={best['brier_score']:.4f}) at the given recall floor."
         )
         typer.echo("")
 
@@ -476,44 +465,139 @@ def _threshold_at_recall_floor(
 ) -> float:
     """Find the lowest drop-threshold that keeps recall ≥ *recall_floor*.
 
-    A candidate is "dropped" when ``p_negative >= threshold``.  Lower
-    thresholds drop more candidates and reduce recall.  This function finds
-    the minimum threshold at which recall still meets the floor, maximising
-    the drop rate for a given recall constraint.
+    A candidate is "dropped" when ``p_negative >= threshold``.  Higher
+    thresholds drop fewer candidates and increase recall.  This function
+    finds the minimum threshold at which recall still meets the floor,
+    maximising the drop rate for a given recall constraint.
 
     Parameters
     ----------
     p_negatives:
         Model output ``p_negative`` for each evaluation candidate.
+        Must contain only *scored* rows (no imputed values).
     y_true:
-        Ground-truth labels: ``1`` = positive, ``0`` = negative.
+        Ground-truth labels aligned with *p_negatives*: ``1`` = positive,
+        ``0`` = negative.
     recall_floor:
         Target minimum recall (e.g. ``0.99``).
 
     Returns
     -------
     float
-        The operating threshold.  Returns ``1.0`` (no drops) when the
-        positive set is empty.
+        The tightest threshold that satisfies the recall floor.
+        Returns ``1.0`` when the positive set is empty.
+        Returns ``max(p_negatives) + 1e-9`` (no drops) when no candidate
+        threshold can satisfy the floor.
+
+    Notes
+    -----
+    The algorithm sweeps unique p_negative values in ascending order.
+    Since false-drop count is monotonically non-increasing as the threshold
+    rises, the first value where ``false_drops ≤ max_false_drops`` is the
+    optimal (minimum) threshold.  If no value in the set satisfies the
+    constraint, we return just above the maximum so that nothing is dropped
+    and recall stays at 1.0.
     """
     n_pos = sum(y_true)
     if n_pos == 0:
         return 1.0
 
     # Maximum number of positives we can afford to drop.
-    max_false_drops = int(n_pos * (1.0 - recall_floor))
+    # Use int() (floor) rather than round() — dropping k positives achieves
+    # recall = (n_pos − k) / n_pos; we need that ≥ recall_floor, so
+    # k ≤ n_pos * (1 − recall_floor).  Float arithmetic can push the product
+    # just below a true integer (e.g. 10 * 0.1 → 0.9999…), so we add a tiny
+    # epsilon before truncating to recover the intended whole number.
+    max_false_drops = int(n_pos * (1.0 - recall_floor) + 1e-9)
 
-    # Candidate thresholds: each unique p_negative value is a potential
-    # boundary.  We try them in ascending order — lower threshold = more
-    # drops.  We stop at the first threshold that drops too many positives.
+    # Sweep ascending: for each candidate threshold T, count how many
+    # positives would be incorrectly dropped (p_negative >= T and y == 1).
+    # False-drop count is non-increasing as T rises, so the first T that
+    # satisfies the constraint IS the minimum (most aggressive) safe threshold.
     for threshold in sorted(set(p_negatives)):
         false_drops = sum(1 for p, y in zip(p_negatives, y_true) if p >= threshold and y == 1)
-        if false_drops > max_false_drops:
-            # This threshold drops too many positives; use a slightly higher
-            # value so the previous set of candidates is still dropped.
-            return threshold + 1e-9
-    # Even the lowest threshold satisfies the recall floor.
-    return min(p_negatives)
+        if false_drops <= max_false_drops:
+            return threshold
+
+    # No value in the candidate set satisfies the floor (e.g. a positive
+    # example has the single highest p_negative in the dataset).
+    # Return just above the maximum so nothing is dropped and recall = 1.0.
+    return max(p_negatives) + 1e-9
+
+
+def _compute_stage_b_metrics(
+    scored_p: list[float],
+    scored_y: list[int],
+    n_pos_total: int,
+    n_total: int,
+    recall_floor: float,
+) -> dict[str, float]:
+    """Compute Stage B evaluation metrics over *scored* candidates only.
+
+    Parameters
+    ----------
+    scored_p:
+        ``p_negative`` values for rows where the scorer returned a score.
+        Must NOT include imputed values for rows that scored ``None``.
+    scored_y:
+        Ground-truth labels aligned with *scored_p* (``1`` = positive).
+    n_pos_total:
+        Total number of positives in the evaluation split, including any
+        rows that were unscored (those pass through without being dropped).
+    n_total:
+        Total number of candidates in the evaluation split.
+    recall_floor:
+        Target minimum recall passed to :func:`_threshold_at_recall_floor`.
+
+    Returns
+    -------
+    dict[str, float]
+        Keys: ``threshold``, ``recall``, ``drop_precision``,
+        ``drop_rate``, ``brier_score``.
+
+    Notes
+    -----
+    *Recall* and *drop_rate* are expressed over the full split (``n_total``,
+    ``n_pos_total``) so unscored rows are correctly treated as pass-through
+    (not dropped) rather than being counted against recall.
+    *Brier score* is computed only over scored rows — that is where we have
+    actual model predictions.
+    """
+    if not scored_p:
+        return {
+            "threshold": 1.0,
+            "recall": 1.0,
+            "drop_precision": 0.0,
+            "drop_rate": 0.0,
+            "brier_score": 0.0,
+        }
+
+    threshold = _threshold_at_recall_floor(scored_p, scored_y, recall_floor)
+    dropped = [p >= threshold for p in scored_p]
+    true_drops = sum(1 for d, y in zip(dropped, scored_y) if d and y == 0)
+    false_drops = sum(1 for d, y in zip(dropped, scored_y) if d and y == 1)
+    total_dropped = sum(dropped)
+
+    # Recall: unscored positives are NOT dropped, so they don't reduce recall.
+    recall = (n_pos_total - false_drops) / n_pos_total if n_pos_total > 0 else 1.0
+    drop_precision = true_drops / total_dropped if total_dropped > 0 else 0.0
+    # Drop rate: over the full split so unscored rows are counted as retained.
+    drop_rate = total_dropped / n_total if n_total > 0 else 0.0
+    # Brier score: MSE between p_positive = (1 − p_negative) and y ∈ {0, 1},
+    # computed only over rows that actually scored.
+    brier = (
+        sum((1.0 - p - y) ** 2 for p, y in zip(scored_p, scored_y)) / len(scored_p)
+        if scored_p
+        else 0.0
+    )
+
+    return {
+        "threshold": threshold,
+        "recall": recall,
+        "drop_precision": drop_precision,
+        "drop_rate": drop_rate,
+        "brier_score": brier,
+    }
 
 
 def _write_evaluate_report(

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 from collections import Counter
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -98,6 +98,14 @@ def retrain_cmd(
         Path | None,
         typer.Option("--config", "-c", help="Path to YAML config file"),
     ] = None,
+    model: Annotated[
+        str,
+        typer.Option(
+            "--model",
+            "-m",
+            help="Stage B model kind: naive_bayes (default) or setfit",
+        ),
+    ] = "naive_bayes",
 ) -> None:
     """Rebuild stage artifacts from labels.parquet.
 
@@ -107,7 +115,13 @@ def retrain_cmd(
     Supported stages
     ----------------
     a   Lexicon (chi-squared weighted terms) + domain reputation parquet.
-    b   Calibrated ComplementNB thin and thick models (scikit-learn joblib).
+    b   Calibrated text classifier.  Use ``--model`` to choose the variant:
+
+        naive_bayes (default)
+            Calibrated ComplementNB on char n-grams; no extra dependencies.
+        setfit
+            SetFit on ``intfloat/multilingual-e5-large``.  Requires the
+            ``prefilter`` extras: ``pip install -e '.[dev,prefilter]'``.
     """
     if config is None:
         typer.echo(
@@ -121,6 +135,15 @@ def retrain_cmd(
     if stage not in {"a", "b"}:
         typer.echo(
             f"Error: --stage {stage!r} is not supported.  Choose 'a' or 'b'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    model = model.lower().strip()
+    if stage == "b" and model not in {"naive_bayes", "setfit"}:
+        typer.echo(
+            f"Error: --model {model!r} is not supported for stage b.  "
+            "Choose 'naive_bayes' or 'setfit'.",
             err=True,
         )
         raise typer.Exit(1)
@@ -154,10 +177,10 @@ def retrain_cmd(
         typer.echo(f"  domain_reputation -> {dom_path}")
         typer.echo("Stage A retrain complete.")
 
-    else:  # stage == "b"
+    elif model == "naive_bayes":
         from denbust.prefilter.stage_b import train_naive_bayes
 
-        typer.echo(f"Retraining Stage B from {prefilter_paths.labels_path} ...")
+        typer.echo(f"Retraining Stage B (naive_bayes) from {prefilter_paths.labels_path} ...")
         meta, stage_dir = train_naive_bayes(
             labels_path=prefilter_paths.labels_path,
             out_dir=prefilter_paths.models_dir,
@@ -166,6 +189,208 @@ def retrain_cmd(
         typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
         typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
         typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
+
+    else:  # setfit
+        from denbust.prefilter.stage_b import train_setfit
+
+        typer.echo(f"Retraining Stage B (setfit) from {prefilter_paths.labels_path} ...")
+        typer.echo("  base model: intfloat/multilingual-e5-large  (download may take a while)")
+        meta, stage_dir = train_setfit(
+            labels_path=prefilter_paths.labels_path,
+            out_dir=prefilter_paths.models_dir,
+        )
+        typer.echo(f"  thin_model/       -> {stage_dir / 'thin_model'}")
+        typer.echo(f"  thick_model/      -> {stage_dir / 'thick_model'}")
+        typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
+        typer.echo(f"Stage B SetFit retrain complete.  model_version={meta.model_version}")
+
+
+@prefilter_app.command("evaluate")
+def evaluate_cmd(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+    split: Annotated[
+        str,
+        typer.Option("--split", help="Labeled split to evaluate on: val or test"),
+    ] = "val",
+    compare_b: Annotated[
+        str | None,
+        typer.Option(
+            "--compare-b",
+            help=(
+                "Comma-separated Stage B model kinds to compare, e.g. "
+                "'naive_bayes,setfit'.  Both must be trained first."
+            ),
+        ),
+    ] = None,
+    recall_floor: Annotated[
+        float,
+        typer.Option(
+            "--recall-floor",
+            help="Minimum recall to maintain when choosing the operating threshold.",
+        ),
+    ] = 0.99,
+    report_path: Annotated[
+        Path | None,
+        typer.Option("--report-path", "-r", help="Write a markdown report to this path."),
+    ] = None,
+) -> None:
+    """Compare Stage B model variants on a labeled evaluation split.
+
+    Loads each model from the configured models directory, scores every
+    candidate in the chosen split using the thin pass (title + snippet), and
+    prints precision / recall / Brier score for each at the threshold that
+    achieves ``--recall-floor`` on that same split.
+
+    Both models must be trained before running this command:
+
+    \\b
+        denbust prefilter retrain --stage b --model naive_bayes --config CFG
+        denbust prefilter retrain --stage b --model setfit --config CFG
+        denbust prefilter evaluate --compare-b naive_bayes,setfit --config CFG
+    """
+    if config is None:
+        typer.echo(
+            "Error: --config is required.  Pass the path to your YAML config file.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if split not in {"val", "test"}:
+        typer.echo(
+            f"Error: --split must be 'val' or 'test', got {split!r}.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if compare_b is None:
+        typer.echo(
+            "Error: --compare-b is required (e.g. --compare-b naive_bayes,setfit).",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    model_kinds = [k.strip() for k in compare_b.split(",") if k.strip()]
+    valid_kinds = {"naive_bayes", "setfit"}
+    unknown = set(model_kinds) - valid_kinds
+    if unknown:
+        typer.echo(
+            f"Error: unknown model kind(s): {', '.join(sorted(unknown))}.  "
+            f"Choose from: {', '.join(sorted(valid_kinds))}.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    from denbust.config import load_config
+    from denbust.prefilter.labels import read_labels_parquet
+    from denbust.prefilter.stage_b import StageBScorer, StageBSetFitScorer
+    from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+    loaded = load_config(config)
+    prefilter_paths = resolve_prefilter_state_paths(
+        state_root=loaded.store.state_root,
+        dataset_name=loaded.dataset_name,
+    )
+
+    if not prefilter_paths.labels_path.exists():
+        typer.echo(
+            f"Error: labels.parquet not found at {prefilter_paths.labels_path}.\n"
+            "Run `denbust prefilter assemble-labels` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    all_rows = read_labels_parquet(prefilter_paths.labels_path)
+    eval_rows = [r for r in all_rows if r.split == split]
+    if not eval_rows:
+        typer.echo(f"No rows found for split='{split}' in {prefilter_paths.labels_path}.", err=True)
+        raise typer.Exit(1)
+
+    y_true = [1 if r.label == "positive" else 0 for r in eval_rows]
+    n_pos = sum(y_true)
+    n_neg = len(y_true) - n_pos
+
+    typer.echo(f"Evaluating on split='{split}': {len(eval_rows)} rows  (pos={n_pos}, neg={n_neg})")
+    typer.echo(f"Recall floor: {recall_floor:.1%}")
+    typer.echo("")
+
+    results: list[dict[str, Any]] = []
+
+    for kind in model_kinds:
+        if kind == "naive_bayes":
+            scorer: StageBScorer | StageBSetFitScorer = StageBScorer(
+                models_dir=prefilter_paths.models_dir
+            )
+        else:
+            scorer = StageBSetFitScorer(models_dir=prefilter_paths.models_dir)
+
+        p_negatives: list[float] = []
+        n_skipped = 0
+        for row in eval_rows:
+            score = scorer.evaluate(row, "thin")
+            if score is None:
+                n_skipped += 1
+                p_negatives.append(0.5)  # no-info fallback: neutral probability
+            else:
+                p_negatives.append(score.p_negative)
+
+        if n_skipped == len(eval_rows):
+            typer.echo(
+                f"  {kind}: scorer returned None for all candidates "
+                "(artifacts missing or package not installed) — skipping.\n"
+            )
+            continue
+
+        threshold = _threshold_at_recall_floor(p_negatives, y_true, recall_floor)
+
+        dropped = [p >= threshold for p in p_negatives]
+        true_drops = sum(1 for d, y in zip(dropped, y_true) if d and y == 0)
+        false_drops = sum(1 for d, y in zip(dropped, y_true) if d and y == 1)
+        total_dropped = sum(dropped)
+
+        recall = (n_pos - false_drops) / n_pos if n_pos > 0 else 1.0
+        drop_precision = true_drops / total_dropped if total_dropped > 0 else 0.0
+        drop_rate = total_dropped / len(y_true)
+        # Brier score: MSE between p_positive = (1 - p_negative) and y ∈ {0, 1}
+        brier = sum((1.0 - p - y) ** 2 for p, y in zip(p_negatives, y_true)) / len(y_true)
+
+        version = scorer.model_version or "(unknown)"
+        typer.echo(f"  {kind}  [version: {version}]")
+        typer.echo(f"    threshold      : {threshold:.4f}")
+        typer.echo(f"    recall         : {recall:.4f}  (target ≥ {recall_floor:.4f})")
+        typer.echo(f"    drop_precision : {drop_precision:.4f}  (true_neg / total_dropped)")
+        typer.echo(f"    drop_rate      : {drop_rate:.4f}")
+        typer.echo(f"    brier_score    : {brier:.4f}")
+        if n_skipped:
+            typer.echo(f"    no-score rows  : {n_skipped} (treated as p_negative=0.5)")
+        typer.echo("")
+
+        results.append(
+            {
+                "kind": kind,
+                "version": version,
+                "threshold": threshold,
+                "recall": recall,
+                "drop_precision": drop_precision,
+                "drop_rate": drop_rate,
+                "brier_score": brier,
+            }
+        )
+
+    if len(results) >= 2:
+        # Prefer higher drop_rate (more negatives filtered); break ties by lower Brier.
+        best = max(results, key=lambda r: (r["drop_rate"], -r["brier_score"]))
+        typer.echo(
+            f"Recommendation: '{best['kind']}' achieves the highest drop rate "
+            f"({best['drop_rate']:.1%}) at the given recall floor."
+        )
+        typer.echo("")
+
+    if report_path is not None and results:
+        _write_evaluate_report(report_path, split, recall_floor, n_pos, n_neg, results)
+        typer.echo(f"Report written to {report_path}")
 
 
 @prefilter_app.command("assemble-labels")
@@ -237,3 +462,85 @@ def assemble_labels_cmd(
     source_totals: Counter[str] = Counter(r.label_source for r in rows)
     for src, cnt in sorted(source_totals.items()):
         typer.echo(f"  {src}: {cnt}")
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _threshold_at_recall_floor(
+    p_negatives: list[float],
+    y_true: list[int],
+    recall_floor: float,
+) -> float:
+    """Find the lowest drop-threshold that keeps recall ≥ *recall_floor*.
+
+    A candidate is "dropped" when ``p_negative >= threshold``.  Lower
+    thresholds drop more candidates and reduce recall.  This function finds
+    the minimum threshold at which recall still meets the floor, maximising
+    the drop rate for a given recall constraint.
+
+    Parameters
+    ----------
+    p_negatives:
+        Model output ``p_negative`` for each evaluation candidate.
+    y_true:
+        Ground-truth labels: ``1`` = positive, ``0`` = negative.
+    recall_floor:
+        Target minimum recall (e.g. ``0.99``).
+
+    Returns
+    -------
+    float
+        The operating threshold.  Returns ``1.0`` (no drops) when the
+        positive set is empty.
+    """
+    n_pos = sum(y_true)
+    if n_pos == 0:
+        return 1.0
+
+    # Maximum number of positives we can afford to drop.
+    max_false_drops = int(n_pos * (1.0 - recall_floor))
+
+    # Candidate thresholds: each unique p_negative value is a potential
+    # boundary.  We try them in ascending order — lower threshold = more
+    # drops.  We stop at the first threshold that drops too many positives.
+    for threshold in sorted(set(p_negatives)):
+        false_drops = sum(1 for p, y in zip(p_negatives, y_true) if p >= threshold and y == 1)
+        if false_drops > max_false_drops:
+            # This threshold drops too many positives; use a slightly higher
+            # value so the previous set of candidates is still dropped.
+            return threshold + 1e-9
+    # Even the lowest threshold satisfies the recall floor.
+    return min(p_negatives)
+
+
+def _write_evaluate_report(
+    path: Path,
+    split: str,
+    recall_floor: float,
+    n_pos: int,
+    n_neg: int,
+    results: list[dict[str, Any]],
+) -> None:
+    """Write a markdown A/B evaluation report to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Stage B A/B Evaluation Report",
+        "",
+        f"**Split:** {split}  |  **Recall floor:** {recall_floor:.1%}  "
+        f"|  **Rows:** {n_pos + n_neg} (pos={n_pos}, neg={n_neg})",
+        "",
+        "| Model | Version | Threshold | Recall | Drop Precision | Drop Rate | Brier |",
+        "|-------|---------|-----------|--------|----------------|-----------|-------|",
+    ]
+    for r in results:
+        lines.append(
+            f"| {r['kind']} | {r['version']} "
+            f"| {r['threshold']:.4f} | {r['recall']:.4f} "
+            f"| {r['drop_precision']:.4f} | {r['drop_rate']:.4f} "
+            f"| {r['brier_score']:.4f} |"
+        )
+    lines += ["", ""]
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -43,7 +43,7 @@ import tempfile
 import warnings
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from denbust.prefilter.models import CandidateView, PassKind, StageScore
 
@@ -62,6 +62,8 @@ _THIN_MODEL_DIRNAME = "thin_model"
 _THICK_MODEL_DIRNAME = "thick_model"
 
 _META_FILE = "meta.json"
+
+_DEFAULT_SETFIT_BASE_MODEL = "intfloat/multilingual-e5-large"
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +99,31 @@ class StageBModelMeta:
     n_train: int
     n_val: int
     n_thick_with_body: int
+    base_model_id: str = ""  # HuggingFace model ID; empty string for naive_bayes
+
+
+# ---------------------------------------------------------------------------
+# Scorer protocol (structural interface shared by both Stage B implementations)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StageBScorerProtocol(Protocol):
+    """Structural interface shared by :class:`StageBScorer` and :class:`StageBSetFitScorer`.
+
+    Any class that exposes ``model_version`` and a compatible ``evaluate``
+    method satisfies this protocol without subclassing.  Use it as the
+    annotation type in code that must accept either implementation.
+    """
+
+    model_version: str
+
+    def evaluate(
+        self,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+        body: str | None = None,
+    ) -> StageScore | None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -284,6 +311,7 @@ class StageBSetFitScorer:
         self._thin_model: Any = None
         self._thick_model: Any = None
         self.model_version: str = ""
+        self.base_model_id: str = ""
 
         if models_dir is None:
             return
@@ -310,6 +338,7 @@ class StageBSetFitScorer:
         if meta_path.exists():
             meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
             self.model_version = str(meta_raw.get("model_version", ""))
+            self.base_model_id = str(meta_raw.get("base_model_id", ""))
         else:
             logger.warning(
                 "Stage B SetFit: meta.json missing from %s; model_version will be empty.",
@@ -426,15 +455,7 @@ def train_naive_bayes(
     train_rows = [r for r in rows if r.split == "train"]
     val_rows = [r for r in rows if r.split == "val"]
 
-    if not train_rows:
-        raise ValueError(f"No training rows found in {labels_path}")
-
-    classes = {r.label for r in train_rows}
-    if len(classes) < 2:
-        raise ValueError(
-            f"Training data contains only one label class ({classes}); "
-            "both 'positive' and 'negative' labels are required."
-        )
+    _validate_training_split(train_rows, labels_path)
 
     # Label mapping: y=0 → "negative", y=1 → "positive".
     # sklearn sorts unique integer labels, so predict_proba columns are ordered
@@ -486,18 +507,10 @@ def train_naive_bayes(
             n_train=len(train_rows),
             n_val=len(val_rows),
             n_thick_with_body=n_thick_with_body,
+            # base_model_id left as "" (default) for naive_bayes
         )
-        # Serialize only the JSON-safe fields — exclude any future Path-typed fields.
-        meta_dict = {
-            "model_kind": meta.model_kind,
-            "model_version": meta.model_version,
-            "trained_at": meta.trained_at,
-            "n_train": meta.n_train,
-            "n_val": meta.n_val,
-            "n_thick_with_body": meta.n_thick_with_body,
-        }
         meta_path.write_text(
-            json.dumps(meta_dict, ensure_ascii=False, indent=2),
+            json.dumps(dataclasses.asdict(meta), ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 
@@ -522,7 +535,7 @@ def train_setfit(
     labels_path: Path,
     out_dir: Path,
     *,
-    base_model_id: str = "intfloat/multilingual-e5-large",
+    base_model_id: str = _DEFAULT_SETFIT_BASE_MODEL,
     seed: int = 20260521,
 ) -> tuple[StageBModelMeta, Path]:
     """Train SetFit classifiers and write Stage B SetFit artifacts.
@@ -584,15 +597,7 @@ def train_setfit(
     train_rows = [r for r in rows if r.split == "train"]
     val_rows = [r for r in rows if r.split == "val"]
 
-    if not train_rows:
-        raise ValueError(f"No training rows found in {labels_path}")
-
-    classes = {r.label for r in train_rows}
-    if len(classes) < 2:
-        raise ValueError(
-            f"Training data contains only one label class ({classes}); "
-            "both 'positive' and 'negative' labels are required."
-        )
+    _validate_training_split(train_rows, labels_path)
 
     label_to_int = {"negative": 0, "positive": 1}
     y_train = [label_to_int[r.label] for r in train_rows]
@@ -626,7 +631,14 @@ def train_setfit(
         return model
 
     thin_model = _train_one(thin_texts, y_train)
-    thick_model = _train_one(thick_texts, y_train)
+
+    # When no body data is available the thick texts are identical to thin texts.
+    # Skip the redundant second training run — copy the thin artifacts instead.
+    thick_from_copy = n_thick_with_body == 0
+    if thick_from_copy:
+        thick_model: Any = thin_model
+    else:
+        thick_model = _train_one(thick_texts, y_train)
 
     # Atomic write
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -638,7 +650,10 @@ def train_setfit(
         meta_path = tmp_dir / _META_FILE
 
         thin_model.save_pretrained(str(thin_path))
-        thick_model.save_pretrained(str(thick_path))
+        if thick_from_copy:
+            shutil.copytree(thin_path, thick_path)
+        else:
+            thick_model.save_pretrained(str(thick_path))
 
         model_version = _sha1_setfit_head(thin_path)[:12]
 
@@ -649,18 +664,10 @@ def train_setfit(
             n_train=len(train_rows),
             n_val=len(val_rows),
             n_thick_with_body=n_thick_with_body,
+            base_model_id=base_model_id,
         )
-        meta_dict = {
-            "model_kind": meta.model_kind,
-            "model_version": meta.model_version,
-            "trained_at": meta.trained_at,
-            "n_train": meta.n_train,
-            "n_val": meta.n_val,
-            "n_thick_with_body": meta.n_thick_with_body,
-            "base_model_id": base_model_id,
-        }
         meta_path.write_text(
-            json.dumps(meta_dict, ensure_ascii=False, indent=2),
+            json.dumps(dataclasses.asdict(meta), ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 
@@ -678,6 +685,22 @@ def train_setfit(
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_training_split(train_rows: list[Any], labels_path: Path) -> None:
+    """Raise :exc:`ValueError` if *train_rows* is empty or single-class.
+
+    Called by both :func:`train_naive_bayes` and :func:`train_setfit` to
+    consolidate identical pre-training guards in one place.
+    """
+    if not train_rows:
+        raise ValueError(f"No training rows found in {labels_path}")
+    classes = {r.label for r in train_rows}
+    if len(classes) < 2:
+        raise ValueError(
+            f"Training data contains only one label class ({classes}); "
+            "both 'positive' and 'negative' labels are required."
+        )
 
 
 def _sha1_file(path: Path) -> str:

--- a/src/denbust/prefilter/stage_b.py
+++ b/src/denbust/prefilter/stage_b.py
@@ -1,25 +1,35 @@
-"""Stage B — trained text classifier (Naive Bayes default).
+"""Stage B — trained text classifier (Naive Bayes default, SetFit alternative).
 
-Implements Stage B as a calibrated Complement Naive Bayes on character
-n-grams (3–5).  Two separate model artifacts are trained and persisted:
+Two scorer implementations are provided:
 
-thin_model.joblib
-    Applied to ``title + " " + snippet`` in the thin (pre-scrape) pass.
-thick_model.joblib
-    Applied to ``article_body`` text in the thick (post-scrape) pass,
-    falling back to title+snippet when body is absent or empty.
-meta.json
-    :class:`StageBModelMeta` — artifact provenance metadata.
+:class:`StageBScorer`
+    Calibrated Complement Naive Bayes on character n-grams (3–5).
+    Artifacts: ``models_dir/stage_b/{thin_model,thick_model}.joblib`` +
+    ``meta.json``.  No heavy dependencies beyond scikit-learn/joblib.
 
-Both models use the labeled-candidates parquet produced by LPF-PR-02.
-The thin model is trained on title+snippet.  The thick model is trained on
-``article_body`` when available and on title+snippet otherwise — so the
-thick model improves automatically as more scraped labels accumulate.
+:class:`StageBSetFitScorer`
+    SetFit on ``intfloat/multilingual-e5-large``.
+    Artifacts: ``models_dir/stage_b_setfit/{thin_model/,thick_model/}`` +
+    ``meta.json``.  Requires the ``prefilter`` extras group
+    (``pip install -e '.[dev,prefilter]'``).
 
-When no trained artifacts exist the scorer returns ``None``, preserving the
-stub behaviour so the cascade continues to Stage C unimpeded.
+Both implementations:
 
-Full SetFit alternative lands in LPF-PR-05.
+- Return ``None`` when no trained artifacts exist so the cascade continues
+  to Stage C unimpeded (stub behaviour).
+- Use separate thin (title + snippet) and thick (article body, with
+  title+snippet fallback) model artifacts.
+- Produce :class:`~denbust.prefilter.models.StageScore` with a
+  ``reason`` tag that names the implementation and pass kind, e.g.
+  ``"nb/thin=0.123"`` or ``"setfit/thick=0.456"``.
+
+Training entry points
+---------------------
+:func:`train_naive_bayes`
+    Trains both NB artifacts from a ``labels.parquet``; returns
+    ``(StageBModelMeta, stage_dir)``.
+:func:`train_setfit`
+    Trains both SetFit artifacts; same return type.
 """
 
 from __future__ import annotations
@@ -29,6 +39,7 @@ import hashlib
 import json
 import logging
 import shutil
+import tempfile
 import warnings
 from datetime import UTC, datetime
 from pathlib import Path
@@ -45,6 +56,11 @@ logger = logging.getLogger(__name__)
 _STAGE_B_SUBDIR = "stage_b"
 _THIN_MODEL_FILE = "thin_model.joblib"
 _THICK_MODEL_FILE = "thick_model.joblib"
+
+_STAGE_B_SETFIT_SUBDIR = "stage_b_setfit"
+_THIN_MODEL_DIRNAME = "thin_model"
+_THICK_MODEL_DIRNAME = "thick_model"
+
 _META_FILE = "meta.json"
 
 
@@ -60,9 +76,9 @@ class StageBModelMeta:
     Attributes
     ----------
     model_kind:
-        Always ``"naive_bayes"`` in LPF-PR-04.  SetFit support: LPF-PR-05.
+        ``"naive_bayes"`` or ``"setfit"``.
     model_version:
-        Short (12-char) SHA-1 of the thin model artifact file.
+        Short (12-char) SHA-1 derived from the primary trained artifact.
     trained_at:
         ISO-8601 UTC timestamp of when the artifacts were written.
     n_train:
@@ -75,7 +91,7 @@ class StageBModelMeta:
         at training time; increases as more scraped labels accumulate.
     """
 
-    model_kind: Literal["naive_bayes"]
+    model_kind: Literal["naive_bayes", "setfit"]
     model_version: str
     trained_at: str
     n_train: int
@@ -84,7 +100,7 @@ class StageBModelMeta:
 
 
 # ---------------------------------------------------------------------------
-# Pipeline builder (module-level so it can be imported and tested directly)
+# NB pipeline builder (module-level so it can be imported and tested directly)
 # ---------------------------------------------------------------------------
 
 
@@ -119,7 +135,7 @@ def _build_nb_pipeline(seed: int) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# StageBScorer
+# StageBScorer — Naive Bayes
 # ---------------------------------------------------------------------------
 
 
@@ -149,7 +165,7 @@ class StageBScorer:
         self._threshold = threshold
         self._thin_model: Any = None
         self._thick_model: Any = None
-        self._model_version: str = ""
+        self.model_version: str = ""
 
         if models_dir is None:
             return
@@ -168,10 +184,10 @@ class StageBScorer:
         self._thick_model = joblib.load(thick_path)
         if meta_path.exists():
             meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
-            self._model_version = str(meta_raw.get("model_version", ""))
+            self.model_version = str(meta_raw.get("model_version", ""))
         else:
             logger.warning(
-                "Stage B: meta.json missing from %s; model_version will be empty "
+                "Stage B NB: meta.json missing from %s; model_version will be empty "
                 "in telemetry.  Re-run `denbust prefilter retrain --stage b` to fix.",
                 stage_dir,
             )
@@ -229,12 +245,130 @@ class StageBScorer:
             threshold=self._threshold,
             dropped=dropped,
             reason=f"nb/{pass_kind}={p_negative:.3f}",
-            model_version=self._model_version,
+            model_version=self.model_version,
         )
 
 
 # ---------------------------------------------------------------------------
-# Artifact builder (used by CLI retrain command)
+# StageBSetFitScorer — SetFit with multilingual-e5-large
+# ---------------------------------------------------------------------------
+
+
+class StageBSetFitScorer:
+    """Stage B cascade scorer: SetFit on ``intfloat/multilingual-e5-large``.
+
+    Returns ``None`` when no trained artifacts exist or when the ``setfit``
+    package is not installed, preserving stub behaviour.
+
+    Requires the ``prefilter`` extras group::
+
+        pip install -e '.[dev,prefilter]'
+
+    Parameters
+    ----------
+    models_dir:
+        Root models directory.  Artifacts expected under
+        ``models_dir/stage_b_setfit/{thin_model/,thick_model/}``.
+    threshold:
+        Drop threshold.  Candidates whose ``p_negative >= threshold`` are
+        tagged ``dropped=True``.
+    """
+
+    def __init__(
+        self,
+        *,
+        models_dir: Path | None = None,
+        threshold: float = 0.95,
+    ) -> None:
+        self._threshold = threshold
+        self._thin_model: Any = None
+        self._thick_model: Any = None
+        self.model_version: str = ""
+
+        if models_dir is None:
+            return
+
+        stage_dir = models_dir / _STAGE_B_SETFIT_SUBDIR
+        thin_path = stage_dir / _THIN_MODEL_DIRNAME
+        thick_path = stage_dir / _THICK_MODEL_DIRNAME
+        meta_path = stage_dir / _META_FILE
+
+        if not (thin_path.is_dir() and thick_path.is_dir()):
+            return
+
+        try:
+            from setfit import SetFitModel  # lazy — setfit is optional
+        except ImportError:
+            logger.warning(
+                "Stage B SetFit: 'setfit' package is not installed; scorer returns None "
+                "for all candidates.  Install with: pip install -e '.[dev,prefilter]'"
+            )
+            return
+
+        self._thin_model = SetFitModel.from_pretrained(str(thin_path))
+        self._thick_model = SetFitModel.from_pretrained(str(thick_path))
+        if meta_path.exists():
+            meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
+            self.model_version = str(meta_raw.get("model_version", ""))
+        else:
+            logger.warning(
+                "Stage B SetFit: meta.json missing from %s; model_version will be empty.",
+                stage_dir,
+            )
+
+    def evaluate(
+        self,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+        body: str | None = None,
+    ) -> StageScore | None:
+        """Evaluate *candidate* and return a :class:`StageScore`, or ``None``.
+
+        Returns ``None`` when no model is loaded.
+
+        Parameters
+        ----------
+        candidate:
+            Candidate to evaluate.
+        pass_kind:
+            ``"thin"`` → thin model on title+snippet.
+            ``"thick"`` → thick model on *body*; falls back to thin text.
+        body:
+            Full article body; only meaningful for the thick pass.
+        """
+        if self._thin_model is None:
+            return None
+
+        title = candidate.title or ""
+        snippet = candidate.snippet or ""
+        thin_text = (title + " " + snippet).strip()
+
+        if pass_kind == "thick" and body and body.strip():
+            text = body.strip()
+            model = self._thick_model
+        else:
+            text = thin_text
+            model = self._thin_model
+
+        # SetFitModel.predict_proba returns an ndarray of shape (n_texts, n_classes).
+        # Classes follow the integer label order: 0 → "negative", 1 → "positive".
+        # proba[0][0] = p(label=0) = p_negative.
+        proba: Any = model.predict_proba([text])
+        p_negative = float(proba[0][0])
+
+        dropped = p_negative >= self._threshold
+        return StageScore(
+            stage="B",
+            p_negative=p_negative,
+            threshold=self._threshold,
+            dropped=dropped,
+            reason=f"setfit/{pass_kind}={p_negative:.3f}",
+            model_version=self.model_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Artifact builder — Naive Bayes
 # ---------------------------------------------------------------------------
 
 
@@ -275,8 +409,7 @@ def train_naive_bayes(
     -------
     tuple[StageBModelMeta, Path]
         ``(meta, stage_dir)`` — provenance metadata and the path of the
-        written artifact directory.  The caller can use ``stage_dir`` to
-        report artifact locations without re-computing the path.
+        written artifact directory.
 
     Raises
     ------
@@ -334,7 +467,6 @@ def train_naive_bayes(
     # rename it into place.  This ensures the stage_b/ directory is either
     # fully written or the old version survives intact.
     out_dir.mkdir(parents=True, exist_ok=True)
-    import tempfile
 
     tmp_dir = Path(tempfile.mkdtemp(dir=out_dir, prefix=f"{_STAGE_B_SUBDIR}.tmp."))
     try:
@@ -382,6 +514,168 @@ def train_naive_bayes(
 
 
 # ---------------------------------------------------------------------------
+# Artifact builder — SetFit
+# ---------------------------------------------------------------------------
+
+
+def train_setfit(
+    labels_path: Path,
+    out_dir: Path,
+    *,
+    base_model_id: str = "intfloat/multilingual-e5-large",
+    seed: int = 20260521,
+) -> tuple[StageBModelMeta, Path]:
+    """Train SetFit classifiers and write Stage B SetFit artifacts.
+
+    Reads *labels_path*, restricts to the ``"train"`` split, then trains:
+
+    - **thin model** on ``title + " " + snippet`` (all train rows)
+    - **thick model** on ``article_body`` when present, else title+snippet
+
+    Training configuration (matches LPF-PR-05 spec)::
+
+        num_iterations=20, batch_size=16,
+        body_learning_rate=2e-5, head_learning_rate=1e-2,
+        num_epochs=1, seed=<seed>
+
+    Artifacts written atomically to ``out_dir/stage_b_setfit/``:
+
+    - ``thin_model/``   — SetFit model directory (sentence encoder + head)
+    - ``thick_model/``  — SetFit model directory
+    - ``meta.json``     — :class:`StageBModelMeta` provenance
+
+    Parameters
+    ----------
+    labels_path:
+        Path to a ``labels.parquet`` from :mod:`denbust.prefilter.labels`.
+    out_dir:
+        Parent directory for ``stage_b_setfit/`` artifacts.
+    base_model_id:
+        HuggingFace model identifier for the sentence-encoder backbone.
+        Default: ``"intfloat/multilingual-e5-large"``.
+    seed:
+        Random seed for training reproducibility.
+
+    Returns
+    -------
+    tuple[StageBModelMeta, Path]
+        ``(meta, stage_dir)``
+
+    Raises
+    ------
+    ImportError
+        When ``setfit``, ``sentence-transformers``, or ``torch`` are not installed.
+        Install with ``pip install -e '.[dev,prefilter]'``.
+    ValueError
+        When the training split is empty or contains only one label class.
+    """
+    try:
+        import datasets as hf_datasets
+        from setfit import SetFitModel, SetFitTrainer
+        from setfit import TrainingArguments as SetFitTrainingArgs
+    except ImportError as exc:
+        raise ImportError(
+            "SetFit training requires the 'prefilter' extras:\n  pip install -e '.[dev,prefilter]'"
+        ) from exc
+
+    from denbust.prefilter.labels import read_labels_parquet
+
+    rows = read_labels_parquet(labels_path)
+    train_rows = [r for r in rows if r.split == "train"]
+    val_rows = [r for r in rows if r.split == "val"]
+
+    if not train_rows:
+        raise ValueError(f"No training rows found in {labels_path}")
+
+    classes = {r.label for r in train_rows}
+    if len(classes) < 2:
+        raise ValueError(
+            f"Training data contains only one label class ({classes}); "
+            "both 'positive' and 'negative' labels are required."
+        )
+
+    label_to_int = {"negative": 0, "positive": 1}
+    y_train = [label_to_int[r.label] for r in train_rows]
+
+    n_thick_with_body = sum(1 for r in train_rows if r.article_body is not None)
+    if n_thick_with_body == 0:
+        warnings.warn(
+            f"All {len(train_rows)} train rows have article_body=None; "
+            "the SetFit thick model is identical to the thin model at this training.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    thin_texts = [(r.title + " " + r.snippet).strip() for r in train_rows]
+    thick_texts = [(r.article_body or (r.title + " " + r.snippet)).strip() for r in train_rows]
+
+    train_args = SetFitTrainingArgs(
+        num_iterations=20,
+        batch_size=16,
+        body_learning_rate=2e-5,
+        head_learning_rate=1e-2,
+        num_epochs=1,
+        seed=seed,
+    )
+
+    def _train_one(texts: list[str], labels: list[int]) -> Any:
+        dataset = hf_datasets.Dataset.from_dict({"text": texts, "label": labels})
+        model = SetFitModel.from_pretrained(base_model_id, labels=[0, 1])
+        trainer = SetFitTrainer(model=model, train_dataset=dataset, args=train_args)
+        trainer.train()
+        return model
+
+    thin_model = _train_one(thin_texts, y_train)
+    thick_model = _train_one(thick_texts, y_train)
+
+    # Atomic write
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tmp_dir = Path(tempfile.mkdtemp(dir=out_dir, prefix=f"{_STAGE_B_SETFIT_SUBDIR}.tmp."))
+    try:
+        thin_path = tmp_dir / _THIN_MODEL_DIRNAME
+        thick_path = tmp_dir / _THICK_MODEL_DIRNAME
+        meta_path = tmp_dir / _META_FILE
+
+        thin_model.save_pretrained(str(thin_path))
+        thick_model.save_pretrained(str(thick_path))
+
+        model_version = _sha1_setfit_head(thin_path)[:12]
+
+        meta = StageBModelMeta(
+            model_kind="setfit",
+            model_version=model_version,
+            trained_at=datetime.now(UTC).isoformat(),
+            n_train=len(train_rows),
+            n_val=len(val_rows),
+            n_thick_with_body=n_thick_with_body,
+        )
+        meta_dict = {
+            "model_kind": meta.model_kind,
+            "model_version": meta.model_version,
+            "trained_at": meta.trained_at,
+            "n_train": meta.n_train,
+            "n_val": meta.n_val,
+            "n_thick_with_body": meta.n_thick_with_body,
+            "base_model_id": base_model_id,
+        }
+        meta_path.write_text(
+            json.dumps(meta_dict, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        stage_dir = out_dir / _STAGE_B_SETFIT_SUBDIR
+        if stage_dir.exists():
+            shutil.rmtree(stage_dir)
+        tmp_dir.rename(stage_dir)
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    return meta, stage_dir
+
+
+# ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
 
@@ -389,3 +683,28 @@ def train_naive_bayes(
 def _sha1_file(path: Path) -> str:
     """Return the full SHA-1 hex digest of *path*'s content."""
     return hashlib.sha1(path.read_bytes()).hexdigest()  # noqa: S324
+
+
+def _sha1_setfit_head(model_dir: Path) -> str:
+    """Return a SHA-1 derived from the SetFit classification head artifact(s).
+
+    Hashes ``model_head.pkl`` and ``config_setfit.json`` when present
+    (small files that capture what training changed), falling back to a
+    recursive hash of all files in the directory.
+    """
+    h = hashlib.sha1()  # noqa: S324
+    candidates = (
+        list(model_dir.rglob("model_head.pkl"))
+        + list(model_dir.rglob("config_setfit.json"))
+        + list(model_dir.rglob("config.json"))
+    )
+    found_any = False
+    for fpath in sorted(candidates):
+        if fpath.is_file():
+            h.update(fpath.read_bytes())
+            found_any = True
+    if not found_any:
+        for fpath in sorted(model_dir.rglob("*")):
+            if fpath.is_file():
+                h.update(fpath.read_bytes())
+    return h.hexdigest()

--- a/tests/unit/prefilter/_helpers.py
+++ b/tests/unit/prefilter/_helpers.py
@@ -7,7 +7,9 @@ self-contained at the import level.
 
 from __future__ import annotations
 
-from typing import Literal
+import json
+from pathlib import Path
+from typing import Any, Literal
 
 from denbust.prefilter.labels import LabeledCandidate
 
@@ -86,3 +88,46 @@ class FakeCandidate:
     @property
     def url(self) -> str | None:
         return self._url
+
+
+# ---------------------------------------------------------------------------
+# Minimal SetFit model stub for SetFit-related tests
+#
+# Defined here so both test_stage_b_setfit_predict.py and
+# test_stage_b_setfit_train.py share one implementation.  numpy is imported
+# lazily inside predict_proba so this file stays importable even without the
+# prefilter extras installed.
+# ---------------------------------------------------------------------------
+
+
+class FakeSetFitModel:
+    """Minimal SetFit model stub for testing: no network, no GPU.
+
+    ``predict_proba`` returns a constant probability matrix parameterised by
+    *p_negative*.  ``save_pretrained`` writes the three files that
+    :func:`~denbust.prefilter.stage_b._sha1_setfit_head` looks for, including
+    *p_negative* in ``config_setfit.json`` so that different instances produce
+    distinct SHA-1 hashes.
+    """
+
+    def __init__(self, p_negative: float = 0.2) -> None:
+        self._p_negative = p_negative
+
+    def predict_proba(self, texts: list[str]) -> Any:
+        import numpy as np  # lazy: only needed when setfit extras are installed
+
+        n = len(texts)
+        result = np.zeros((n, 2), dtype=np.float64)
+        result[:, 0] = self._p_negative
+        result[:, 1] = 1.0 - self._p_negative
+        return result
+
+    def save_pretrained(self, path: str) -> None:
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        (p / "config_setfit.json").write_text(
+            json.dumps({"model_type": "fake_setfit", "p_negative": self._p_negative}),
+            encoding="utf-8",
+        )
+        (p / "model_head.pkl").write_bytes(b"fake-head-bytes")
+        (p / "config.json").write_text(json.dumps({"hidden_size": 4}), encoding="utf-8")

--- a/tests/unit/prefilter/test_evaluate_metrics.py
+++ b/tests/unit/prefilter/test_evaluate_metrics.py
@@ -1,0 +1,245 @@
+"""Unit tests for _threshold_at_recall_floor and _compute_stage_b_metrics.
+
+These are pure-Python helpers extracted from the ``evaluate`` CLI command so
+that the core metric logic can be tested independently of CLI plumbing or
+file I/O.  No model loading, no filesystem access.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from denbust.prefilter.cli import _compute_stage_b_metrics, _threshold_at_recall_floor
+
+# ---------------------------------------------------------------------------
+# _threshold_at_recall_floor
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdAtRecallFloor:
+    """Unit tests for the threshold search algorithm."""
+
+    def test_no_positives_returns_one(self) -> None:
+        """When there are no positives, any threshold is safe — return 1.0."""
+        p = [0.1, 0.2, 0.9]
+        y = [0, 0, 0]
+        assert _threshold_at_recall_floor(p, y, recall_floor=0.99) == 1.0
+
+    def test_floor_satisfied_at_minimum_threshold(self) -> None:
+        """When the minimum unique value already satisfies the floor, return it."""
+        # All positives have very low p_negative; the tightest threshold (0.1)
+        # does not drop any positives.
+        p = [0.1, 0.2, 0.8, 0.9]
+        y = [1, 1, 0, 0]  # positives at 0.1, 0.2
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=0.99)
+        # At threshold=0.1, false_drops = 2 (both positives); 2 > 0 → skip.
+        # At threshold=0.2, false_drops = 2 (both positives); still > 0 → skip.
+        # At threshold=0.8, false_drops = 0 ≤ 0 → return 0.8.
+        assert threshold == 0.8
+
+    def test_partial_floor_allows_one_false_drop(self) -> None:
+        """With recall_floor=0.9 and 10 positives, one false drop is allowed."""
+        # max_false_drops = int(10 * 0.1) = 1
+        pos_p = [0.8, 0.9] + [0.1] * 8  # 2 high-p positives, 8 low-p positives
+        neg_p = [0.95, 0.97]
+        p = pos_p + neg_p
+        y = [1] * 10 + [0] * 2
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=0.9)
+        # At threshold=0.8: false_drops=2 > 1 → skip
+        # At threshold=0.9: false_drops=1 ≤ 1 → return 0.9
+        assert threshold == 0.9
+
+    def test_bug_regression_first_violation_not_returned(self) -> None:
+        """Key regression: violating at T must not return T+1e-9 prematurely.
+
+        Old algorithm bailed at the first threshold that violated and returned
+        ``T + 1e-9``.  If T was the minimum value in the set, ``T + 1e-9``
+        still dropped every positive above T, violating the floor.
+
+        New algorithm continues until it finds a threshold that satisfies the
+        constraint, only returning above-max when none does.
+        """
+        # recall_floor=1.0 → max_false_drops=0 (no false drops allowed).
+        # Positives are at 0.3, 0.5, 0.7; negatives at 0.1, 0.2.
+        # Every candidate threshold in [0.1..0.7] drops at least one positive.
+        # The only safe answer is above 0.7 (max of all p_negatives).
+        p = [0.1, 0.2, 0.3, 0.5, 0.7]
+        y = [0, 0, 1, 1, 1]  # positives at 0.3, 0.5, 0.7
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=1.0)
+
+        # Returned threshold must be above 0.7 so no positive is dropped.
+        assert threshold > 0.7
+        # Verify recall is actually 1.0 at the returned threshold.
+        false_drops = sum(1 for pv, yv in zip(p, y) if pv >= threshold and yv == 1)
+        assert false_drops == 0
+
+    def test_no_threshold_satisfies_returns_above_max(self) -> None:
+        """When even the strictest threshold still drops a positive, return max+eps."""
+        # Single positive with the highest p_negative in the dataset.
+        # No threshold can avoid dropping it without dropping nothing.
+        p = [0.9, 0.5, 0.3]
+        y = [1, 0, 0]  # the single positive has the max p
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=1.0)
+        assert threshold > 0.9
+        # At this threshold, the positive (p=0.9) is not dropped.
+        assert not (threshold <= 0.9)
+
+    def test_single_positive_zero_drop_required(self) -> None:
+        """recall_floor=1.0 with one positive; threshold must be above that positive's p."""
+        p = [0.95, 0.6, 0.4]
+        y = [1, 0, 0]
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=1.0)
+        assert threshold > 0.95
+
+    def test_all_same_probability_no_floor_violation(self) -> None:
+        """When all p_negatives are identical and a false drop is allowed, drop them."""
+        # max_false_drops = int(2 * 0.5) = 1; one false drop allowed.
+        p = [0.7, 0.7, 0.7, 0.7]
+        y = [1, 1, 0, 0]
+        threshold = _threshold_at_recall_floor(p, y, recall_floor=0.5)
+        # At threshold=0.7: false_drops=2 > 1 → skip.
+        # No more thresholds → return max(p)+1e-9 = 0.7+1e-9.
+        assert threshold > 0.7
+
+    def test_returned_threshold_always_satisfies_floor(self) -> None:
+        """Property: the returned threshold must never violate the recall floor."""
+        import random
+
+        rng = random.Random(42)
+        for _ in range(50):
+            n = rng.randint(5, 20)
+            p = [round(rng.random(), 2) for _ in range(n)]
+            y = [rng.randint(0, 1) for _ in range(n)]
+            floor = rng.choice([0.8, 0.9, 0.95, 0.99, 1.0])
+            threshold = _threshold_at_recall_floor(p, y, recall_floor=floor)
+            n_pos = sum(y)
+            if n_pos == 0:
+                continue
+            false_drops = sum(1 for pv, yv in zip(p, y) if pv >= threshold and yv == 1)
+            recall = (n_pos - false_drops) / n_pos
+            assert recall >= floor - 1e-9, (
+                f"Recall {recall:.4f} < floor {floor} at threshold {threshold:.6f} (p={p}, y={y})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# _compute_stage_b_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStageBMetrics:
+    """Unit tests for the extracted metric computation helper."""
+
+    def test_empty_scored_rows_returns_safe_defaults(self) -> None:
+        result = _compute_stage_b_metrics(
+            scored_p=[], scored_y=[], n_pos_total=5, n_total=10, recall_floor=0.99
+        )
+        assert result["recall"] == 1.0
+        assert result["drop_rate"] == 0.0
+        assert result["brier_score"] == 0.0
+        assert result["drop_precision"] == 0.0
+
+    def test_perfect_model_brier_near_zero(self) -> None:
+        """A perfect model assigns p_negative=1.0 to negatives, 0.0 to positives."""
+        scored_p = [1.0, 1.0, 0.0, 0.0]  # neg, neg, pos, pos
+        scored_y = [0, 0, 1, 1]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p, scored_y=scored_y, n_pos_total=2, n_total=4, recall_floor=0.99
+        )
+        assert result["brier_score"] == pytest.approx(0.0)
+
+    def test_worst_model_brier_near_one(self) -> None:
+        """A completely inverted model assigns p_negative=0.0 to negatives, 1.0 to positives."""
+        scored_p = [0.0, 0.0, 1.0, 1.0]  # neg, neg, pos, pos
+        scored_y = [0, 0, 1, 1]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p, scored_y=scored_y, n_pos_total=2, n_total=4, recall_floor=0.99
+        )
+        assert result["brier_score"] == pytest.approx(1.0)
+
+    def test_drop_rate_uses_n_total_not_n_scored(self) -> None:
+        """drop_rate = dropped / n_total, not dropped / len(scored_p)."""
+        # 3 rows scored out of 10 total: 2 high-scoring negatives and 1 positive
+        # that the model correctly keeps (low p_negative).  The threshold lands
+        # at 0.85 (first value that drops no positives), so both negatives are
+        # dropped.  With n_total=10, drop_rate = 2/10 = 0.2, NOT 2/3 ≈ 0.67.
+        scored_p = [0.95, 0.85, 0.1]
+        scored_y = [0, 0, 1]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p,
+            scored_y=scored_y,
+            n_pos_total=1,
+            n_total=10,
+            recall_floor=0.99,
+        )
+        assert result["drop_rate"] == pytest.approx(0.2)
+
+    def test_recall_uses_n_pos_total_not_scored_positives(self) -> None:
+        """Unscored positives are NOT dropped; recall uses n_pos_total."""
+        # 3 positives in total; 2 are scored (neither dropped), 1 was unscored.
+        scored_p = [0.1, 0.2]  # both well below any threshold
+        scored_y = [1, 1]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p,
+            scored_y=scored_y,
+            n_pos_total=3,  # one extra unscored positive
+            n_total=10,
+            recall_floor=0.99,
+        )
+        # No positives among scored rows are dropped, so false_drops=0.
+        # recall = (3 - 0) / 3 = 1.0.
+        assert result["recall"] == pytest.approx(1.0)
+
+    def test_false_drop_reduces_recall(self) -> None:
+        """A positive that scores above the threshold reduces recall."""
+        # recall_floor=0.5 → allow up to 1 false drop among 2 positives.
+        # Threshold will be chosen such that recall ≥ 0.5.
+        scored_p = [0.95, 0.1]  # first is positive, second is positive
+        scored_y = [1, 1]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p,
+            scored_y=scored_y,
+            n_pos_total=2,
+            n_total=4,
+            recall_floor=0.5,
+        )
+        assert result["recall"] >= 0.5
+
+    def test_drop_precision_all_true_drops(self) -> None:
+        """When every dropped candidate is truly negative, drop_precision = 1.0."""
+        scored_p = [0.9, 0.8, 0.05, 0.05]
+        scored_y = [0, 0, 1, 1]  # dropped items are negatives
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p,
+            scored_y=scored_y,
+            n_pos_total=2,
+            n_total=4,
+            recall_floor=0.99,
+        )
+        assert result["drop_precision"] == pytest.approx(1.0)
+
+    def test_no_positives_recall_is_one(self) -> None:
+        """When the eval split has no positives, recall defaults to 1.0."""
+        scored_p = [0.9, 0.8]
+        scored_y = [0, 0]
+        result = _compute_stage_b_metrics(
+            scored_p=scored_p, scored_y=scored_y, n_pos_total=0, n_total=2, recall_floor=0.99
+        )
+        assert result["recall"] == pytest.approx(1.0)
+
+    def test_threshold_satisfies_floor(self) -> None:
+        """The chosen threshold must always achieve the declared recall floor."""
+        scored_p = [0.95, 0.85, 0.3, 0.2, 0.1]
+        scored_y = [0, 0, 1, 1, 1]
+        for floor in [0.8, 0.9, 0.99, 1.0]:
+            result = _compute_stage_b_metrics(
+                scored_p=scored_p,
+                scored_y=scored_y,
+                n_pos_total=3,
+                n_total=5,
+                recall_floor=floor,
+            )
+            assert result["recall"] >= floor - 1e-9, (
+                f"recall {result['recall']:.4f} < floor {floor} "
+                f"at threshold {result['threshold']:.6f}"
+            )

--- a/tests/unit/prefilter/test_stage_b_setfit_predict.py
+++ b/tests/unit/prefilter/test_stage_b_setfit_predict.py
@@ -1,0 +1,282 @@
+"""Unit tests for StageBSetFitScorer inference in prefilter.stage_b.
+
+SetFit loading calls ``SetFitModel.from_pretrained`` which normally
+downloads a large model from HuggingFace.  All tests here monkeypatch that
+call with a lightweight fake so no network access occurs.
+
+Skipped entirely when ``setfit`` is not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+setfit = pytest.importorskip("setfit")  # skip whole module if setfit not installed
+
+from denbust.prefilter.models import StageScore
+from denbust.prefilter.stage_b import StageBSetFitScorer
+from tests.unit.prefilter._helpers import FakeCandidate
+
+# ---------------------------------------------------------------------------
+# Fake SetFit model that covers both save_pretrained and predict_proba
+# ---------------------------------------------------------------------------
+
+
+class _FakeSetFitModel:
+    """Lightweight SetFit model stub for predict tests."""
+
+    def __init__(self, p_negative: float = 0.2) -> None:
+        self._p_negative = p_negative
+
+    def predict_proba(self, texts: list[str]) -> Any:
+        import numpy as np
+
+        n = len(texts)
+        result = np.zeros((n, 2), dtype=np.float64)
+        result[:, 0] = self._p_negative
+        result[:, 1] = 1.0 - self._p_negative
+        return result
+
+    def save_pretrained(self, path: str) -> None:
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        (p / "config_setfit.json").write_text(
+            json.dumps({"model_type": "fake_setfit"}), encoding="utf-8"
+        )
+        (p / "model_head.pkl").write_bytes(b"fake")
+        (p / "config.json").write_text(json.dumps({"hidden_size": 4}), encoding="utf-8")
+
+
+def _fake_from_pretrained(path: str, **_kwargs: Any) -> _FakeSetFitModel:
+    """Fake loader: deterministically varies p_negative based on model path."""
+    # Thin model gets p_negative=0.2 (positive-leaning);
+    # thick model gets p_negative=0.8 (negative-leaning).
+    p_neg = 0.2 if "thin" in str(path) else 0.8
+    return _FakeSetFitModel(p_negative=p_neg)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a minimal stage_b_setfit/ artifact directory (module-scoped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def setfit_models_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a minimal stage_b_setfit/ directory with fake model artifacts."""
+    base = tmp_path_factory.mktemp("stage_b_setfit")
+    models_dir = base / "models"
+    stage_dir = models_dir / "stage_b_setfit"
+
+    thin_dir = stage_dir / "thin_model"
+    thick_dir = stage_dir / "thick_model"
+
+    fake_thin = _FakeSetFitModel(p_negative=0.2)
+    fake_thick = _FakeSetFitModel(p_negative=0.8)
+    fake_thin.save_pretrained(str(thin_dir))
+    fake_thick.save_pretrained(str(thick_dir))
+
+    meta = {
+        "model_kind": "setfit",
+        "model_version": "abc123def456",
+        "trained_at": "2026-05-22T00:00:00+00:00",
+        "n_train": 20,
+        "n_val": 6,
+        "n_thick_with_body": 20,
+        "base_model_id": "intfloat/multilingual-e5-large",
+    }
+    (stage_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    return models_dir
+
+
+_PATCH_FROM_PRETRAINED = "setfit.SetFitModel.from_pretrained"
+
+
+# ---------------------------------------------------------------------------
+# Stub behaviour — no artifacts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestStageBSetFitScorerStub:
+    """StageBSetFitScorer returns None when no artifacts are present."""
+
+    def test_none_models_dir_returns_none_thin(self) -> None:
+        scorer = StageBSetFitScorer(models_dir=None)
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+
+    def test_none_models_dir_returns_none_thick(self) -> None:
+        scorer = StageBSetFitScorer(models_dir=None)
+        assert scorer.evaluate(FakeCandidate(), "thick", body="some body") is None
+
+    def test_missing_dir_returns_none(self, tmp_path: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=tmp_path / "nonexistent")
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+
+    def test_empty_models_dir_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "stage_b_setfit").mkdir()
+        scorer = StageBSetFitScorer(models_dir=tmp_path)
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+
+    def test_partial_artifacts_missing_thick_returns_none(self, tmp_path: Path) -> None:
+        stage_dir = tmp_path / "stage_b_setfit"
+        stage_dir.mkdir()
+        (stage_dir / "thin_model").mkdir()
+        scorer = StageBSetFitScorer(models_dir=tmp_path)
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+
+    def test_setfit_not_installed_logs_warning_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When setfit import fails, scorer logs a warning and returns None."""
+        import builtins
+
+        stage_dir = tmp_path / "stage_b_setfit"
+        (stage_dir / "thin_model").mkdir(parents=True)
+        (stage_dir / "thick_model").mkdir(parents=True)
+
+        real_import = builtins.__import__
+
+        def _block_setfit(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "setfit":
+                raise ImportError("No module named 'setfit'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_setfit)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="denbust.prefilter.stage_b"):
+            scorer = StageBSetFitScorer(models_dir=tmp_path)
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+        assert any("setfit" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Loaded model behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestStageBSetFitScorerLoaded:
+    """StageBSetFitScorer loaded from fake artifacts produces valid StageScore."""
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thin_returns_stage_score(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert isinstance(result, StageScore)
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thick_with_body_returns_stage_score(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="החשוד נעצר")
+        assert isinstance(result, StageScore)
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thick_without_body_falls_back_to_thin(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body=None)
+        assert isinstance(result, StageScore)
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_stage_score_has_stage_b(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.stage == "B"
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_p_negative_in_unit_interval_thin(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert 0.0 <= result.p_negative <= 1.0
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_p_negative_in_unit_interval_thick(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="החשוד נעצר")
+        assert result is not None
+        assert 0.0 <= result.p_negative <= 1.0
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thin_reason_starts_with_setfit_thin(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.reason.startswith("setfit/thin=")
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thick_reason_starts_with_setfit_thick(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="החשוד נעצר")
+        assert result is not None
+        assert result.reason.startswith("setfit/thick=")
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_threshold_propagated(self, setfit_models_dir: Path) -> None:
+        custom = 0.7
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir, threshold=custom)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.threshold == custom
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_dropped_flag_consistent_with_threshold(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir, threshold=0.95)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.dropped == (result.p_negative >= 0.95)
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_model_version_loaded_from_meta(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        assert scorer.model_version == "abc123def456"
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_model_version_propagated_to_stage_score(self, setfit_models_dir: Path) -> None:
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is not None
+        assert result.model_version == "abc123def456"
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_deterministic_thin_same_input(self, setfit_models_dir: Path) -> None:
+        """Same input to the same scorer must produce the same p_negative."""
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        r1 = scorer.evaluate(cand, "thin")
+        r2 = scorer.evaluate(cand, "thin")
+        assert r1 is not None and r2 is not None
+        assert r1.p_negative == r2.p_negative
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thin_and_thick_use_different_models(self, setfit_models_dir: Path) -> None:
+        """Thin and thick pass with a body must use different model objects."""
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        cand = FakeCandidate()
+        r_thin = scorer.evaluate(cand, "thin")
+        r_thick = scorer.evaluate(cand, "thick", body="body text here")
+        assert r_thin is not None and r_thick is not None
+        # fake_from_pretrained returns different p_negative for thin vs thick
+        assert r_thin.p_negative != r_thick.p_negative
+        assert r_thin.reason.startswith("setfit/thin=")
+        assert r_thick.reason.startswith("setfit/thick=")
+
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thick_without_body_uses_thin_model(self, setfit_models_dir: Path) -> None:
+        """When body is absent the thick pass falls back to the thin model."""
+        scorer = StageBSetFitScorer(models_dir=setfit_models_dir)
+        cand = FakeCandidate()
+        r_thin = scorer.evaluate(cand, "thin")
+        r_thick_no_body = scorer.evaluate(cand, "thick", body=None)
+        assert r_thin is not None and r_thick_no_body is not None
+        # Both should use the thin model (p_negative=0.2), so values should match.
+        assert r_thin.p_negative == r_thick_no_body.p_negative

--- a/tests/unit/prefilter/test_stage_b_setfit_predict.py
+++ b/tests/unit/prefilter/test_stage_b_setfit_predict.py
@@ -16,48 +16,19 @@ from unittest.mock import patch
 
 import pytest
 
-setfit = pytest.importorskip("setfit")  # skip whole module if setfit not installed
+_ = pytest.importorskip("setfit")  # skip whole module if setfit not installed
 
 from denbust.prefilter.models import StageScore
 from denbust.prefilter.stage_b import StageBSetFitScorer
-from tests.unit.prefilter._helpers import FakeCandidate
-
-# ---------------------------------------------------------------------------
-# Fake SetFit model that covers both save_pretrained and predict_proba
-# ---------------------------------------------------------------------------
+from tests.unit.prefilter._helpers import FakeCandidate, FakeSetFitModel
 
 
-class _FakeSetFitModel:
-    """Lightweight SetFit model stub for predict tests."""
-
-    def __init__(self, p_negative: float = 0.2) -> None:
-        self._p_negative = p_negative
-
-    def predict_proba(self, texts: list[str]) -> Any:
-        import numpy as np
-
-        n = len(texts)
-        result = np.zeros((n, 2), dtype=np.float64)
-        result[:, 0] = self._p_negative
-        result[:, 1] = 1.0 - self._p_negative
-        return result
-
-    def save_pretrained(self, path: str) -> None:
-        p = Path(path)
-        p.mkdir(parents=True, exist_ok=True)
-        (p / "config_setfit.json").write_text(
-            json.dumps({"model_type": "fake_setfit"}), encoding="utf-8"
-        )
-        (p / "model_head.pkl").write_bytes(b"fake")
-        (p / "config.json").write_text(json.dumps({"hidden_size": 4}), encoding="utf-8")
-
-
-def _fake_from_pretrained(path: str, **_kwargs: Any) -> _FakeSetFitModel:
+def _fake_from_pretrained(path: str, **_kwargs: Any) -> FakeSetFitModel:
     """Fake loader: deterministically varies p_negative based on model path."""
     # Thin model gets p_negative=0.2 (positive-leaning);
     # thick model gets p_negative=0.8 (negative-leaning).
     p_neg = 0.2 if "thin" in str(path) else 0.8
-    return _FakeSetFitModel(p_negative=p_neg)
+    return FakeSetFitModel(p_negative=p_neg)
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +46,8 @@ def setfit_models_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     thin_dir = stage_dir / "thin_model"
     thick_dir = stage_dir / "thick_model"
 
-    fake_thin = _FakeSetFitModel(p_negative=0.2)
-    fake_thick = _FakeSetFitModel(p_negative=0.8)
+    fake_thin = FakeSetFitModel(p_negative=0.2)
+    fake_thick = FakeSetFitModel(p_negative=0.8)
     fake_thin.save_pretrained(str(thin_dir))
     fake_thick.save_pretrained(str(thick_dir))
 

--- a/tests/unit/prefilter/test_stage_b_setfit_train.py
+++ b/tests/unit/prefilter/test_stage_b_setfit_train.py
@@ -1,0 +1,301 @@
+"""Unit tests for train_setfit() in prefilter.stage_b.
+
+SetFit training downloads a large (~560 MB) sentence-encoder from HuggingFace,
+which is incompatible with the project's "no live network calls in tests" rule.
+All tests here monkeypatch ``SetFitModel.from_pretrained`` and
+``SetFitTrainer`` with lightweight fakes so that:
+
+- The full artifact-write path (train → save → atomic rename) is exercised.
+- No network access occurs.
+- The test suite runs fast even when the ``prefilter`` extras are installed.
+
+Skipped entirely when ``setfit`` is not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+setfit = pytest.importorskip("setfit")  # skip whole module if setfit not installed
+
+from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
+from denbust.prefilter.stage_b import StageBModelMeta, train_setfit
+from tests.unit.prefilter._helpers import make_labeled_row
+
+# ---------------------------------------------------------------------------
+# Fake SetFit model & trainer (avoids any network or GPU usage)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSetFitModel:
+    """Minimal SetFit model stub that persists/loads without real weights."""
+
+    def __init__(self, p_negative: float = 0.2) -> None:
+        self._p_negative = p_negative
+
+    def predict_proba(self, texts: list[str]) -> Any:
+        import numpy as np
+
+        n = len(texts)
+        result = np.zeros((n, 2), dtype=np.float64)
+        result[:, 0] = self._p_negative
+        result[:, 1] = 1.0 - self._p_negative
+        return result
+
+    def save_pretrained(self, path: str) -> None:
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        # Write the files that _sha1_setfit_head looks for.
+        (p / "config_setfit.json").write_text(
+            json.dumps({"model_type": "fake_setfit", "p_negative": self._p_negative}),
+            encoding="utf-8",
+        )
+        (p / "model_head.pkl").write_bytes(b"fake-head-bytes")
+        (p / "config.json").write_text(
+            json.dumps({"hidden_size": 4}),
+            encoding="utf-8",
+        )
+
+
+def _fake_from_pretrained(*_args: Any, **_kwargs: Any) -> _FakeSetFitModel:
+    return _FakeSetFitModel()
+
+
+class _FakeSetFitTrainer:
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+    def train(self) -> None:
+        pass  # no-op — no real training
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_fixture(tmp_path: Path, n_per_class: int = 10) -> Path:
+    rows: list[LabeledCandidate] = []
+    idx = 0
+    for split, count in [("train", n_per_class), ("val", 3), ("test", 3)]:
+        for _ in range(count):
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "negative",
+                    split,  # type: ignore[arg-type]
+                    title="ספורט ופנאי",
+                    snippet="כדורגל ושחמט",
+                    body="משחקי כדורגל" if split == "train" else None,
+                )
+            )
+            idx += 1
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "positive",
+                    split,  # type: ignore[arg-type]
+                    title="עצור חשוד ברצח",
+                    snippet="המשטרה עצרה חשוד",
+                    body="החשוד נעצר" if split == "train" else None,
+                )
+            )
+            idx += 1
+    labels_path = tmp_path / "labels.parquet"
+    write_labels_parquet(rows, labels_path)
+    return labels_path
+
+
+# ---------------------------------------------------------------------------
+# All tests patch SetFit internals so no network is needed.
+# ---------------------------------------------------------------------------
+
+_PATCH_FROM_PRETRAINED = "setfit.SetFitModel.from_pretrained"
+_PATCH_TRAINER = "denbust.prefilter.stage_b.SetFitTrainer"
+
+
+@pytest.mark.slow
+class TestTrainSetfit:
+    """train_setfit() writes correct artifacts when SetFit is mocked."""
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_returns_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert isinstance(meta, StageBModelMeta)
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_returns_stage_dir(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        assert stage_dir.is_dir()
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_stage_dir_matches_returned_path(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        assert stage_dir == tmp_path / "models" / "stage_b_setfit"
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_meta_model_kind_is_setfit(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert meta.model_kind == "setfit"
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_meta_n_train_matches_split(self, tmp_path: Path) -> None:
+        n = 10
+        labels_path = _write_fixture(tmp_path, n_per_class=n)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert meta.n_train == n * 2  # n positive + n negative
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_meta_n_val_matches_split(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert meta.n_val == 6  # 3 positive + 3 negative
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thin_model_dir_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        assert (stage_dir / "thin_model").is_dir()
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_thick_model_dir_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        assert (stage_dir / "thick_model").is_dir()
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_meta_json_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        assert (stage_dir / "meta.json").exists()
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_meta_json_is_valid(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models")
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
+        assert raw["model_kind"] == "setfit"
+        assert len(raw["model_version"]) == 12
+        assert isinstance(raw["n_train"], int)
+        assert isinstance(raw["n_val"], int)
+        assert isinstance(raw["n_thick_with_body"], int)
+        assert raw["base_model_id"] == "intfloat/multilingual-e5-large"
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_model_version_is_12_char_hex(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert len(meta.model_version) == 12
+        assert all(c in "0123456789abcdef" for c in meta.model_version)
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_n_thick_with_body_counted_correctly(self, tmp_path: Path) -> None:
+        n = 10
+        labels_path = _write_fixture(tmp_path, n_per_class=n)
+        meta, _ = train_setfit(labels_path, tmp_path / "models")
+        assert meta.n_thick_with_body == n * 2  # all train rows have bodies
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_atomic_write_no_tmp_dir_left_on_success(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_setfit(labels_path, models_dir)
+        tmp_dirs = list(models_dir.glob("stage_b_setfit.tmp.*"))
+        assert tmp_dirs == [], f"Stale tmp dirs: {tmp_dirs}"
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_second_retrain_replaces_artifacts(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        _, stage_dir1 = train_setfit(labels_path, models_dir)
+        _, stage_dir2 = train_setfit(labels_path, models_dir)
+        assert stage_dir1 == stage_dir2
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_warns_when_all_bodies_none(self, tmp_path: Path) -> None:
+        rows: list[LabeledCandidate] = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ] + [
+            make_labeled_row(i + 10, "positive", "train", "עצור", "חשוד")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.warns(UserWarning, match="identical to the thin model"):
+            train_setfit(labels_path, tmp_path / "models")
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_raises_on_empty_training_split(self, tmp_path: Path) -> None:
+        rows = [
+            make_labeled_row(0, "negative", "val", "ספורט", "כדורגל"),  # type: ignore[arg-type]
+            make_labeled_row(1, "positive", "val", "עצור", "חשוד"),  # type: ignore[arg-type]
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.raises(ValueError, match="No training rows"):
+            train_setfit(labels_path, tmp_path / "models")
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_raises_on_single_class_training(self, tmp_path: Path) -> None:
+        rows = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.raises(ValueError, match="only one label class"):
+            train_setfit(labels_path, tmp_path / "models")
+
+    def test_raises_import_error_when_setfit_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """train_setfit raises ImportError with a helpful message when setfit is missing."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name in ("datasets", "setfit"):
+                raise ImportError(f"No module named '{name}'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+        labels_path = _write_fixture(tmp_path)
+        with pytest.raises(ImportError, match="prefilter"):
+            train_setfit(labels_path, tmp_path / "models")
+
+    @patch(_PATCH_TRAINER, _FakeSetFitTrainer)
+    @patch(_PATCH_FROM_PRETRAINED, _fake_from_pretrained)
+    def test_custom_base_model_id_written_to_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        custom_id = "intfloat/multilingual-e5-small"
+        _, stage_dir = train_setfit(labels_path, tmp_path / "models", base_model_id=custom_id)
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
+        assert raw["base_model_id"] == custom_id

--- a/tests/unit/prefilter/test_stage_b_setfit_train.py
+++ b/tests/unit/prefilter/test_stage_b_setfit_train.py
@@ -21,49 +21,15 @@ from unittest.mock import patch
 
 import pytest
 
-setfit = pytest.importorskip("setfit")  # skip whole module if setfit not installed
+_ = pytest.importorskip("setfit")  # skip whole module if setfit not installed
 
 from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
 from denbust.prefilter.stage_b import StageBModelMeta, train_setfit
-from tests.unit.prefilter._helpers import make_labeled_row
-
-# ---------------------------------------------------------------------------
-# Fake SetFit model & trainer (avoids any network or GPU usage)
-# ---------------------------------------------------------------------------
+from tests.unit.prefilter._helpers import FakeSetFitModel, make_labeled_row
 
 
-class _FakeSetFitModel:
-    """Minimal SetFit model stub that persists/loads without real weights."""
-
-    def __init__(self, p_negative: float = 0.2) -> None:
-        self._p_negative = p_negative
-
-    def predict_proba(self, texts: list[str]) -> Any:
-        import numpy as np
-
-        n = len(texts)
-        result = np.zeros((n, 2), dtype=np.float64)
-        result[:, 0] = self._p_negative
-        result[:, 1] = 1.0 - self._p_negative
-        return result
-
-    def save_pretrained(self, path: str) -> None:
-        p = Path(path)
-        p.mkdir(parents=True, exist_ok=True)
-        # Write the files that _sha1_setfit_head looks for.
-        (p / "config_setfit.json").write_text(
-            json.dumps({"model_type": "fake_setfit", "p_negative": self._p_negative}),
-            encoding="utf-8",
-        )
-        (p / "model_head.pkl").write_bytes(b"fake-head-bytes")
-        (p / "config.json").write_text(
-            json.dumps({"hidden_size": 4}),
-            encoding="utf-8",
-        )
-
-
-def _fake_from_pretrained(*_args: Any, **_kwargs: Any) -> _FakeSetFitModel:
-    return _FakeSetFitModel()
+def _fake_from_pretrained(*_args: Any, **_kwargs: Any) -> FakeSetFitModel:
+    return FakeSetFitModel()
 
 
 class _FakeSetFitTrainer:


### PR DESCRIPTION
## Summary

- **`StageBSetFitScorer`** — drop-in alternative to `StageBScorer` (ComplementNB); loads `thin_model/` and `thick_model/` SetFit checkpoints from `models/stage_b_setfit/`; falls back gracefully to `None` when `setfit` is not installed or artifacts are absent.
- **`train_setfit()`** — trains two SetFit classifiers (thin: title+snippet, thick: title+snippet+body) on the labeled-candidates parquet, writes artifacts atomically via `tempfile.mkdtemp + os.rename`, stamps `meta.json` with a 12-char SHA-1 version derived from model head files.
- **`[prefilter]` extras group** — `setfit>=1.0`, `sentence-transformers>=3.0`, `torch>=2.3`, `faiss-cpu>=1.8`, `mlx-lm>=0.18` (macOS), `datasets>=2.20`; dev env needs only `.[dev]`, training/inference needs `.[dev,prefilter]`.
- **`denbust prefilter retrain --model setfit`** — dispatches to `train_setfit()`; existing `--model naive_bayes` path unchanged.
- **`denbust prefilter evaluate`** — new command; scores the val (or test) split under each requested Stage B model kind (`--compare-b naive_bayes,setfit`), finds the threshold that meets `--recall-floor`, reports Brier score, drop rate, and drop precision; optionally writes a markdown report via `--report-path`.
- **38 new tests** (20 predict + 18 train) — fully mocked, no network access; skipped automatically via `pytest.importorskip` when `setfit` is not installed; tagged `@pytest.mark.slow`.

## Architecture notes

- `StageBModelMeta.model_kind` widened to `Literal["naive_bayes", "setfit"]` — backward compatible (NB artifacts still have `"naive_bayes"` in `meta.json`).
- Both scorers expose a public `model_version: str` attribute so `evaluate_cmd` can access it without `type: ignore`.
- `_sha1_setfit_head()` hashes `model_head.pkl + config_setfit.json + config.json` (the small files that change when training changes), with a full-directory fallback.
- `_threshold_at_recall_floor()` sweeps ascending unique p_negative values and returns the tightest threshold that keeps false-drop rate ≤ `n_pos × (1 − recall_floor)`.
- mypy overrides added for `faiss.*`, `mlx_lm.*`, `sentence_transformers.*` (no src imports yet — reserved for upcoming Stage C/D PRs).

## Test plan

- [x] `ruff format . && ruff check .` — clean
- [x] `mypy src/` — clean (3 unused-section notes for future-use overrides, not errors)
- [x] `pytest -q tests/unit/prefilter/` — 248 passed, 2 skipped (setfit modules auto-skipped; install `.[dev,prefilter]` to run them)
- [ ] Install `.[dev,prefilter]` and run `pytest -q -m slow tests/unit/prefilter/test_stage_b_setfit_*.py` to exercise the mocked SetFit tests end-to-end
- [ ] Manual smoke: `denbust prefilter retrain --stage b --model naive_bayes` still works after CLI refactor
- [ ] Manual smoke: `denbust prefilter evaluate --compare-b naive_bayes` on a labelled dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)