### PR TITLE
feat(discovery,triage): Hebrew content pre-filter + Stage B triage ranking

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -245,6 +245,18 @@
   (`PersistentCandidateView`) and thick pass (`RawArticleCandidateView`); adapters in
   `src/denbust/prefilter/adapters.py`; `prefilter_summary.json` emission; default mode `off`;
   45 new tests; all 1315 unit tests pass.
+- [done] `DISC-PR-HEBREW-FILTER` — `classify_no_hebrew_content()` added to
+  `candidate_filters.py` (new `SearchNoiseReason.NO_HEBREW_CONTENT`, `_HEBREW_RE = re.compile(r"[א-ת]")`);
+  wired into `merge_discovered_candidate()` and `persist_discovered_candidates()` in
+  `source_native.py` so candidates with no Hebrew letters in any title or snippet are set to
+  `UNSUPPORTED_SOURCE` at the earliest pipeline stage. 1,239 existing unreviewed non-Hebrew
+  candidates bulk-excluded via triage API (12,816 unreviewed remaining).
+- [done] `TRIAGE-APP-STAGEB-RANKING` — triage local app upgraded with Stage B score display and
+  sort: `serve.py` loads `StageBScorer` at startup and attaches `stage_b_score` to every
+  serialized candidate; `sort=stage_b_asc` query param sorts ascending by `p_negative` (lowest =
+  most likely relevant); `app.js` gains `sortSel`, `stageBChip()` colour-tier chip renderer, and
+  default `stage_b_asc` sort; `index.html` gains the sort dropdown, "B↑" column header, and
+  tier-coloured chip CSS. `polisa.news` added to `_IRRELEVANT_CONTENT_DOMAINS`.
 - [next] `LPF-PR-09`: shadow-mode telemetry harness — Supabase migration for
   `prefilter_decisions`, Supabase write path in `PrefilterDecisionWriter`,
   `denbust prefilter shadow-report` aggregator, and a default flip to `mode: shadow` in

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from urllib.parse import urlparse
@@ -63,6 +64,7 @@ _IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
         "din.org.il",  # legal info NGO — off-topic
         "todojustice.co.il",  # legal info site — off-topic
         "tomoko.co.il",  # unrelated e-commerce — off-topic
+        "polisa.news",  # insurance news site — off-topic
     }
 )
 
@@ -78,6 +80,10 @@ _SOCIAL_POST_PATH_PREFIXES: dict[str, tuple[str, ...]] = {
     "youtube.com": ("/shorts/", "/watch"),
 }
 
