### PR TITLE
fix(filters): Stage B2 sweep — blocklist 57 spam/off-topic domains

### DIFF
--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -65,6 +65,67 @@ _IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
         "todojustice.co.il",  # legal info site — off-topic
         "tomoko.co.il",  # unrelated e-commerce — off-topic
         "polisa.news",  # insurance news site — off-topic
+        # ── Stage B2 sweep 2026-06: escort / massage / webcam sex-service spam ──
+        "healworlds.blogspot.com",  # "women for sale" spam blog
+        "business-ladies.co.il",  # escort listing
+        "serviciosfiat.com",  # massage-ad spam (hijacked domain)
+        "getsdiscreet.com",  # discreet-massage/escort ad
+        "getsmassage.com",  # massage ad
+        "doska777.co.il",  # escort listing board
+        "sharapplus.co.il",  # private-clinic SEO — not news
+        "il.blablacams.com",  # webcam models
+        "escortinisrael.co.il",  # escort listing
+        "swipecherry.com",  # escort listing
+        "il.rulet-18.com",  # sex-cam roulette
+        "il.chat-rulet-18.com",  # sex-cam roulette
+        "il.chatrulet-18.com",  # sex-cam roulette
+        "il.didichat.ru",  # sex-cam
+        "il.nextchat.ru",  # sex-cam
+        "il.russianroulette.su",  # live sex-cam
+        "xmassage.co.il",  # massage ad
+        "alternabe.co.il",  # massage ad
+        "boobpedia.com",  # adult-content wiki / escort agency posts
+        "bigboyztoyz69.com",  # escort listing
+        "shop69.co.il",  # sex-toy shop
+        "opulentcharm.co.il",  # OnlyFans agency SEO
+        "spaplus.co.il",  # spa/massage packages
+        "skdance.co.il",  # cabaret dancers for hire — not news
+        "healthwise.co.il",  # sex/health SEO content
+        # ── Stage B2 sweep 2026-06: off-topic commerce / real-estate / SEO ──
+        "weconnex.co.il",  # office-rental listings
+        "gal-gefen.co.il",  # local PR/advertising site
+        "b144.co.il",  # business directory
+        "rea-me.co.il",  # real-estate listings
+        "astlv.co.il",  # real-estate listings
+        "okyanus.co.il",  # office-rental listings
+        "supply-chain1.co.il",  # logistics directory
+        "rent.org.il",  # equipment-rental listings
+        "nmrk.co.il",  # commercial real-estate
+        "carwiz.co.il",  # car sales
+        "zapcars.co.il",  # car sales
+        "litrom.org.il",  # presentation-design SEO
+        "pc.co.il",  # networking/branding SEO
+        "mivzaklive.co.il",  # fraud-awareness SEO content
+        "shvirega.co.il",  # therapist SEO
+        # ── Stage B2 sweep 2026-06: legal-advice SEO / lawyer directories ──
+        "findlaw.co.il",  # legal Q&A SEO
+        "dobin-law.com",  # immigration-lawyer SEO
+        "din.co.il",  # lawyer directory
+        "ese.co.il",  # fraud-lawyer SEO
+        # ── Stage B2 sweep 2026-06: religious admin / Q&A ──
+        "rabanut.co.il",  # religious-council admin pages
+        "hidabroot.org",  # religious Q&A
+        "be7.co.il",  # B'Sheva religious opinion
+        "bshch.blogspot.com",  # haredi community blog
+        # ── Stage B2 sweep 2026-06: reference / foreign advocacy / off-topic ──
+        "he.wikisource.org",  # source-text wiki
+        "en.wikipedia.org",  # encyclopedia
+        "commons.wikimedia.org",  # media repository
+        "timesofmalta.com",  # foreign outlet — not Israeli enforcement
+        "swopbehindbars.org",  # US sex-worker advocacy
+        "abolition2014.blogspot.com",  # foreign anti-prostitution blog
+        "one.co.il",  # sports outlet — off-topic
+        "tlvtimes.co.il",  # local lifestyle/PR magazine — off-topic
     }
 )
 


### PR DESCRIPTION
## Summary

First **Stage B2** review (per `docs/batch_scraping_protocol.md`) of the 2026 scrape pool. Adds 57 domains to `_IRRELEVANT_CONTENT_DOMAINS` — they pass the statistical Stage B prefilter (keyword-rich) but are clear junk/spam that will never be an enforcement event.

| Category | Count | Examples |
|---|---:|---|
| escort / massage / webcam sex-service | 25 | doska777, business-ladies, xmassage, swipecherry, escortinisrael, *.rulet-18 cams, boobpedia, shop69 |
| off-topic commerce / real-estate / SEO | 15 | weconnex, b144, rea-me, carwiz, zapcars, rent.org.il, nmrk, litrom, pc.co.il |
| legal-advice SEO / lawyer directories | 4 | findlaw, dobin-law, din.co.il, ese |
| religious admin / Q&A | 4 | rabanut, hidabroot, be7, bshch.blogspot |
| reference / foreign advocacy / off-topic | 9 | en.wikipedia, he.wikisource, commons.wikimedia, timesofmalta, swopbehindbars, one.co.il, tlvtimes |

Effect: excluded from future discovery (via `globally_excluded_search_domains`) and marked `unsupported_source` at persist (via `classify_search_noise`). Existing candidates on these domains are retroactively suppressed in the operational store with `candidates-b2-suppress --domains`.

Domains kept deliberately (could carry enforcement signal; left to Claude): `law.co.il` (court rulings), `emess`, `kore`, `ch10`, `jpost`, `jdn`, `timeout`, `newsru`, `israelinfo`.

## Test plan
- [x] 48 candidate-filter unit tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)