### PR TITLE
fix(filters): blocklist escort directories that reached the index

### DIFF
--- a/src/denbust/discovery/candidate_filters.py
+++ b/src/denbust/discovery/candidate_filters.py
@@ -235,6 +235,9 @@ _IRRELEVANT_CONTENT_DOMAINS: frozenset[str] = frozenset(
         "merriam-webster.com",  # dictionary
         "nziv.net",  # foreign exposé reposts
         "news.un.org",  # UN global reports — not Israeli enforcement events
+        # ── Stage B2 sweep 2026-06 (round 8): escort directories that reached the index ──
+        "sexiaoniu5.com",  # escort/"discreet apartments" directory (SEXIAN)
+        "thediscreetgentleman.com",  # escort directory
     }
 )
 


### PR DESCRIPTION
Batch 3 surfaced a Stage B2 miss: `sexiaoniu5.com` (escort 'discreet apartments' directory, branded SEXIAN) was classified `index_relevant=True` because the page is literally about prostitution venues — but it's a listing site, not an enforcement event. `thediscreetgentleman.com` is the same. Blocklisted both; the one materialized record is pulled from the index separately. Per `docs/batch_scraping_protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)