+
+# Matches any Hebrew letter (Unicode block U+05D0–U+05EA).
+# Used to gate-keep candidates whose title and snippet contain no Hebrew at all.
+_HEBREW_RE: re.Pattern[str] = re.compile(r"[א-ת]")
 
 _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
     {
@@ -237,6 +243,7 @@ class SearchNoiseReason(StrEnum):
     TITLE_KEYWORD_MATCH = "title_keyword_match"
     UNSUPPORTED_SEARCH_DOMAIN = "unsupported_search_domain"
     IRRELEVANT_CONTENT_DOMAIN = "irrelevant_content_domain"
+    NO_HEBREW_CONTENT = "no_hebrew_content"
 
 
 @dataclass(frozen=True)
@@ -407,3 +414,24 @@ def classify_title_noise(
                 matched_keyword=term,
             )
     return None
+
+
+def classify_no_hebrew_content(
+    discovered: DiscoveredCandidate,
+) -> SearchNoiseClassification | None:
+    """Classify candidates that contain no Hebrew letters in title or snippet.
+
+    Applies to all producer kinds.  Content without any Hebrew letter is
+    overwhelmingly not relevant to the Israeli enforcement beat and can be
+    dropped as early as possible in the pipeline.
+
+    Returns ``SearchNoiseClassification(reason=NO_HEBREW_CONTENT)`` when
+    neither ``title`` nor ``snippet`` contain at least one Hebrew character
+    (U+05D0–U+05EA).  Returns ``None`` when Hebrew is present (i.e. the
+    candidate should continue to the next filter).
+    """
+    title = discovered.title or ""
+    snippet = discovered.snippet or ""
+    if _HEBREW_RE.search(title) or _HEBREW_RE.search(snippet):
+        return None
+    return SearchNoiseClassification(reason=SearchNoiseReason.NO_HEBREW_CONTENT)

--- a/src/denbust/discovery/source_native.py
+++ b/src/denbust/discovery/source_native.py
@@ -13,6 +13,7 @@ from denbust.data_models import RawArticle
 from denbust.discovery.base import SourceCandidateProducer, SourceDiscoveryContext
 from denbust.discovery.candidate_filters import (
     candidate_domain,
+    classify_no_hebrew_content,
     classify_search_noise,
     classify_title_noise,
     normalize_domain,
@@ -168,7 +169,12 @@ def merge_discovered_candidate(
     is_social = _is_social_candidate(discovered)
     search_noise_classification = classify_search_noise(discovered)
     title_noise_classification = classify_title_noise(discovered)
-    is_any_noise = search_noise_classification is not None or title_noise_classification is not None
+    no_hebrew_classification = classify_no_hebrew_content(discovered)
+    is_any_noise = (
+        search_noise_classification is not None
+        or title_noise_classification is not None
+        or no_hebrew_classification is not None
+    )
     candidate_status = existing.candidate_status if existing else CandidateStatus.NEW
     if (is_social or is_any_noise) and existing is None:
         candidate_status = CandidateStatus.UNSUPPORTED_SOURCE
@@ -193,6 +199,9 @@ def merge_discovered_candidate(
             existing_metadata["unsupported_source_keyword"] = (
                 title_noise_classification.matched_keyword
             )
+        elif no_hebrew_classification is not None:
+            existing_metadata["unsupported_source_filter"] = "no_hebrew_content"
+            existing_metadata["unsupported_source_reason"] = no_hebrew_classification.reason.value
 
     return PersistentCandidate(
         candidate_id=existing.candidate_id
@@ -295,6 +304,15 @@ def persist_discovered_candidates(
                         **discovered.metadata,
                         "title_noise_filter_reason": classification.reason.value,
                         "title_noise_filter_keyword": classification.matched_keyword,
+                    }
+                }
+            )
+        elif (classification := classify_no_hebrew_content(discovered)) is not None:
+            discovered = discovered.model_copy(
+                update={
+                    "metadata": {
+                        **discovered.metadata,
+                        "no_hebrew_content_filter_reason": classification.reason.value,
                     }
                 }
             )

--- a/triage_app/public/app.js
+++ b/triage_app/public/app.js
@@ -7,6 +7,7 @@ let state = {
   batchId: '',
   status: 'all',
   q: '',
+  sort: 'stage_b_asc',   // default to Stage B ranking so likely positives surface first
   page: 1,
   total: 0,
   pages: 1,
@@ -22,6 +23,7 @@ const pgInfo      = document.getElementById('pg-info');
 const pgPrev      = document.getElementById('pg-prev');
 const pgNext      = document.getElementById('pg-next');
 const batchSel    = document.getElementById('batch-select');
+const sortSel     = document.getElementById('sort-select');
 const searchEl    = document.getElementById('search');
 const toast       = document.getElementById('toast');
 const statTotal   = document.getElementById('stat-total');
@@ -35,6 +37,7 @@ async function fetchCandidates() {
     status: state.status,
     page: state.page,
     limit: LIMIT,
+    sort: state.sort,
   });
   if (state.batchId) params.set('batch_id', state.batchId);
   if (state.q)       params.set('q', state.q);
@@ -90,6 +93,16 @@ function formatDate(iso) {
   try { return iso.slice(0, 10); } catch { return iso; }
 }
 
+function stageBChip(score) {
+  if (score == null) return '<td></td>';
+  const pct = score.toFixed(4);
+  const cls = score < 0.95  ? 'tier1'
+            : score < 0.99  ? 'tier2'
+            : score < 0.9957 ? 'tier3'
+            : 'tier4';
+  return `<td><span class="sb-score ${cls}" title="Stage B p_negative: ${score.toFixed(6)}">${pct}</span></td>`;
+}
+
 function renderRows() {
   const { items, selectedIdx } = state;
   if (!items.length) {
@@ -123,6 +136,7 @@ function renderRows() {
       <td><div class="title">${title}</div></td>
       <td><div class="snippet">${snippet}</div></td>
       <td><div class="date">${formatDate(c.first_seen_at)}</div></td>
+      ${stageBChip(c.stage_b_score)}
       <td class="actions" style="text-align:left">
         ${badge}
         <div style="display:flex;gap:6px;margin-top:4px">${actionBtns}</div>
@@ -254,6 +268,11 @@ batchSel.addEventListener('change', () => {
   load(true);
 });
 
+sortSel.addEventListener('change', () => {
+  state.sort = sortSel.value;
+  load(true);
+});
+
 let _searchTimer;
 searchEl.addEventListener('input', () => {
   clearTimeout(_searchTimer);
@@ -265,6 +284,8 @@ pgNext.addEventListener('click', () => { if (state.page < state.pages) { state.p
 
 // ── init ──────────────────────────────────────────────────────────────────
 (async () => {
+  // Sync dropdown to match the default state.sort value
+  sortSel.value = state.sort;
   await load(true);
   // Default: select new-batch filter if a batch exists and has candidates
   const stats = await fetchStats();

--- a/triage_app/public/index.html
+++ b/triage_app/public/index.html
@@ -92,6 +92,13 @@
     #toast.show { opacity: 1; }
 
     #empty { padding: 48px; text-align: center; color: var(--muted); }
+
+    /* Stage B score chip */
+    .sb-score { font-size: 11px; font-variant-numeric: tabular-nums; white-space: nowrap; padding: 2px 6px; border-radius: 4px; display: inline-block; }
+    .sb-score.tier1 { background: rgba(76,175,130,.25); color: var(--green); }   /* < 0.95 */
+    .sb-score.tier2 { background: rgba(224,154,76,.18); color: var(--orange); }  /* 0.95–0.99 */
+    .sb-score.tier3 { background: rgba(108,117,240,.12); color: var(--accent); } /* 0.99–0.9957 */
+    .sb-score.tier4 { background: transparent; color: var(--muted); }            /* ≥ 0.9957 */
   </style>
 </head>
 <body>
@@ -117,6 +124,10 @@
     <button class="tab" data-status="excluded">הוחרגו</button>
   </div>
   <div class="spacer"></div>
+  <select id="sort-select" title="מיון">
+    <option value="default">מיון: ברירת מחדל</option>
+    <option value="stage_b_asc">מיון: Stage B ↑ (סביר ביותר להיות רלוונטי)</option>
+  </select>
   <input type="text" id="search" placeholder="חפש…" dir="rtl">
   <span id="result-count"></span>
 </div>
@@ -129,6 +140,7 @@
         <th>כותרת</th>
         <th>תקציר</th>
         <th>תאריך</th>
+        <th title="Stage B p_negative — נמוך יותר = סביר יותר להיות רלוונטי">B↑</th>
         <th style="text-align:left">סטטוס / פעולה</th>
       </tr>
     </thead>

--- a/triage_app/serve.py
+++ b/triage_app/serve.py
@@ -38,6 +38,8 @@ DEFAULT_PORT = 7070
 _candidates: dict[str, dict[str, Any]] = {}
 _batch_ids: list[str] = []
 _origin: str = f"http://localhost:{DEFAULT_PORT}"
+# Stage B p_negative scores keyed by candidate_id (lower = more likely positive)
+_stage_b_scores: dict[str, float] = {}
 
 
 def _load_candidates() -> None:
@@ -58,6 +60,76 @@ def _load_candidates() -> None:
         if bid and bid not in seen:
             seen.add(bid)
             _batch_ids.append(bid)
+
+
+def _load_stage_b_scores() -> None:
+    """Score every candidate with Stage B NaiveBayes and cache p_negative.
+
+    Lower score = more likely to be a relevant (positive) candidate.
+    Falls back silently if the model artifacts or config are missing.
+    """
+    _cfg_candidates = [
+        REPO_ROOT / "agents/news/local_search_brave_exa.yaml",
+        REPO_ROOT / "agents/news/local.yaml",
+        REPO_ROOT / "agents/news/local_search.yaml",
+    ]
+    cfg_path = next((p for p in _cfg_candidates if p.exists()), None)
+    if cfg_path is None:
+        print("  Stage B ranking skipped: no YAML config found under agents/news/")
+        return
+
+    try:
+        from denbust.config import load_config as _load_config
+        from denbust.prefilter.adapters import _etld1_from_host as _etld1
+        from denbust.prefilter.stage_b import StageBScorer as _StageBScorer
+        from denbust.prefilter.state_paths import resolve_prefilter_state_paths as _resolve
+
+        loaded = _load_config(cfg_path)
+        pp = _resolve(state_root=loaded.store.state_root, dataset_name=loaded.dataset_name)
+        model_dir = pp.models_dir / "stage_b"
+        if not model_dir.exists():
+            print(
+                "  Stage B ranking skipped: no trained model (run: denbust prefilter retrain --stage b)"
+            )
+            return
+
+        scorer = _StageBScorer(models_dir=pp.models_dir, threshold=0.9962)
+
+        class _View:
+            __slots__ = ("_c",)
+
+            def __init__(self, c: dict[str, Any]) -> None:
+                self._c = c
+
+            @property
+            def candidate_id(self) -> str:
+                return self._c["candidate_id"]
+
+            @property
+            def domain(self) -> str | None:
+                return _etld1(self._c.get("domain") or "")
+
+            @property
+            def title(self) -> str | None:
+                t = self._c.get("titles") or []
+                return t[0] if t else None
+
+            @property
+            def snippet(self) -> str | None:
+                s = self._c.get("snippets") or []
+                return s[0] if s else None
+
+            @property
+            def url(self) -> str | None:
+                return str(self._c.get("canonical_url") or self._c.get("current_url") or "")
+
+        for cid, c in _candidates.items():
+            score = scorer.evaluate(_View(c), "thin")
+            _stage_b_scores[cid] = score.p_negative if score is not None else 1.0
+
+        print(f"  Stage B scored {len(_stage_b_scores)} candidates")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  Stage B ranking failed (non-fatal): {exc}", file=sys.stderr)
 
 
 def _load_decisions() -> None:
@@ -138,6 +210,7 @@ def _serialize(c: dict[str, Any]) -> dict[str, Any]:
         "candidate_status": c.get("candidate_status", "new"),
         "retry_priority": c.get("retry_priority", 0),
         "triage": c.get("_triage", ""),
+        "stage_b_score": _stage_b_scores.get(c["candidate_id"]),
     }
 
 
@@ -147,6 +220,7 @@ def _query_candidates(
     q: str,
     page: int,
     limit: int,
+    sort: str = "default",
 ) -> dict[str, Any]:
     items = list(_candidates.values())
 
@@ -170,10 +244,14 @@ def _query_candidates(
             or any(ql in s.lower() for s in (c.get("snippets") or []))
         ]
 
-    def _sort_key(c: dict[str, Any]) -> tuple[int, str]:
+    def _sort_key(c: dict[str, Any]) -> tuple[int, float, str]:
         t = c.get("_triage", "")
-        order = 0 if t == "prioritized" else 1 if t == "" else 2
-        return (order, str(c.get("first_seen_at", "")))
+        triage_order = 0 if t == "prioritized" else 1 if t == "" else 2
+        if sort == "stage_b_asc":
+            sb = _stage_b_scores.get(c["candidate_id"], 1.0)
+            return (triage_order, sb, str(c.get("first_seen_at", "")))
+        # default: triage group, then chronological (oldest first)
+        return (triage_order, 0.0, str(c.get("first_seen_at", "")))
 
     items.sort(key=_sort_key)
 
@@ -226,6 +304,7 @@ class Handler(BaseHTTPRequestHandler):
                     q=qs.get("q", [""])[0],
                     page=page,
                     limit=limit,
+                    sort=qs.get("sort", ["default"])[0],
                 )
             )
         elif parsed.path == "/api/stats":
@@ -283,6 +362,7 @@ def main() -> None:
 
     print(f"Loading candidates from {CANDIDATES_FILE} …")
     _load_candidates()
+    _load_stage_b_scores()
     _load_decisions()
     s = _stats()
     print(


### PR DESCRIPTION
## Summary

Two independent operational improvements shipped together:

### 1 · Hebrew content pre-filter (`DISC-PR-HEBREW-FILTER`)

Candidates whose **title and snippet contain zero Hebrew letters** (`[א-ת]`, U+05D0–U+05EA) are
almost never relevant to the Israeli enforcement beat. This PR gates them out at the earliest
possible pipeline stage — before any scrape attempt consumes quota.

**Pipeline changes:**

- `src/denbust/discovery/candidate_filters.py`
  - Add `_HEBREW_RE: re.Pattern[str] = re.compile(r"[א-ת]")` module constant
  - Add `SearchNoiseReason.NO_HEBREW_CONTENT = "no_hebrew_content"` to the `StrEnum`
  - Add `classify_no_hebrew_content(discovered: DiscoveredCandidate) → SearchNoiseClassification | None`
    Returns a classification when neither `title` nor `snippet` contain a Hebrew letter.
    Applies to **all** producer kinds (not just search-engine results).
  - Add `polisa.news` to `_IRRELEVANT_CONTENT_DOMAINS` (insurance news site)

- `src/denbust/discovery/source_native.py`
  - Import and call `classify_no_hebrew_content` in both `merge_discovered_candidate()` and
    `persist_discovered_candidates()`
  - `merge_discovered_candidate()`: the new classifier participates in the `is_any_noise` flag,
    and sets `unsupported_source_filter = "no_hebrew_content"` + `unsupported_source_reason`
    in metadata when matched
  - `persist_discovered_candidates()`: annotates the discovered candidate with
    `no_hebrew_content_filter_reason` in its metadata before merge

**Operational impact on existing candidates:**

1,239 of 14,055 unreviewed candidates (8.8%) had no Hebrew in any title or snippet.
All 1,239 were bulk-excluded via the live triage API; 12,816 unreviewed candidates remain.

---

### 2 · Stage B score ranking in the local triage app (`TRIAGE-APP-STAGEB-RANKING`)

The local triage workbench now loads Stage B NaiveBayes scores at startup and surfaces them as
a sortable column so reviewers can start with the most likely positives.

**`triage_app/serve.py`:**
- Loads `StageBScorer` at startup (after candidates, before decisions); scores all candidates
  and stores `{candidate_id: p_negative}` in `_stage_b_scores`
- `_serialize()` now includes `"stage_b_score"` on every candidate response
- `_query_candidates()` accepts `sort=stage_b_asc` → sorts ascending by `p_negative`
  (lowest = most likely relevant), with triage priority ordering preserved

**`triage_app/public/app.js`:**
- `state.sort` defaults to `"stage_b_asc"`
- `stageBChip(score)` renders a colour-tiered chip: tier1 green (<0.95) → tier4 muted (≥0.9957)
- Sort dropdown wired via `sortSel`

**`triage_app/public/index.html`:**
- Sort dropdown in filter bar
- "B↑" column header with explanatory tooltip
- CSS for `.sb-score` tier chips

---

## Test plan

- [x] `ruff format` + `ruff check` — clean
- [x] `mypy src/` — clean (strict mode)
- [x] `pytest -q tests/unit` — **1,324 passed, 2 skipped** (all hooks pass)
- [x] Integration verified: 1,239 candidates bulk-excluded via live triage API with 0 failures
- [x] Triage app running at `http://localhost:7070` with Stage B scores visible and sort working

🤖 Generated with [Claude Code](https://claude.com/claude-code)