### PR TITLE
fix(discovery): apply title-noise blacklist to snippet as well as title

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -251,6 +251,9 @@
   `source_native.py` so candidates with no Hebrew letters in any title or snippet are set to
   `UNSUPPORTED_SOURCE` at the earliest pipeline stage. 1,239 existing unreviewed non-Hebrew
   candidates bulk-excluded via triage API (12,816 unreviewed remaining).
+- [done] `DISC-PR-SNIPPET-NOISE-COVERAGE` — `classify_title_noise()` expanded to search both
+  `title` and `snippet` fields (was title-only); 691 additional unreviewed candidates matched
+  by snippet and bulk-excluded via triage API.
 - [done] `DISC-PR-BLACKLIST-BATCH2` — 10 new title-noise blacklist terms added to
   `_EXCLUDED_TITLE_TERMS`: `לאתר בנייה` (construction-site dative), `grok` + `gemini` + `claude`
   (English AI brand names, complementing existing Hebrew forms), `מגיע לך` + `מגיע לכם`

--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -411,16 +411,20 @@ def classify_search_noise(
 def classify_title_noise(
     discovered: DiscoveredCandidate,
 ) -> SearchNoiseClassification | None:
-    """Classify candidates whose title contains an excluded keyword.
+    """Classify candidates whose title or snippet contains an excluded keyword.
 
     Applies to all producer kinds — this is a pre-scrape cost filter, not
-    a search-result surface filter.  Returns the first matching term.
+    a search-result surface filter.  Both ``title`` and ``snippet`` are
+    searched so that noise terms buried only in the snippet are caught too.
+    Returns the first matching term.
     """
     title = (discovered.title or "").casefold()
-    if not title:
+    snippet = (discovered.snippet or "").casefold()
+    text = title + " " + snippet
+    if not text.strip():
         return None
     for term in sorted(_EXCLUDED_TITLE_TERMS, key=len, reverse=True):
-        if term.casefold() in title:
+        if term.casefold() in text:
             return SearchNoiseClassification(
                 reason=SearchNoiseReason.TITLE_KEYWORD_MATCH,
                 matched_keyword=term,


### PR DESCRIPTION
## Summary

`classify_title_noise()` previously only checked `DiscoveredCandidate.title`. This meant
candidates whose off-topic content appeared in the search-result snippet (תקציר) but not the
headline were passed through the pre-scrape noise filter uncaught.

**Change:** search both `title` and `snippet` for any term in `_EXCLUDED_TITLE_TERMS`.

```python
# before
title = (discovered.title or "").casefold()
if not title:
    return None
for term in ...:
    if term.casefold() in title:

# after
title   = (discovered.title   or "").casefold()
snippet = (discovered.snippet or "").casefold()
text = title + " " + snippet
if not text.strip():
    return None
for term in ...:
    if term.casefold() in text:
```

The `SearchNoiseReason.TITLE_KEYWORD_MATCH` reason and all downstream metadata keys are
unchanged — callers that already handle this reason need no updates.

## Operational impact (applied live before this PR)

691 additional unreviewed candidates were matched via snippet (but not title) and
bulk-excluded via the triage API. Top contributors:

| Term | Candidates |
|---|---|
| `המס` | 76 |
| `איראן` | 57 |
| `קנס` | 51 |
| `פוליטי` | 41 |
| `ספורט` | 28 |
| `בזק` | 28 |
| `מעשים מגונים` | 24 |
| … | … |

## Test plan

- [x] `ruff format` + `ruff check` — clean
- [x] `mypy` — clean (strict)
- [x] pre-commit smoke tests pass
- [x] 691 bulk-exclusions via live triage API — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)