### PR TITLE
feat(discovery): blacklist-batch-2 — 10 new title-noise terms + AI brand names

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -251,6 +251,15 @@
   `source_native.py` so candidates with no Hebrew letters in any title or snippet are set to
   `UNSUPPORTED_SOURCE` at the earliest pipeline stage. 1,239 existing unreviewed non-Hebrew
   candidates bulk-excluded via triage API (12,816 unreviewed remaining).
+- [done] `DISC-PR-BLACKLIST-BATCH2` — 10 new title-noise blacklist terms added to
+  `_EXCLUDED_TITLE_TERMS`: `לאתר בנייה` (construction-site dative), `grok` + `gemini` + `claude`
+  (English AI brand names, complementing existing Hebrew forms), `מגיע לך` + `מגיע לכם`
+  (prize/reward-phrase noise), `צו סגירה לעסק` + `צו סגירה ניתן לעסק` + `צו סגירה הוצא לעסק`
+  (generic business closure orders), `תורה` (Torah/religious content). 71 existing unreviewed
+  candidates matched and bulk-excluded via triage API. 18 historical strong-positive article URLs
+  seeded as prioritized candidates (titles fetched); Stage B retrained on the updated labels
+  dataset — positives doubled from 53 → 109 (train=77, val=16, test=16); new model version
+  `6003e08b0343`.
 - [done] `TRIAGE-APP-STAGEB-RANKING` — triage local app upgraded with Stage B score display and
   sort: `serve.py` loads `StageBScorer` at startup and attaches `stage_b_score` to every
   serialized candidate; `sort=stage_b_asc` query param sorts ascending by `p_negative` (lowest =

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -138,6 +138,7 @@ _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
         "עסקי מזון",  # food businesses (plural construct)
         # ── construction / real-estate noise ─────────────────────────────────
         "אתר בנייה",  # construction site
+        "לאתר בנייה",  # to a construction site (dative)
         "אתר הבנייה",  # the construction site
         "דירה למכירה",  # apartment for sale
         "דירות למכירה",  # apartments for sale
@@ -153,6 +154,9 @@ _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
         "צו סגירה למפעל",  # factory closure order
         "צו סגירה לסניף",  # branch closure order
         "צו סגירה למאפיה",  # bakery closure order (מאפיה = bakery in Hebrew)
+        "צו סגירה לעסק",  # business closure order (generic)
+        "צו סגירה ניתן לעסק",  # business closure order issued to business
+        "צו סגירה הוצא לעסק",  # business closure order issued to business (alt form)
         # ── retail / brand noise ─────────────────────────────────────────────
         "המשביר",  # HaMashbir department-store chain
         "איקאה",  # IKEA
@@ -160,9 +164,12 @@ _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
         "מסחר בבורסה",  # stock-market trading
         "מסחר עצמאי",  # independent trading / freelance commerce
         # ── AI / tech noise ──────────────────────────────────────────────────
-        "גרוק",  # Grok AI
-        "ג'מיני",  # Gemini AI
+        "גרוק",  # Grok AI (Hebrew)
+        "grok",  # Grok AI (English, case-insensitive)
+        "ג'מיני",  # Gemini AI (Hebrew)
+        "gemini",  # Gemini AI (English, case-insensitive)
         "chatgpt",  # ChatGPT (case-insensitive)
+        "claude",  # Claude AI (case-insensitive)
         "מודל שפה",  # language model
         # ── unrelated legal / civic ───────────────────────────────────────────
         "בגצ",  # HCJ (no punctuation)
@@ -213,6 +220,11 @@ _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
         "הטרדה מינית",  # sexual harassment — covers "להטרדה מינית", "הוטרדה מינית"
         # ── AI / tech (second batch) ─────────────────────────────────────────
         "בינה מלאכותית",  # artificial intelligence
+        # ── religious content noise ──────────────────────────────────────────
+        "תורה",  # Torah — religious content, off-topic
+        # ── generic reward / prize phrases ────────────────────────────────────
+        "מגיע לך",  # "you deserve it" — prize/reward noise
+        "מגיע לכם",  # "you all deserve it" — prize/reward noise
         # ── civic / protest noise ────────────────────────────────────────────
         "מפגינים",  # protesters
         # ── license revocation (driving/professional, non-enforcement) ────────


### PR DESCRIPTION
## Summary

Adds 10 new exclusion terms to `_EXCLUDED_TITLE_TERMS` in `candidate_filters.py`, covering
AI brand names (English forms), prize/reward noise, generic business closure orders, and
religious content.

### New terms

| Category | Terms |
|---|---|
| Construction site (dative) | `לאתר בנייה` |
| AI brand names (English) | `grok`, `gemini`, `claude` |
| Reward/prize noise | `מגיע לך`, `מגיע לכם` |
| Generic business closure | `צו סגירה לעסק`, `צו סגירה ניתן לעסק`, `צו סגירה הוצא לעסק` |
| Religious content | `תורה` |

Notes:
- AI English names complement the already-present Hebrew forms `גרוק`, `ג'מיני`, `chatgpt`
- Business closure forms complement existing `צו סגירה למפעל/לסניף/למאפיה`
- All terms are matched case-insensitively as substrings (existing filter contract)

### Operational impact (applied live before this PR)
- **71** existing unreviewed candidates matched and bulk-excluded via triage API
- **18** historical strong-positive article URLs seeded as prioritized candidates with fetched titles
- Stage B retrained on updated labels: positives **53 → 109** (model_version=`6003e08b0343`)

## Test plan

- [x] `ruff format` + `ruff check` — clean
- [x] `mypy` — clean
- [x] `pytest -q tests/unit` (smoke tests via pre-commit hook) — pass
- [x] All 71 bulk-exclusions confirmed via triage API (0 failures)
- [x] Triage app live at `http://localhost:7070` with retrained Stage B scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)