### PR TITLE
feat(scrape): Stage B2 manual LLM filtering in the batch protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,24 @@ denbust backup --dataset news_items --config agents/backup/news_items.yaml
 - Normalize Mako URLs before deduplication or seen-state writes so query params do not fork duplicate records.
 - Do not fabricate article details or inferred facts beyond what exists in the source text and structured model outputs.
 
+## Batch Scraping Protocol (mandatory)
+
+Scraping runs against the backlog go through fixed-size batches under a limited
+scraping budget. Full protocol: `docs/batch_scraping_protocol.md`.
+
+- Select batches with `denbust run --job scrape_candidates --balanced-batch N`
+  (month-frequency-weighted, source-balanced selection).
+- **Stage B2 — manual LLM filtering is mandatory before scraping a batch.** The
+  operating agent reviews the planned batch's titles/snippets/domains and
+  removes clear junk/spam (escort/massage listings, ad pages, SEO bait) that
+  passed the statistical Stage B prefilter, *before* spending scrape budget.
+- Suppress B2-removed candidates so they never re-enter a batch:
+  `denbust candidates-b2-suppress --ids …` (one-off junk) or `--domains …`
+  (whole spam domains; also add the domain to `_IRRELEVANT_CONTENT_DOMAINS`).
+- Re-plan after suppression so the batch tops up with clean candidates, then run.
+- Report each batch: month×source allocation, Stage B2 removals, scrape
+  outcomes, classification outcomes, and any domains added to the blocklist.
+
 ## Config And Secrets
 
 - Keep durable personal config outside the repo, for example under `~/.config/denbust/`.

--- a/docs/batch_scraping_protocol.md
+++ b/docs/batch_scraping_protocol.md
@@ -1,0 +1,104 @@
+# Batch Scraping Protocol
+
+This document defines the standing protocol for working through the candidate
+backlog under a **limited scraping budget** (rate-limit / block risk, time
+cost, and Claude classification spend). It is mandatory for any agent running
+`scrape_candidates` against the backlog.
+
+## Why batches
+
+Discovery finds thousands of candidates per month. The prefilter cascade and
+the candidation steps below cut that to a small, high-signal set so we spend
+scrape and Claude budget only where an enforcement event might actually exist.
+We process the backlog in **fixed-size batches** (default 60) rather than
+draining the whole queue at once.
+
+## The pipeline, end to end
+
+```
+discover → candidates → Stage B (NaiveBayes) → balanced batch selection
+        → Stage B2 (manual LLM filter) → scrape → Stage C/D (disabled)
+        → Claude classification → operational record → release
+```
+
+| Stage | What | Cost | Who |
+|-------|------|------|-----|
+| Stage A | lexicon / domain reputation | free | model (disabled) |
+| **Stage B** | NaiveBayes thin prefilter, `enforce` mode | free / CPU | model |
+| Balanced selection | month-frequency-weighted, source-balanced batch | free | code (`--balanced-batch N`) |
+| **Stage B2** | **manual LLM/agent junk-and-spam filter** | agent judgment | **the operating agent** |
+| Scrape | fetch + extract article body | HTTP budget | code |
+| Stage C/D | embeddings / SLM thick pass | free / CPU | model (disabled) |
+| Claude classification | enforcement-relevance on full text | Claude API | model |
+
+## Stage B2 — manual LLM filtering (the new rule)
+
+Stage B is statistical and lets through a long tail of **keyword-rich spam**:
+escort-listing sites, massage-ad pages, and SEO-bait domains whose title and
+snippet contain the enforcement lexicon (`זנות`, `עיסוי`, `ליווי`, …) but which
+will never yield a real enforcement event.
+
+**Stage B2 is a mandatory judgment pass performed by the operating agent (the
+LLM) on the planned batch, before any scrape budget is spent.** The agent reads
+each candidate's title, snippet, and domain and removes the ones that are
+clearly junk by common sense.
+
+### Protocol
+
+1. **Plan** the batch (`--balanced-batch N`) or dry-run the planner to list the
+   selected candidates with `title`, `snippet`, `domain`, `candidate_id`.
+2. **Review (Stage B2).** For each candidate decide: real news outlet covering
+   a plausible enforcement event → **keep**; escort/massage listing, ad page,
+   SEO spam, off-topic aggregator → **remove**.
+3. **Suppress** the removed candidates so they leave the pool permanently and
+   never re-enter a future batch:
+   - **Whole spam domain** → add it to `_IRRELEVANT_CONTENT_DOMAINS` in
+     `src/denbust/discovery/candidate_filters.py` (a PR — this also blocks
+     future discovery) **and** retroactively suppress existing rows:
+     ```bash
+     denbust candidates-b2-suppress --config <cfg> --domains spam1.co.il,spam2.com \
+             --note "B2: escort-listing spam"
+     ```
+   - **One-off junk on an otherwise-legitimate domain** →
+     ```bash
+     denbust candidates-b2-suppress --config <cfg> --ids cand_a,cand_b \
+             --note "B2: off-topic"
+     ```
+4. **Re-plan** the batch. With the junk suppressed, the planner tops up to the
+   full batch size with clean candidates.
+5. **Run** the scrape on the clean batch.
+6. **Record** what Stage B2 removed in the batch report.
+
+### Decision heuristics
+
+Remove when:
+- domain is an escort/massage/companionship listing or directory,
+- the page is an ad, classified, or "girls near you" aggregator,
+- the domain is generic SEO spam unrelated to Israeli enforcement news,
+- the title is obviously a service listing, not journalism.
+
+Keep when in doubt about a *real news outlet* — Claude classification is the
+final guard on borderline journalism. Stage B2 only removes the **clearly**
+junk; it is a precision tool against spam, not a second relevance judge.
+
+## Balanced batch selection
+
+`--balanced-batch N` selects N candidates from the full Stage-B-passing pool:
+
+- **Frequency-weighted across months** — months with more passers get
+  proportionally more slots (largest-remainder apportionment), so the busy,
+  under-covered months are prioritised without starving quiet ones.
+- **Source-balanced within each month** — round-robin across publication
+  sources/source-families (by scrape priority) so no single site monopolises a
+  month and load is spread to reduce per-host block risk.
+
+Implementation: `src/denbust/discovery/balanced_selection.py`.
+
+## Outputs of each batch
+
+Every batch run should report:
+- month × source allocation of the planned batch,
+- Stage B2 removals (ids/domains and why),
+- scrape outcomes (succeeded / failed / partial),
+- Claude classification outcomes (relevant / not),
+- any spam domains newly added to the blocklist.

