### PR TITLE
feat(triage-app): publication-year filter for reviewing historical candidates

### DIFF
--- a/triage_app/public/app.js
+++ b/triage_app/public/app.js
@@ -8,6 +8,7 @@ let state = {
   status: 'all',
   q: '',
   sort: 'stage_b_asc',   // default to Stage B ranking so likely positives surface first
+  pubYearBefore: '',
   page: 1,
   total: 0,
   pages: 1,
@@ -24,6 +25,7 @@ const pgPrev      = document.getElementById('pg-prev');
 const pgNext      = document.getElementById('pg-next');
 const batchSel    = document.getElementById('batch-select');
 const sortSel     = document.getElementById('sort-select');
+const pubYearSel  = document.getElementById('pub-year-select');
 const searchEl    = document.getElementById('search');
 const toast       = document.getElementById('toast');
 const statTotal   = document.getElementById('stat-total');
@@ -39,8 +41,9 @@ async function fetchCandidates() {
     limit: LIMIT,
     sort: state.sort,
   });
-  if (state.batchId) params.set('batch_id', state.batchId);
-  if (state.q)       params.set('q', state.q);
+  if (state.batchId)       params.set('batch_id', state.batchId);
+  if (state.q)             params.set('q', state.q);
+  if (state.pubYearBefore) params.set('pub_year_before', state.pubYearBefore);
   const res = await fetch(`${API}/api/candidates?${params}`);
   return res.json();
 }
