### PR TITLE
feat(scrape): add --pub-date-from for targeted recent-candidate scraping

### DIFF
--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -65,12 +65,26 @@ def run(
         int | None,
         typer.Option("--days", "-d", help="Days back to search (ingest only)"),
     ] = None,
+    pub_date_from: Annotated[
+        str | None,
+        typer.Option(
+            "--pub-date-from",
+            help="ISO date (YYYY-MM-DD): only scrape candidates published on or after this date"
+            " (scrape_candidates job only).",
+        ),
+    ] = None,
 ) -> None:
     """Run a dataset/job pair through the registry."""
     from denbust.pipeline import run_job
 
     config_path = config or Path("agents/news/local.yaml")
-    run_job(config_path=config_path, dataset_name=dataset, job_name=job, days_override=days)
+    run_job(
+        config_path=config_path,
+        dataset_name=dataset,
+        job_name=job,
+        days_override=days,
+        scrape_pub_date_from=pub_date_from,
+    )
 
 
 @app.command("diagnose-sources")

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -2,6 +2,7 @@
 
 import os
 from collections.abc import Mapping
+from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 
@@ -435,6 +436,7 @@ class Config(BaseModel):
     job_name: JobName = JobName.INGEST
     days: int = Field(default=3, ge=1)
     max_articles: int = Field(default=30, ge=1)
+    scrape_pub_date_from: datetime | None = None
     keywords: list[str] = Field(default_factory=lambda: DEFAULT_KEYWORDS.copy())
     sources: list[SourceConfig] = Field(default_factory=list)
     classifier: ClassifierConfig = Field(default_factory=ClassifierConfig)

--- a/src/denbust/discovery/scrape_queue.py
+++ b/src/denbust/discovery/scrape_queue.py
@@ -94,10 +94,23 @@ def select_candidates_for_scrape(
     *,
     limit: int,
     now: datetime | None = None,
+    pub_date_from: datetime | None = None,
 ) -> list[PersistentCandidate]:
-    """Return eligible durable candidates for scraping."""
+    """Return eligible durable candidates for scraping.
+
+    When *pub_date_from* is set only candidates whose
+    ``latest_publication_datetime_hint`` is on or after that date are
+    considered.  Candidates with no publication date hint are excluded when the
+    filter is active so the targeted window is strict.
+    """
     current_time = now or datetime.now(UTC)
     candidates = persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+    if pub_date_from is not None:
+        candidates = [
+            c
+            for c in candidates
+            if (pub := _backfill_publication_datetime(c)) is not None and pub >= pub_date_from
+        ]
     return order_scrape_eligible_candidates(candidates, now=current_time)[:limit]
 
 

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -1417,17 +1417,21 @@ async def _run_candidate_scrape_job(
     sources: list[Source],
     limit: int,
     orchestrator: CascadeOrchestrator | None = None,
+    pub_date_from: datetime | None = None,
 ) -> tuple[CandidateScrapeBatch, list[PrefilterDecision]]:
     """Select queued candidates, apply the thin prefilter, and run the scrape-attempt layer.
 
     Returns ``(scrape_batch, thin_decisions)``.  When *orchestrator* is ``None``
-    the thin pass is skipped and ``thin_decisions`` is empty.
+    the thin pass is skipped and ``thin_decisions`` is empty.  When
+    *pub_date_from* is set only candidates published on or after that date are
+    considered (targeted / recent-only scrape).
     """
     persistence = create_discovery_persistence(config)
     try:
         selected_candidates = select_candidates_for_scrape(
             persistence,
             limit=limit,
+            pub_date_from=pub_date_from,
         )
     finally:
         persistence.close()
@@ -2494,6 +2498,7 @@ async def run_news_scrape_candidates_job(
             sources=sources,
             limit=config.max_articles,
             orchestrator=orchestrator,
+            pub_date_from=config.scrape_pub_date_from,
         )
         result.raw_article_count = len(scrape_batch.raw_articles)
         if scrape_batch.errors:
@@ -3294,6 +3299,7 @@ def _run_job_from_config(
     job_name: JobName | None,
     days_override: int | None = None,
     operational_store: OperationalStore | None = None,
+    scrape_pub_date_from: str | None = None,
 ) -> RunSnapshot:
     """Shared sync wrapper for CLI-triggered job runs."""
     setup_logging()