--- a/docs/local_prefilter_cascade_design.md
+++ b/docs/local_prefilter_cascade_design.md
@@ -64,6 +64,13 @@ Insertion point: **between `scrape_candidates` and `ingest`**, conceptually:
 discover → triage → scrape_candidates → [local_prefilter (NEW)] → ingest (Claude) → release
 ```
 
+> **Stage B2 (manual LLM filtering).** In addition to the statistical stages
+> below, the batch scraping protocol adds a **Stage B2** judgment pass performed
+> by the operating agent on the selected batch before scraping: it removes the
+> keyword-rich spam (escort/massage listings, ad/SEO pages) that the NaiveBayes
+> Stage B cannot reliably catch. See `docs/batch_scraping_protocol.md` and
+> `src/denbust/discovery/manual_filter.py`.
+
 Two questions follow:
 
 1. **Pre-scrape or post-scrape?** Pre-scrape we have only title, snippet, domain, URL, and the search query that found the candidate. Post-scrape we additionally have the full article text. We will run the cascade in **both** positions: a "thin" pass on pre-scrape signals (Stages A + B) inside the existing scrape-queue selection, and a "thick" pass on full article text (Stages C + D) after a successful scrape. Pre-scrape filtering also saves scrape bandwidth and queue capacity; post-scrape filtering catches noise that title/snippet hide.

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -556,6 +556,65 @@ def live_check(
         raise typer.Exit(code=1)
 
 
+@app.command("candidates-b2-suppress")
+def candidates_b2_suppress(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+    ids: Annotated[
+        str | None,
+        typer.Option("--ids", help="Comma-separated candidate ids to suppress (Stage B2)."),
+    ] = None,
+    domains: Annotated[
+        str | None,
+        typer.Option(
+            "--domains",
+            help="Comma-separated spam domains; suppress all still-scrapeable candidates on them.",
+        ),
+    ] = None,
+    note: Annotated[
+        str | None,
+        typer.Option("--note", help="Optional reason recorded on suppressed candidates."),
+    ] = None,
+) -> None:
+    """Stage B2 — manually suppress clearly-junk candidates before they consume scrape budget.
+
+    Use ``--ids`` for one-off junk on legitimate domains, ``--domains`` for whole
+    spam domains (also add the domain to ``_IRRELEVANT_CONTENT_DOMAINS`` to block
+    future discovery). See ``docs/batch_scraping_protocol.md``.
+    """
+    from denbust.config import load_config
+    from denbust.discovery.manual_filter import (
+        suppress_candidates_b2,
+        suppress_candidates_b2_by_domain,
+    )
+    from denbust.discovery.storage import create_discovery_persistence
+
+    if not ids and not domains:
+        typer.echo("Provide --ids and/or --domains.")
+        raise typer.Exit(code=1)
+
+    config_path = config or Path("agents/news/local.yaml")
+    cfg = load_config(config_path)
+    persistence = create_discovery_persistence(cfg)
+    total = 0
+    try:
+        if ids:
+            id_list = [value.strip() for value in ids.split(",") if value.strip()]
+            suppressed = suppress_candidates_b2(persistence, id_list, note=note)
+            total += len(suppressed)
+            typer.echo(f"Stage B2: suppressed {len(suppressed)} candidate(s) by id.")
+        if domains:
+            domain_list = [value.strip() for value in domains.split(",") if value.strip()]
+            suppressed = suppress_candidates_b2_by_domain(persistence, domain_list, note=note)
+            total += len(suppressed)
+            typer.echo(f"Stage B2: suppressed {len(suppressed)} candidate(s) by domain.")
+    finally:
+        persistence.close()
+    typer.echo(f"Stage B2 total suppressed: {total}")
+
+
 @app.command()
 def version() -> None:
     """Show version information."""

--- a/src/denbust/discovery/manual_filter.py
+++ b/src/denbust/discovery/manual_filter.py
@@ -1,0 +1,112 @@
+"""Stage B2 — manual LLM/agent pre-scrape filtering of selected candidates.
+
+Stage B (the NaiveBayes prefilter) is statistical and lets through a long tail
+of keyword-rich spam — escort-listing sites, massage-ad pages, SEO-bait domains
+— whose title/snippet contain the enforcement lexicon but which will never
+yield a real enforcement event.  **Stage B2** is the judgment pass that closes
+that gap: before any scrape budget is spent on a planned batch, the operating
+agent (LLM) reviews each candidate's title, snippet, and domain and *suppresses*
+the ones that are clearly junk.
+
+Suppression is terminal: a Stage-B2-suppressed candidate moves to
+``CandidateStatus.SUPPRESSED`` and therefore leaves the scrapeable pool
+permanently, so it never re-enters a future balanced batch.  This module is the
+durable side-effect layer for that decision; the *judgment* itself lives with
+the agent (and the protocol documented in ``docs/batch_scraping_protocol.md``).
+
+Two entry points:
+
+* ``suppress_candidates_b2`` — suppress an explicit list of candidate ids
+  (one-off junk on otherwise-legitimate domains).
+* ``suppress_candidates_b2_by_domain`` — suppress every still-scrapeable
+  candidate on one or more spam domains (use together with adding the domain to
+  ``_IRRELEVANT_CONTENT_DOMAINS`` so future discovery is blocked too).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from denbust.discovery.candidate_filters import normalize_domain
+from denbust.discovery.models import CandidateStatus, PersistentCandidate
+from denbust.discovery.scrape_queue import SCRAPEABLE_CANDIDATE_STATUSES
+from denbust.discovery.storage import DiscoveryPersistence
+
+#: Metadata marker + reason recorded on every Stage-B2-suppressed candidate.
+B2_FILTER_METADATA_KEY = "b2_manual_filter"
+B2_SUPPRESSION_REASON = "b2_manual_llm_filter"
+
+
+def _b2_suppressed(candidate: PersistentCandidate, *, note: str | None) -> PersistentCandidate:
+    """Return *candidate* transitioned to SUPPRESSED with Stage-B2 provenance."""
+    metadata = {
+        **candidate.metadata,
+        B2_FILTER_METADATA_KEY: True,
+        "b2_reason": B2_SUPPRESSION_REASON,
+    }
+    if note:
+        metadata["b2_note"] = note
+    return candidate.model_copy(
+        update={
+            "candidate_status": CandidateStatus.SUPPRESSED,
+            "needs_review": False,
+            "self_heal_eligible": False,
+            "next_scrape_attempt_at": None,
+            "metadata": metadata,
+        }
+    )
+
+
+def suppress_candidates_b2(
+    persistence: DiscoveryPersistence,
+    candidate_ids: Iterable[str],
+    *,
+    note: str | None = None,
+) -> list[PersistentCandidate]:
+    """Stage B2: suppress candidates by id; return the rows actually suppressed.
+
+    Already-suppressed and missing ids are skipped.  The change is persisted via
+    ``upsert_candidates`` so the candidates leave the scrapeable pool.
+    """
+    suppressed: list[PersistentCandidate] = []
+    for candidate_id in dict.fromkeys(candidate_ids):  # de-dupe, preserve order
+        candidate = persistence.get_candidate(candidate_id)
+        if candidate is None or candidate.candidate_status is CandidateStatus.SUPPRESSED:
+            continue
+        suppressed.append(_b2_suppressed(candidate, note=note))
+    if suppressed:
+        persistence.upsert_candidates(suppressed)
+    return suppressed
+
+
+def _domain_matches(candidate_domain: str | None, targets: frozenset[str]) -> bool:
+    normalized = normalize_domain(candidate_domain) if candidate_domain else None
+    if not normalized:
+        return False
+    return any(normalized == base or normalized.endswith(f".{base}") for base in targets)
+
+
+def suppress_candidates_b2_by_domain(
+    persistence: DiscoveryPersistence,
+    domains: Sequence[str],
+    *,
+    note: str | None = None,
+) -> list[PersistentCandidate]:
+    """Stage B2: suppress every still-scrapeable candidate on *domains*.
+
+    Subdomains are matched (``sport1.maariv.co.il`` matches target
+    ``maariv.co.il``).  Pair with adding the domain to
+    ``_IRRELEVANT_CONTENT_DOMAINS`` to block future discovery as well.
+    """
+    targets = frozenset(normalize_domain(d) or d for d in domains)
+    if not targets:
+        return []
+    scrapeable = persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+    suppressed = [
+        _b2_suppressed(candidate, note=note)
+        for candidate in scrapeable
+        if _domain_matches(candidate.domain, targets)
+    ]
+    if suppressed:
+        persistence.upsert_candidates(suppressed)
+    return suppressed

--- a/tests/unit/test_manual_filter.py
+++ b/tests/unit/test_manual_filter.py
@@ -1,0 +1,105 @@
+"""Unit tests for Stage B2 manual-filter suppression."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import HttpUrl
+
+from denbust.discovery.manual_filter import (
+    B2_FILTER_METADATA_KEY,
+    B2_SUPPRESSION_REASON,
+    suppress_candidates_b2,
+    suppress_candidates_b2_by_domain,
+)
+from denbust.discovery.models import CandidateStatus, PersistentCandidate
+from denbust.discovery.state_paths import resolve_discovery_state_paths
+from denbust.discovery.storage import StateRepoDiscoveryPersistence
+from denbust.models.common import DatasetName
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    domain: str,
+    status: CandidateStatus = CandidateStatus.NEW,
+) -> PersistentCandidate:
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        canonical_url=HttpUrl(f"https://{domain}/a/{candidate_id}"),
+        current_url=HttpUrl(f"https://{domain}/a/{candidate_id}"),
+        domain=domain,
+        titles=["t"],
+        snippets=["s"],
+        discovered_via=["brave"],
+        discovery_queries=["q"],
+        source_hints=["brave"],
+        first_seen_at=datetime(2026, 1, 1, tzinfo=UTC),
+        last_seen_at=datetime(2026, 1, 1, tzinfo=UTC),
+        candidate_status=status,
+    )
+
+
+def _store(tmp_path: Path) -> StateRepoDiscoveryPersistence:
+    paths = resolve_discovery_state_paths(state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS)
+    return StateRepoDiscoveryPersistence(paths)
+
+
+def test_suppress_by_ids_marks_terminal_and_records_provenance(tmp_path: Path) -> None:
+    """Suppressing by id moves rows to SUPPRESSED with Stage-B2 metadata."""
+    store = _store(tmp_path)
+    store.upsert_candidates(
+        [_candidate("a", domain="ynet.co.il"), _candidate("b", domain="spam.example")]
+    )
+
+    suppressed = suppress_candidates_b2(store, ["b"], note="B2: junk")
+
+    assert [c.candidate_id for c in suppressed] == ["b"]
+    reloaded = store.get_candidate("b")
+    assert reloaded is not None
+    assert reloaded.candidate_status is CandidateStatus.SUPPRESSED
+    assert reloaded.metadata[B2_FILTER_METADATA_KEY] is True
+    assert reloaded.metadata["b2_reason"] == B2_SUPPRESSION_REASON
+    assert reloaded.metadata["b2_note"] == "B2: junk"
+    # Untouched candidate stays scrapeable.
+    assert store.get_candidate("a").candidate_status is CandidateStatus.NEW  # type: ignore[union-attr]
+
+
+def test_suppress_by_ids_skips_missing_and_already_suppressed(tmp_path: Path) -> None:
+    """Missing ids and already-suppressed rows are no-ops."""
+    store = _store(tmp_path)
+    store.upsert_candidates(
+        [_candidate("done", domain="x.example", status=CandidateStatus.SUPPRESSED)]
+    )
+    suppressed = suppress_candidates_b2(store, ["done", "missing"])
+    assert suppressed == []
+
+
+def test_suppress_by_domain_matches_subdomains(tmp_path: Path) -> None:
+    """Domain suppression collapses subdomains and only touches scrapeable rows."""
+    store = _store(tmp_path)
+    store.upsert_candidates(
+        [
+            _candidate("keep", domain="ynet.co.il"),
+            _candidate("spam1", domain="escort.example"),
+            _candidate("spam2", domain="sub.escort.example"),
+            _candidate("already", domain="escort.example", status=CandidateStatus.SCRAPE_SUCCEEDED),
+        ]
+    )
+
+    suppressed = suppress_candidates_b2_by_domain(store, ["escort.example"], note="B2: spam")
+
+    assert {c.candidate_id for c in suppressed} == {"spam1", "spam2"}
+    assert store.get_candidate("spam1").candidate_status is CandidateStatus.SUPPRESSED  # type: ignore[union-attr]
+    assert store.get_candidate("spam2").candidate_status is CandidateStatus.SUPPRESSED  # type: ignore[union-attr]
+    # Non-scrapeable status is left as-is; legitimate domain untouched.
+    assert store.get_candidate("already").candidate_status is CandidateStatus.SCRAPE_SUCCEEDED  # type: ignore[union-attr]
+    assert store.get_candidate("keep").candidate_status is CandidateStatus.NEW  # type: ignore[union-attr]
+
+
+def test_suppress_by_domain_empty_input_is_noop(tmp_path: Path) -> None:
+    """No domains → nothing suppressed."""
+    store = _store(tmp_path)
+    store.upsert_candidates([_candidate("a", domain="ynet.co.il")])
+    assert suppress_candidates_b2_by_domain(store, []) == []


### PR DESCRIPTION
## Summary

Formalises **Stage B2 — manual LLM filtering** as a mandatory step in the batch scraping protocol, with durable suppression tooling.

Stage B (NaiveBayes) is statistical and lets through keyword-rich spam — escort/massage listings, ad pages, SEO bait — whose title/snippet contain the enforcement lexicon (`זנות`, `עיסוי`, `ליווי`…) but which never yield an enforcement event. Stage B2 is the agent's judgment pass on the planned batch, **before** scrape budget is spent.

## Mechanism — `denbust/discovery/manual_filter.py`
- `suppress_candidates_b2(persistence, ids, note)` — terminal `SUPPRESSED` with `b2_manual_filter` / `b2_reason` provenance; skips missing + already-suppressed.
- `suppress_candidates_b2_by_domain(persistence, domains, note)` — suppress all still-scrapeable candidates on spam domains (subdomain-aware).

Suppressed candidates leave the scrapeable pool permanently and never re-enter a future balanced batch.

## CLI
```bash
denbust candidates-b2-suppress --ids a,b --domains spam1.com --note "B2: escort spam"
```

## Docs
- `docs/batch_scraping_protocol.md` — full end-to-end protocol: pipeline table, Stage B2 rule + decision heuristics, suppression workflow, per-batch reporting.
- `AGENTS.md` — new **Batch Scraping Protocol** section making Stage B2 mandatory.
- `local_prefilter_cascade_design.md` — Stage B2 cross-reference.

## Test plan
- [x] 4 new unit tests (`test_manual_filter.py`): id suppression + provenance, skip missing/already-suppressed, subdomain domain matching, empty input.
- [x] 1339 unit tests pass; ruff + mypy clean; hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)