@@ -135,7 +138,7 @@ function renderRows() {
       </td>
       <td><div class="title">${title}</div></td>
       <td><div class="snippet">${snippet}</div></td>
-      <td><div class="date">${formatDate(c.first_seen_at)}</div></td>
+      <td><div class="date${c.pub_year && c.pub_year < 2019 ? ' old' : ''}">${c.pub_year || formatDate(c.first_seen_at)}</div></td>
       ${stageBChip(c.stage_b_score)}
       <td class="actions" style="text-align:left">
         ${badge}
@@ -270,6 +273,11 @@ batchSel.addEventListener('change', () => {
 
 sortSel.addEventListener('change', () => {
   state.sort = sortSel.value;
+  load(true);
+});
+
+pubYearSel.addEventListener('change', () => {
+  state.pubYearBefore = pubYearSel.value;
   load(true);
 });
 

--- a/triage_app/public/index.html
+++ b/triage_app/public/index.html
@@ -67,6 +67,7 @@
     .title { font-size: 13px; font-weight: 500; direction: rtl; }
     .snippet { font-size: 12px; color: var(--muted); direction: rtl; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; max-width: 480px; }
     .date { font-size: 11px; color: var(--muted); white-space: nowrap; direction: ltr; }
+    .date.old { color: var(--orange); font-weight: 700; }
     .url-link { font-size: 11px; color: var(--accent); word-break: break-all; direction: ltr; }
     .triage-badge { display: inline-block; padding: 3px 9px; border-radius: 99px; font-size: 12px; font-weight: 700; letter-spacing: .01em; }
     .triage-badge.unreviewed  { background: #1e2030; color: var(--muted); }
@@ -124,6 +125,12 @@
     <button class="tab" data-status="excluded">הוחרגו</button>
   </div>
   <div class="spacer"></div>
+  <select id="pub-year-select" title="שנת פרסום">
+    <option value="">כל השנים</option>
+    <option value="2019">לפני 2019</option>
+    <option value="2021">לפני 2021</option>
+    <option value="2023">לפני 2023</option>
+  </select>
   <select id="sort-select" title="מיון">
     <option value="default">מיון: ברירת מחדל</option>
     <option value="stage_b_asc">מיון: Stage B ↑ (סביר ביותר להיות רלוונטי)</option>
@@ -139,7 +146,7 @@
         <th>מקור</th>
         <th>כותרת</th>
         <th>תקציר</th>
-        <th>תאריך</th>
+        <th>פורסם</th>
         <th title="Stage B p_negative — נמוך יותר = סביר יותר להיות רלוונטי">B↑</th>
         <th style="text-align:left">סטטוס / פעולה</th>
       </tr>

--- a/triage_app/serve.py
+++ b/triage_app/serve.py
@@ -12,6 +12,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import mimetypes
 import sys
@@ -103,7 +104,7 @@ def _load_stage_b_scores() -> None:
 
             @property
             def candidate_id(self) -> str:
-                return self._c["candidate_id"]
+                return str(self._c["candidate_id"])
 
             @property
             def domain(self) -> str | None:
@@ -196,6 +197,16 @@ def _stats() -> dict[str, Any]:
     }
 
 
+def _pub_year(c: dict[str, Any]) -> int | None:
+    hint = (c.get("metadata") or {}).get("latest_publication_datetime_hint")
+    if hint and len(hint) >= 4:
+        try:
+            return int(hint[:4])
+        except ValueError:
+            pass
+    return None
+
+
 def _serialize(c: dict[str, Any]) -> dict[str, Any]:
     titles = c.get("titles") or []
     snippets = c.get("snippets") or []
@@ -206,6 +217,7 @@ def _serialize(c: dict[str, Any]) -> dict[str, Any]:
         "title": titles[0] if titles else "",
         "snippet": snippets[0] if snippets else "",
         "first_seen_at": str(c.get("first_seen_at", "")),
+        "pub_year": _pub_year(c),
         "backfill_batch_id": c.get("backfill_batch_id"),
         "candidate_status": c.get("candidate_status", "new"),
         "retry_priority": c.get("retry_priority", 0),
@@ -221,6 +233,7 @@ def _query_candidates(
     page: int,
     limit: int,
     sort: str = "default",
+    pub_year_before: int | None = None,
 ) -> dict[str, Any]:
     items = list(_candidates.values())
 
@@ -233,6 +246,9 @@ def _query_candidates(
         items = [c for c in items if c.get("_triage") == "excluded"]
     elif status == "prioritized":
         items = [c for c in items if c.get("_triage") == "prioritized"]
+
+    if pub_year_before is not None:
+        items = [c for c in items if (_pub_year(c) or 9999) < pub_year_before]
 
     if q:
         ql = q.lower()
@@ -297,6 +313,11 @@ class Handler(BaseHTTPRequestHandler):
             except ValueError:
                 self._json({"error": "invalid page or limit"}, 400)
                 return
+            raw_pyb = qs.get("pub_year_before", [None])[0]
+            pub_year_before: int | None = None
+            if raw_pyb:
+                with contextlib.suppress(ValueError):
+                    pub_year_before = int(raw_pyb)
             self._json(
                 _query_candidates(
                     batch_id=qs.get("batch_id", [None])[0],
@@ -305,6 +326,7 @@ class Handler(BaseHTTPRequestHandler):
                     page=page,
                     limit=limit,
                     sort=qs.get("sort", ["default"])[0],
+                    pub_year_before=pub_year_before,
                 )
             )
         elif parsed.path == "/api/stats":


### PR DESCRIPTION
## Summary

Adds a **publication year** filter to the local triage workbench so operators can focus
a review session on a specific date range — especially useful for isolating the ~134
unreviewed pre-2019 candidates to triage for potential positive training examples.

### Changes

**`serve.py`**
- `_pub_year(c)` — extracts the year from `metadata.latest_publication_datetime_hint`
  (96.1% coverage across the candidate store)
- `pub_year` included in every serialized candidate  
- `pub_year_before: int | None` param in `_query_candidates()` — when set, only
  candidates whose pub year is strictly < the cutoff are returned; candidates with
  no date hint are excluded from this filtered view

**`index.html`**
- Pub-year dropdown in the filter bar: *כל השנים* / *לפני 2019* / *לפני 2021* / *לפני 2023*
- Column header renamed "תאריך" → "פורסם"

**`app.js`**
- `pubYearBefore` state field + `pubYearSel` DOM ref
- `pub_year_before` param forwarded to the API when set
- Date cell shows `pub_year` when available (fallback to `first_seen_at`);
  years < 2019 render in **orange bold** so they stand out immediately

### Usage

Select *לפני 2019* in the new dropdown → the table narrows to exactly the
134 unreviewed candidates published before 2019, sorted by Stage B score
(most likely positives first). Use `p` / `e` keyboard shortcuts to triage;
the counter in the header updates live.

## Test plan

- [x] `ruff` + `mypy` clean
- [x] `curl .../api/candidates?status=unreviewed&pub_year_before=2019` → 134 items
- [x] Triage server restarted and confirmed live at http://localhost:7070

🤖 Generated with [Claude Code](https://claude.com/claude-code)