### PR TITLE
fix(filters): replace broad קנס exclusion with specific non-enforcement bigrams

### DIFF
--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -200,7 +200,17 @@ _EXCLUDED_TITLE_TERMS: frozenset[str] = frozenset(
         "מסים",  # taxes — covers "המסים" substring too
         "המס",  # the tax (shorter form; avoids over-blocking "מסים" in other contexts)
         "תקציב",  # budget — covers "התקציב"
-        "קנס",  # fine — covers "קנסות"
+        # "קנס" (fine) was here but removed — 98% of matched articles were enforcement-relevant
+        # (prostitution-law fines, client-penalisation statistics). Replaced with specific
+        # non-enforcement bigrams below.
+        "קנס חנייה",  # parking fine
+        "קנס תנועה",  # traffic fine
+        "קנס רכב",  # vehicle fine
+        "קנס מנהלי",  # administrative fine (generic regulatory noise)
+        "נקנס המועדון",  # sports club was fined
+        "נקנסה חברת",  # [company name] company was fined (business noise)
+        "קנס פיפא",  # FIFA fine
+        'קנס אופ"א',  # UEFA fine
         "עסקה",  # deal/transaction
         "עסקת",  # deal-of (construct form)
         "זכיינות",  # franchising


### PR DESCRIPTION
## Summary

`קנס` (fine) was in `_EXCLUDED_TITLE_TERMS` but empirically matched ~98% false positives: enforcement-relevant articles about prostitution-law fine statistics, client-penalisation reporting, and related legislation.

**Data:** 46 articles filtered by `קנס`; only 1 was off-topic (Real Madrid sports fine). Examples of wrongly excluded enforcement content:
- "קריסת האכיפה נגד לקוחות זנות: ירידה של 94% במספר הקנסות"
- "26 קנסות מחוץ לגוש דן ב-3 שנים: נחשפו נתוני אכיפת החוק להפללת לקוחות זנות"
- "N12 - השרים אישרו: קנס לצרכני זנות"
- "כולל ניצול מיני: מטא נקנסה במאות מיליוני דולרים"

## Change

Remove `קנס` from exclusions. Replace with 8 specific non-enforcement bigrams:

| Bigram | Context |
|---|---|
| `קנס חנייה` | Parking fine |
| `קנס תנועה` | Traffic fine |
| `קנס רכב` | Vehicle fine |
| `קנס מנהלי` | Generic administrative fine |
| `נקנס המועדון` | Sports club fined |
| `נקנסה חברת` | Company fined (business noise) |
| `קנס פיפא` | FIFA fine |
| `קנס אופ"א` | UEFA fine |

Sports articles without those specific bigrams will fall through to Stage B Naive Bayes, which will correctly reject them for lack of enforcement signal.

## Test plan
- [x] 48 candidate filter unit tests pass
- [x] ruff, mypy clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)