### PR TITLE
feat(scrape): automated per-domain LLM verdict gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,11 @@ scraping budget. Full protocol: `docs/batch_scraping_protocol.md`.
 - Suppress B2-removed candidates so they never re-enter a batch:
   `denbust candidates-b2-suppress --ids …` (one-off junk) or `--domains …`
   (whole spam domains; also add the domain to `_IRRELEVANT_CONTENT_DOMAINS`).
+- Prefer the **automated per-domain LLM verdict gate** over manual blocklist
+  rounds: `denbust classify-domains --suppress` judges each new domain once and
+  caches it; `denbust run --job scrape_candidates --use-domain-verdicts` applies
+  the cache. Reserve manual `_IRRELEVANT_CONTENT_DOMAINS` edits for confirmed
+  always-block cases.
 - Re-plan after suppression so the batch tops up with clean candidates, then run.
 - Report each batch: month×source allocation, Stage B2 removals, scrape
   outcomes, classification outcomes, and any domains added to the blocklist.

--- a/docs/batch_scraping_protocol.md
+++ b/docs/batch_scraping_protocol.md
@@ -118,6 +118,33 @@ This is the primary tool for the single-shot tail; the domain blocklist and
 Stage B2 still handle recurring spam that clears the gate. Implementation:
 `domain_frequencies` + `filter_by_domain_frequency` in `balanced_selection.py`.
 
+## Automated per-domain LLM verdict gate
+
+The frequency gate kills the single-shot tail, but **recurring** off-topic
+domains (real-estate/finance/escort sites seen 2+ times) still need judgment —
+previously a manual blocklist PR per batch. The verdict gate automates that:
+
+```bash
+# 1. Classify not-yet-judged domains once; cache the verdicts (and optionally
+#    suppress candidates on block-verdict domains immediately):
+denbust classify-domains --config <cfg> --suppress
+
+# 2. Apply the cached verdicts as a gate at scrape-selection time:
+denbust run --job scrape_candidates --balanced-batch 60 \
+            --min-domain-frequency 2 --use-domain-verdicts
+```
+
+Each new domain is sent to the LLM **once** with a few sample titles and judged
+`allow` (a plausible Israeli enforcement-news source — including niche/Russian/
+English Israeli outlets) or `block` (escort/SEO/foreign/off-topic). The verdict
+is cached durably in `domain_verdicts.jsonl`, so the cost is one cheap call per
+*new* domain, never per batch. Known outlets are exempt; the static
+`_IRRELEVANT_CONTENT_DOMAINS` blocklist is honoured as an always-block set.
+
+This is the scalable successor to manual Stage B2 blocklist rounds: instead of a
+human enumerating bad domains forever, the model judges each domain once and the
+decision compounds. Implementation: `src/denbust/discovery/domain_verdicts.py`.
+
 ## Outputs of each batch
 
 Every batch run should report:

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -90,6 +90,14 @@ def run(
             " spam tail. Balanced-batch mode only.",
         ),
     ] = None,
+    use_domain_verdicts: Annotated[
+        bool,
+        typer.Option(
+            "--use-domain-verdicts",
+            help="Apply the cached per-domain LLM verdict gate (drop 'block' domains)."
+            " Populate the cache first with `denbust classify-domains`. Balanced-batch mode only.",
+        ),
+    ] = False,
 ) -> None:
     """Run a dataset/job pair through the registry."""
     from denbust.pipeline import run_job
@@ -103,6 +111,7 @@ def run(
         scrape_pub_date_from=pub_date_from,
         scrape_balanced_batch_size=balanced_batch,
         scrape_min_domain_frequency=min_domain_frequency,
+        scrape_use_domain_verdicts=use_domain_verdicts,
     )
 
 
