### PR TITLE
fix(discovery): cap Brave -site: exclusions at 15, deprioritise ICE

### DIFF
--- a/agents/news/local_search_brave_exa.yaml
+++ b/agents/news/local_search_brave_exa.yaml
@@ -12,7 +12,7 @@ name: enforcement-news-local-search-brave-exa
 dataset_name: news_items
 job_name: ingest
 days: 21
-max_articles: 30
+max_articles: 100
 
 sources:
   - name: ynet

--- a/src/denbust/discovery/engines/brave.py
+++ b/src/denbust/discovery/engines/brave.py
@@ -18,6 +18,39 @@ from denbust.discovery.models import (
 )
 from denbust.news_items.normalize import canonicalize_news_url
 
+# Brave returns HTTP 422 when the query string grows too long from many -site:
+# operators.  We cap the number of excluded domains and prioritise the highest-
+# traffic ones so the cap never silently drops the most impactful exclusions.
+_BRAVE_MAX_EXCLUDED_DOMAINS: int = 15
+
+# Domains sorted from most to least important to exclude.  Any domain that
+# appears here is promoted to the front of the exclusion list before capping;
+# the remainder are appended alphabetically.
+_BRAVE_EXCLUDED_DOMAIN_PRIORITY: tuple[str, ...] = (
+    "he.wikipedia.org",
+    "themarker.com",
+    "globes.co.il",
+    "calcalist.co.il",
+    "kikar.co.il",
+    "srugim.co.il",
+    "sport1.maariv.co.il",
+    "collab.mako.co.il",
+    "nevo.co.il",
+    "bizportal.co.il",
+    "he.wikiquote.org",
+    "kolzchut.org.il",
+)
+
+
+def _brave_excluded_domains(domains: list[str]) -> list[str]:
+    """Return *domains* sorted by exclusion priority, capped at the Brave limit."""
+    priority_index = {d: i for i, d in enumerate(_BRAVE_EXCLUDED_DOMAIN_PRIORITY)}
+    sorted_domains = sorted(
+        domains,
+        key=lambda d: (priority_index.get(d, len(_BRAVE_EXCLUDED_DOMAIN_PRIORITY)), d),
+    )
+    return sorted_domains[:_BRAVE_MAX_EXCLUDED_DOMAINS]
+
 
 class BraveSearchEngine:
     """Brave Search API adapter for discovery candidates."""
@@ -93,7 +126,8 @@ class BraveSearchEngine:
         # instead.  Only applied when the query is not already scoped to a
         # preferred domain (source-targeted queries don't need it).
         if query.excluded_domains and not query.preferred_domains:
-            parts.extend(f"-site:{domain}" for domain in query.excluded_domains)
+            for domain in _brave_excluded_domains(query.excluded_domains):
+                parts.append(f"-site:{domain}")
         return " ".join(parts)
 
     def _result_to_candidate(

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -44,7 +44,7 @@ _SOURCE_SCRAPE_PRIORITY: dict[str, int] = {
     "maariv": 10,  # 5.8 % true-positive density
     "walla": 9,  # 5.6 %
     "haaretz": 8,  # 3.5 %
-    "ice": 7,  # 2.9 %
+    "ice": 1,  # celebrity/entertainment mix — low enforcement density; de-prioritised
     "mako": 6,  # 2.0 %
     "ynet": 5,  # 1.4 %
     "israelhayom": 4,


### PR DESCRIPTION
## Summary

- **Brave 422 fix**: The full `_IRRELEVANT_CONTENT_DOMAINS` set (24 entries) caused Brave to return HTTP 422 when embedded as `-site:` operators in the query string. Added `_brave_excluded_domains()` in `brave.py` that sorts domains by a priority tuple (Wikipedia, TheMarker, Globes, Calcalist, Kikar, Srugim, sport1.maariv, collab.mako, nevo, bizportal, he.wikiquote, kolzchut) and caps at 15. The highest-impact exclusions are always kept; low-traffic ones fall off gracefully.
- **ICE scrape priority 7 → 1**: `ice.co.il` is a celebrity/entertainment outlet. Discovery runs found 54 ICE articles, all of which were irrelevant to the enforcement beat (Rita's farewell, space news, etc.). Lowering the priority ensures Maariv, Walla, Haaretz, Mako, and Ynet candidates are all drained before ICE articles are attempted.
- **`max_articles: 100`** in `local_search_brave_exa.yaml`: raised from 30 so each scrape run processes a larger slice of the backfill queue through the Stage B prefilter thin pass.

## Test plan

- [ ] `uv run pytest -q tests/unit -k "brave or scrape_queue"` — all pass
- [ ] `uv run ruff check` + `uv run mypy src/` — clean
- [ ] Next discovery run: Brave should return 200 (not 422) and log results
- [ ] Next scrape run: ICE candidates appear after Maariv/Walla/Haaretz/Mako/Ynet in the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)