@@ -3304,6 +3310,14 @@ def _run_job_from_config(
         update["dataset_name"] = DatasetName(dataset_name)
     if job_name is not None:
         update["job_name"] = JobName(job_name)
+    if scrape_pub_date_from is not None:
+        try:
+            update["scrape_pub_date_from"] = datetime.fromisoformat(scrape_pub_date_from).replace(
+                tzinfo=UTC
+            )
+        except ValueError as exc:
+            print(f"Error: --pub-date-from must be an ISO date (YYYY-MM-DD): {exc}")
+            sys.exit(1)
     if update:
         config = config.model_copy(update=update)
 
@@ -3379,6 +3393,7 @@ def run_job(
     job_name: JobName,
     days_override: int | None = None,
     operational_store: OperationalStore | None = None,
+    scrape_pub_date_from: str | None = None,
 ) -> None:
     """Run a dataset/job pair through the generic registry."""
     _run_job_from_config(
@@ -3387,6 +3402,7 @@ def run_job(
         job_name=job_name,
         days_override=days_override,
         operational_store=operational_store,
+        scrape_pub_date_from=scrape_pub_date_from,
     )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -70,6 +70,7 @@ class TestCli:
             dataset_name: DatasetName,
             job_name: JobName,
             days_override: int | None = None,
+            scrape_pub_date_from: str | None = None,  # noqa: ARG001
         ) -> None:
             captured["config_path"] = config_path
             captured["dataset_name"] = dataset_name

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2429,7 +2429,7 @@ class TestRunPipelineAsync:
         assert batch.selected_candidates == selected_candidates
         assert thin_decisions == []
         assert persistence.closed is True
-        select_mock.assert_called_once_with(persistence, limit=3)
+        select_mock.assert_called_once_with(persistence, limit=3, pub_date_from=None)
         scrape_mock.assert_awaited_once_with(
             config=config,
             candidates=selected_candidates,
@@ -2573,6 +2573,7 @@ class TestRunPipelineAsync:
             sources: list[FakeSource],
             limit: int,
             orchestrator: object = None,  # noqa: ARG001
+            pub_date_from: object = None,  # noqa: ARG001
         ) -> tuple[CandidateScrapeBatch, list[object]]:
             captured["days"] = config.days
             captured["limit"] = limit
@@ -4057,6 +4058,7 @@ class TestRunPipeline:
             "job_name": JobName.INGEST,
             "days_override": 5,
             "operational_store": None,
+            "scrape_pub_date_from": None,
         }
 
     def test_run_job_from_config_passes_operational_store_to_async_runner(


### PR DESCRIPTION
## Summary

Adds a `--pub-date-from YYYY-MM-DD` flag to `denbust run --job scrape_candidates` so the scrape can be scoped to recently-published articles without draining the full multi-month backlog or manually bumping candidate priorities.

**Problem:** With 15k+ `new` candidates spanning Jan–May 2026, a 100-candidate scrape budget always selects the highest-priority-source / earliest-retry candidates. Last-week articles (118 candidates published May 26–Jun 2) are unreachable without this filter.

**Usage:**
```bash
denbust run --dataset news_items --job scrape_candidates \
            --config agents/news/local_search_brave_exa.yaml \
            --pub-date-from 2026-05-26
```

## Changes

| File | Change |
|---|---|
| `config.py` | `Config.scrape_pub_date_from: datetime \| None` field |
| `scrape_queue.py` | `pub_date_from` kwarg on `select_candidates_for_scrape` — filters before ordering; no-hint candidates excluded when filter is active |
| `pipeline.py` | Thread through `_run_candidate_scrape_job` → reads from `config.scrape_pub_date_from`; `run_job` / `_run_job_from_config` accept and parse the ISO date string |
| `cli.py` | `--pub-date-from` option on `run` command |

When `--pub-date-from` is not set behaviour is identical to before (no regression).

## Test plan
- [x] 1325 unit tests pass, 0 failures
- [x] ruff format/check, mypy strict — clean
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)