@@ -623,6 +632,69 @@ def candidates_b2_suppress(
     finally:
         persistence.close()
     typer.echo(f"Stage B2 total suppressed: {total}")
+
+
+@app.command("classify-domains")
+def classify_domains(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Max number of new domains to classify this run."),
+    ] = None,
+    suppress: Annotated[
+        bool,
+        typer.Option("--suppress", help="Stage-B2-suppress candidates on 'block'-verdict domains."),
+    ] = False,
+) -> None:
+    """Classify not-yet-judged candidate domains with the per-domain LLM verdict gate.
+
+    Populates the durable verdict cache (``domain_verdicts.jsonl``). The automated
+    successor to manual blocklist rounds: each new domain is judged once and
+    cached. With ``--suppress``, candidates on ``block`` domains are removed from
+    the scrapeable pool immediately. See ``docs/batch_scraping_protocol.md``.
+    """
+    from denbust.config import load_config
+    from denbust.discovery.candidate_filters import globally_excluded_search_domains
+    from denbust.discovery.domain_verdicts import (
+        DomainClassifier,
+        DomainVerdictStore,
+        blocked_domains,
+        classify_pool_domains,
+    )
+    from denbust.discovery.manual_filter import suppress_candidates_b2_by_domain
+    from denbust.discovery.scrape_queue import SCRAPEABLE_CANDIDATE_STATUSES
+    from denbust.discovery.storage import create_discovery_persistence
+
+    cfg = load_config(config or Path("agents/news/local.yaml"))
+    if not cfg.anthropic_api_key:
+        typer.echo("ANTHROPIC_API_KEY not set.")
+        raise typer.Exit(code=1)
+
+    store = DomainVerdictStore(cfg.discovery_state_paths.domain_verdicts_path)
+    classifier = DomainClassifier(api_key=cfg.anthropic_api_key, model=cfg.classifier.model)
+    persistence = create_discovery_persistence(cfg)
+    try:
+        pool = persistence.list_candidates(statuses=SCRAPEABLE_CANDIDATE_STATUSES)
+        new_verdicts = classify_pool_domains(
+            pool,
+            store=store,
+            classifier=classifier,
+            static_blocklist=frozenset(globally_excluded_search_domains()),
+            limit=limit,
+        )
+        allow = sum(1 for v in new_verdicts if v.decision == "allow")
+        block = sum(1 for v in new_verdicts if v.decision == "block")
+        typer.echo(f"Classified {len(new_verdicts)} new domain(s): {allow} allow, {block} block.")
+        if suppress:
+            suppressed = suppress_candidates_b2_by_domain(
+                persistence, blocked_domains(store), note="domain-verdict gate: block"
+            )
+            typer.echo(f"Suppressed {len(suppressed)} candidate(s) on block-verdict domains.")
+    finally:
+        persistence.close()
 
 
 @app.command()

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -439,6 +439,7 @@ class Config(BaseModel):
     scrape_pub_date_from: datetime | None = None
     scrape_balanced_batch_size: int | None = Field(default=None, ge=1)
     scrape_min_domain_frequency: int | None = Field(default=None, ge=1)
+    scrape_use_domain_verdicts: bool = False
     keywords: list[str] = Field(default_factory=lambda: DEFAULT_KEYWORDS.copy())
     sources: list[SourceConfig] = Field(default_factory=list)
     classifier: ClassifierConfig = Field(default_factory=ClassifierConfig)

