### PR TITLE
feat(prefilter): LPF-PR-08 — wire CascadeOrchestrator into pipeline (thin + thick pass)

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,21 +6,21 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `LPF-PR-07` — Stage D local SLM judge: `StageDScorer` and
-  `bake_stage_d()` via MLX (`dicta-il/dictalm2.0-instruct` default,
-  `Qwen/Qwen2.5-7B-Instruct` fallback), scoring `p("כן")` vs `p("לא")` at the answer token
-  position, hard per-candidate timeout via `ThreadPoolExecutor`, circuit-breaker on consecutive
-  timeouts, atomic artifact write (`tempfile.mkdtemp` → rename-aside), `StageDModelMeta` frozen
-  dataclass, SHA-1 12-char `prompt_version`, `denbust prefilter retrain --stage d` CLI wiring,
-  Stage D evaluation section in `denbust prefilter evaluate`, ruff E402 per-file-ignores for
-  Stage D test files, `FakeMLXTokenizer` in `_helpers.py`, and 52 unit tests (24 bake, 28
-  inference with timeout/circuit-breaker coverage) — all passing with patched `mlx_lm.load`
-  and `_mlx_score`, no live network access in tests. `cascade.py` updated to use
-  `StageDScorer` in place of the LPF-PR-01 `StageDJudge` stub.
-- Next planned PR: `LPF-PR-08` — cascade orchestrator wiring the four stages with calibrated
-  thresholds, pipeline insertion points in `src/denbust/discovery/scrape_queue.py` (thin pass)
-  and `src/denbust/news_items/ingest.py` (thick pass), and `prefilter_summary.json` emission.
-  Default mode remains `off`.
+- Last merged PR on main: `LPF-PR-08` — `CascadeOrchestrator` wired into `pipeline.py` with a
+  thin pass (pre-scrape, wrapping `PersistentCandidate` via `PersistentCandidateView`) and a
+  thick pass (post-scrape/pre-classifier, wrapping `RawArticle` via `RawArticleCandidateView`).
+  Both adapters live in `src/denbust/prefilter/adapters.py`. `_build_cascade_orchestrator`,
+  `_thin_pass_prefilter`, `_thick_pass_prefilter`, `_build_prefilter_pass_dict`, and
+  `_write_prefilter_run_summary` helpers added to `pipeline.py`. `prefilter_summary.json`
+  written to `prefilter_paths.reports_dir` with schema `prefilter.run_summary.v1` on every
+  scrape-candidates, ingest, and backfill-scrape run. `_run_candidate_scrape_job` and
+  `_run_backfill_candidate_scrape_job` now return `tuple[CandidateScrapeBatch, list[PrefilterDecision]]`.
+  Default mode remains `off` (no behavior change unless explicitly enabled). 45 new unit tests
+  in `tests/unit/prefilter/test_pipeline_wiring.py`; all 1315 unit tests pass.
+- Next planned PR: `LPF-PR-09` — shadow-mode telemetry harness: Supabase migration for
+  `prefilter_decisions`, Supabase write path in `PrefilterDecisionWriter`,
+  `denbust prefilter shadow-report` aggregator, and a default flip to `mode: shadow` in
+  `agents/news/local_search.yaml` (other configs unchanged).
 - Current blockers on main: The 2026 backfill (`BACKFILL-PR-CLASSIFIER-QUOTA-RESUME`) is blocked
   on Anthropic workspace API usage limits; quota is scheduled to return 2026-06-01 00:00 UTC.
   Google CSE returns `403 PERMISSION_DENIED` locally; use
@@ -241,11 +241,11 @@
   `p("כן")` vs `p("לא")` at the answer token position, hard per-candidate timeout,
   circuit-breaker on consecutive timeouts, versioned prompt template, atomic artifact write,
   52 unit tests (all mocked), CLI wiring for `retrain --stage d` and `evaluate`.
-- [next] `LPF-PR-08`: cascade orchestrator wiring the four stages with calibrated thresholds,
-  pipeline insertion points in `src/denbust/discovery/scrape_queue.py` (thin pass) and
-  `src/denbust/news_items/ingest.py` (thick pass), and `prefilter_summary.json` emission.
-  Default mode remains `off`.
-- [later] `LPF-PR-09`: shadow-mode telemetry harness — Supabase migration for
+- [done] `LPF-PR-08`: cascade orchestrator wired into `pipeline.py` with thin pass
+  (`PersistentCandidateView`) and thick pass (`RawArticleCandidateView`); adapters in
+  `src/denbust/prefilter/adapters.py`; `prefilter_summary.json` emission; default mode `off`;
+  45 new tests; all 1315 unit tests pass.
+- [next] `LPF-PR-09`: shadow-mode telemetry harness — Supabase migration for
   `prefilter_decisions`, Supabase write path in `PrefilterDecisionWriter`,
   `denbust prefilter shadow-report` aggregator, and a default flip to `mode: shadow` in
   `agents/news/local_search.yaml` (other configs unchanged).

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -114,6 +115,11 @@ from denbust.ops.factory import create_operational_store
 from denbust.ops.storage import OperationalStore
 from denbust.output.email import send_email_report
 from denbust.output.formatter import print_items
+from denbust.prefilter.adapters import PersistentCandidateView, RawArticleCandidateView
+from denbust.prefilter.cascade import CascadeOrchestrator
+from denbust.prefilter.config import PrefilterMode
+from denbust.prefilter.models import PrefilterDecision
+from denbust.prefilter.state_paths import resolve_prefilter_state_paths
 from denbust.sources.base import Source
 from denbust.sources.haaretz import create_haaretz_source
 from denbust.sources.ice import create_ice_source
@@ -228,6 +234,161 @@ def release_publication_dir(config: Config) -> Path:
     return config.store.publication_dir or (
         config.store.state_root / config.dataset_name / JobName.RELEASE / "publication"
     )
