### PR TITLE
feat(prefilter): LPF-PR-06 — Stage C embedding similarity scorer

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,37 +6,23 @@
 
 ## Mainline Status
 
-- Last merged PR on main: PRs #140–#159 include: sport1.maariv.co.il domain exclusion (#140),
-  labeling/workbench UX reference docs (#141), Cloudflare Pages manual ingest workbench (#142),
-  review-app HE/EN toggle + bulk exclude + sort order + 3 new discovery keywords + title-noise
-  filter + few-shot examples + source scrape-priority ordering (#143), cross-run backfill query
-  tracking with `executed_queries.jsonl` (#144), agent-plan post-144 update (#145), backfill
-  `max_candidates_per_run` cap enforcement raised 500 → 5000 (#146), noise filter expansion +
-  local pre-classification cascade design and plan docs (#157), LPF-PR-01 prefilter package
-  foundation — models, config, telemetry, no-op cascade, 54 unit tests (#158), LPF-PR-02
-  labeled-candidates dataset assembly with `LabeledCandidate`, `assemble_labels()`,
-  `write_labels_parquet()`, `denbust prefilter assemble-labels` CLI, 57 unit tests (#159),
-  LPF-PR-03 Stage A scorer — `LexiconScorer` with chi-squared weighted terms + default
-  lexicon from `_EXCLUDED_TITLE_TERMS`, `DomainReputationScorer` with Beta-Binomial posterior,
-  `UrlHeuristicScorer`, independence-formula blend, `StageAScorer.evaluate()` returning
-  `StageScore`, `build_stage_a_artifacts()` retrain function, `denbust prefilter retrain
-  --stage a` CLI, and 56 unit tests covering all sub-scorers and the blend (#160),
-  LPF-PR-04 Stage B calibrated ComplementNB — `StageBScorer` loading thin and thick joblib
-  artifacts, `StageBModelMeta` provenance dataclass, `train_naive_bayes()` retrain function,
-  `denbust prefilter retrain --stage b` CLI, scikit-learn/joblib dependencies, and 47 unit
-  tests covering training, inference, calibration, and cascade integration (#161), and
-  LPF-PR-05 Stage B SetFit alternative — `StageBSetFitScorer` + `train_setfit()` using
-  `intfloat/multilingual-e5-large`, A/B evaluation harness via `denbust prefilter evaluate
-  --compare-b naive_bayes,setfit`, `[prefilter]` optional extras group (setfit, sentence-
-  transformers, torch, faiss-cpu, mlx-lm, datasets), mypy overrides for all heavy deps,
-  `slow` pytest marker registration, and 37 unit tests (all mocked, no network access).
-- Next planned PR: `LPF-PR-06` — Stage C embedding similarity using
-  `intfloat/multilingual-e5-large` with centroid-cosine and FAISS-HNSW kNN-max-cosine signals,
-  sigmoid-calibrated on validation pairs, thick pass only by default.
-- Current blockers on main: Anthropic workspace API quota blocks only the ingest/classify step;
-  the backfill-discover and backfill-scrape CI jobs can proceed immediately. Google CSE remains
-  disabled in `github.yaml`; use `agents/news/local_search_brave_exa.yaml` locally when CSE
-  returns `403 PERMISSION_DENIED`.
+- Last merged PR on main: `LPF-PR-06` — Stage C embedding-similarity scorer: `StageCScorer`
+  and `train_stage_c()` using `intfloat/multilingual-e5-large` embeddings with two cosine
+  signals (centroid-cosine against the L2-normalised mean of training positives; FAISS-HNSW
+  kNN-max-cosine via `IndexHNSWFlat`), combined as `max(centroid_cos, knn_max_cos)`, sigmoid-
+  calibrated on the validation split (`LogisticRegression`), thick-pass only, atomic artifact
+  write (`tempfile.mkdtemp` → rename), `StageCModelMeta` frozen dataclass, SHA-1 12-char
+  `model_version`, `denbust prefilter retrain --stage c` CLI wiring, ruff E402 per-file-ignores
+  for Stage C test files, and 38 unit tests (20 training, 18 inference) — all passing with a
+  `FakeSentenceTransformer` MD5-hash stub, no live network access in tests.
+- Next planned PR: `LPF-PR-07` — Stage D local SLM judge via MLX
+  (`dicta-il/dictalm2.0-instruct` default, `Qwen/Qwen2.5-7B-Instruct` fallback), scoring
+  `p("כן")` vs `p("לא")` at the answer token slot, with hard per-candidate timeout,
+  circuit-breaker on consecutive timeouts, and versioned prompt template.
+- Current blockers on main: The 2026 backfill (`BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`) is blocked
+  on Anthropic workspace API usage limits; quota is scheduled to return 2026-06-01 00:00 UTC.
+  Google CSE returns `403 PERMISSION_DENIED` locally; use
+  `agents/news/local_search_brave_exa.yaml` for wet tests.
 
 ## Task Ledger
 
@@ -244,10 +230,11 @@
   an A/B harness in `denbust prefilter evaluate --compare-b naive_bayes,setfit`. Introduces the
   optional `[prefilter]` extras group (`sentence-transformers`, `setfit`, `torch`, `faiss-cpu`,
   `mlx-lm`, `datasets`).
-- [next] `LPF-PR-06`: Stage C — embedding similarity using `multilingual-e5-large` with both
-  centroid-cosine and FAISS-HNSW kNN-max-cosine signals, sigmoid-calibrated on validation pairs.
-  Thick-pass only by default.
-- [later] `LPF-PR-07`: Stage D — local SLM judge via MLX (`dicta-il/dictalm2.0-instruct` default,
+- [done] `LPF-PR-06`: Stage C — `StageCScorer` + `train_stage_c()` using
+  `intfloat/multilingual-e5-large` with centroid-cosine and FAISS-HNSW kNN-max-cosine signals
+  (both on L2-normalised embeddings), combined as `max(centroid_cos, knn_max_cos)`, sigmoid-
+  calibrated on val split, thick-pass only, atomic artifact write, 38 unit tests (all mocked).
+- [next] `LPF-PR-07`: Stage D — local SLM judge via MLX (`dicta-il/dictalm2.0-instruct` default,
   `Qwen/Qwen2.5-7B-Instruct` fallback), scoring `p("כן")` vs `p("לא")` at the answer token slot.
   Includes hard per-candidate timeout, circuit-breaker on consecutive timeouts, and versioned
   prompt template.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ known-first-party = ["denbust"]
 [tool.ruff.lint.per-file-ignores]
 # importorskip must precede application imports; E402 is expected here.
 "tests/unit/prefilter/test_stage_b_setfit_*.py" = ["E402"]
+"tests/unit/prefilter/test_stage_c_*.py" = ["E402"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -119,6 +120,7 @@ module = [
     "joblib.*",
     "kaggle.*",
     "mlx_lm.*",
+    "numpy.*",
     "pyarrow.*",
     "playwright.*",
     "sentence_transformers.*",

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -122,6 +122,10 @@ def retrain_cmd(
         setfit
             SetFit on ``intfloat/multilingual-e5-large``.  Requires the
             ``prefilter`` extras: ``pip install -e '.[dev,prefilter]'``.
+
+    c   Embedding similarity (centroid-cosine + FAISS kNN).  Requires the
+        ``prefilter`` extras: ``pip install -e '.[dev,prefilter]'``.
+        Thick-pass only — returns None on thin-pass candidates.
     """
     if config is None:
         typer.echo(
@@ -132,9 +136,9 @@ def retrain_cmd(
         raise typer.Exit(1)
 
     stage = stage.lower().strip()
-    if stage not in {"a", "b"}:
+    if stage not in {"a", "b", "c"}:
         typer.echo(
-            f"Error: --stage {stage!r} is not supported.  Choose 'a' or 'b'.",
+            f"Error: --stage {stage!r} is not supported.  Choose 'a', 'b', or 'c'.",
             err=True,
         )
         raise typer.Exit(1)
@@ -189,6 +193,21 @@ def retrain_cmd(
         typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
         typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
         typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
+
+    elif stage == "c":
+        from denbust.prefilter.stage_c import _DEFAULT_BASE_MODEL, train_stage_c
+
+        typer.echo(f"Retraining Stage C from {prefilter_paths.labels_path} ...")
+        typer.echo(f"  base model: {_DEFAULT_BASE_MODEL}  (download may take a while)")
+        c_meta, stage_dir = train_stage_c(
+            labels_path=prefilter_paths.labels_path,
+            out_dir=prefilter_paths.models_dir,
+        )
+        typer.echo(f"  centroid.npy      -> {stage_dir / 'centroid.npy'}")
+        typer.echo(f"  index.faiss       -> {stage_dir / 'index.faiss'}")
+        typer.echo(f"  calibration.json  -> {stage_dir / 'calibration.json'}")
+        typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
+        typer.echo(f"Stage C retrain complete.  model_version={c_meta.model_version}")
 
     else:  # setfit
         from denbust.prefilter.stage_b import _DEFAULT_SETFIT_BASE_MODEL, train_setfit

--- a/src/denbust/prefilter/cli.py
+++ b/src/denbust/prefilter/cli.py
@@ -92,7 +92,7 @@ def summary(
 def retrain_cmd(
     stage: Annotated[
         str,
-        typer.Option("--stage", "-s", help="Stage to retrain: a, b"),
+        typer.Option("--stage", "-s", help="Stage to retrain: a, b, or c"),
     ],
     config: Annotated[
         Path | None,
@@ -181,20 +181,35 @@ def retrain_cmd(
         typer.echo(f"  domain_reputation -> {dom_path}")
         typer.echo("Stage A retrain complete.")
 
-    elif model == "naive_bayes":
-        from denbust.prefilter.stage_b import train_naive_bayes
+    elif stage == "b":
+        if model == "naive_bayes":
+            from denbust.prefilter.stage_b import train_naive_bayes
 
-        typer.echo(f"Retraining Stage B (naive_bayes) from {prefilter_paths.labels_path} ...")
-        meta, stage_dir = train_naive_bayes(
-            labels_path=prefilter_paths.labels_path,
-            out_dir=prefilter_paths.models_dir,
-        )
-        typer.echo(f"  thin_model        -> {stage_dir / 'thin_model.joblib'}")
-        typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
-        typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
-        typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
+            typer.echo(f"Retraining Stage B (naive_bayes) from {prefilter_paths.labels_path} ...")
+            meta, stage_dir = train_naive_bayes(
+                labels_path=prefilter_paths.labels_path,
+                out_dir=prefilter_paths.models_dir,
+            )
+            typer.echo(f"  thin_model        -> {stage_dir / 'thin_model.joblib'}")
+            typer.echo(f"  thick_model       -> {stage_dir / 'thick_model.joblib'}")
+            typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
+            typer.echo(f"Stage B retrain complete.  model_version={meta.model_version}")
 
-    elif stage == "c":
+        else:  # setfit
+            from denbust.prefilter.stage_b import _DEFAULT_SETFIT_BASE_MODEL, train_setfit
+
+            typer.echo(f"Retraining Stage B (setfit) from {prefilter_paths.labels_path} ...")
+            typer.echo(f"  base model: {_DEFAULT_SETFIT_BASE_MODEL}  (download may take a while)")
+            meta, stage_dir = train_setfit(
+                labels_path=prefilter_paths.labels_path,
+                out_dir=prefilter_paths.models_dir,
+            )
+            typer.echo(f"  thin_model/       -> {stage_dir / 'thin_model'}")
+            typer.echo(f"  thick_model/      -> {stage_dir / 'thick_model'}")
+            typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
+            typer.echo(f"Stage B SetFit retrain complete.  model_version={meta.model_version}")
+
+    else:  # stage == "c"
         from denbust.prefilter.stage_c import _DEFAULT_BASE_MODEL, train_stage_c
 
         typer.echo(f"Retraining Stage C from {prefilter_paths.labels_path} ...")
@@ -208,20 +223,6 @@ def retrain_cmd(
         typer.echo(f"  calibration.json  -> {stage_dir / 'calibration.json'}")
         typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
         typer.echo(f"Stage C retrain complete.  model_version={c_meta.model_version}")
-
-    else:  # setfit
-        from denbust.prefilter.stage_b import _DEFAULT_SETFIT_BASE_MODEL, train_setfit
-
-        typer.echo(f"Retraining Stage B (setfit) from {prefilter_paths.labels_path} ...")
-        typer.echo(f"  base model: {_DEFAULT_SETFIT_BASE_MODEL}  (download may take a while)")
-        meta, stage_dir = train_setfit(
-            labels_path=prefilter_paths.labels_path,
-            out_dir=prefilter_paths.models_dir,
-        )
-        typer.echo(f"  thin_model/       -> {stage_dir / 'thin_model'}")
-        typer.echo(f"  thick_model/      -> {stage_dir / 'thick_model'}")
-        typer.echo(f"  meta.json         -> {stage_dir / 'meta.json'}")
-        typer.echo(f"Stage B SetFit retrain complete.  model_version={meta.model_version}")
 
 
 @prefilter_app.command("evaluate")
@@ -256,19 +257,26 @@ def evaluate_cmd(
         typer.Option("--report-path", "-r", help="Write a markdown report to this path."),
     ] = None,
 ) -> None:
-    """Evaluate Stage B model variants on a labeled split.
+    """Evaluate prefilter stage models on a labeled split.
 
-    Loads each model from the configured models directory, scores every
-    candidate in the chosen split using the thin pass (title + snippet), and
-    prints precision / recall / Brier score for each at the threshold that
-    achieves ``--recall-floor`` on that same split.  Unscored candidates
-    (scorer returned ``None``) are excluded from metric calculations.
+    Stage B (thin pass, title + snippet): loads each model kind listed in
+    ``--compare-b`` and prints precision / recall / Brier score at the
+    threshold that achieves ``--recall-floor``.
+
+    Stage C (thick pass, title + body/snippet): evaluated automatically when
+    trained artifacts exist under the configured models directory.  Uses the
+    ``article_body`` field from the labeled dataset as the thick-pass body,
+    falling back to ``snippet`` when absent.
+
+    Unscored candidates (scorer returned ``None``) are excluded from metric
+    calculations but are treated as pass-through in the drop-rate denominator.
 
     Models must be trained before running this command:
 
     \\b
         denbust prefilter retrain --stage b --model naive_bayes --config CFG
         denbust prefilter retrain --stage b --model setfit --config CFG
+        denbust prefilter retrain --stage c --config CFG
         denbust prefilter evaluate --compare-b naive_bayes,setfit --config CFG
     """
     if config is None:
@@ -396,8 +404,67 @@ def evaluate_cmd(
         )
         typer.echo("")
 
-    if report_path is not None and results:
-        _write_evaluate_report(report_path, split, recall_floor, n_pos, n_neg, results)
+    # Stage C evaluation (thick pass) — automatic when artifacts exist.
+    stage_c_result: dict[str, Any] | None = None
+    from denbust.prefilter.stage_c import _CENTROID_FILE, _STAGE_C_SUBDIR, StageCScorer
+
+    stage_c_dir = prefilter_paths.models_dir / _STAGE_C_SUBDIR
+    if (stage_c_dir / _CENTROID_FILE).exists():
+        scorer_c = StageCScorer(models_dir=prefilter_paths.models_dir)
+        scored_p_c: list[float] = []
+        scored_y_c: list[int] = []
+        n_skipped_c = 0
+        for row, y in zip(eval_rows, y_true):
+            score_c = scorer_c.evaluate(row, "thick", body=row.article_body)
+            if score_c is None:
+                n_skipped_c += 1
+            else:
+                scored_p_c.append(score_c.p_negative)
+                scored_y_c.append(y)
+
+        if scored_p_c:
+            metrics_c = _compute_stage_b_metrics(
+                scored_p=scored_p_c,
+                scored_y=scored_y_c,
+                n_pos_total=n_pos,
+                n_total=len(y_true),
+                recall_floor=recall_floor,
+            )
+            version_c = scorer_c.model_version or "(unknown)"
+            typer.echo(f"  stage_c (thick)  [version: {version_c}]")
+            typer.echo(f"    threshold      : {metrics_c['threshold']:.4f}")
+            typer.echo(
+                f"    recall         : {metrics_c['recall']:.4f}  (target ≥ {recall_floor:.4f})"
+            )
+            typer.echo(
+                f"    drop_precision : {metrics_c['drop_precision']:.4f}"
+                f"  (true_neg / total_dropped)"
+            )
+            typer.echo(f"    drop_rate      : {metrics_c['drop_rate']:.4f}")
+            typer.echo(f"    brier_score    : {metrics_c['brier_score']:.4f}")
+            if n_skipped_c:
+                typer.echo(
+                    f"    no-score rows  : {n_skipped_c} (excluded from metrics; "
+                    "treated as pass-through in production)"
+                )
+            typer.echo("")
+            stage_c_result = {"kind": "stage_c", "version": version_c, **metrics_c}
+        else:
+            typer.echo(
+                "  stage_c: scorer returned None for all candidates "
+                "(prefilter extras missing or artifacts corrupt) — skipping.\n"
+            )
+
+    if report_path is not None and (results or stage_c_result):
+        _write_evaluate_report(
+            report_path,
+            split,
+            recall_floor,
+            n_pos,
+            n_neg,
+            results,
+            stage_c_result=stage_c_result,
+        )
         typer.echo(f"Report written to {report_path}")
 
 
@@ -626,24 +693,44 @@ def _write_evaluate_report(
     n_pos: int,
     n_neg: int,
     results: list[dict[str, Any]],
+    stage_c_result: dict[str, Any] | None = None,
 ) -> None:
-    """Write a markdown A/B evaluation report to *path*."""
+    """Write a markdown prefilter evaluation report to *path*."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = [
-        "# Stage B A/B Evaluation Report",
+        "# Prefilter Evaluation Report",
         "",
         f"**Split:** {split}  |  **Recall floor:** {recall_floor:.1%}  "
         f"|  **Rows:** {n_pos + n_neg} (pos={n_pos}, neg={n_neg})",
         "",
-        "| Model | Version | Threshold | Recall | Drop Precision | Drop Rate | Brier |",
-        "|-------|---------|-----------|--------|----------------|-----------|-------|",
     ]
-    for r in results:
-        lines.append(
-            f"| {r['kind']} | {r['version']} "
+    if results:
+        lines += [
+            "## Stage B (thin pass)",
+            "",
+            "| Model | Version | Threshold | Recall | Drop Precision | Drop Rate | Brier |",
+            "|-------|---------|-----------|--------|----------------|-----------|-------|",
+        ]
+        for r in results:
+            lines.append(
+                f"| {r['kind']} | {r['version']} "
+                f"| {r['threshold']:.4f} | {r['recall']:.4f} "
+                f"| {r['drop_precision']:.4f} | {r['drop_rate']:.4f} "
+                f"| {r['brier_score']:.4f} |"
+            )
+        lines.append("")
+    if stage_c_result:
+        r = stage_c_result
+        lines += [
+            "## Stage C (thick pass)",
+            "",
+            "| Version | Threshold | Recall | Drop Precision | Drop Rate | Brier |",
+            "|---------|-----------|--------|----------------|-----------|-------|",
+            f"| {r['version']} "
             f"| {r['threshold']:.4f} | {r['recall']:.4f} "
             f"| {r['drop_precision']:.4f} | {r['drop_rate']:.4f} "
-            f"| {r['brier_score']:.4f} |"
-        )
-    lines += ["", ""]
+            f"| {r['brier_score']:.4f} |",
+            "",
+        ]
+    lines.append("")
     path.write_text("\n".join(lines), encoding="utf-8")

--- a/src/denbust/prefilter/stage_c.py
+++ b/src/denbust/prefilter/stage_c.py
@@ -1,7 +1,7 @@
 """Stage C — multilingual embedding centroid + FAISS kNN similarity.
 
 :class:`StageCScorer`
-    Centroid-cosine + FAISS-HNSW kNN-max-cosine similarity scorer,
+    Centroid-cosine + FAISS-HNSW kNN-mean-cosine similarity scorer,
     sigmoid-calibrated on the validation split.
     Artifacts: ``models_dir/stage_c/{centroid.npy, index.faiss,
     calibration.json, meta.json}``.  Requires the ``prefilter`` extras
@@ -27,13 +27,24 @@ signals against the *positive* training set:
 centroid_cos
     Cosine similarity between the candidate embedding and the L2-normalised
     mean embedding of all training positives.
-knn_max_cos
-    Maximum cosine similarity over the *n_neighbors* nearest training
-    positives found via the FAISS HNSW index.
+knn_mean_cos
+    Mean cosine similarity over the *n_neighbors* nearest training positives
+    found via the FAISS HNSW index.  Larger values of *n_neighbors* smooth the
+    signal over a broader neighbourhood; the parameter has a real effect on the
+    output because the mean is taken over all *k* retrieved results, not just
+    the closest one.
 
-The combined raw signal is ``raw = max(centroid_cos, knn_max_cos)``.  A
+The combined raw signal is ``raw = max(centroid_cos, knn_mean_cos)``.  A
 logistic-regression sigmoid calibration maps *raw* to ``p_positive``; the
 final ``p_negative = 1 − p_positive``.
+
+Text format
+-----------
+``intfloat/multilingual-e5-large`` requires a ``"passage: "`` prefix for
+document embeddings (see the model card).  :func:`_build_text` applies this
+prefix to *all* inputs — both at training time and at inference time — so the
+embedding space is consistent across the two phases.  Changing this function
+changes both training and inference; there is no separate logic to drift.
 """
 
 from __future__ import annotations
@@ -43,6 +54,7 @@ import hashlib
 import json
 import logging
 import math
+import os
 import shutil
 import tempfile
 import warnings
@@ -67,6 +79,13 @@ _META_FILE = "meta.json"
 _DEFAULT_BASE_MODEL = "intfloat/multilingual-e5-large"
 _DEFAULT_N_NEIGHBORS = 5
 _HNSW_M = 32  # connections per HNSW layer; 32 is a solid default for recall
+_HNSW_EF_CONSTRUCTION = 200  # higher → better index quality at build time
+_HNSW_EF_SEARCH = 64  # fixed search budget — must NOT scale with corpus size or
+# HNSW degrades to O(n) traversal, defeating its purpose
+
+# intfloat/multilingual-e5-large requires this prefix for document embeddings.
+# See: https://huggingface.co/intfloat/multilingual-e5-large
+_E5_PASSAGE_PREFIX = "passage: "
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +100,8 @@ class StageCModelMeta:
     Attributes
     ----------
     model_version:
-        Short (12-char) SHA-1 prefix derived from the centroid artifact.
+        Short (12-char) SHA-1 prefix derived from the centroid, FAISS index,
+        and calibration artifacts combined — changes whenever any artifact does.
     trained_at:
         ISO-8601 UTC timestamp of when the artifacts were written.
     n_train_positives:
@@ -91,7 +111,7 @@ class StageCModelMeta:
     base_model_id:
         HuggingFace model ID used for encoding.
     n_neighbors:
-        Number of HNSW neighbours queried for the kNN-max-cosine signal.
+        Number of HNSW neighbours queried for the kNN-mean-cosine signal.
     """
 
     model_version: str
@@ -125,19 +145,36 @@ def _l2_normalize(v: Any) -> Any:
     return v / norm
 
 
-def _thick_text(candidate: CandidateView, body: str | None) -> str:
-    """Assemble the thick-pass input text for *candidate*."""
-    title = candidate.title or ""
-    if body and body.strip():
-        return (title + " " + body.strip()).strip()
-    snippet = candidate.snippet or ""
-    return (title + " " + snippet).strip()
+def _build_text(title: str | None, body_or_snippet: str | None) -> str:
+    """Assemble the E5-format passage text for a candidate.
+
+    This is the **single source of truth** for text assembly — called by both
+    :func:`train_stage_c` (for training positives and validation rows) and
+    :meth:`StageCScorer.evaluate` (for inference), guaranteeing train/serve
+    consistency.
+
+    ``intfloat/multilingual-e5-large`` requires a ``"passage: "`` prefix for
+    all document embeddings; omitting it measurably degrades retrieval quality.
+    Both *title* and *body_or_snippet* are stripped independently before
+    concatenation so leading/trailing whitespace never leaks into the input.
+    Falls back to title-only when *body_or_snippet* is absent or blank.
+    """
+    t = (title or "").strip()
+    b = (body_or_snippet or "").strip()
+    core = f"{t} {b}".strip() if b else t
+    return f"{_E5_PASSAGE_PREFIX}{core}"
 
 
-def _sha1_file(path: Path) -> str:
-    """Return the first 12 hex chars of the SHA-1 of *path*."""
+def _sha1_files(*paths: Path) -> str:
+    """Return the first 12 hex chars of SHA-1 over the concatenated bytes of *paths*.
+
+    Feed paths in a fixed caller-chosen order so the hash is deterministic.
+    Hashing multiple artifacts together means the version changes when *any*
+    of them changes — not just the first one.
+    """
     h = hashlib.sha1(usedforsecurity=False)  # noqa: S324
-    h.update(path.read_bytes())
+    for path in paths:
+        h.update(path.read_bytes())
     return h.hexdigest()[:12]
 
 
@@ -166,18 +203,22 @@ def _build_hnsw_index(embeddings: Any) -> Any:
         L2-normalised.  L2 distance on normalised vectors is equivalent to
         cosine distance, so the nearest neighbour by L2 is the nearest
         neighbour by cosine similarity.
+
+    Notes
+    -----
+    ``efSearch`` is set to :data:`_HNSW_EF_SEARCH` (64), a fixed constant.
+    Setting it to ``n`` (the corpus size) would force HNSW to explore every
+    node at query time — O(n) cost — making it worse than brute-force search.
     """
     import faiss
     import numpy as np
 
     arr: Any = np.ascontiguousarray(embeddings, dtype=np.float32)
-    n, dim = arr.shape
+    _n, dim = arr.shape
     index = faiss.IndexHNSWFlat(dim, _HNSW_M)
-    # Higher efConstruction → better recall at index time; 200 is a safe default.
-    index.hnsw.efConstruction = 200
+    index.hnsw.efConstruction = _HNSW_EF_CONSTRUCTION
     index.add(arr)
-    # Bump efSearch for query accuracy (can be overridden by callers).
-    index.hnsw.efSearch = max(64, n)
+    index.hnsw.efSearch = _HNSW_EF_SEARCH
     return index
 
 
@@ -187,7 +228,7 @@ def _compute_similarity(
     index: Any,
     n_neighbors: int,
 ) -> tuple[float, float]:
-    """Return ``(centroid_cos, knn_max_cos)`` for *query*.
+    """Return ``(centroid_cos, knn_mean_cos)`` for *query*.
 
     Parameters
     ----------
@@ -198,7 +239,16 @@ def _compute_similarity(
     index:
         Populated FAISS HNSW index (L2 metric, normalised vectors).
     n_neighbors:
-        Number of neighbours to retrieve.
+        Number of neighbours to retrieve.  The *mean* cosine over all *k*
+        retrieved neighbours is returned as ``knn_mean_cos``, so this parameter
+        has a genuine effect on the signal: larger values average over a
+        broader neighbourhood rather than just the single closest point.
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(centroid_cos, knn_mean_cos)`` both clipped to ``[−1, 1]``.
+        ``knn_mean_cos`` is ``−1.0`` when the index is empty.
     """
     import numpy as np
 
@@ -212,11 +262,12 @@ def _compute_similarity(
     q2d: Any = query.reshape(1, -1).astype(np.float32)
     dists, _ = index.search(q2d, k)
     # FAISS returns squared L2 for normalised vectors: d² = 2(1 − cos)
-    # → cos = 1 − d²/2.
-    min_dist_sq = float(dists[0, 0])
-    knn_max_cos = max(-1.0, min(1.0, 1.0 - min_dist_sq / 2.0))
+    # → cos = 1 − d²/2.  Take the mean over all k retrieved neighbours so
+    # that n_neighbors controls the signal rather than being a no-op.
+    cosines: Any = np.clip(1.0 - dists[0] / 2.0, -1.0, 1.0)
+    knn_mean_cos = float(cosines.mean())
 
-    return centroid_cos, knn_max_cos
+    return centroid_cos, knn_mean_cos
 
 
 def _fit_calibration(
@@ -256,7 +307,7 @@ def _fit_calibration(
 
 
 class StageCScorer:
-    """Stage C cascade scorer: embedding centroid + kNN similarity.
+    """Stage C cascade scorer: embedding centroid + kNN mean similarity.
 
     Returns ``None`` for the thin pass (this stage is thick-pass only), and
     when no trained artifacts exist or the ``prefilter`` extras are missing.
@@ -271,7 +322,7 @@ class StageCScorer:
         Drop threshold.  Candidates whose ``p_negative >= threshold`` are
         tagged ``dropped=True``.
     n_neighbors:
-        Number of HNSW neighbours used for the kNN-max-cosine signal.
+        Number of HNSW neighbours used for the kNN-mean-cosine signal.
         When ``None`` the value from ``meta.json`` is used; falls back to
         :data:`_DEFAULT_N_NEIGHBORS`.
     """
@@ -344,8 +395,11 @@ class StageCScorer:
             self._embed_model = SentenceTransformer(model_id)
 
         except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Stage C: failed to load artifacts from %s: %s",
+            # Artifacts are present but corrupt or incompatible — log at ERROR
+            # so operators can distinguish this from a "not yet trained" state.
+            logger.error(
+                "Stage C: artifacts at %s are present but failed to load: %s — "
+                "run `denbust prefilter retrain --stage c` to rebuild.",
                 stage_dir,
                 exc,
             )
@@ -387,20 +441,20 @@ class StageCScorer:
 
         import numpy as np
 
-        text = _thick_text(candidate, body)
+        text = _build_text(candidate.title, body or candidate.snippet)
         emb_batch: Any = _embed_texts(self._embed_model, [text])
         query: Any = emb_batch[0]  # shape (dim,)
 
-        centroid_cos, knn_max_cos = _compute_similarity(
+        centroid_cos, knn_mean_cos = _compute_similarity(
             query, self._centroid, self._index, self._n_neighbors
         )
-        raw_score = max(centroid_cos, knn_max_cos)
+        raw_score = max(centroid_cos, knn_mean_cos)
 
         p_positive = _sigmoid(self._calib_coef * raw_score + self._calib_intercept)
         p_negative = float(np.clip(1.0 - p_positive, 0.0, 1.0))
 
         dropped = p_negative >= self._threshold
-        reason = f"embed/thick=centroid:{centroid_cos:.3f},knn:{knn_max_cos:.3f}"
+        reason = f"embed/thick=centroid:{centroid_cos:.3f},knn_mean:{knn_mean_cos:.3f}"
         return StageScore(
             stage="C",
             p_negative=p_negative,
@@ -430,7 +484,7 @@ def train_stage_c(
     1. Embeds training positives with :class:`sentence_transformers.SentenceTransformer`.
     2. Computes the L2-normalised centroid of positive embeddings.
     3. Builds a FAISS HNSW index over the positive embeddings.
-    4. Scores every validation row (centroid-cosine + kNN-max-cosine).
+    4. Scores every validation row (centroid-cosine + kNN-mean-cosine).
     5. Fits a sigmoid calibration (logistic regression) on the validation scores.
     6. Writes all artifacts atomically under ``out_dir/stage_c/``.
 
@@ -454,7 +508,7 @@ def train_stage_c(
     base_model_id:
         HuggingFace model ID for the sentence encoder.
     n_neighbors:
-        Number of HNSW neighbours for the kNN-max-cosine signal.
+        Number of HNSW neighbours for the kNN-mean-cosine signal.
 
     Returns
     -------
@@ -470,9 +524,11 @@ def train_stage_c(
     ValueError
         When the training split contains no positive examples.
     """
+    # Single import block: guard + acquire the names used throughout.
     try:
-        import faiss  # noqa: F401
-        from sentence_transformers import SentenceTransformer  # noqa: F401
+        import faiss
+        import numpy as np
+        from sentence_transformers import SentenceTransformer
     except ImportError as exc:
         raise ImportError(
             "Stage C training requires the prefilter extras. "
@@ -493,11 +549,9 @@ def train_stage_c(
             "centroid and FAISS index."
         )
 
-    import numpy as np
-    from sentence_transformers import SentenceTransformer
-
-    # Build thick-pass text for each training positive.
-    pos_texts = [(r.title + " " + (r.article_body or r.snippet)).strip() for r in train_positives]
+    # Build E5-format passage texts via _build_text — the same function used
+    # at inference time, so training and serving share identical text assembly.
+    pos_texts = [_build_text(r.title, r.article_body or r.snippet) for r in train_positives]
     model = SentenceTransformer(base_model_id)
     pos_embeddings = _embed_texts(model, pos_texts)  # shape (n_pos, dim)
 
@@ -513,7 +567,7 @@ def train_stage_c(
     val_labels: list[int] = []
 
     if val_rows:
-        val_texts = [(r.title + " " + (r.article_body or r.snippet)).strip() for r in val_rows]
+        val_texts = [_build_text(r.title, r.article_body or r.snippet) for r in val_rows]
         val_embeddings = _embed_texts(model, val_texts)
 
         for i, row in enumerate(val_rows):
@@ -528,14 +582,13 @@ def train_stage_c(
     out_dir.mkdir(parents=True, exist_ok=True)
     final_dir = out_dir / _STAGE_C_SUBDIR
 
+    old_dir: Path | None = None
     tmp_dir = Path(tempfile.mkdtemp(dir=out_dir, prefix=f"{_STAGE_C_SUBDIR}.tmp."))
     try:
         centroid_path = tmp_dir / _CENTROID_FILE
         index_path = tmp_dir / _INDEX_FILE
         calib_path = tmp_dir / _CALIBRATION_FILE
         meta_path = tmp_dir / _META_FILE
-
-        import faiss
 
         np.save(str(centroid_path), centroid)
         faiss.write_index(index, str(index_path))
@@ -548,7 +601,9 @@ def train_stage_c(
             encoding="utf-8",
         )
 
-        model_version = _sha1_file(centroid_path)
+        # Hash all three artifacts so model_version changes when any of them
+        # does — not just the centroid.
+        model_version = _sha1_files(centroid_path, index_path, calib_path)
 
         meta = StageCModelMeta(
             model_version=model_version,
@@ -563,13 +618,27 @@ def train_stage_c(
             encoding="utf-8",
         )
 
-        # Replace old artifact dir atomically.
+        # Replace old artifact dir using rename-aside so readers never see a
+        # missing directory.  Both rename() calls are atomic at the filesystem
+        # level; the old content is accessible in old_dir until cleanup below.
         if final_dir.exists():
-            shutil.rmtree(final_dir)
+            old_dir = out_dir / f"{_STAGE_C_SUBDIR}.old.{os.getpid()}"
+            final_dir.rename(old_dir)
         tmp_dir.rename(final_dir)
 
     except Exception:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+        # Restore the displaced old artifacts so the scorer stays usable.
+        if old_dir is not None and not final_dir.exists():
+            try:
+                old_dir.rename(final_dir)
+                old_dir = None
+            except OSError:
+                pass
         raise
+
+    # Clean up the displaced old artifacts on success.
+    if old_dir is not None:
+        shutil.rmtree(old_dir, ignore_errors=True)
 
     return meta, final_dir

--- a/src/denbust/prefilter/stage_c.py
+++ b/src/denbust/prefilter/stage_c.py
@@ -1,26 +1,575 @@
 """Stage C — multilingual embedding centroid + FAISS kNN similarity.
 
-LPF-PR-01 stub: ``evaluate`` always returns ``None`` (stage skipped).
-Full implementation lands in LPF-PR-06.
+:class:`StageCScorer`
+    Centroid-cosine + FAISS-HNSW kNN-max-cosine similarity scorer,
+    sigmoid-calibrated on the validation split.
+    Artifacts: ``models_dir/stage_c/{centroid.npy, index.faiss,
+    calibration.json, meta.json}``.  Requires the ``prefilter`` extras
+    (``pip install -e '.[dev,prefilter]'``).
+
+    **Thick-pass only**: :meth:`~StageCScorer.evaluate` returns ``None``
+    when *pass_kind* is ``"thin"`` so Stage C is silently skipped during the
+    pre-scrape cascade pass.
+
+Training entry point
+--------------------
+:func:`train_stage_c`
+    Embeds training positives using
+    :class:`sentence_transformers.SentenceTransformer`, builds a centroid
+    vector and a FAISS HNSW index, fits sigmoid calibration on the validation
+    split, then writes artifacts atomically.
+
+Scoring
+-------
+For each thick-pass candidate the scorer computes two cosine-similarity
+signals against the *positive* training set:
+
+centroid_cos
+    Cosine similarity between the candidate embedding and the L2-normalised
+    mean embedding of all training positives.
+knn_max_cos
+    Maximum cosine similarity over the *n_neighbors* nearest training
+    positives found via the FAISS HNSW index.
+
+The combined raw signal is ``raw = max(centroid_cos, knn_max_cos)``.  A
+logistic-regression sigmoid calibration maps *raw* to ``p_positive``; the
+final ``p_negative = 1 − p_positive``.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import hashlib
+import json
+import logging
+import math
+import shutil
+import tempfile
+import warnings
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
 from denbust.prefilter.models import CandidateView, PassKind, StageScore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Artifact path constants
+# ---------------------------------------------------------------------------
+
+_STAGE_C_SUBDIR = "stage_c"
+_CENTROID_FILE = "centroid.npy"
+_INDEX_FILE = "index.faiss"
+_CALIBRATION_FILE = "calibration.json"
+_META_FILE = "meta.json"
+
+_DEFAULT_BASE_MODEL = "intfloat/multilingual-e5-large"
+_DEFAULT_N_NEIGHBORS = 5
+_HNSW_M = 32  # connections per HNSW layer; 32 is a solid default for recall
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class StageCModelMeta:
+    """Provenance metadata for trained Stage C artifacts.
+
+    Attributes
+    ----------
+    model_version:
+        Short (12-char) SHA-1 prefix derived from the centroid artifact.
+    trained_at:
+        ISO-8601 UTC timestamp of when the artifacts were written.
+    n_train_positives:
+        Number of positive training examples used to build the index.
+    n_val:
+        Total validation rows available at training time.
+    base_model_id:
+        HuggingFace model ID used for encoding.
+    n_neighbors:
+        Number of HNSW neighbours queried for the kNN-max-cosine signal.
+    """
+
+    model_version: str
+    trained_at: str
+    n_train_positives: int
+    n_val: int
+    base_model_id: str
+    n_neighbors: int
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically-stable sigmoid."""
+    if x >= 0.0:
+        return 1.0 / (1.0 + math.exp(-x))
+    ex = math.exp(x)
+    return ex / (1.0 + ex)
+
+
+def _l2_normalize(v: Any) -> Any:
+    """Return an L2-normalised copy of 1-D array *v* (numpy)."""
+    import numpy as np
+
+    norm = float(np.linalg.norm(v))
+    if norm < 1e-9:
+        return v.copy()
+    return v / norm
+
+
+def _thick_text(candidate: CandidateView, body: str | None) -> str:
+    """Assemble the thick-pass input text for *candidate*."""
+    title = candidate.title or ""
+    if body and body.strip():
+        return (title + " " + body.strip()).strip()
+    snippet = candidate.snippet or ""
+    return (title + " " + snippet).strip()
+
+
+def _sha1_file(path: Path) -> str:
+    """Return the first 12 hex chars of the SHA-1 of *path*."""
+    h = hashlib.sha1(usedforsecurity=False)  # noqa: S324
+    h.update(path.read_bytes())
+    return h.hexdigest()[:12]
+
+
+def _embed_texts(
+    model: Any,
+    texts: list[str],
+) -> Any:
+    """Encode *texts* with *model*, returning L2-normalised float32 embeddings."""
+    import numpy as np
+
+    emb: Any = model.encode(
+        texts,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    )
+    return emb.astype(np.float32)
+
+
+def _build_hnsw_index(embeddings: Any) -> Any:
+    """Build a FAISS HNSW index from L2-normalised *embeddings*.
+
+    Parameters
+    ----------
+    embeddings:
+        Float32 numpy array of shape ``(n, dim)`` — must already be
+        L2-normalised.  L2 distance on normalised vectors is equivalent to
+        cosine distance, so the nearest neighbour by L2 is the nearest
+        neighbour by cosine similarity.
+    """
+    import faiss
+    import numpy as np
+
+    arr: Any = np.ascontiguousarray(embeddings, dtype=np.float32)
+    n, dim = arr.shape
+    index = faiss.IndexHNSWFlat(dim, _HNSW_M)
+    # Higher efConstruction → better recall at index time; 200 is a safe default.
+    index.hnsw.efConstruction = 200
+    index.add(arr)
+    # Bump efSearch for query accuracy (can be overridden by callers).
+    index.hnsw.efSearch = max(64, n)
+    return index
+
+
+def _compute_similarity(
+    query: Any,
+    centroid: Any,
+    index: Any,
+    n_neighbors: int,
+) -> tuple[float, float]:
+    """Return ``(centroid_cos, knn_max_cos)`` for *query*.
+
+    Parameters
+    ----------
+    query:
+        L2-normalised float32 embedding of shape ``(dim,)``.
+    centroid:
+        L2-normalised centroid embedding of shape ``(dim,)``.
+    index:
+        Populated FAISS HNSW index (L2 metric, normalised vectors).
+    n_neighbors:
+        Number of neighbours to retrieve.
+    """
+    import numpy as np
+
+    centroid_cos = float(np.dot(query, centroid))
+    centroid_cos = max(-1.0, min(1.0, centroid_cos))
+
+    k = min(n_neighbors, index.ntotal)
+    if k == 0:
+        return centroid_cos, -1.0
+
+    q2d: Any = query.reshape(1, -1).astype(np.float32)
+    dists, _ = index.search(q2d, k)
+    # FAISS returns squared L2 for normalised vectors: d² = 2(1 − cos)
+    # → cos = 1 − d²/2.
+    min_dist_sq = float(dists[0, 0])
+    knn_max_cos = max(-1.0, min(1.0, 1.0 - min_dist_sq / 2.0))
+
+    return centroid_cos, knn_max_cos
+
+
+def _fit_calibration(
+    raw_scores: list[float],
+    labels: list[int],
+) -> tuple[float, float]:
+    """Fit logistic-regression sigmoid calibration.
+
+    Returns ``(coef, intercept)`` for ``p_positive = sigmoid(coef*s + b)``.
+    Falls back to ``(1.0, 0.0)`` when calibration is not possible (empty
+    data or single class in labels).
+    """
+    if not raw_scores or len(set(labels)) < 2:
+        if raw_scores and len(set(labels)) < 2:
+            warnings.warn(
+                "Stage C calibration: validation split has fewer than 2 label "
+                "classes; using uncalibrated sigmoid (coef=1.0, intercept=0.0). "
+                "Add more labeled data and retrain to improve calibration.",
+                UserWarning,
+                stacklevel=3,
+            )
+        return 1.0, 0.0
+
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+
+    X: Any = np.array(raw_scores, dtype=np.float64).reshape(-1, 1)
+    y: Any = np.array(labels, dtype=np.int32)
+    lr = LogisticRegression(C=1.0, max_iter=1000, solver="lbfgs")
+    lr.fit(X, y)
+    return float(lr.coef_[0, 0]), float(lr.intercept_[0])
+
+
+# ---------------------------------------------------------------------------
+# StageCScorer
+# ---------------------------------------------------------------------------
 
 
 class StageCScorer:
-    """Stub scorer for Stage C.
+    """Stage C cascade scorer: embedding centroid + kNN similarity.
 
-    Returns ``None`` for every candidate so the cascade always passes
-    through this stage.  Replace with the real implementation in LPF-PR-06.
+    Returns ``None`` for the thin pass (this stage is thick-pass only), and
+    when no trained artifacts exist or the ``prefilter`` extras are missing.
+
+    Parameters
+    ----------
+    models_dir:
+        Root models directory (``PrefilterStatePaths.models_dir``).
+        Artifacts expected under ``models_dir/stage_c/``.  When ``None`` or
+        artifacts are absent the scorer returns ``None`` for every call.
+    threshold:
+        Drop threshold.  Candidates whose ``p_negative >= threshold`` are
+        tagged ``dropped=True``.
+    n_neighbors:
+        Number of HNSW neighbours used for the kNN-max-cosine signal.
+        When ``None`` the value from ``meta.json`` is used; falls back to
+        :data:`_DEFAULT_N_NEIGHBORS`.
     """
+
+    def __init__(
+        self,
+        *,
+        models_dir: Path | None = None,
+        threshold: float = 0.90,
+        n_neighbors: int | None = None,
+    ) -> None:
+        self._threshold = threshold
+        self._n_neighbors: int = n_neighbors if n_neighbors is not None else _DEFAULT_N_NEIGHBORS
+        self._centroid: Any = None  # np.ndarray, L2-normalised, shape (dim,)
+        self._index: Any = None  # faiss.IndexHNSWFlat
+        self._calib_coef: float = 1.0
+        self._calib_intercept: float = 0.0
+        self._embed_model: Any = None  # sentence_transformers.SentenceTransformer
+        self.model_version: str = ""
+        self.base_model_id: str = ""
+
+        if models_dir is None:
+            return
+
+        stage_dir = models_dir / _STAGE_C_SUBDIR
+        centroid_path = stage_dir / _CENTROID_FILE
+        index_path = stage_dir / _INDEX_FILE
+        calib_path = stage_dir / _CALIBRATION_FILE
+        meta_path = stage_dir / _META_FILE
+
+        if not (centroid_path.exists() and index_path.exists() and calib_path.exists()):
+            return
+
+        try:
+            import faiss
+            import numpy as np
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            logger.warning(
+                "Stage C: required package missing (%s); install the prefilter extras "
+                "(pip install -e '.[dev,prefilter]'). "
+                "Scorer will return None for all candidates.",
+                exc,
+            )
+            return
+
+        try:
+            self._centroid = np.load(str(centroid_path))
+            self._index = faiss.read_index(str(index_path))
+
+            calib_raw = json.loads(calib_path.read_text(encoding="utf-8"))
+            self._calib_coef = float(calib_raw["coef"])
+            self._calib_intercept = float(calib_raw["intercept"])
+
+            if meta_path.exists():
+                meta_raw = json.loads(meta_path.read_text(encoding="utf-8"))
+                self.model_version = str(meta_raw.get("model_version", ""))
+                self.base_model_id = str(meta_raw.get("base_model_id", _DEFAULT_BASE_MODEL))
+                if n_neighbors is None:
+                    self._n_neighbors = int(meta_raw.get("n_neighbors", _DEFAULT_N_NEIGHBORS))
+            else:
+                self.base_model_id = _DEFAULT_BASE_MODEL
+                logger.warning(
+                    "Stage C: meta.json missing from %s; model_version will be empty "
+                    "in telemetry.  Re-run `denbust prefilter retrain --stage c` to fix.",
+                    stage_dir,
+                )
+
+            model_id = self.base_model_id or _DEFAULT_BASE_MODEL
+            self._embed_model = SentenceTransformer(model_id)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Stage C: failed to load artifacts from %s: %s",
+                stage_dir,
+                exc,
+            )
+            self._centroid = None
+            self._index = None
+            self._embed_model = None
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
 
     def evaluate(
         self,
-        _candidate: CandidateView,
-        _pass_kind: PassKind,
-        _body: str | None = None,
+        candidate: CandidateView,
+        pass_kind: PassKind,
+        body: str | None = None,
     ) -> StageScore | None:
-        """Return ``None`` — stage is not yet implemented."""
-        return None
+        """Evaluate *candidate* and return a :class:`StageScore`, or ``None``.
+
+        Always returns ``None`` for the thin pass (Stage C is thick-pass only).
+        Returns ``None`` when no trained artifacts are loaded.
+
+        Parameters
+        ----------
+        candidate:
+            Candidate to evaluate.
+        pass_kind:
+            ``"thin"`` → returns ``None`` unconditionally.
+            ``"thick"`` → scores the candidate using body+title (or
+            title+snippet when *body* is absent).
+        body:
+            Full article body text; only meaningful for the thick pass.
+        """
+        if pass_kind == "thin":
+            return None  # Stage C is thick-pass only
+
+        if self._centroid is None or self._index is None or self._embed_model is None:
+            return None
+
+        import numpy as np
+
+        text = _thick_text(candidate, body)
+        emb_batch: Any = _embed_texts(self._embed_model, [text])
+        query: Any = emb_batch[0]  # shape (dim,)
+
+        centroid_cos, knn_max_cos = _compute_similarity(
+            query, self._centroid, self._index, self._n_neighbors
+        )
+        raw_score = max(centroid_cos, knn_max_cos)
+
+        p_positive = _sigmoid(self._calib_coef * raw_score + self._calib_intercept)
+        p_negative = float(np.clip(1.0 - p_positive, 0.0, 1.0))
+
+        dropped = p_negative >= self._threshold
+        reason = f"embed/thick=centroid:{centroid_cos:.3f},knn:{knn_max_cos:.3f}"
+        return StageScore(
+            stage="C",
+            p_negative=p_negative,
+            threshold=self._threshold,
+            dropped=dropped,
+            reason=reason,
+            model_version=self.model_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def train_stage_c(
+    labels_path: Path,
+    out_dir: Path,
+    *,
+    base_model_id: str = _DEFAULT_BASE_MODEL,
+    n_neighbors: int = _DEFAULT_N_NEIGHBORS,
+) -> tuple[StageCModelMeta, Path]:
+    """Train Stage C embedding-similarity artifacts and write them atomically.
+
+    Reads *labels_path*, extracts training positives and validation rows, then:
+
+    1. Embeds training positives with :class:`sentence_transformers.SentenceTransformer`.
+    2. Computes the L2-normalised centroid of positive embeddings.
+    3. Builds a FAISS HNSW index over the positive embeddings.
+    4. Scores every validation row (centroid-cosine + kNN-max-cosine).
+    5. Fits a sigmoid calibration (logistic regression) on the validation scores.
+    6. Writes all artifacts atomically under ``out_dir/stage_c/``.
+
+    Artifacts written
+    -----------------
+    ``centroid.npy``
+        L2-normalised mean embedding of training positives.
+    ``index.faiss``
+        FAISS HNSW index of training positive embeddings.
+    ``calibration.json``
+        Sigmoid calibration parameters ``{"coef": float, "intercept": float}``.
+    ``meta.json``
+        :class:`StageCModelMeta` provenance record.
+
+    Parameters
+    ----------
+    labels_path:
+        Path to a ``labels.parquet`` from :mod:`denbust.prefilter.labels`.
+    out_dir:
+        Parent directory for ``stage_c/`` artifacts.
+    base_model_id:
+        HuggingFace model ID for the sentence encoder.
+    n_neighbors:
+        Number of HNSW neighbours for the kNN-max-cosine signal.
+
+    Returns
+    -------
+    tuple[StageCModelMeta, Path]
+        ``(meta, stage_dir)`` — provenance metadata and the written artifact
+        directory.
+
+    Raises
+    ------
+    ImportError
+        When ``sentence_transformers``, ``faiss``, or ``scikit-learn`` are not
+        installed.
+    ValueError
+        When the training split contains no positive examples.
+    """
+    try:
+        import faiss  # noqa: F401
+        from sentence_transformers import SentenceTransformer  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "Stage C training requires the prefilter extras. "
+            "Install with: pip install -e '.[dev,prefilter]'"
+        ) from exc
+
+    from denbust.prefilter.labels import read_labels_parquet
+
+    all_rows = read_labels_parquet(labels_path)
+    train_rows = [r for r in all_rows if r.split == "train"]
+    val_rows = [r for r in all_rows if r.split == "val"]
+
+    train_positives = [r for r in train_rows if r.label == "positive"]
+    if not train_positives:
+        raise ValueError(
+            f"No positive training examples found in {labels_path}. "
+            "Stage C requires at least one labeled positive to build the "
+            "centroid and FAISS index."
+        )
+
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    # Build thick-pass text for each training positive.
+    pos_texts = [(r.title + " " + (r.article_body or r.snippet)).strip() for r in train_positives]
+    model = SentenceTransformer(base_model_id)
+    pos_embeddings = _embed_texts(model, pos_texts)  # shape (n_pos, dim)
+
+    # Centroid: mean of L2-normalised embeddings, then re-normalise.
+    centroid_raw: Any = np.mean(pos_embeddings, axis=0)
+    centroid = _l2_normalize(centroid_raw).astype(np.float32)
+
+    # FAISS HNSW index over positive embeddings.
+    index = _build_hnsw_index(pos_embeddings)
+
+    # Score validation rows to fit the sigmoid calibration.
+    raw_scores: list[float] = []
+    val_labels: list[int] = []
+
+    if val_rows:
+        val_texts = [(r.title + " " + (r.article_body or r.snippet)).strip() for r in val_rows]
+        val_embeddings = _embed_texts(model, val_texts)
+
+        for i, row in enumerate(val_rows):
+            query = val_embeddings[i]
+            c_cos, k_cos = _compute_similarity(query, centroid, index, n_neighbors)
+            raw_scores.append(max(c_cos, k_cos))
+            val_labels.append(1 if row.label == "positive" else 0)
+
+    calib_coef, calib_intercept = _fit_calibration(raw_scores, val_labels)
+
+    # Atomic write -----------------------------------------------------------
+    out_dir.mkdir(parents=True, exist_ok=True)
+    final_dir = out_dir / _STAGE_C_SUBDIR
+
+    tmp_dir = Path(tempfile.mkdtemp(dir=out_dir, prefix=f"{_STAGE_C_SUBDIR}.tmp."))
+    try:
+        centroid_path = tmp_dir / _CENTROID_FILE
+        index_path = tmp_dir / _INDEX_FILE
+        calib_path = tmp_dir / _CALIBRATION_FILE
+        meta_path = tmp_dir / _META_FILE
+
+        import faiss
+
+        np.save(str(centroid_path), centroid)
+        faiss.write_index(index, str(index_path))
+
+        calib_path.write_text(
+            json.dumps(
+                {"coef": calib_coef, "intercept": calib_intercept},
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        model_version = _sha1_file(centroid_path)
+
+        meta = StageCModelMeta(
+            model_version=model_version,
+            trained_at=datetime.now(UTC).isoformat(),
+            n_train_positives=len(train_positives),
+            n_val=len(val_rows),
+            base_model_id=base_model_id,
+            n_neighbors=n_neighbors,
+        )
+        meta_path.write_text(
+            json.dumps(dataclasses.asdict(meta), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        # Replace old artifact dir atomically.
+        if final_dir.exists():
+            shutil.rmtree(final_dir)
+        tmp_dir.rename(final_dir)
+
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    return meta, final_dir

--- a/tests/unit/prefilter/_helpers.py
+++ b/tests/unit/prefilter/_helpers.py
@@ -100,6 +100,52 @@ class FakeCandidate:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Minimal SentenceTransformer stub for Stage C tests
+#
+# Defined here so both test_stage_c_train.py and test_stage_c_predict.py
+# share one implementation.  numpy and faiss are imported lazily so this
+# file stays importable without the prefilter extras.
+# ---------------------------------------------------------------------------
+
+
+class FakeSentenceTransformer:
+    """Minimal SentenceTransformer stub for Stage C tests.
+
+    ``encode`` returns deterministic, text-dependent float32 embeddings of
+    dimension *dim*.  When *normalize_embeddings=True* the rows are L2-
+    normalised before returning (matching the real SentenceTransformer API).
+    """
+
+    def __init__(self, dim: int = 8) -> None:
+        self._dim = dim
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        normalize_embeddings: bool = False,
+        show_progress_bar: bool = False,  # noqa: ARG002
+        batch_size: int = 32,  # noqa: ARG002
+    ) -> Any:
+        import hashlib
+
+        import numpy as np
+
+        result = np.zeros((len(texts), self._dim), dtype=np.float32)
+        for i, text in enumerate(texts):
+            raw = hashlib.md5(text.encode(), usedforsecurity=False).digest()  # noqa: S324
+            for j in range(self._dim):
+                result[i, j] = (raw[j % len(raw)] / 127.5) - 1.0  # in (−1, 1)
+
+        if normalize_embeddings:
+            norms = np.linalg.norm(result, axis=1, keepdims=True)
+            norms = np.maximum(norms, 1e-9)
+            result = result / norms
+
+        return result
+
+
 class FakeSetFitModel:
     """Minimal SetFit model stub for testing: no network, no GPU.
 

--- a/tests/unit/prefilter/test_stage_c_predict.py
+++ b/tests/unit/prefilter/test_stage_c_predict.py
@@ -60,7 +60,8 @@ def stage_c_models_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                     split,  # type: ignore[arg-type]
                     title="ספורט ופנאי",
                     snippet="כדורגל ושחמט",
-                    body="משחקי כדורגל וטניס" if split == "train" else None,
+                    # Include idx so each training row has a unique embedding.
+                    body=f"משחקי כדורגל וטניס {idx}" if split == "train" else None,
                 )
             )
             idx += 1
@@ -71,7 +72,10 @@ def stage_c_models_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                     split,  # type: ignore[arg-type]
                     title="עצור חשוד ברצח",
                     snippet="המשטרה עצרה חשוד",
-                    body="החשוד נעצר לאחר חקירה" if split == "train" else None,
+                    # Include idx so each training positive has a unique embedding.
+                    # This ensures that knn_mean(k=1) ≠ knn_mean(k=5) in tests
+                    # that verify n_neighbors has a genuine effect on the signal.
+                    body=f"החשוד נעצר לאחר חקירה {idx}" if split == "train" else None,
                 )
             )
             idx += 1
@@ -185,11 +189,12 @@ class TestStageCStoreScorerLoaded:
         assert 0.0 <= result.p_negative <= 1.0
 
     @patch(_PATCH_ST, _fake_st)
-    def test_reason_starts_with_embed_thick(self, stage_c_models_dir: Path) -> None:
+    def test_reason_format(self, stage_c_models_dir: Path) -> None:
         scorer = StageCScorer(models_dir=stage_c_models_dir)
         result = scorer.evaluate(FakeCandidate(), "thick", body="body")
         assert result is not None
-        assert result.reason.startswith("embed/thick=")
+        assert result.reason.startswith("embed/thick=centroid:")
+        assert "knn_mean:" in result.reason
 
     @patch(_PATCH_ST, _fake_st)
     def test_threshold_propagated(self, stage_c_models_dir: Path) -> None:
@@ -235,9 +240,30 @@ class TestStageCStoreScorerLoaded:
         assert r1.p_negative == r2.p_negative
 
     @patch(_PATCH_ST, _fake_st)
-    def test_n_neighbors_override_respected(self, stage_c_models_dir: Path) -> None:
+    def test_n_neighbors_override_stored(self, stage_c_models_dir: Path) -> None:
         """A caller-supplied n_neighbors overrides the value from meta.json."""
         scorer = StageCScorer(models_dir=stage_c_models_dir, n_neighbors=1)
         assert scorer._n_neighbors == 1
         result = scorer.evaluate(FakeCandidate(), "thick", body="body")
         assert isinstance(result, StageScore)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_n_neighbors_affects_score(self, stage_c_models_dir: Path) -> None:
+        """n_neighbors=1 (nearest-neighbour cosine) differs from n_neighbors=5 (mean over 5).
+
+        With the fixed implementation, knn_mean_cos is the mean cosine over k
+        neighbours.  k=1 gives the cosine to the single nearest neighbour;
+        k=5 averages over 5 neighbours — these are distinct signals unless all
+        5 neighbours are equidistant (astronomically unlikely with hash-based
+        fake embeddings and 12 distinct training positives).
+        """
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        scorer1 = StageCScorer(models_dir=stage_c_models_dir, n_neighbors=1)
+        scorer5 = StageCScorer(models_dir=stage_c_models_dir, n_neighbors=5)
+        r1 = scorer1.evaluate(cand, "thick", body="נעצר לאחר חקירה")
+        r5 = scorer5.evaluate(cand, "thick", body="נעצר לאחר חקירה")
+        assert r1 is not None and r5 is not None
+        assert r1.p_negative != r5.p_negative, (
+            "n_neighbors=1 and n_neighbors=5 produced identical p_negative — "
+            "the knn_mean signal is not actually using k neighbours"
+        )

--- a/tests/unit/prefilter/test_stage_c_predict.py
+++ b/tests/unit/prefilter/test_stage_c_predict.py
@@ -1,0 +1,243 @@
+"""Unit tests for StageCScorer inference in prefilter.stage_c.
+
+All tests monkeypatch ``sentence_transformers.SentenceTransformer`` with a
+lightweight fake so no network access occurs and the test suite stays fast.
+
+Skipped entirely when ``faiss`` or ``sentence_transformers`` are not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_ = pytest.importorskip("sentence_transformers")  # also implies faiss from [prefilter] extras
+
+from denbust.prefilter.models import StageScore
+from denbust.prefilter.stage_c import StageCScorer, train_stage_c
+from tests.unit.prefilter._helpers import FakeCandidate, FakeSentenceTransformer, make_labeled_row
+
+_PATCH_ST = "sentence_transformers.SentenceTransformer"
+
+
+def _fake_st(*_args: Any, **_kwargs: Any) -> FakeSentenceTransformer:
+    return FakeSentenceTransformer(dim=8)
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture: real artifacts produced by train_stage_c with the
+# fake SentenceTransformer (no network, no GPU).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def stage_c_models_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build Stage C artifacts once for the whole test module.
+
+    Uses ``unittest.mock.patch`` as a context manager rather than a decorator
+    because ``@patch`` does not compose reliably with ``scope="module"``
+    fixtures in pytest.
+    """
+    from unittest.mock import patch as _patch
+
+    from denbust.prefilter.labels import write_labels_parquet
+
+    base = tmp_path_factory.mktemp("stage_c_models")
+    models_dir = base / "models"
+
+    rows = []
+    idx = 0
+    for split, count in [("train", 12), ("val", 4), ("test", 4)]:
+        for _ in range(count):
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "negative",
+                    split,  # type: ignore[arg-type]
+                    title="ספורט ופנאי",
+                    snippet="כדורגל ושחמט",
+                    body="משחקי כדורגל וטניס" if split == "train" else None,
+                )
+            )
+            idx += 1
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "positive",
+                    split,  # type: ignore[arg-type]
+                    title="עצור חשוד ברצח",
+                    snippet="המשטרה עצרה חשוד",
+                    body="החשוד נעצר לאחר חקירה" if split == "train" else None,
+                )
+            )
+            idx += 1
+
+    labels_path = base / "labels.parquet"
+    write_labels_parquet(rows, labels_path)
+    with _patch(_PATCH_ST, _fake_st):
+        train_stage_c(labels_path, models_dir)
+    return models_dir
+
+
+# ---------------------------------------------------------------------------
+# Stub behaviour — no artifacts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestStageCStoreScorerStub:
+    """StageCScorer returns None when no artifacts are present."""
+
+    def test_none_models_dir_returns_none_thick(self) -> None:
+        scorer = StageCScorer(models_dir=None)
+        assert scorer.evaluate(FakeCandidate(), "thick", body="some body") is None
+
+    def test_none_models_dir_returns_none_thin(self) -> None:
+        scorer = StageCScorer(models_dir=None)
+        assert scorer.evaluate(FakeCandidate(), "thin") is None
+
+    def test_missing_dir_returns_none(self, tmp_path: Path) -> None:
+        scorer = StageCScorer(models_dir=tmp_path / "nonexistent")
+        assert scorer.evaluate(FakeCandidate(), "thick", body="body") is None
+
+    def test_empty_models_dir_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "stage_c").mkdir()
+        scorer = StageCScorer(models_dir=tmp_path)
+        assert scorer.evaluate(FakeCandidate(), "thick", body="body") is None
+
+    def test_thin_pass_always_returns_none_even_when_loaded(self, stage_c_models_dir: Path) -> None:
+        """Thin pass must return None regardless of whether artifacts are loaded."""
+        with patch(_PATCH_ST, _fake_st):
+            scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thin")
+        assert result is None
+
+    def test_sentence_transformers_not_installed_returns_none(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When sentence_transformers is missing the scorer logs a warning."""
+        import builtins
+        import logging
+
+        # Build a minimal (but incomplete) stage_c dir to trigger the import path.
+        stage_dir = tmp_path / "stage_c"
+        stage_dir.mkdir()
+        (stage_dir / "centroid.npy").write_bytes(b"fake")
+        (stage_dir / "index.faiss").write_bytes(b"fake")
+        (stage_dir / "calibration.json").write_text(
+            json.dumps({"coef": 1.0, "intercept": 0.0}), encoding="utf-8"
+        )
+
+        real_import = builtins.__import__
+
+        def _block(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name in ("faiss", "sentence_transformers"):
+                raise ImportError(f"No module named '{name}'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block)
+        with caplog.at_level(logging.WARNING, logger="denbust.prefilter.stage_c"):
+            scorer = StageCScorer(models_dir=tmp_path)
+        assert scorer.evaluate(FakeCandidate(), "thick", body="body") is None
+        assert any("prefilter" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Loaded model behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestStageCStoreScorerLoaded:
+    """StageCScorer loaded from real artifacts (fake embedder) returns valid scores."""
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_thick_returns_stage_score(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="החשוד נעצר")
+        assert isinstance(result, StageScore)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_thick_without_body_falls_back_to_snippet(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body=None)
+        assert isinstance(result, StageScore)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_stage_score_has_stage_c(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert result is not None
+        assert result.stage == "C"
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_p_negative_in_unit_interval(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="some body text")
+        assert result is not None
+        assert 0.0 <= result.p_negative <= 1.0
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_reason_starts_with_embed_thick(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert result is not None
+        assert result.reason.startswith("embed/thick=")
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_threshold_propagated(self, stage_c_models_dir: Path) -> None:
+        custom = 0.7
+        scorer = StageCScorer(models_dir=stage_c_models_dir, threshold=custom)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert result is not None
+        assert result.threshold == custom
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_dropped_flag_consistent_with_threshold(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir, threshold=0.5)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert result is not None
+        assert result.dropped == (result.p_negative >= 0.5)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_model_version_loaded_from_meta(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        assert len(scorer.model_version) == 12
+        assert all(c in "0123456789abcdef" for c in scorer.model_version)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_model_version_propagated_to_stage_score(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert result is not None
+        assert result.model_version == scorer.model_version
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_base_model_id_loaded_from_meta(self, stage_c_models_dir: Path) -> None:
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        assert scorer.base_model_id == "intfloat/multilingual-e5-large"
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_deterministic_same_input(self, stage_c_models_dir: Path) -> None:
+        """Same input to the same scorer must produce the same p_negative."""
+        scorer = StageCScorer(models_dir=stage_c_models_dir)
+        cand = FakeCandidate(title="עצור חשוד ברצח", snippet="המשטרה עצרה חשוד")
+        r1 = scorer.evaluate(cand, "thick", body="נעצר")
+        r2 = scorer.evaluate(cand, "thick", body="נעצר")
+        assert r1 is not None and r2 is not None
+        assert r1.p_negative == r2.p_negative
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_n_neighbors_override_respected(self, stage_c_models_dir: Path) -> None:
+        """A caller-supplied n_neighbors overrides the value from meta.json."""
+        scorer = StageCScorer(models_dir=stage_c_models_dir, n_neighbors=1)
+        assert scorer._n_neighbors == 1
+        result = scorer.evaluate(FakeCandidate(), "thick", body="body")
+        assert isinstance(result, StageScore)

--- a/tests/unit/prefilter/test_stage_c_train.py
+++ b/tests/unit/prefilter/test_stage_c_train.py
@@ -1,0 +1,251 @@
+"""Unit tests for train_stage_c() in prefilter.stage_c.
+
+Stage C training downloads ``intfloat/multilingual-e5-large`` from HuggingFace,
+which is incompatible with the "no live network calls in tests" rule.  All
+tests here monkeypatch ``sentence_transformers.SentenceTransformer`` with a
+lightweight fake so that:
+
+- The full artifact-write path (embed → centroid → FAISS index → calibration
+  → atomic rename) is exercised.
+- No network access occurs.
+- Tests run fast even when the ``prefilter`` extras are installed.
+
+Skipped entirely when ``faiss`` or ``sentence_transformers`` are not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_ = pytest.importorskip("sentence_transformers")  # also implies faiss from [prefilter] extras
+
+from denbust.prefilter.labels import LabeledCandidate, write_labels_parquet
+from denbust.prefilter.stage_c import StageCModelMeta, train_stage_c
+from tests.unit.prefilter._helpers import FakeSentenceTransformer, make_labeled_row
+
+_PATCH_ST = "sentence_transformers.SentenceTransformer"
+
+
+def _fake_st(*_args: Any, **_kwargs: Any) -> FakeSentenceTransformer:
+    return FakeSentenceTransformer(dim=8)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_fixture(tmp_path: Path, n_per_class: int = 10) -> Path:
+    rows: list[LabeledCandidate] = []
+    idx = 0
+    for split, count in [("train", n_per_class), ("val", 4), ("test", 4)]:
+        for _ in range(count):
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "negative",
+                    split,  # type: ignore[arg-type]
+                    title="ספורט ופנאי",
+                    snippet="כדורגל ושחמט",
+                    body="משחקי כדורגל" if split == "train" else None,
+                )
+            )
+            idx += 1
+            rows.append(
+                make_labeled_row(
+                    idx,
+                    "positive",
+                    split,  # type: ignore[arg-type]
+                    title="עצור חשוד ברצח",
+                    snippet="המשטרה עצרה חשוד",
+                    body="החשוד נעצר" if split == "train" else None,
+                )
+            )
+            idx += 1
+    labels_path = tmp_path / "labels.parquet"
+    write_labels_parquet(rows, labels_path)
+    return labels_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestTrainStageC:
+    """train_stage_c() writes correct artifacts when SentenceTransformer is mocked."""
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_returns_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_stage_c(labels_path, tmp_path / "models")
+        assert isinstance(meta, StageCModelMeta)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_returns_stage_dir(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert stage_dir.is_dir()
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_stage_dir_matches_returned_path(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert stage_dir == tmp_path / "models" / "stage_c"
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_centroid_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert (stage_dir / "centroid.npy").exists()
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_faiss_index_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert (stage_dir / "index.faiss").exists()
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_calibration_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert (stage_dir / "calibration.json").exists()
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_meta_json_artifact_created(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        assert (stage_dir / "meta.json").exists()
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_meta_json_is_valid(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
+        assert len(raw["model_version"]) == 12
+        assert isinstance(raw["n_train_positives"], int)
+        assert isinstance(raw["n_val"], int)
+        assert isinstance(raw["n_neighbors"], int)
+        assert raw["base_model_id"] == "intfloat/multilingual-e5-large"
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_meta_n_train_positives_matches_split(self, tmp_path: Path) -> None:
+        n = 10
+        labels_path = _write_fixture(tmp_path, n_per_class=n)
+        meta, _ = train_stage_c(labels_path, tmp_path / "models")
+        assert meta.n_train_positives == n
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_meta_n_val_matches_split(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_stage_c(labels_path, tmp_path / "models")
+        assert meta.n_val == 8  # 4 positive + 4 negative
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_model_version_is_12_char_hex(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        meta, _ = train_stage_c(labels_path, tmp_path / "models")
+        assert len(meta.model_version) == 12
+        assert all(c in "0123456789abcdef" for c in meta.model_version)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_calibration_json_has_coef_and_intercept(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        raw = json.loads((stage_dir / "calibration.json").read_text(encoding="utf-8"))
+        assert "coef" in raw
+        assert "intercept" in raw
+        assert isinstance(raw["coef"], float)
+        assert isinstance(raw["intercept"], float)
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_centroid_is_l2_normalised(self, tmp_path: Path) -> None:
+        import numpy as np
+
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models")
+        centroid = np.load(str(stage_dir / "centroid.npy"))
+        norm = float(np.linalg.norm(centroid))
+        assert abs(norm - 1.0) < 1e-5
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_atomic_write_no_tmp_dir_left_on_success(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        train_stage_c(labels_path, models_dir)
+        tmp_dirs = list(models_dir.glob("stage_c.tmp.*"))
+        assert tmp_dirs == [], f"Stale tmp dirs: {tmp_dirs}"
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_second_retrain_replaces_artifacts(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        models_dir = tmp_path / "models"
+        _, stage_dir1 = train_stage_c(labels_path, models_dir)
+        _, stage_dir2 = train_stage_c(labels_path, models_dir)
+        assert stage_dir1 == stage_dir2
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_custom_base_model_id_written_to_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        custom_id = "intfloat/multilingual-e5-small"
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models", base_model_id=custom_id)
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
+        assert raw["base_model_id"] == custom_id
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_custom_n_neighbors_written_to_meta(self, tmp_path: Path) -> None:
+        labels_path = _write_fixture(tmp_path)
+        _, stage_dir = train_stage_c(labels_path, tmp_path / "models", n_neighbors=3)
+        raw = json.loads((stage_dir / "meta.json").read_text(encoding="utf-8"))
+        assert raw["n_neighbors"] == 3
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_raises_on_no_positive_training_rows(self, tmp_path: Path) -> None:
+        rows = [
+            make_labeled_row(i, "negative", "train", "ספורט", "כדורגל")  # type: ignore[arg-type]
+            for i in range(10)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.raises(ValueError, match="No positive training examples"):
+            train_stage_c(labels_path, tmp_path / "models")
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_warns_when_val_has_single_class(self, tmp_path: Path) -> None:
+        """Calibration emits UserWarning when val split has only one label class."""
+        rows = [
+            make_labeled_row(i, "positive", "train", "עצור", "חשוד")  # type: ignore[arg-type]
+            for i in range(10)
+        ] + [
+            # val split: only positives (single class → calibration fallback)
+            make_labeled_row(i + 10, "positive", "val", "עצור", "חשוד")  # type: ignore[arg-type]
+            for i in range(4)
+        ]
+        labels_path = tmp_path / "labels.parquet"
+        write_labels_parquet(rows, labels_path)
+        with pytest.warns(UserWarning, match="fewer than 2 label classes"):
+            train_stage_c(labels_path, tmp_path / "models")
+
+    @patch(_PATCH_ST, _fake_st)
+    def test_raises_import_error_when_sentence_transformers_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name in ("faiss", "sentence_transformers"):
+                raise ImportError(f"No module named '{name}'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+        labels_path = _write_fixture(tmp_path)
+        with pytest.raises(ImportError, match="prefilter extras"):
+            train_stage_c(labels_path, tmp_path / "models")


### PR DESCRIPTION
## Summary

Implements **Stage C** of the local pre-classification filter cascade: an embedding-similarity scorer that uses `intfloat/multilingual-e5-large` to compare candidate text against the training-positive distribution.

### Scoring logic

Two cosine signals are computed over L2-normalised embeddings:

| Signal | Method |
|--------|--------|
| `centroid_cos` | Cosine to the L2-normalised mean of all training-positive embeddings |
| `knn_max_cos` | Maximum cosine over the k-nearest training positives via FAISS HNSW (`IndexHNSWFlat`, M=32, efConstruction=200) |

Combined: `raw = max(centroid_cos, knn_max_cos)`.

**Calibration**: logistic sigmoid fitted by `LogisticRegression` on the validation split → `p_positive = sigmoid(coef × raw + intercept)`, `p_negative = 1 − p_positive`.

Stage C is **thick-pass only** — `evaluate()` returns `None` unconditionally for the thin pass.

### New public API

```python
# Training
from denbust.prefilter.stage_c import train_stage_c, StageCModelMeta

meta, stage_dir = train_stage_c(
    labels_path=Path("labels.parquet"),
    out_dir=Path("models/"),
    base_model_id="intfloat/multilingual-e5-large",  # default
    n_neighbors=5,                                    # default
)

# Inference
from denbust.prefilter.stage_c import StageCScorer

scorer = StageCScorer(models_dir=Path("models/"), threshold=0.5)
result = scorer.evaluate(candidate, "thick", body=article_text)
# result.stage == "C"
# result.p_negative in [0.0, 1.0]
# result.reason == "embed/thick=centroid:0.812,knn:0.794"
```

### CLI

```bash
denbust prefilter retrain --stage c
```

Prints artifact paths and the 12-char hex `model_version` on completion.

### Artifacts written (atomic)

| File | Contents |
|------|----------|
| `stage_c/centroid.npy` | L2-normalised mean of training positive embeddings |
| `stage_c/index.faiss` | HNSW index over training positive embeddings |
| `stage_c/calibration.json` | `{"coef": float, "intercept": float}` |
| `stage_c/meta.json` | `StageCModelMeta` — version, counts, base_model_id, n_neighbors |

Writes to `stage_c.tmp.<random>/` first, then renames atomically; cleans up on failure.

### Error handling

- `ValueError("No positive training examples")` when train split has no positives
- `UserWarning("fewer than 2 label classes …")` when val split has a single class (calibration falls back to intercept-only)
- `ImportError("… install the [prefilter] extras …")` when `faiss` / `sentence_transformers` are absent
- Returns `None` (with a `WARNING` log) when scorer is loaded but extras become unavailable at inference time

### Other changes

- `numpy.*` added to mypy `ignore_missing_imports` overrides (numpy is a transitive dep of the `[prefilter]` extras but was missing from the override list)
- `tests/unit/prefilter/test_stage_c_*.py` added to ruff `E402` per-file-ignores (required because `pytest.importorskip()` must precede application imports)

## Tests

38 new unit tests across two files — **all pass with a `FakeSentenceTransformer` stub; no live network access**.

| File | Tests | Coverage |
|------|-------|----------|
| `test_stage_c_train.py` | 20 | artifact creation, meta validity, centroid L2-norm, atomic write (no stale tmp dirs), second retrain replaces, custom `base_model_id`/`n_neighbors`, `ValueError` on empty positives, `UserWarning` on single-class val, `ImportError` when extras absent |
| `test_stage_c_predict.py` | 18 | `None` when no artifacts / missing dir / empty dir / thin pass, warning log when extras absent, `StageScore` shape (`stage="C"`, `p_negative ∈ [0,1]`, `reason` prefix, `threshold`, `dropped`, `model_version`), determinism, `n_neighbors` override |

`FakeSentenceTransformer` (added to `tests/unit/prefilter/_helpers.py`): deterministic MD5-hash embeddings of configurable dimension, supports `normalize_embeddings=True`, lazy numpy import — importable even without the `[prefilter]` extras.

## Test plan

- [x] `pytest -q tests/unit/prefilter/test_stage_c_train.py tests/unit/prefilter/test_stage_c_predict.py` — all 38 pass (2 skipped on missing extras)
- [x] `pytest -q tests/unit` — 1214 passed, 2 skipped
- [x] `ruff format . && ruff check .` — clean
- [x] `mypy src/` — no issues (97 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)