--- a/src/denbust/discovery/domain_verdicts.py
+++ b/src/denbust/discovery/domain_verdicts.py
@@ -1,0 +1,245 @@
+"""Automated per-domain LLM verdict gate.
+
+Open-web discovery on prostitution/escort/massage keywords drags in an
+unbounded tail of off-topic and spam domains. The domain blocklist
+(``_IRRELEVANT_CONTENT_DOMAINS``) and Stage B2 handle this manually, one
+blocklist PR per batch. This module automates that judgment: each *new* domain
+is classified once by an LLM ("is this a plausible Israeli enforcement-news
+source, or junk?"), the verdict is cached durably, and the gate then holds back
+candidates on ``block`` domains — with zero per-batch manual work.
+
+Pieces:
+
+* ``DomainVerdict`` — the cached decision for one domain.
+* ``DomainVerdictStore`` — JSONL-backed cache under the discovery state dir.
+* ``DomainClassifier`` — Anthropic-backed; ``classify(domain, titles)`` returns
+  a verdict (or ``None`` on provider error, so a transient failure never blocks).
+* ``classify_pool_domains`` — orchestration: pick unjudged domains from the
+  candidate pool, classify them, upsert the cache. Takes an injected classifier
+  so it is testable without live calls.
+* ``filter_by_domain_verdict`` — the gate used at scrape-selection time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+from denbust.discovery.balanced_selection import KNOWN_SOURCE_FAMILIES, candidate_source_key
+from denbust.discovery.models import PersistentCandidate
+
+logger = logging.getLogger(__name__)
+
+DomainDecision = Literal["allow", "block"]
+
+#: How many sample titles to show the classifier per domain.
+_DEFAULT_SAMPLE_SIZE = 5
+
+
+class DomainVerdict(BaseModel):
+    """A cached allow/block decision for one publication domain/source family."""
+
+    domain: str
+    decision: DomainDecision
+    reason: str = ""
+    model: str = ""
+    sample_titles: list[str] = Field(default_factory=list)
+
+
+class DomainVerdictStore:
+    """JSONL-backed cache of per-domain verdicts under the discovery state dir."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._cache: dict[str, DomainVerdict] = {}
+        self._loaded = False
+
+    def load(self) -> dict[str, DomainVerdict]:
+        """Return all verdicts keyed by domain (lazily read once)."""
+        if self._loaded:
+            return self._cache
+        if self.path.exists():
+            with open(self.path, encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        verdict = DomainVerdict.model_validate_json(line)
+                        self._cache[verdict.domain] = verdict
+        self._loaded = True
+        return self._cache
+
+    def get(self, domain: str) -> DomainVerdict | None:
+        return self.load().get(domain)
+
+    def upsert(self, verdicts: Sequence[DomainVerdict]) -> None:
+        """Merge *verdicts* into the cache and rewrite the JSONL file."""
+        if not verdicts:
+            return
+        self.load()
+        for verdict in verdicts:
+            self._cache[verdict.domain] = verdict
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ordered = sorted(self._cache.values(), key=lambda v: v.domain)
+        with open(self.path, "w", encoding="utf-8") as handle:
+            for verdict in ordered:
+                handle.write(verdict.model_dump_json())
+                handle.write("\n")
+
+
+class DomainClassifierProtocol(Protocol):
+    """Anything that can verdict a domain from a few sample titles."""
+
+    def classify(self, domain: str, sample_titles: list[str]) -> DomainVerdict | None: ...
+
+
+_SYSTEM_PROMPT = (
+    "You decide whether a web domain is a plausible SOURCE of Israeli "
+    "law-enforcement news about sex trafficking and prostitution.\n"
+    'Reply with ONLY a JSON object: {"decision": "allow" | "block", "reason": "<short>"}.\n'
+    "allow = an Israeli news outlet or official source that could report enforcement "
+    "events such as raids, indictments, arrests, brothel closures, or client fines — "
+    "including niche, local, or Russian/English-language Israeli outlets.\n"
+    "block = escort/massage/webcam listings, SEO/ad/marketing pages, real-estate, cars, "
+    "finance, gadgets, dictionaries, academic papers, blogs/forums, social media, "
+    "religious-study sites, or any FOREIGN (non-Israeli) outlet.\n"
+    "When unsure, choose block (precision over recall)."
+)
+
+
+class DomainClassifier:
+    """Anthropic-backed domain classifier."""
+
+    def __init__(self, *, api_key: str, model: str = "claude-sonnet-4-20250514") -> None:
+        import anthropic
+
+        self._client = anthropic.Anthropic(api_key=api_key)
+        self._model = model
+
+    def classify(self, domain: str, sample_titles: list[str]) -> DomainVerdict | None:
+        import anthropic
+        from anthropic.types import TextBlock
+
+        titles = "\n".join(f"- {t[:120]}" for t in sample_titles[:_DEFAULT_SAMPLE_SIZE] if t)
+        prompt = (
+            f"Domain: {domain}\nSample candidate titles from this domain:\n{titles or '(none)'}"
+        )
+        try:
+            response = self._client.messages.create(
+                model=self._model,
+                max_tokens=128,
+                system=_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.APIError as error:
+            logger.warning("Domain classify failed for %s: %s", domain, type(error).__name__)
+            return None
+        text = ""
+        if response.content and isinstance(response.content[0], TextBlock):
+            text = response.content[0].text
+        return _parse_verdict(domain, text, model=self._model, sample_titles=sample_titles)
+
+
+def _parse_verdict(
+    domain: str, text: str, *, model: str, sample_titles: list[str]
+) -> DomainVerdict | None:
+    """Parse a ``{"decision","reason"}`` JSON object from the model text."""
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        payload = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    decision = payload.get("decision")
+    if decision not in ("allow", "block"):
+        return None
+    return DomainVerdict(
+        domain=domain,
+        decision=decision,
+        reason=str(payload.get("reason", ""))[:200],
+        model=model,
+        sample_titles=[t for t in sample_titles[:_DEFAULT_SAMPLE_SIZE] if t],
+    )
+
+
+def _domain_samples(
+    candidates: Sequence[PersistentCandidate],
+    *,
+    skip: frozenset[str],
+    sample_size: int,
+) -> dict[str, list[str]]:
+    """Group candidate titles by source key, skipping exempt/known domains."""
+    samples: dict[str, list[str]] = defaultdict(list)
+    for candidate in candidates:
+        key = candidate_source_key(candidate)
+        if key in skip or key in KNOWN_SOURCE_FAMILIES:
+            continue
+        if len(samples[key]) < sample_size and candidate.titles:
+            samples[key].append(candidate.titles[0])
+    return samples
+
+
+def classify_pool_domains(
+    candidates: Sequence[PersistentCandidate],
+    *,
+    store: DomainVerdictStore,
+    classifier: DomainClassifierProtocol,
+    static_blocklist: frozenset[str] = frozenset(),
+    limit: int | None = None,
+    sample_size: int = _DEFAULT_SAMPLE_SIZE,
+) -> list[DomainVerdict]:
+    """Classify and cache verdicts for not-yet-judged domains in the pool.
+
+    Domains that are known families, already in *static_blocklist*, or already
+    cached are skipped. Returns the newly written verdicts.
+    """
+    already = set(store.load()) | set(static_blocklist)
+    samples = _domain_samples(candidates, skip=frozenset(already), sample_size=sample_size)
+    domains = sorted(samples, key=lambda d: (-len(samples[d]), d))
+    if limit is not None:
+        domains = domains[:limit]
+    new_verdicts: list[DomainVerdict] = []
+    for domain in domains:
+        verdict = classifier.classify(domain, samples[domain])
+        if verdict is not None:
+            new_verdicts.append(verdict)
+    store.upsert(new_verdicts)
+    return new_verdicts
+
+
+def blocked_domains(store: DomainVerdictStore) -> list[str]:
+    """Return all domains the cache has decided to block."""
+    return [d for d, v in store.load().items() if v.decision == "block"]
+
+
+def filter_by_domain_verdict(
+    candidates: list[PersistentCandidate],
+    *,
+    verdicts: dict[str, DomainVerdict],
+    exempt_known_families: bool = True,
+    block_unjudged: bool = False,
+) -> list[PersistentCandidate]:
+    """Hold back candidates whose domain verdict is ``block``.
+
+    Known families (when *exempt_known_families*) and domains with an ``allow``
+    verdict pass. Unjudged domains pass unless *block_unjudged* is set.
+    """
+    kept: list[PersistentCandidate] = []
+    for candidate in candidates:
+        key = candidate_source_key(candidate)
+        if exempt_known_families and key in KNOWN_SOURCE_FAMILIES:
+            kept.append(candidate)
+            continue
+        verdict = verdicts.get(key)
+        if verdict is None:
+            if not block_unjudged:
+                kept.append(candidate)
+        elif verdict.decision == "allow":
+            kept.append(candidate)
+    return kept

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -37,6 +37,7 @@ class DiscoveryStatePaths(BaseModel):
     source_suggestions_latest_path: Path
     backfill_executed_queries_path: Path
     engine_query_cache_dir: Path
+    domain_verdicts_path: Path
 
 
 def resolve_discovery_state_paths(
@@ -61,6 +62,7 @@ def resolve_discovery_state_paths(
         metrics_dir=metrics_dir,
         backfill_batches_dir=backfill_batches_dir,
         engine_query_cache_dir=candidates_dir / "engine_query_cache",
+        domain_verdicts_path=candidates_dir / "domain_verdicts.jsonl",
         latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
         latest_backfill_batches_path=backfill_batches_dir / "latest_backfill_batches.jsonl",
         retry_queue_path=candidates_dir / "retry_queue.jsonl",

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -49,6 +49,7 @@ from denbust.discovery.balanced_selection import (
     plan_balanced_scrape_batch,
 )
 from denbust.discovery.base import DiscoveryContext, SourceDiscoveryContext
+from denbust.discovery.domain_verdicts import DomainVerdictStore, filter_by_domain_verdict
 from denbust.discovery.engine_checkpoint import (
     cache_path as _engine_cache_path,
 )
@@ -1427,6 +1428,7 @@ async def _run_candidate_scrape_job(
     pub_date_from: datetime | None = None,
     balanced_batch_size: int | None = None,
     min_domain_frequency: int | None = None,
+    use_domain_verdicts: bool = False,
 ) -> tuple[CandidateScrapeBatch, list[PrefilterDecision]]:
     """Select queued candidates, apply the thin prefilter, and run the scrape-attempt layer.
 
@@ -1466,6 +1468,19 @@ async def _run_candidate_scrape_job(
                     min_domain_frequency,
                     len(passed_pool),
                     before,
+                )
+            if use_domain_verdicts:
+                verdict_store = DomainVerdictStore(
+                    config.discovery_state_paths.domain_verdicts_path
+                )
+                verdicts = verdict_store.load()
+                before = len(passed_pool)
+                passed_pool = filter_by_domain_verdict(passed_pool, verdicts=verdicts)
+                logger.info(
+                    "Domain-verdict gate: %d/%d candidates passed (%d cached verdicts).",
+                    len(passed_pool),
+                    before,
+                    len(verdicts),
                 )
             passed_candidates = plan_balanced_scrape_batch(
                 passed_pool,
@@ -2547,6 +2562,7 @@ async def run_news_scrape_candidates_job(
             pub_date_from=config.scrape_pub_date_from,
             balanced_batch_size=config.scrape_balanced_batch_size,
             min_domain_frequency=config.scrape_min_domain_frequency,
+            use_domain_verdicts=config.scrape_use_domain_verdicts,
         )
         result.raw_article_count = len(scrape_batch.raw_articles)
         if scrape_batch.errors:
@@ -3350,6 +3366,7 @@ def _run_job_from_config(
     scrape_pub_date_from: str | None = None,
     scrape_balanced_batch_size: int | None = None,
     scrape_min_domain_frequency: int | None = None,
+    scrape_use_domain_verdicts: bool = False,
 ) -> RunSnapshot:
     """Shared sync wrapper for CLI-triggered job runs."""
     setup_logging()
@@ -3378,6 +3395,8 @@ def _run_job_from_config(
             print("Error: --min-domain-frequency must be a positive integer")
             sys.exit(1)
         update["scrape_min_domain_frequency"] = scrape_min_domain_frequency
+    if scrape_use_domain_verdicts:
+        update["scrape_use_domain_verdicts"] = True
     if update:
         config = config.model_copy(update=update)
 
@@ -3456,6 +3475,7 @@ def run_job(
     scrape_pub_date_from: str | None = None,
     scrape_balanced_batch_size: int | None = None,
     scrape_min_domain_frequency: int | None = None,
+    scrape_use_domain_verdicts: bool = False,
 ) -> None:
     """Run a dataset/job pair through the generic registry."""
     _run_job_from_config(
@@ -3467,6 +3487,7 @@ def run_job(
         scrape_pub_date_from=scrape_pub_date_from,
         scrape_balanced_batch_size=scrape_balanced_batch_size,
         scrape_min_domain_frequency=scrape_min_domain_frequency,
+        scrape_use_domain_verdicts=scrape_use_domain_verdicts,
     )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -73,6 +73,7 @@ class TestCli:
             scrape_pub_date_from: str | None = None,  # noqa: ARG001
             scrape_balanced_batch_size: int | None = None,  # noqa: ARG001
             scrape_min_domain_frequency: int | None = None,  # noqa: ARG001
+            scrape_use_domain_verdicts: bool = False,  # noqa: ARG001
         ) -> None:
             captured["config_path"] = config_path
             captured["dataset_name"] = dataset_name

--- a/tests/unit/test_domain_verdicts.py
+++ b/tests/unit/test_domain_verdicts.py
@@ -1,0 +1,155 @@
+"""Unit tests for the automated per-domain LLM verdict gate."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import HttpUrl
+
+from denbust.discovery.domain_verdicts import (
+    DomainClassifierProtocol,
+    DomainVerdict,
+    DomainVerdictStore,
+    _parse_verdict,
+    blocked_domains,
+    classify_pool_domains,
+    filter_by_domain_verdict,
+)
+from denbust.discovery.models import CandidateStatus, PersistentCandidate
+
+
+def _cand(candidate_id: str, *, domain: str, title: str = "t") -> PersistentCandidate:
+    return PersistentCandidate(
+        candidate_id=candidate_id,
+        canonical_url=HttpUrl(f"https://{domain}/a/{candidate_id}"),
+        current_url=HttpUrl(f"https://{domain}/a/{candidate_id}"),
+        domain=domain,
+        titles=[title],
+        snippets=["s"],
+        discovered_via=["brave"],
+        discovery_queries=["q"],
+        source_hints=["brave"],
+        first_seen_at=datetime(2026, 1, 1, tzinfo=UTC),
+        last_seen_at=datetime(2026, 1, 1, tzinfo=UTC),
+        candidate_status=CandidateStatus.NEW,
+    )
+
+
+class FakeClassifier(DomainClassifierProtocol):
+    """Verdicts domains by a fixed allow/block lookup; records calls."""
+
+    def __init__(self, decisions: dict[str, str]) -> None:
+        self.decisions = decisions
+        self.calls: list[str] = []
+
+    def classify(self, domain: str, sample_titles: list[str]) -> DomainVerdict | None:
+        self.calls.append(domain)
+        decision = self.decisions.get(domain)
+        if decision is None:
+            return None
+        return DomainVerdict(
+            domain=domain, decision=decision, reason="t", sample_titles=sample_titles
+        )
+
+
+def test_verdict_store_round_trips(tmp_path: Path) -> None:
+    """Verdicts persist to JSONL and reload, keyed by domain."""
+    store = DomainVerdictStore(tmp_path / "verdicts.jsonl")
+    store.upsert(
+        [
+            DomainVerdict(domain="newsru.co.il", decision="allow", reason="news"),
+            DomainVerdict(domain="xmassage.example", decision="block", reason="escort"),
+        ]
+    )
+    fresh = DomainVerdictStore(tmp_path / "verdicts.jsonl")
+    loaded = fresh.load()
+    assert loaded["newsru.co.il"].decision == "allow"
+    assert loaded["xmassage.example"].decision == "block"
+    assert blocked_domains(fresh) == ["xmassage.example"]
+
+
+def test_verdict_store_upsert_overwrites(tmp_path: Path) -> None:
+    """Re-judging a domain replaces the prior verdict."""
+    store = DomainVerdictStore(tmp_path / "v.jsonl")
+    store.upsert([DomainVerdict(domain="d.example", decision="block", reason="x")])
+    store.upsert([DomainVerdict(domain="d.example", decision="allow", reason="y")])
+    assert DomainVerdictStore(tmp_path / "v.jsonl").get("d.example").decision == "allow"  # type: ignore[union-attr]
+
+
+def test_parse_verdict_extracts_json() -> None:
+    """The parser tolerates surrounding prose and validates the decision."""
+    v = _parse_verdict(
+        "d.example",
+        'sure: {"decision": "block", "reason": "escort"} done',
+        model="m",
+        sample_titles=[],
+    )
+    assert v is not None and v.decision == "block"
+    assert _parse_verdict("d.example", "no json here", model="m", sample_titles=[]) is None
+    assert _parse_verdict("d.example", '{"decision": "maybe"}', model="m", sample_titles=[]) is None
+
+
+def test_classify_pool_domains_skips_known_static_and_cached(tmp_path: Path) -> None:
+    """Only unjudged, non-known, non-blocklisted domains get classified."""
+    store = DomainVerdictStore(tmp_path / "v.jsonl")
+    store.upsert([DomainVerdict(domain="already.example", decision="allow", reason="cached")])
+    pool = [
+        _cand("k", domain="ynet.co.il"),  # known family → skip
+        _cand("s", domain="static.example"),  # in static blocklist → skip
+        _cand("c", domain="already.example"),  # cached → skip
+        _cand("n1", domain="fresh.example", title="escort ad"),  # new → classify
+        _cand("n2", domain="news.example", title="police raid"),  # new → classify
+    ]
+    classifier = FakeClassifier({"fresh.example": "block", "news.example": "allow"})
+
+    new = classify_pool_domains(
+        pool,
+        store=store,
+        classifier=classifier,
+        static_blocklist=frozenset({"static.example"}),
+    )
+
+    assert set(classifier.calls) == {"fresh.example", "news.example"}
+    assert {v.domain: v.decision for v in new} == {
+        "fresh.example": "block",
+        "news.example": "allow",
+    }
+    # Persisted and merged with the pre-existing cached verdict.
+    assert set(DomainVerdictStore(tmp_path / "v.jsonl").load()) == {
+        "already.example",
+        "fresh.example",
+        "news.example",
+    }
+
+
+def test_classify_pool_domains_limit(tmp_path: Path) -> None:
+    """The limit caps how many new domains are classified per run."""
+    store = DomainVerdictStore(tmp_path / "v.jsonl")
+    pool = [_cand(f"c{i}", domain=f"d{i}.example") for i in range(5)]
+    classifier = FakeClassifier({f"d{i}.example": "block" for i in range(5)})
+    new = classify_pool_domains(pool, store=store, classifier=classifier, limit=2)
+    assert len(new) == 2
+    assert len(classifier.calls) == 2
+
+
+def test_filter_by_domain_verdict_blocks_and_exempts() -> None:
+    """Block verdicts are held; allow + known + unjudged pass by default."""
+    verdicts = {
+        "escort.example": DomainVerdict(domain="escort.example", decision="block", reason="x"),
+        "news.example": DomainVerdict(domain="news.example", decision="allow", reason="y"),
+    }
+    pool = [
+        _cand("a", domain="escort.example"),  # block → drop
+        _cand("b", domain="news.example"),  # allow → keep
+        _cand("c", domain="ynet.co.il"),  # known → keep
+        _cand("d", domain="unjudged.example"),  # unjudged → keep (default)
+    ]
+    kept = {c.candidate_id for c in filter_by_domain_verdict(pool, verdicts=verdicts)}
+    assert kept == {"b", "c", "d"}
+
+    strict = {
+        c.candidate_id
+        for c in filter_by_domain_verdict(pool, verdicts=verdicts, block_unjudged=True)
+    }
+    assert strict == {"b", "c"}  # unjudged now held too

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2576,6 +2576,7 @@ class TestRunPipelineAsync:
             pub_date_from: object = None,  # noqa: ARG001
             balanced_batch_size: object = None,  # noqa: ARG001
             min_domain_frequency: object = None,  # noqa: ARG001
+            use_domain_verdicts: object = False,  # noqa: ARG001
         ) -> tuple[CandidateScrapeBatch, list[object]]:
             captured["days"] = config.days
             captured["limit"] = limit
@@ -4063,6 +4064,7 @@ class TestRunPipeline:
             "scrape_pub_date_from": None,
             "scrape_balanced_batch_size": None,
             "scrape_min_domain_frequency": None,
+            "scrape_use_domain_verdicts": False,
         }
 
     def test_run_job_from_config_passes_operational_store_to_async_runner(


### PR DESCRIPTION
## Summary

Replaces the manual blocklist rounds (10 of them this session) with a **cached per-domain LLM verdict gate**. Each new domain is judged once — "is this a plausible Israeli enforcement-news source, or junk?" — the verdict is cached durably, and the gate holds back candidates on `block`-verdict domains with **zero per-batch manual work**.

The frequency gate kills the *single-shot* tail; this handles the **recurring** off-topic domains that clear it (real-estate/finance/escort sites seen 2+ times), which previously needed a manual blocklist PR every batch.

## New module `denbust/discovery/domain_verdicts.py`
- `DomainVerdict` (model) + `DomainVerdictStore` (JSONL cache under the discovery state dir)
- `DomainClassifier` — Anthropic-backed; returns `None` on provider error so a transient failure never wrongly blocks
- `classify_pool_domains()` — orchestration over an **injected** classifier (testable without live calls); skips known families, the static `_IRRELEVANT_CONTENT_DOMAINS` set, and already-cached domains; classifies highest-volume unjudged domains first
- `filter_by_domain_verdict()` — the scrape-selection gate
- `blocked_domains()` helper

## CLI
```bash
# Judge new domains once, cache verdicts, optionally suppress block domains now:
denbust classify-domains --config <cfg> --suppress

# Apply the cache as a gate at selection:
denbust run --job scrape_candidates --balanced-batch 60 \
            --min-domain-frequency 2 --use-domain-verdicts
```

## Wiring
- `Config.scrape_use_domain_verdicts`, `DiscoveryStatePaths.domain_verdicts_path`
- Gate applied after the frequency gate in `_run_candidate_scrape_job` (logs pass count)
- Threaded through `run_job` / `_run_job_from_config`; `--use-domain-verdicts` flag

## Why this is the scalable successor
Manual blocklisting is a denylist — you must name every villain, forever. The verdict gate makes the model judge each domain **once**; the decision compounds in the cache. Known outlets exempt; static blocklist honoured as always-block.

## Test plan
- [x] 6 new unit tests (store round-trip/overwrite, JSON parse, classify skips known/static/cached, limit, gate block/exempt/unjudged) — all with an injected fake classifier, no live calls
- [x] 1349 unit tests pass; ruff + mypy clean; hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)