### PR TITLE
fix(filters): Stage B2 sweep round 4 — 20 foreign-policy + local junk domains

### DIFF
--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -156,6 +156,27 @@ _IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
         "xn--7dbl2a.com",  # "knowledge-production" blog (punycode)
         "252project.co.il",  # dating/relationship coaching
         "3cat.cat",  # Catalan broadcaster — foreign
+        # ── Stage B2 sweep 2026-06 (round 4): foreign-policy + local SEO/junk ──
+        "ben54.jp",  # Japanese legal news — foreign
+        "tagesschau.de",  # German broadcaster — foreign
+        "askoy24.no",  # Norwegian outlet — foreign
+        "amsterdamredlightdistricttour.com",  # tourism / foreign opinion
+        "avivbar.com",  # personal business card
+        "bhklita.blogspot.com",  # kibbutz blog
+        "bizzness.net",  # consumer-pricing SEO
+        "bosmetic.co.il",  # cosmetics store
+        "90fm.co.il",  # radio show listings
+        "aig.co.il",  # insurance / compliance marketing
+        "allpallets.it",  # hijacked-domain SEO spam
+        "amit.org.il",  # education NGO
+        "allmarketing.co.il",  # marketing-news SEO
+        "ashdodnews.co.il",  # appliance ads
+        "askezra.co.il",  # health Q&A SEO
+        "b7net.co.il",  # local early-childhood PR
+        "behance.net",  # design portfolios
+        "babynames.com",  # baby-name dictionary
+        "ashdods.co.il",  # local animal-cruelty story — off-topic
+        "ashkelnayes.co.il",  # local daycare-abuse story — off-vertical
     }
 )
 


### PR DESCRIPTION
Fourth Stage B2 pass: foreign prostitution-policy outlets (ben54.jp, tagesschau.de, askoy24.no, amsterdam tour) out of scope for the Israeli index, plus local SEO/ad/blog junk. Kept Israeli enforcement signal incl. Russian-language brothel-raid reports (newsru/mignews) and an Ashdod closure-order story. Per `docs/batch_scraping_protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)