+
+
+# ---------------------------------------------------------------------------
+# Pre-classification filter (prefilter) helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_cascade_orchestrator(config: Config) -> CascadeOrchestrator | None:
+    """Construct a :class:`CascadeOrchestrator` for *config*, or ``None``.
+
+    Returns ``None`` when ``config.prefilter.enabled`` is ``False`` or the
+    configured mode is ``OFF`` so callers can short-circuit filter wiring
+    without the cost of loading stage model artifacts.
+    """
+    if not config.prefilter.enabled or config.prefilter.mode == PrefilterMode.OFF:
+        return None
+    prefilter_paths = resolve_prefilter_state_paths(
+        state_root=config.store.state_root,
+        dataset_name=config.dataset_name,
+    )
+    return CascadeOrchestrator(
+        config=config.prefilter,
+        decisions_dir=prefilter_paths.decisions_dir,
+        models_dir=prefilter_paths.models_dir,
+    )
+
+
+def _thin_pass_prefilter(
+    candidates: list[PersistentCandidate],
+    orchestrator: CascadeOrchestrator | None,
+) -> tuple[list[PersistentCandidate], list[PrefilterDecision]]:
+    """Apply the thin (pre-scrape) prefilter pass to *candidates*.
+
+    Returns ``(passed_candidates, all_decisions)``.  When *orchestrator* is
+    ``None`` all candidates pass through unchanged and the decision list is
+    empty.  In SHADOW mode the orchestrator downgrades ``"drop"`` to ``"pass"``
+    internally, so all candidates still flow to the scrape queue — only the
+    telemetry reflects the simulated drop.
+    """
+    if orchestrator is None:
+        return candidates, []
+    passed: list[PersistentCandidate] = []
+    decisions: list[PrefilterDecision] = []
+    for candidate in candidates:
+        decision = orchestrator.evaluate_thin(PersistentCandidateView(candidate))
+        decisions.append(decision)
+        if decision.verdict != "drop":
+            passed.append(candidate)
+    if decisions:
+        logger.info(
+            "Prefilter thin pass: %d/%d candidates passed (mode=%s).",
+            len(passed),
+            len(candidates),
+            orchestrator._config.mode.value,
+        )
+    return passed, decisions
+
+
+def _thick_pass_prefilter(
+    articles: list[RawArticle],
+    orchestrator: CascadeOrchestrator | None,
+    *,
+    candidate_id_map: dict[str, str],
+) -> tuple[list[RawArticle], list[PrefilterDecision]]:
+    """Apply the thick (post-scrape, pre-classifier) prefilter pass to *articles*.
+
+    Returns ``(passed_articles, all_decisions)``.  When *orchestrator* is
+    ``None`` all articles pass through unchanged and the decision list is empty.
+
+    Parameters
+    ----------
+    candidate_id_map:
+        Mapping from canonicalized URL strings to ``candidate_id`` values built
+        from the scrape batch's ``selected_candidates``.  When a URL has no
+        entry the raw URL string is used as the decision ``candidate_id``.
+    """
+    if orchestrator is None:
+        return articles, []
+    passed: list[RawArticle] = []
+    decisions: list[PrefilterDecision] = []
+    for article in articles:
+        url_key = canonicalize_news_url(str(article.url))
+        candidate_id = candidate_id_map.get(url_key, str(article.url))
+        view = RawArticleCandidateView(article, candidate_id=candidate_id)
+        decision = orchestrator.evaluate_thick(view, body=article.snippet)
+        decisions.append(decision)
+        if decision.verdict != "drop":
+            passed.append(article)
+    if decisions:
+        logger.info(
+            "Prefilter thick pass: %d/%d articles passed (mode=%s).",
+            len(passed),
+            len(articles),
+            orchestrator._config.mode.value,
+        )
+    return passed, decisions
+
+
+def _build_prefilter_pass_dict(decisions: list[PrefilterDecision]) -> dict[str, object]:
+    """Build a per-pass summary dict from a list of :class:`PrefilterDecision` records.
+
+    ``stage_stopped_counts`` counts decisions where ``stopped_at_stage``
+    is a stage name (not ``"passed_all"``).  This captures both effective drops
+    (ENFORCE mode) and shadow would-drops (SHADOW mode) per stage.
+    """
+    evaluated = len(decisions)
+    dropped = sum(1 for d in decisions if d.verdict == "drop")
+    stage_stopped: dict[str, int] = {}
+    for d in decisions:
+        if d.stopped_at_stage != "passed_all":
+            stage = str(d.stopped_at_stage)
+            stage_stopped[stage] = stage_stopped.get(stage, 0) + 1
+    return {
+        "evaluated": evaluated,
+        "passed": evaluated - dropped,
+        "dropped": dropped,
+        "stage_stopped_counts": stage_stopped,
+    }
+
+
+def _write_prefilter_run_summary(
+    config: Config,
+    *,
+    thin_decisions: list[PrefilterDecision],
+    thick_decisions: list[PrefilterDecision],
+) -> None:
+    """Write ``prefilter_summary.json`` to the prefilter reports directory.
+
+    Silently skipped when the prefilter is disabled (both decision lists empty
+    and ``config.prefilter.enabled`` is ``False``).  Errors during write are
+    caught and logged so they never abort the surrounding pipeline job.
+    """
+    if not thin_decisions and not thick_decisions and not config.prefilter.enabled:
+        return
+    try:
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=config.store.state_root,
+            dataset_name=config.dataset_name,
+        )
+        prefilter_paths.reports_dir.mkdir(parents=True, exist_ok=True)
+        summary: dict[str, object] = {
+            "schema_version": "prefilter.run_summary.v1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "mode": config.prefilter.mode.value,
+            "thin_pass": _build_prefilter_pass_dict(thin_decisions),
+            "thick_pass": _build_prefilter_pass_dict(thick_decisions),
+        }
+        out_path = prefilter_paths.reports_dir / "prefilter_summary.json"
+        out_path.write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        logger.debug("Prefilter run summary written to %s", out_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to write prefilter run summary: %s", exc)
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -1176,8 +1337,13 @@ async def _run_candidate_scrape_job(
     config: Config,
     sources: list[Source],
     limit: int,
-) -> CandidateScrapeBatch:
-    """Select queued candidates and run the scrape-attempt layer."""
+    orchestrator: CascadeOrchestrator | None = None,
+) -> tuple[CandidateScrapeBatch, list[PrefilterDecision]]:
+    """Select queued candidates, apply the thin prefilter, and run the scrape-attempt layer.
+
+    Returns ``(scrape_batch, thin_decisions)``.  When *orchestrator* is ``None``
+    the thin pass is skipped and ``thin_decisions`` is empty.
+    """
     persistence = create_discovery_persistence(config)
     try:
         selected_candidates = select_candidates_for_scrape(
@@ -1187,11 +1353,13 @@ async def _run_candidate_scrape_job(
     finally:
         persistence.close()
 
-    return await _scrape_candidate_batch(
+    passed_candidates, thin_decisions = _thin_pass_prefilter(selected_candidates, orchestrator)
+    batch = await _scrape_candidate_batch(
         config=config,
-        candidates=selected_candidates,
+        candidates=passed_candidates,
         sources=sources,
     )
+    return batch, thin_decisions
 
 
 async def _run_backfill_candidate_scrape_job(
@@ -1200,8 +1368,13 @@ async def _run_backfill_candidate_scrape_job(
     sources: list[Source],
     limit: int,
     batch_id: str | None = None,
-) -> CandidateScrapeBatch:
-    """Select one historical batch and run the scrape-attempt layer over it."""
+    orchestrator: CascadeOrchestrator | None = None,
+) -> tuple[CandidateScrapeBatch, list[PrefilterDecision]]:
+    """Select one historical batch, apply the thin prefilter, and run the scrape-attempt layer.
+
+    Returns ``(scrape_batch, thin_decisions)``.  When *orchestrator* is ``None``
+    the thin pass is skipped and ``thin_decisions`` is empty.
+    """
     persistence = create_discovery_persistence(config)
     try:
         selected_candidates = select_backfill_candidates_for_scrape(
@@ -1212,12 +1385,14 @@ async def _run_backfill_candidate_scrape_job(
     finally:
         persistence.close()
 
-    return await _scrape_candidate_batch(
+    passed_candidates, thin_decisions = _thin_pass_prefilter(selected_candidates, orchestrator)
+    batch = await _scrape_candidate_batch(
         config=config,
-        candidates=selected_candidates,
+        candidates=passed_candidates,
         sources=sources,
         backfill_mode=True,
     )
+    return batch, thin_decisions
 
 
 async def _process_ingest_articles(
@@ -1992,13 +2167,26 @@ async def run_news_ingest_job(
                 f"source_native_candidate_persistence_failed={type(exc).__name__}: {exc}"
             )
 
-    result.raw_article_count = len(ingest_articles)
+    # Thick prefilter pass — applied to the final article list before classification.
+    # For the ingest job there is no candidate_id_map (articles come from RSS feeds
+    # directly), so the article URL itself is used as the candidate_id.
+    orchestrator = _build_cascade_orchestrator(config)
+    thick_articles, thick_decisions = _thick_pass_prefilter(
+        ingest_articles, orchestrator, candidate_id_map={}
+    )
+    if len(thick_articles) < len(ingest_articles):
+        result.warnings.append(
+            f"prefilter_thick_dropped={len(ingest_articles) - len(thick_articles)}"
+        )
+    _write_prefilter_run_summary(config, thin_decisions=[], thick_decisions=thick_decisions)
+
+    result.raw_article_count = len(thick_articles)
     return await _process_ingest_articles(
         config=config,
         result=result,
         source_names=source_names,
         sources=sources,
-        all_articles=ingest_articles,
+        all_articles=thick_articles,
         seen_store=seen_store,
         classifier=classifier,
         deduplicator=deduplicator,
@@ -2219,18 +2407,21 @@ async def run_news_scrape_candidates_job(
     result.seen_count_before = seen_store.count
     store = operational_store
     owns_store = False
+    orchestrator = _build_cascade_orchestrator(config)
 
     try:
-        scrape_batch = await _run_candidate_scrape_job(
+        scrape_batch, thin_decisions = await _run_candidate_scrape_job(
             config=config.model_copy(update={"days": days}),
             sources=sources,
             limit=config.max_articles,
+            orchestrator=orchestrator,
         )
         result.raw_article_count = len(scrape_batch.raw_articles)
         if scrape_batch.errors:
             result.errors.extend(scrape_batch.errors)
             result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
         if not scrape_batch.selected_candidates:
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result.finish("no queued candidates eligible for scrape")
 
         if store is None and (scrape_batch.raw_articles or scrape_batch.fallback_candidates):
@@ -2249,6 +2440,7 @@ async def run_news_scrape_candidates_job(
                 sanitized_error,
             )
             result.seen_count_after = seen_store.count
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result.finish("fatal: classifier provider error")
         if fallback_records and store is not None:
             store.upsert_records(
@@ -2273,14 +2465,31 @@ async def run_news_scrape_candidates_job(
                     fallback_record_count=len(fallback_records),
                 )
             )
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result
 
+        # Build URL → candidate_id map for the thick pass.
+        candidate_id_map = {
+            canonicalize_news_url(str(c.canonical_url or c.current_url)): c.candidate_id
+            for c in scrape_batch.selected_candidates
+        }
+        thick_articles, thick_decisions = _thick_pass_prefilter(
+            scrape_batch.raw_articles, orchestrator, candidate_id_map=candidate_id_map
+        )
+        if len(thick_articles) < len(scrape_batch.raw_articles):
+            result.warnings.append(
+                f"prefilter_thick_dropped={len(scrape_batch.raw_articles) - len(thick_articles)}"
+            )
+
+        _write_prefilter_run_summary(
+            config, thin_decisions=thin_decisions, thick_decisions=thick_decisions
+        )
         processed = await _process_ingest_articles(
             config=config,
             result=result,
             source_names=source_names,
             sources=sources,
-            all_articles=scrape_batch.raw_articles,
+            all_articles=thick_articles,
             seen_store=seen_store,
             classifier=classifier,
             deduplicator=deduplicator,
@@ -2563,19 +2772,23 @@ async def run_news_backfill_scrape_job(
     store = operational_store
     owns_store = False
     scrape_batch: CandidateScrapeBatch | None = None
+    orchestrator = _build_cascade_orchestrator(config)
+    thin_decisions: list[PrefilterDecision] = []
 
     try:
-        scrape_batch = await _run_backfill_candidate_scrape_job(
+        scrape_batch, thin_decisions = await _run_backfill_candidate_scrape_job(
             config=config.model_copy(update={"days": days}),
             sources=sources,
             limit=config.backfill.max_scrape_attempts_per_run,
             batch_id=batch_id,
+            orchestrator=orchestrator,
         )
         result.raw_article_count = len(scrape_batch.raw_articles)
         if scrape_batch.errors:
             result.errors.extend(scrape_batch.errors)
             result.warnings.append(f"candidate_scrape_failures={len(scrape_batch.errors)}")
         if not scrape_batch.selected_candidates:
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result.finish("no queued backfill candidates eligible for scrape")
 
         if store is None and (scrape_batch.raw_articles or scrape_batch.fallback_candidates):
@@ -2657,14 +2870,31 @@ async def run_news_backfill_scrape_job(
                     batch_id=batch_id,
                 )
             )
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result
+
+        # Thick prefilter pass — post-window-filter, pre-classifier.
+        candidate_id_map = {
+            canonicalize_news_url(str(c.canonical_url or c.current_url)): c.candidate_id
+            for c in scrape_batch.selected_candidates
+        }
+        thick_articles, thick_decisions = _thick_pass_prefilter(
+            scrape_batch.raw_articles, orchestrator, candidate_id_map=candidate_id_map
+        )
+        if len(thick_articles) < len(scrape_batch.raw_articles):
+            result.warnings.append(
+                f"prefilter_thick_dropped={len(scrape_batch.raw_articles) - len(thick_articles)}"
+            )
+        _write_prefilter_run_summary(
+            config, thin_decisions=thin_decisions, thick_decisions=thick_decisions
+        )
 
         processed = await _process_ingest_articles(
             config=config,
             result=result,
             source_names=[source.name for source in sources],
             sources=sources,
-            all_articles=scrape_batch.raw_articles,
+            all_articles=thick_articles,
             seen_store=seen_store,
             classifier=classifier,
             deduplicator=deduplicator,

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 from uuid import uuid4
 
 from denbust.classifier.relevance import (
@@ -287,7 +287,7 @@ def _thin_pass_prefilter(
             "Prefilter thin pass: %d/%d candidates passed (mode=%s).",
             len(passed),
             len(candidates),
-            orchestrator._config.mode.value,
+            orchestrator.mode.value,
         )
     return passed, decisions
 
@@ -318,7 +318,10 @@ def _thick_pass_prefilter(
         url_key = canonicalize_news_url(str(article.url))
         candidate_id = candidate_id_map.get(url_key, str(article.url))
         view = RawArticleCandidateView(article, candidate_id=candidate_id)
-        decision = orchestrator.evaluate_thick(view, body=article.snippet)
+        # TODO: pass body=article.body once RawArticle gains a full-body field
+        # from the scraper.  Until then, body=None lets each stage fall back to
+        # candidate.snippet, which is the same text as the thin pass already had.
+        decision = orchestrator.evaluate_thick(view, body=None)
         decisions.append(decision)
         if decision.verdict != "drop":
             passed.append(article)
@@ -327,13 +330,22 @@ def _thick_pass_prefilter(
             "Prefilter thick pass: %d/%d articles passed (mode=%s).",
             len(passed),
             len(articles),
-            orchestrator._config.mode.value,
+            orchestrator.mode.value,
         )
     return passed, decisions
 
 
-def _build_prefilter_pass_dict(decisions: list[PrefilterDecision]) -> dict[str, object]:
-    """Build a per-pass summary dict from a list of :class:`PrefilterDecision` records.
+class _PrefilterPassSummary(TypedDict):
+    """Typed schema for one prefilter pass entry in ``prefilter_summary.json``."""
+
+    evaluated: int
+    passed: int
+    dropped: int
+    stage_stopped_counts: dict[str, int]
+
+
+def _build_prefilter_pass_dict(decisions: list[PrefilterDecision]) -> _PrefilterPassSummary:
+    """Build a typed per-pass summary from a list of :class:`PrefilterDecision` records.
 
     ``stage_stopped_counts`` counts decisions where ``stopped_at_stage``
     is a stage name (not ``"passed_all"``).  This captures both effective drops
@@ -346,12 +358,12 @@ def _build_prefilter_pass_dict(decisions: list[PrefilterDecision]) -> dict[str, 
         if d.stopped_at_stage != "passed_all":
             stage = str(d.stopped_at_stage)
             stage_stopped[stage] = stage_stopped.get(stage, 0) + 1
-    return {
-        "evaluated": evaluated,
-        "passed": evaluated - dropped,
-        "dropped": dropped,
-        "stage_stopped_counts": stage_stopped,
-    }
+    return _PrefilterPassSummary(
+        evaluated=evaluated,
+        passed=evaluated - dropped,
+        dropped=dropped,
+        stage_stopped_counts=stage_stopped,
+    )
 
 
 def _write_prefilter_run_summary(
@@ -366,7 +378,7 @@ def _write_prefilter_run_summary(
     and ``config.prefilter.enabled`` is ``False``).  Errors during write are
     caught and logged so they never abort the surrounding pipeline job.
     """
-    if not thin_decisions and not thick_decisions and not config.prefilter.enabled:
+    if not (config.prefilter.enabled or thin_decisions or thick_decisions):
         return
     try:
         prefilter_paths = resolve_prefilter_state_paths(
@@ -2837,6 +2849,7 @@ async def run_news_backfill_scrape_job(
                     batch_id=batch_id,
                 )
             )
+            _write_prefilter_run_summary(config, thin_decisions=thin_decisions, thick_decisions=[])
             return result
 
         out_of_window_article_count = len(scrape_batch.raw_articles)

--- a/src/denbust/prefilter/adapters.py
+++ b/src/denbust/prefilter/adapters.py
@@ -15,7 +15,7 @@ Usage example::
     decision = orchestrator.evaluate_thin(view)
 
     article_view = RawArticleCandidateView(article, candidate_id=cid)
-    decision = orchestrator.evaluate_thick(article_view, body=article.snippet)
+    decision = orchestrator.evaluate_thick(article_view, body=None)
 """
 
 from __future__ import annotations
@@ -25,18 +25,76 @@ from urllib.parse import urlparse
 from denbust.data_models import RawArticle
 from denbust.discovery.models import PersistentCandidate
 
+# ---------------------------------------------------------------------------
+# Two-part TLD suffixes (no public-suffix-list dependency)
+#
+# ``_etld1_from_host`` checks whether the last two labels of a hostname form a
+# known two-part suffix and, if so, takes one extra label so that, e.g.,
+# ``www.ynet.co.il`` yields ``ynet.co.il`` rather than the useless ``co.il``.
+# The set covers the suffixes relevant to Israeli news and a handful of other
+# common two-part ccTLDs.  It is intentionally small; add entries as needed
+# rather than pulling in ``tldextract``.
+# ---------------------------------------------------------------------------
+
+_TWO_PART_TLDS: frozenset[str] = frozenset(
+    {
+        # Israeli
+        "co.il",
+        "org.il",
+        "net.il",
+        "ac.il",
+        "gov.il",
+        "k12.il",
+        # British
+        "co.uk",
+        "org.uk",
+        "me.uk",
+        "net.uk",
+        "ltd.uk",
+        "plc.uk",
+        # Australian / New Zealand
+        "com.au",
+        "net.au",
+        "org.au",
+        "edu.au",
+        "co.nz",
+        "org.nz",
+        "net.nz",
+        # South African
+        "co.za",
+        "org.za",
+    }
+)
+
+
+def _etld1_from_host(host: str) -> str | None:
+    """Return a best-effort eTLD+1 from a bare *host* string.
+
+    Unlike a naïve last-two-labels approach, this function checks against a
+    curated :data:`_TWO_PART_TLDS` set so that ``www.ynet.co.il`` yields
+    ``ynet.co.il`` rather than the meaningless ``co.il``.
+
+    Always returns a non-empty string or ``None`` — never an empty string.
+    """
+    parts = [p for p in host.split(".") if p]
+    if len(parts) >= 3:
+        two_part = ".".join(parts[-2:])
+        if two_part in _TWO_PART_TLDS:
+            return ".".join(parts[-3:])
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return parts[0] if parts else None
+
 
 def _etld1(url_str: str) -> str | None:
-    """Return a best-effort eTLD+1 from *url_str* without external dependencies.
+    """Return a best-effort eTLD+1 from a full *url_str* without external dependencies.
 
-    Uses only stdlib ``urllib.parse``; always returns a non-empty string or
+    Delegates hostname extraction to stdlib :func:`urllib.parse.urlparse`, then
+    calls :func:`_etld1_from_host`.  Always returns a non-empty string or
     ``None`` — never an empty string.
     """
     host = urlparse(url_str).hostname or ""
-    parts = [p for p in host.split(".") if p]
-    if len(parts) >= 2:
-        return ".".join(parts[-2:])
-    return host or None
+    return _etld1_from_host(host)
 
 
 class PersistentCandidateView:
@@ -47,7 +105,10 @@ class PersistentCandidateView:
     ``candidate_id``
         → ``PersistentCandidate.candidate_id``
     ``domain``
-        → ``PersistentCandidate.domain``
+        → best-effort eTLD+1 derived from ``PersistentCandidate.domain`` (the
+        stored netloc) via :func:`_etld1_from_host`.  For example, a stored
+        domain of ``www.ynet.co.il`` yields ``ynet.co.il``.  Consistent with
+        :class:`RawArticleCandidateView`.
     ``title``
         → first element of ``PersistentCandidate.titles``, or ``None``
     ``snippet``
@@ -65,7 +126,10 @@ class PersistentCandidateView:
 
     @property
     def domain(self) -> str | None:
-        return self._c.domain
+        # _c.domain stores the raw netloc (e.g. "www.ynet.co.il").  Normalise
+        # to eTLD+1 so domain-reputation lookups use the same key regardless of
+        # whether a candidate or a raw article is being evaluated.
+        return _etld1_from_host(self._c.domain or "")
 
     @property
     def title(self) -> str | None:

--- a/src/denbust/prefilter/adapters.py
+++ b/src/denbust/prefilter/adapters.py
@@ -1,0 +1,131 @@
+"""Adapters exposing pipeline objects as CandidateView for the prefilter cascade.
+
+This module bridges :class:`~denbust.discovery.models.PersistentCandidate` and
+:class:`~denbust.data_models.RawArticle` – which live in the pipeline data layer –
+into the :class:`~denbust.prefilter.models.CandidateView` protocol consumed by the
+cascade stages.  Both adapters are lightweight (no copies, no I/O) and are kept
+here rather than inside ``discovery/`` or ``data_models`` to avoid introducing a
+dependency cycle.
+
+Usage example::
+
+    from denbust.prefilter.adapters import PersistentCandidateView, RawArticleCandidateView
+
+    view = PersistentCandidateView(candidate)
+    decision = orchestrator.evaluate_thin(view)
+
+    article_view = RawArticleCandidateView(article, candidate_id=cid)
+    decision = orchestrator.evaluate_thick(article_view, body=article.snippet)
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from denbust.data_models import RawArticle
+from denbust.discovery.models import PersistentCandidate
+
+
+def _etld1(url_str: str) -> str | None:
+    """Return a best-effort eTLD+1 from *url_str* without external dependencies.
+
+    Uses only stdlib ``urllib.parse``; always returns a non-empty string or
+    ``None`` — never an empty string.
+    """
+    host = urlparse(url_str).hostname or ""
+    parts = [p for p in host.split(".") if p]
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return host or None
+
+
+class PersistentCandidateView:
+    """Read-only adapter that exposes :class:`PersistentCandidate` as ``CandidateView``.
+
+    Attribute mapping
+    -----------------
+    ``candidate_id``
+        → ``PersistentCandidate.candidate_id``
+    ``domain``
+        → ``PersistentCandidate.domain``
+    ``title``
+        → first element of ``PersistentCandidate.titles``, or ``None``
+    ``snippet``
+        → first element of ``PersistentCandidate.snippets``, or ``None``
+    ``url``
+        → ``str(canonical_url)`` when set, else ``str(current_url)``
+    """
+
+    def __init__(self, candidate: PersistentCandidate) -> None:
+        self._c = candidate
+
+    @property
+    def candidate_id(self) -> str:
+        return self._c.candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return self._c.domain
+
+    @property
+    def title(self) -> str | None:
+        return self._c.titles[0] if self._c.titles else None
+
+    @property
+    def snippet(self) -> str | None:
+        return self._c.snippets[0] if self._c.snippets else None
+
+    @property
+    def url(self) -> str | None:
+        return str(self._c.canonical_url or self._c.current_url)
+
+
+class RawArticleCandidateView:
+    """Read-only adapter that exposes :class:`RawArticle` as ``CandidateView``.
+
+    Parameters
+    ----------
+    article:
+        The scraped article to wrap.
+    candidate_id:
+        The persistent-candidate ID that produced this article.  Callers
+        should supply the ID from the scrape batch's ``selected_candidates``
+        list; fall back to ``str(article.url)`` when the mapping is absent.
+
+    Attribute mapping
+    -----------------
+    ``candidate_id``
+        → caller-supplied (see *candidate_id* above)
+    ``domain``
+        → best-effort eTLD+1 extracted from ``article.url`` via :func:`_etld1`
+    ``title``
+        → ``article.title``
+    ``snippet``
+        → ``article.snippet``
+    ``url``
+        → ``str(article.url)``
+    """
+
+    def __init__(self, article: RawArticle, *, candidate_id: str) -> None:
+        self._a = article
+        self._candidate_id = candidate_id
+
+    @property
+    def candidate_id(self) -> str:
+        return self._candidate_id
+
+    @property
+    def domain(self) -> str | None:
+        return _etld1(str(self._a.url))
+
+    @property
+    def title(self) -> str | None:
+        return self._a.title
+
+    @property
+    def snippet(self) -> str | None:
+        return self._a.snippet
+
+    @property
+    def url(self) -> str | None:
+        return str(self._a.url)

--- a/src/denbust/prefilter/cascade.py
+++ b/src/denbust/prefilter/cascade.py
@@ -76,6 +76,15 @@ class CascadeOrchestrator:
         self._stage_d: StageDScorer | None = StageDScorer() if config.stages.d.enabled else None
 
     # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def mode(self) -> PrefilterMode:
+        """The configured :class:`PrefilterMode` for this orchestrator."""
+        return self._config.mode
+
+    # ------------------------------------------------------------------
     # Public evaluation interface
     # ------------------------------------------------------------------
 
@@ -113,7 +122,7 @@ class CascadeOrchestrator:
 
         return self._conclude("thin", "pass", "passed_all", candidate, tuple(scores))
 
-    def evaluate_thick(self, candidate: CandidateView, body: str) -> PrefilterDecision:
+    def evaluate_thick(self, candidate: CandidateView, body: str | None) -> PrefilterDecision:
         """Run the thick (post-scrape) pass: Stages A through D.
 
         In OFF mode (or when ``enabled=False``) returns a pass decision
@@ -124,7 +133,11 @@ class CascadeOrchestrator:
         candidate:
             A :class:`CandidateView`-compatible object.
         body:
-            Full article body text (truncation handled per stage).
+            Full article body text (truncation handled per stage), or ``None``
+            when no full body is available.  All body-dependent stages (B, C,
+            D) fall back gracefully to ``candidate.snippet`` when *body* is
+            ``None`` or empty.  Pass ``None`` until :class:`~denbust.data_models.RawArticle`
+            gains a full-body field populated by the scraper.
 
         Note
         ----

--- a/tests/unit/prefilter/test_pipeline_wiring.py
+++ b/tests/unit/prefilter/test_pipeline_wiring.py
@@ -1,0 +1,575 @@
+"""Unit tests for prefilter pipeline wiring.
+
+Covers:
+- :class:`~denbust.prefilter.adapters.PersistentCandidateView` property mapping
+- :class:`~denbust.prefilter.adapters.RawArticleCandidateView` property mapping
+- :func:`~denbust.prefilter.adapters._etld1` domain extraction
+- Pipeline helper functions exposed by ``denbust.pipeline``:
+  ``_build_cascade_orchestrator``, ``_thin_pass_prefilter``,
+  ``_thick_pass_prefilter``, ``_build_prefilter_pass_dict``,
+  ``_write_prefilter_run_summary``
+
+All tests are offline (no network, no model inference).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pydantic import HttpUrl
+
+import denbust.pipeline as pipeline_module
+from denbust.config import Config
+from denbust.data_models import RawArticle
+from denbust.discovery.models import PersistentCandidate
+from denbust.prefilter.adapters import (
+    PersistentCandidateView,
+    RawArticleCandidateView,
+    _etld1,
+)
+from denbust.prefilter.models import PrefilterDecision
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_persistent_candidate(
+    *,
+    candidate_id: str = "cand-001",
+    canonical_url: str | None = "https://www.ynet.co.il/news/article/1234",
+    current_url: str = "https://www.ynet.co.il/news/article/1234",
+    titles: list[str] | None = None,
+    snippets: list[str] | None = None,
+    domain: str | None = None,
+) -> PersistentCandidate:
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        current_url=HttpUrl(current_url),
+        canonical_url=HttpUrl(canonical_url) if canonical_url else None,
+        titles=titles if titles is not None else ["כותרת ראשית"],
+        snippets=snippets if snippets is not None else ["קטעי תוכן"],
+        domain=domain,
+    )
+
+
+def _make_raw_article(
+    url: str = "https://www.mako.co.il/news/article/abc",
+    title: str = "כותרת כתבה",
+    snippet: str = "תקציר הכתבה",
+) -> RawArticle:
+    return RawArticle(
+        url=HttpUrl(url),
+        title=title,
+        snippet=snippet,
+        date=datetime(2026, 1, 15, tzinfo=UTC),
+        source_name="mako",
+    )
+
+
+def _make_decision(
+    candidate_id: str = "cand-001",
+    verdict: str = "pass",
+    stopped_at_stage: str = "passed_all",
+) -> PrefilterDecision:
+    d = MagicMock(spec=PrefilterDecision)
+    d.candidate_id = candidate_id
+    d.verdict = verdict
+    d.stopped_at_stage = stopped_at_stage
+    return d
+
+
+# ===========================================================================
+# _etld1
+# ===========================================================================
+
+
+class TestEtld1:
+    """_etld1 extracts a best-effort eTLD+1 from a URL string."""
+
+    def test_standard_two_part_domain(self) -> None:
+        assert _etld1("https://example.com/path") == "example.com"
+
+    def test_subdomain_trimmed(self) -> None:
+        assert _etld1("https://www.ynet.co.il/news") == "co.il"
+
+    def test_bare_hostname(self) -> None:
+        assert (
+            _etld1("https://localhost/path") is None
+            or _etld1("https://localhost/path") == "localhost"
+        )
+
+    def test_empty_url(self) -> None:
+        assert _etld1("") is None
+
+    def test_no_dots(self) -> None:
+        result = _etld1("https://intranet/resource")
+        # single-label host: return as-is or None
+        assert result in ("intranet", None)
+
+    def test_co_il_domain(self) -> None:
+        assert _etld1("https://www.mako.co.il/article/123") == "co.il"
+
+    def test_news_domain(self) -> None:
+        assert _etld1("https://haaretz.co.il/article") == "co.il"
+
+
+# ===========================================================================
+# PersistentCandidateView
+# ===========================================================================
+
+
+class TestPersistentCandidateView:
+    """PersistentCandidateView maps PersistentCandidate fields to CandidateView protocol."""
+
+    def test_candidate_id(self) -> None:
+        c = _make_persistent_candidate(candidate_id="xyz-999")
+        view = PersistentCandidateView(c)
+        assert view.candidate_id == "xyz-999"
+
+    def test_domain_from_candidate(self) -> None:
+        c = _make_persistent_candidate()
+        view = PersistentCandidateView(c)
+        assert view.domain is not None
+        assert "ynet" in view.domain or "co.il" in view.domain
+
+    def test_title_returns_first_title(self) -> None:
+        c = _make_persistent_candidate(titles=["כותרת ראשונה", "כותרת שניה"])
+        view = PersistentCandidateView(c)
+        assert view.title == "כותרת ראשונה"
+
+    def test_title_returns_none_when_empty(self) -> None:
+        c = _make_persistent_candidate(titles=[])
+        view = PersistentCandidateView(c)
+        assert view.title is None
+
+    def test_snippet_returns_first_snippet(self) -> None:
+        c = _make_persistent_candidate(snippets=["תקציר א", "תקציר ב"])
+        view = PersistentCandidateView(c)
+        assert view.snippet == "תקציר א"
+
+    def test_snippet_returns_none_when_empty(self) -> None:
+        c = _make_persistent_candidate(snippets=[])
+        view = PersistentCandidateView(c)
+        assert view.snippet is None
+
+    def test_url_prefers_canonical(self) -> None:
+        c = _make_persistent_candidate(
+            canonical_url="https://canonical.example.com/",
+            current_url="https://current.example.com/",
+        )
+        view = PersistentCandidateView(c)
+        assert "canonical" in view.url  # type: ignore[operator]
+
+    def test_url_falls_back_to_current(self) -> None:
+        c = _make_persistent_candidate(
+            canonical_url=None,
+            current_url="https://current.example.com/article",
+        )
+        view = PersistentCandidateView(c)
+        assert view.url is not None
+        assert "current" in view.url
+
+    def test_url_is_string(self) -> None:
+        c = _make_persistent_candidate()
+        view = PersistentCandidateView(c)
+        assert isinstance(view.url, str)
+
+
+# ===========================================================================
+# RawArticleCandidateView
+# ===========================================================================
+
+
+class TestRawArticleCandidateView:
+    """RawArticleCandidateView maps RawArticle + caller-supplied candidate_id."""
+
+    def test_candidate_id_from_caller(self) -> None:
+        a = _make_raw_article()
+        view = RawArticleCandidateView(a, candidate_id="caller-cand-007")
+        assert view.candidate_id == "caller-cand-007"
+
+    def test_title_from_article(self) -> None:
+        a = _make_raw_article(title="כותרת הכתבה")
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        assert view.title == "כותרת הכתבה"
+
+    def test_snippet_from_article(self) -> None:
+        a = _make_raw_article(snippet="תקציר הכתבה")
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        assert view.snippet == "תקציר הכתבה"
+
+    def test_url_from_article(self) -> None:
+        a = _make_raw_article(url="https://www.example.co.il/path")
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        assert view.url == "https://www.example.co.il/path"
+
+    def test_url_is_string(self) -> None:
+        a = _make_raw_article()
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        assert isinstance(view.url, str)
+
+    def test_domain_extracted_from_url(self) -> None:
+        a = _make_raw_article(url="https://news.walla.co.il/article/3456")
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        # _etld1("https://news.walla.co.il/article/3456") → "co.il"
+        assert view.domain is not None
+        assert "." in view.domain
+
+    def test_domain_none_for_invalid_url(self) -> None:
+        # We can't construct a RawArticle with a truly invalid URL (pydantic validates)
+        # but we can verify domain doesn't crash on an unusual structure.
+        a = _make_raw_article(url="https://example.com/path")
+        view = RawArticleCandidateView(a, candidate_id="c-1")
+        assert view.domain == "example.com"
+
+
+# ===========================================================================
+# _build_cascade_orchestrator
+# ===========================================================================
+
+
+class TestBuildCascadeOrchestrator:
+    """_build_cascade_orchestrator returns None when prefilter is disabled/OFF."""
+
+    def test_returns_none_when_prefilter_disabled(self, tmp_path: Path) -> None:
+        config = Config(store={"state_root": tmp_path})
+        # Default config has prefilter.enabled = False or mode = OFF
+        result = pipeline_module._build_cascade_orchestrator(config)
+        assert result is None
+
+    def test_returns_none_with_mode_off(self, tmp_path: Path) -> None:
+        config = Config(
+            store={"state_root": tmp_path},
+            prefilter={"mode": "off"},
+        )
+        result = pipeline_module._build_cascade_orchestrator(config)
+        assert result is None
+
+
+# ===========================================================================
+# _build_prefilter_pass_dict
+# ===========================================================================
+
+
+class TestBuildPrefilterPassDict:
+    """_build_prefilter_pass_dict produces correctly structured pass summary dicts."""
+
+    def test_empty_decisions(self) -> None:
+        result = pipeline_module._build_prefilter_pass_dict([])
+        assert result["evaluated"] == 0
+        assert result["passed"] == 0
+        assert result["dropped"] == 0
+        assert result["stage_stopped_counts"] == {}
+
+    def test_all_passed(self) -> None:
+        decisions = [
+            _make_decision(verdict="pass", stopped_at_stage="passed_all") for _ in range(5)
+        ]
+        result = pipeline_module._build_prefilter_pass_dict(decisions)
+        assert result["evaluated"] == 5
+        assert result["passed"] == 5
+        assert result["dropped"] == 0
+        assert result["stage_stopped_counts"] == {}
+
+    def test_some_dropped(self) -> None:
+        decisions = [
+            _make_decision(verdict="pass", stopped_at_stage="passed_all"),
+            _make_decision(verdict="drop", stopped_at_stage="stage_a"),
+            _make_decision(verdict="drop", stopped_at_stage="stage_a"),
+        ]
+        result = pipeline_module._build_prefilter_pass_dict(decisions)
+        assert result["evaluated"] == 3
+        assert result["passed"] == 1
+        assert result["dropped"] == 2
+        assert result["stage_stopped_counts"] == {"stage_a": 2}
+
+    def test_mixed_stages(self) -> None:
+        decisions = [
+            _make_decision(verdict="drop", stopped_at_stage="stage_a"),
+            _make_decision(verdict="drop", stopped_at_stage="stage_b"),
+            _make_decision(verdict="drop", stopped_at_stage="stage_a"),
+            _make_decision(verdict="pass", stopped_at_stage="passed_all"),
+        ]
+        result = pipeline_module._build_prefilter_pass_dict(decisions)
+        assert result["dropped"] == 3
+        assert result["stage_stopped_counts"] == {"stage_a": 2, "stage_b": 1}
+
+    def test_passed_all_not_counted_in_stage_stopped(self) -> None:
+        decisions = [
+            _make_decision(verdict="pass", stopped_at_stage="passed_all"),
+            _make_decision(verdict="pass", stopped_at_stage="passed_all"),
+        ]
+        result = pipeline_module._build_prefilter_pass_dict(decisions)
+        assert result["stage_stopped_counts"] == {}
+
+
+# ===========================================================================
+# _thin_pass_prefilter
+# ===========================================================================
+
+
+class TestThinPassPrefilter:
+    """_thin_pass_prefilter short-circuits when orchestrator is None."""
+
+    def test_no_orchestrator_returns_all_candidates(self) -> None:
+        candidates = [
+            _make_persistent_candidate(candidate_id="c1"),
+            _make_persistent_candidate(candidate_id="c2"),
+        ]
+        passed, decisions = pipeline_module._thin_pass_prefilter(candidates, None)
+        assert passed == candidates
+        assert decisions == []
+
+    def test_orchestrator_pass_keeps_all(self) -> None:
+        candidates = [_make_persistent_candidate(candidate_id=f"c{i}") for i in range(3)]
+
+        orchestrator = MagicMock()
+        pass_decision = MagicMock(spec=PrefilterDecision)
+        pass_decision.verdict = "pass"
+        orchestrator.evaluate_thin.return_value = pass_decision
+
+        passed, decisions = pipeline_module._thin_pass_prefilter(candidates, orchestrator)
+        assert len(passed) == 3
+        assert len(decisions) == 3
+
+    def test_orchestrator_drop_removes_candidates(self) -> None:
+        candidates = [
+            _make_persistent_candidate(candidate_id="keep"),
+            _make_persistent_candidate(candidate_id="drop"),
+        ]
+
+        drop_decision = MagicMock(spec=PrefilterDecision)
+        drop_decision.verdict = "drop"
+        pass_decision = MagicMock(spec=PrefilterDecision)
+        pass_decision.verdict = "pass"
+
+        orchestrator = MagicMock()
+        orchestrator.evaluate_thin.side_effect = [pass_decision, drop_decision]
+
+        passed, decisions = pipeline_module._thin_pass_prefilter(candidates, orchestrator)
+        assert len(passed) == 1
+        assert passed[0].candidate_id == "keep"
+        assert len(decisions) == 2
+
+    def test_empty_candidates_with_orchestrator(self) -> None:
+        orchestrator = MagicMock()
+        passed, decisions = pipeline_module._thin_pass_prefilter([], orchestrator)
+        assert passed == []
+        assert decisions == []
+        orchestrator.evaluate_thin.assert_not_called()
+
+
+# ===========================================================================
+# _thick_pass_prefilter
+# ===========================================================================
+
+
+class TestThickPassPrefilter:
+    """_thick_pass_prefilter short-circuits when orchestrator is None."""
+
+    def test_no_orchestrator_returns_all_articles(self) -> None:
+        articles = [_make_raw_article(url=f"https://example.com/{i}") for i in range(3)]
+        passed, decisions = pipeline_module._thick_pass_prefilter(
+            articles, None, candidate_id_map={}
+        )
+        assert passed == articles
+        assert decisions == []
+
+    def test_orchestrator_pass_keeps_all(self) -> None:
+        articles = [
+            _make_raw_article(url="https://example.com/a"),
+            _make_raw_article(url="https://example.com/b"),
+        ]
+        pass_decision = MagicMock(spec=PrefilterDecision)
+        pass_decision.verdict = "pass"
+
+        orchestrator = MagicMock()
+        orchestrator.evaluate_thick.return_value = pass_decision
+
+        passed, decisions = pipeline_module._thick_pass_prefilter(
+            articles, orchestrator, candidate_id_map={}
+        )
+        assert len(passed) == 2
+        assert len(decisions) == 2
+
+    def test_orchestrator_drop_removes_articles(self) -> None:
+        articles = [
+            _make_raw_article(url="https://example.com/keep"),
+            _make_raw_article(url="https://example.com/drop"),
+        ]
+        pass_decision = MagicMock(spec=PrefilterDecision)
+        pass_decision.verdict = "pass"
+        drop_decision = MagicMock(spec=PrefilterDecision)
+        drop_decision.verdict = "drop"
+
+        orchestrator = MagicMock()
+        orchestrator.evaluate_thick.side_effect = [pass_decision, drop_decision]
+
+        passed, decisions = pipeline_module._thick_pass_prefilter(
+            articles, orchestrator, candidate_id_map={}
+        )
+        assert len(passed) == 1
+        assert str(passed[0].url).endswith("/keep")
+        assert len(decisions) == 2
+
+    def test_candidate_id_map_used_for_lookup(self) -> None:
+        """candidate_id_map should map canonicalized URL → candidate_id."""
+        article = _make_raw_article(url="https://example.com/article")
+        pass_decision = MagicMock(spec=PrefilterDecision)
+        pass_decision.verdict = "pass"
+
+        orchestrator = MagicMock()
+        orchestrator.evaluate_thick.return_value = pass_decision
+
+        pipeline_module._thick_pass_prefilter(
+            [article],
+            orchestrator,
+            candidate_id_map={"https://example.com/article": "mapped-cand-id"},
+        )
+
+        # The view passed to evaluate_thick should use the mapped candidate_id
+        call_args = orchestrator.evaluate_thick.call_args
+        view = call_args[0][0]  # positional arg 0
+        assert view.candidate_id == "mapped-cand-id"
+
+    def test_empty_articles_with_orchestrator(self) -> None:
+        orchestrator = MagicMock()
+        passed, decisions = pipeline_module._thick_pass_prefilter(
+            [], orchestrator, candidate_id_map={}
+        )
+        assert passed == []
+        assert decisions == []
+        orchestrator.evaluate_thick.assert_not_called()
+
+
+# ===========================================================================
+# _write_prefilter_run_summary
+# ===========================================================================
+
+
+class TestWritePrefilterRunSummary:
+    """_write_prefilter_run_summary writes a valid JSON summary to reports_dir."""
+
+    def test_writes_json_file(self, tmp_path: Path) -> None:
+        config = Config(store={"state_root": tmp_path})
+        # Force prefilter enabled to trigger the write even with empty decisions
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=[_make_decision()],
+            thick_decisions=[_make_decision()],
+        )
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        summary_path = prefilter_paths.reports_dir / "prefilter_summary.json"
+        assert summary_path.exists()
+
+    def test_json_schema_version(self, tmp_path: Path) -> None:
+        config = Config(store={"state_root": tmp_path})
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=[_make_decision()],
+            thick_decisions=[],
+        )
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        raw = json.loads(
+            (prefilter_paths.reports_dir / "prefilter_summary.json").read_text(encoding="utf-8")
+        )
+        assert raw["schema_version"] == "prefilter.run_summary.v1"
+
+    def test_json_contains_thin_and_thick_keys(self, tmp_path: Path) -> None:
+        config = Config(store={"state_root": tmp_path})
+        thin = [
+            _make_decision(verdict="pass"),
+            _make_decision(verdict="drop", stopped_at_stage="stage_a"),
+        ]
+        thick = [_make_decision(verdict="pass")]
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=thin,
+            thick_decisions=thick,
+        )
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        raw = json.loads(
+            (prefilter_paths.reports_dir / "prefilter_summary.json").read_text(encoding="utf-8")
+        )
+        assert "thin_pass" in raw
+        assert "thick_pass" in raw
+        assert raw["thin_pass"]["evaluated"] == 2
+        assert raw["thin_pass"]["dropped"] == 1
+        assert raw["thick_pass"]["evaluated"] == 1
+        assert raw["thick_pass"]["dropped"] == 0
+
+    def test_skips_write_when_empty_and_disabled(self, tmp_path: Path) -> None:
+        """With no decisions and prefilter disabled, nothing should be written."""
+        config = Config(store={"state_root": tmp_path}, prefilter={"mode": "off"})
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=[],
+            thick_decisions=[],
+        )
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        assert not (prefilter_paths.reports_dir / "prefilter_summary.json").exists()
+
+    def test_generated_at_is_iso8601(self, tmp_path: Path) -> None:
+        config = Config(store={"state_root": tmp_path})
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=[_make_decision()],
+            thick_decisions=[],
+        )
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        raw = json.loads(
+            (prefilter_paths.reports_dir / "prefilter_summary.json").read_text(encoding="utf-8")
+        )
+        dt = datetime.fromisoformat(raw["generated_at"])
+        assert dt.tzinfo is not None
+
+    def test_does_not_raise_on_write_failure(self, tmp_path: Path) -> None:
+        """Summary write errors must be swallowed, never propagate."""
+        config = Config(store={"state_root": tmp_path})
+        # Point reports_dir at a file (not a dir) to force a write error
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths
+
+        prefilter_paths = resolve_prefilter_state_paths(
+            state_root=tmp_path,
+            dataset_name=config.dataset_name,
+        )
+        prefilter_paths.reports_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Create a file at the reports_dir path so mkdir fails
+        prefilter_paths.reports_dir.parent.joinpath(prefilter_paths.reports_dir.name).write_text(
+            "blocker", encoding="utf-8"
+        )
+        # Should not raise
+        pipeline_module._write_prefilter_run_summary(
+            config,
+            thin_decisions=[_make_decision()],
+            thick_decisions=[],
+        )

--- a/tests/unit/prefilter/test_pipeline_wiring.py
+++ b/tests/unit/prefilter/test_pipeline_wiring.py
@@ -29,6 +29,7 @@ from denbust.prefilter.adapters import (
     PersistentCandidateView,
     RawArticleCandidateView,
     _etld1,
+    _etld1_from_host,
 )
 from denbust.prefilter.models import PrefilterDecision
 
@@ -93,8 +94,18 @@ class TestEtld1:
     def test_standard_two_part_domain(self) -> None:
         assert _etld1("https://example.com/path") == "example.com"
 
-    def test_subdomain_trimmed(self) -> None:
-        assert _etld1("https://www.ynet.co.il/news") == "co.il"
+    def test_co_il_subdomain_returns_domain_not_tld(self) -> None:
+        # Previously (bug): returned "co.il". Correct value is "ynet.co.il".
+        assert _etld1("https://www.ynet.co.il/news") == "ynet.co.il"
+
+    def test_co_il_no_subdomain(self) -> None:
+        assert _etld1("https://haaretz.co.il/article") == "haaretz.co.il"
+
+    def test_co_il_with_subdomain_mako(self) -> None:
+        assert _etld1("https://www.mako.co.il/article/123") == "mako.co.il"
+
+    def test_com_domain_with_subdomain(self) -> None:
+        assert _etld1("https://www.example.com/path") == "example.com"
 
     def test_bare_hostname(self) -> None:
         assert (
@@ -110,11 +121,35 @@ class TestEtld1:
         # single-label host: return as-is or None
         assert result in ("intranet", None)
 
-    def test_co_il_domain(self) -> None:
-        assert _etld1("https://www.mako.co.il/article/123") == "co.il"
+    def test_co_il_suffix_alone_never_returned_for_three_label_host(self) -> None:
+        # Regression: "co.il" must NOT be returned when the host has 3+ labels.
+        result = _etld1("https://news.walla.co.il/article")
+        assert result == "walla.co.il"
+        assert result != "co.il"
 
-    def test_news_domain(self) -> None:
-        assert _etld1("https://haaretz.co.il/article") == "co.il"
+    def test_co_uk_treated_as_two_part_tld(self) -> None:
+        assert _etld1("https://www.bbc.co.uk/news") == "bbc.co.uk"
+
+
+class TestEtld1FromHost:
+    """_etld1_from_host operates on bare hostnames (no scheme/path)."""
+
+    def test_two_label_com_host(self) -> None:
+        assert _etld1_from_host("example.com") == "example.com"
+
+    def test_netloc_with_co_il(self) -> None:
+        # PersistentCandidate.domain stores netloc; adapter normalises it.
+        assert _etld1_from_host("www.ynet.co.il") == "ynet.co.il"
+
+    def test_netloc_without_subdomain_co_il(self) -> None:
+        assert _etld1_from_host("haaretz.co.il") == "haaretz.co.il"
+
+    def test_empty_host(self) -> None:
+        assert _etld1_from_host("") is None
+
+    def test_single_label(self) -> None:
+        result = _etld1_from_host("localhost")
+        assert result in ("localhost", None)
 
 
 # ===========================================================================
@@ -130,11 +165,27 @@ class TestPersistentCandidateView:
         view = PersistentCandidateView(c)
         assert view.candidate_id == "xyz-999"
 
-    def test_domain_from_candidate(self) -> None:
-        c = _make_persistent_candidate()
+    def test_domain_normalised_to_etld1(self) -> None:
+        # PersistentCandidate.domain stores the raw netloc ("www.ynet.co.il").
+        # The adapter must normalise it to eTLD+1 ("ynet.co.il") so that
+        # domain-reputation lookups use the same key as RawArticleCandidateView.
+        c = _make_persistent_candidate(
+            canonical_url="https://www.ynet.co.il/news/article/1234",
+            current_url="https://www.ynet.co.il/news/article/1234",
+        )
         view = PersistentCandidateView(c)
-        assert view.domain is not None
-        assert "ynet" in view.domain or "co.il" in view.domain
+        assert view.domain == "ynet.co.il"
+
+    def test_domain_consistent_with_raw_article_view(self) -> None:
+        # Both adapters should return the same eTLD+1 for the same underlying site.
+        c = _make_persistent_candidate(
+            canonical_url="https://www.mako.co.il/news/article/abc",
+            current_url="https://www.mako.co.il/news/article/abc",
+        )
+        a = _make_raw_article(url="https://www.mako.co.il/news/article/abc")
+        pv = PersistentCandidateView(c)
+        av = RawArticleCandidateView(a, candidate_id="c-1")
+        assert pv.domain == av.domain == "mako.co.il"
 
     def test_title_returns_first_title(self) -> None:
         c = _make_persistent_candidate(titles=["כותרת ראשונה", "כותרת שניה"])
@@ -213,11 +264,10 @@ class TestRawArticleCandidateView:
         assert isinstance(view.url, str)
 
     def test_domain_extracted_from_url(self) -> None:
+        # news.walla.co.il → "walla.co.il" (not "co.il")
         a = _make_raw_article(url="https://news.walla.co.il/article/3456")
         view = RawArticleCandidateView(a, candidate_id="c-1")
-        # _etld1("https://news.walla.co.il/article/3456") → "co.il"
-        assert view.domain is not None
-        assert "." in view.domain
+        assert view.domain == "walla.co.il"
 
     def test_domain_none_for_invalid_url(self) -> None:
         # We can't construct a RawArticle with a truly invalid URL (pydantic validates)
@@ -431,10 +481,12 @@ class TestThickPassPrefilter:
             candidate_id_map={"https://example.com/article": "mapped-cand-id"},
         )
 
-        # The view passed to evaluate_thick should use the mapped candidate_id
+        # The view passed to evaluate_thick should use the mapped candidate_id,
+        # and body=None should be passed (RawArticle has no full-body field yet).
         call_args = orchestrator.evaluate_thick.call_args
         view = call_args[0][0]  # positional arg 0
         assert view.candidate_id == "mapped-cand-id"
+        assert call_args.kwargs.get("body") is None
 
     def test_empty_articles_with_orchestrator(self) -> None:
         orchestrator = MagicMock()

--- a/tests/unit/test_backfill_pipeline.py
+++ b/tests/unit/test_backfill_pipeline.py
@@ -736,23 +736,26 @@ async def test_run_news_backfill_scrape_job_marks_classifier_provider_error_fata
     monkeypatch.setattr(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
-            return_value=build_scrape_batch(
-                raw_articles=[
-                    RawArticle(
-                        url=HttpUrl("https://example.com/outside-window"),
-                        title="outside",
-                        snippet="outside",
-                        date=datetime(2026, 3, 2, tzinfo=UTC),
-                        source_name="ynet",
-                    ),
-                    RawArticle(
-                        url=HttpUrl("https://example.com/raw"),
-                        title="title",
-                        snippet="snippet",
-                        date=datetime(2026, 1, 2, tzinfo=UTC),
-                        source_name="ynet",
-                    ),
-                ]
+            return_value=(
+                build_scrape_batch(
+                    raw_articles=[
+                        RawArticle(
+                            url=HttpUrl("https://example.com/outside-window"),
+                            title="outside",
+                            snippet="outside",
+                            date=datetime(2026, 3, 2, tzinfo=UTC),
+                            source_name="ynet",
+                        ),
+                        RawArticle(
+                            url=HttpUrl("https://example.com/raw"),
+                            title="title",
+                            snippet="snippet",
+                            date=datetime(2026, 1, 2, tzinfo=UTC),
+                            source_name="ynet",
+                        ),
+                    ]
+                ),
+                [],
             )
         ),
     )
@@ -797,22 +800,25 @@ async def test_run_news_backfill_scrape_job_marks_fallback_provider_error_fatal(
     monkeypatch.setattr(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
-            return_value=build_scrape_batch(
-                fallback_candidates=[
-                    build_candidate("batch-1").model_copy(
-                        update={
-                            "metadata": {
-                                "backfill_window_start": datetime(
-                                    2026, 1, 1, tzinfo=UTC
-                                ).isoformat(),
-                                "fallback_publication_datetime": datetime(
-                                    2026, 1, 2, tzinfo=UTC
-                                ).isoformat(),
+            return_value=(
+                build_scrape_batch(
+                    fallback_candidates=[
+                        build_candidate("batch-1").model_copy(
+                            update={
+                                "metadata": {
+                                    "backfill_window_start": datetime(
+                                        2026, 1, 1, tzinfo=UTC
+                                    ).isoformat(),
+                                    "fallback_publication_datetime": datetime(
+                                        2026, 1, 2, tzinfo=UTC
+                                    ).isoformat(),
+                                }
                             }
-                        }
-                    )
-                ],
-                raw_articles=[],
+                        )
+                    ],
+                    raw_articles=[],
+                ),
+                [],
             )
         ),
     )
@@ -1146,13 +1152,16 @@ async def test_run_news_backfill_scrape_job_returns_when_selected_batch_drains_t
     monkeypatch.setattr(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
-            return_value=CandidateScrapeBatch(
-                selected_candidates=[],
-                updated_candidates=[],
-                fallback_candidates=[],
-                attempts=[],
-                raw_articles=[],
-                errors=[],
+            return_value=(
+                CandidateScrapeBatch(
+                    selected_candidates=[],
+                    updated_candidates=[],
+                    fallback_candidates=[],
+                    attempts=[],
+                    raw_articles=[],
+                    errors=[],
+                ),
+                [],
             )
         ),
     )
@@ -1180,7 +1189,9 @@ async def test_run_news_backfill_scrape_job_keeps_batch_open_for_future_retries(
     monkeypatch.setattr("denbust.pipeline.create_deduplicator", lambda **_kwargs: MagicMock())
     monkeypatch.setattr("denbust.pipeline.create_seen_store", lambda _path: MagicMock(count=0))
 
-    async def fake_scrape_job(**_kwargs: object) -> CandidateScrapeBatch:
+    async def fake_scrape_job(
+        **_kwargs: object,
+    ) -> tuple[CandidateScrapeBatch, list[object]]:
         store.upsert_candidates(
             [
                 build_candidate("batch-1").model_copy(
@@ -1192,7 +1203,9 @@ async def test_run_news_backfill_scrape_job_keeps_batch_open_for_future_retries(
                 )
             ]
         )
-        return build_scrape_batch(raw_articles=[], fallback_candidates=[], errors=["retry later"])
+        return build_scrape_batch(
+            raw_articles=[], fallback_candidates=[], errors=["retry later"]
+        ), []
 
     monkeypatch.setattr("denbust.pipeline._run_backfill_candidate_scrape_job", fake_scrape_job)
     monkeypatch.setattr(
@@ -1239,10 +1252,13 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
     monkeypatch.setattr(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
-            return_value=build_scrape_batch(
-                fallback_candidates=[build_candidate("batch-1")],
-                raw_articles=[],
-                errors=["candidate failed"],
+            return_value=(
+                build_scrape_batch(
+                    fallback_candidates=[build_candidate("batch-1")],
+                    raw_articles=[],
+                    errors=["candidate failed"],
+                ),
+                [],
             )
         ),
     )
@@ -1310,23 +1326,26 @@ async def test_run_news_backfill_scrape_job_handles_fallback_and_processed_paths
     monkeypatch.setattr(
         "denbust.pipeline._run_backfill_candidate_scrape_job",
         AsyncMock(
-            return_value=build_scrape_batch(
-                raw_articles=[
-                    RawArticle(
-                        url=HttpUrl("https://example.com/outside-window"),
-                        title="outside",
-                        snippet="outside",
-                        date=datetime(2026, 3, 2, tzinfo=UTC),
-                        source_name="ynet",
-                    ),
-                    RawArticle(
-                        url=HttpUrl("https://example.com/raw"),
-                        title="title",
-                        snippet="snippet",
-                        date=datetime(2026, 1, 2, tzinfo=UTC),
-                        source_name="ynet",
-                    ),
-                ]
+            return_value=(
+                build_scrape_batch(
+                    raw_articles=[
+                        RawArticle(
+                            url=HttpUrl("https://example.com/outside-window"),
+                            title="outside",
+                            snippet="outside",
+                            date=datetime(2026, 3, 2, tzinfo=UTC),
+                            source_name="ynet",
+                        ),
+                        RawArticle(
+                            url=HttpUrl("https://example.com/raw"),
+                            title="title",
+                            snippet="snippet",
+                            date=datetime(2026, 1, 2, tzinfo=UTC),
+                            source_name="ynet",
+                        ),
+                    ]
+                ),
+                [],
             )
         ),
     )

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -1910,13 +1910,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[MagicMock()],
-                    updated_candidates=[],
-                    fallback_candidates=[],
-                    attempts=[],
-                    raw_articles=[raw_article],
-                    errors=["candidate-1: generic fetch fallback not implemented yet"],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[MagicMock()],
+                        updated_candidates=[],
+                        fallback_candidates=[],
+                        attempts=[],
+                        raw_articles=[raw_article],
+                        errors=["candidate-1: generic fetch fallback not implemented yet"],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2018,13 +2021,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[fallback_candidate],
-                    updated_candidates=[fallback_candidate],
-                    fallback_candidates=[fallback_candidate],
-                    attempts=[],
-                    raw_articles=[],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[fallback_candidate],
+                        updated_candidates=[fallback_candidate],
+                        fallback_candidates=[fallback_candidate],
+                        attempts=[],
+                        raw_articles=[],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2136,13 +2142,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[MagicMock()],
-                    updated_candidates=[],
-                    fallback_candidates=[],
-                    attempts=[],
-                    raw_articles=[raw_article],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[MagicMock()],
+                        updated_candidates=[],
+                        fallback_candidates=[],
+                        attempts=[],
+                        raw_articles=[raw_article],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2191,13 +2200,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[fallback_candidate],
-                    updated_candidates=[],
-                    fallback_candidates=[fallback_candidate],
-                    attempts=[],
-                    raw_articles=[],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[fallback_candidate],
+                        updated_candidates=[],
+                        fallback_candidates=[fallback_candidate],
+                        attempts=[],
+                        raw_articles=[],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2237,13 +2249,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[MagicMock()],
-                    updated_candidates=[],
-                    fallback_candidates=[],
-                    attempts=[],
-                    raw_articles=[raw_article],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[MagicMock()],
+                        updated_candidates=[],
+                        fallback_candidates=[],
+                        attempts=[],
+                        raw_articles=[raw_article],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2325,13 +2340,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[fallback_candidate],
-                    updated_candidates=[fallback_candidate],
-                    fallback_candidates=[fallback_candidate],
-                    attempts=[],
-                    raw_articles=[],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[fallback_candidate],
+                        updated_candidates=[fallback_candidate],
+                        fallback_candidates=[fallback_candidate],
+                        attempts=[],
+                        raw_articles=[],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2382,13 +2400,14 @@ class TestRunPipelineAsync:
         monkeypatch.setattr("denbust.pipeline._scrape_candidate_batch", scrape_mock)
 
         sources = [FakeSource("ynet", [])]
-        result = await pipeline_module._run_candidate_scrape_job(
+        batch, thin_decisions = await pipeline_module._run_candidate_scrape_job(
             config=config,
             sources=sources,
             limit=3,
         )
 
-        assert result.selected_candidates == selected_candidates
+        assert batch.selected_candidates == selected_candidates
+        assert thin_decisions == []
         assert persistence.closed is True
         select_mock.assert_called_once_with(persistence, limit=3)
         scrape_mock.assert_awaited_once_with(
@@ -2497,13 +2516,16 @@ class TestRunPipelineAsync:
         monkeypatch.setattr(
             "denbust.pipeline._run_candidate_scrape_job",
             AsyncMock(
-                return_value=CandidateScrapeBatch(
-                    selected_candidates=[],
-                    updated_candidates=[],
-                    fallback_candidates=[],
-                    attempts=[],
-                    raw_articles=[],
-                    errors=[],
+                return_value=(
+                    CandidateScrapeBatch(
+                        selected_candidates=[],
+                        updated_candidates=[],
+                        fallback_candidates=[],
+                        attempts=[],
+                        raw_articles=[],
+                        errors=[],
+                    ),
+                    [],
                 )
             ),
         )
@@ -2530,17 +2552,21 @@ class TestRunPipelineAsync:
             config: Config,
             sources: list[FakeSource],
             limit: int,
-        ) -> CandidateScrapeBatch:
+            orchestrator: object = None,  # noqa: ARG001
+        ) -> tuple[CandidateScrapeBatch, list[object]]:
             captured["days"] = config.days
             captured["limit"] = limit
             captured["sources"] = [source.name for source in sources]
-            return CandidateScrapeBatch(
-                selected_candidates=[],
-                updated_candidates=[],
-                fallback_candidates=[],
-                attempts=[],
-                raw_articles=[],
-                errors=[],
+            return (
+                CandidateScrapeBatch(
+                    selected_candidates=[],
+                    updated_candidates=[],
+                    fallback_candidates=[],
+                    attempts=[],
+                    raw_articles=[],
+                    errors=[],
+                ),
+                [],
             )
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Wires `CascadeOrchestrator` into `pipeline.py` with a **thin pass** (pre-scrape) and a **thick pass** (post-scrape, pre-classifier). Default mode remains `off` — no behaviour change unless explicitly enabled.

### New file: `src/denbust/prefilter/adapters.py`

- **`PersistentCandidateView`** — read-only adapter bridging `PersistentCandidate` → `CandidateView` protocol: maps `titles[0]` → `title`, `snippets[0]` → `snippet`, prefers `canonical_url` over `current_url`, etc.
- **`RawArticleCandidateView`** — read-only adapter bridging `RawArticle` + caller-supplied `candidate_id` → `CandidateView`: extracts eTLD+1 domain via stdlib `urlparse`.
- **`_etld1(url_str)`** — pure-stdlib best-effort eTLD+1 extractor (no public-suffix-list dependency).

Both adapters are zero-copy and zero-I/O. Kept in `prefilter/adapters.py` rather than `discovery/` to avoid a circular import.

### Changes to `pipeline.py`

New helper functions (all private):

| Helper | Purpose |
|--------|---------|
| `_build_cascade_orchestrator(config)` | Returns `CascadeOrchestrator` or `None` when `mode == off` |
| `_thin_pass_prefilter(candidates, orchestrator)` | Wraps each candidate in `PersistentCandidateView`, calls `evaluate_thin`; returns `(passed, decisions)` |
| `_thick_pass_prefilter(articles, orchestrator, *, candidate_id_map)` | Wraps each article in `RawArticleCandidateView`, calls `evaluate_thick`; returns `(passed, decisions)` |
| `_build_prefilter_pass_dict(decisions)` | Builds per-pass summary dict with `evaluated`/`passed`/`dropped`/`stage_stopped_counts` |
| `_write_prefilter_run_summary(config, *, thin_decisions, thick_decisions)` | Writes `prefilter_summary.json` to `prefilter_paths.reports_dir`; swallows write errors as warnings |

**Thin pass insertion point**: between `select_candidates_for_scrape` and `_scrape_candidate_batch` inside `_run_candidate_scrape_job` / `_run_backfill_candidate_scrape_job`.

**Thick pass insertion point**: after `scrape_batch` is available, before `_process_ingest_articles`, in all three job functions (`run_news_scrape_candidates_job`, `run_news_ingest_job`, `run_news_backfill_scrape_job`).

`_run_candidate_scrape_job` and `_run_backfill_candidate_scrape_job` return types updated to `tuple[CandidateScrapeBatch, list[PrefilterDecision]]`.

**`candidate_id_map`** is built from `scrape_batch.selected_candidates` using `canonicalize_news_url`. For `run_news_ingest_job` (no candidate layer), an empty map is passed so `str(article.url)` serves as the fallback candidate id.

### Summary emission

`prefilter_summary.json` schema `prefilter.run_summary.v1`:
```json
{
  "schema_version": "prefilter.run_summary.v1",
  "generated_at": "<ISO-8601-UTC>",
  "mode": "off|shadow|enforce",
  "thin_pass": { "evaluated": N, "passed": N, "dropped": N, "stage_stopped_counts": {...} },
  "thick_pass": { "evaluated": N, "passed": N, "dropped": N, "stage_stopped_counts": {...} }
}
```

Write failures are caught and logged as `WARNING`; they never abort the surrounding pipeline job.

### Test changes

- **`tests/unit/prefilter/test_pipeline_wiring.py`** (new, 45 tests): covers `_etld1`, `PersistentCandidateView`, `RawArticleCandidateView`, `_build_cascade_orchestrator`, `_build_prefilter_pass_dict`, `_thin_pass_prefilter`, `_thick_pass_prefilter`, and `_write_prefilter_run_summary`.
- **`tests/unit/test_pipeline_core.py`** and **`tests/unit/test_backfill_pipeline.py`**: all `AsyncMock(return_value=CandidateScrapeBatch(...))` mocks for `_run_candidate_scrape_job` / `_run_backfill_candidate_scrape_job` updated to return tuples; direct-call tests updated to unpack the tuple.

**All 1315 unit tests pass. `ruff check`, `ruff format`, and `mypy src/` are all clean.**

## Test plan

- [x] `ruff format .` — clean
- [x] `ruff check .` — clean
- [x] `mypy src/` — clean (98 source files, no issues)
- [x] `pytest -q tests/unit/` — 1315 passed, 2 skipped
- [x] New 45 tests in `test_pipeline_wiring.py` — all pass
- [x] Pre-commit hooks pass on push (ruff, mypy, unit tests, integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)