### PR TITLE
fix(scrape): flush domain verdicts incrementally

### DIFF
--- a/src/denbust/discovery/domain_verdicts.py
+++ b/src/denbust/discovery/domain_verdicts.py
@@ -185,6 +185,11 @@ def _domain_samples(
     return samples
 
 
+#: Flush the verdict cache to disk every this many classifications, so a long
+#: run killed mid-way keeps its progress (re-running resumes from the cache).
+_CLASSIFY_FLUSH_EVERY = 10
+
+
 def classify_pool_domains(
     candidates: Sequence[PersistentCandidate],
     *,
@@ -193,11 +198,14 @@ def classify_pool_domains(
     static_blocklist: frozenset[str] = frozenset(),
     limit: int | None = None,
     sample_size: int = _DEFAULT_SAMPLE_SIZE,
+    flush_every: int = _CLASSIFY_FLUSH_EVERY,
 ) -> list[DomainVerdict]:
     """Classify and cache verdicts for not-yet-judged domains in the pool.
 
     Domains that are known families, already in *static_blocklist*, or already
-    cached are skipped. Returns the newly written verdicts.
+    cached are skipped. Verdicts are flushed to the store every *flush_every*
+    classifications (and once at the end), so a long run killed mid-way keeps
+    its progress and a re-run resumes from the cache. Returns the new verdicts.
     """
     already = set(store.load()) | set(static_blocklist)
     samples = _domain_samples(candidates, skip=frozenset(already), sample_size=sample_size)
@@ -205,11 +213,17 @@ def classify_pool_domains(
     if limit is not None:
         domains = domains[:limit]
     new_verdicts: list[DomainVerdict] = []
+    pending: list[DomainVerdict] = []
     for domain in domains:
         verdict = classifier.classify(domain, samples[domain])
         if verdict is not None:
             new_verdicts.append(verdict)
-    store.upsert(new_verdicts)
+            pending.append(verdict)
+        if len(pending) >= flush_every:
+            store.upsert(pending)
+            pending = []
+    if pending:
+        store.upsert(pending)
     return new_verdicts
 
 

--- a/tests/unit/test_domain_verdicts.py
+++ b/tests/unit/test_domain_verdicts.py
@@ -123,6 +123,34 @@ def test_classify_pool_domains_skips_known_static_and_cached(tmp_path: Path) -> 
     }
 
 
+def test_classify_pool_domains_flushes_incrementally(tmp_path: Path) -> None:
+    """Verdicts are persisted mid-run so a kill keeps progress."""
+    path = tmp_path / "v.jsonl"
+    pool = [_cand(f"c{i}", domain=f"d{i}.example") for i in range(7)]
+    decisions = {f"d{i}.example": "block" for i in range(7)}
+
+    flushes: list[int] = []
+
+    class CountingClassifier(FakeClassifier):
+        def classify(self, domain: str, sample_titles: list[str]) -> DomainVerdict | None:
+            # After each classification, record how many verdicts are on disk.
+            result = super().classify(domain, sample_titles)
+            flushes.append(len(DomainVerdictStore(path).load()))
+            return result
+
+    classify_pool_domains(
+        pool,
+        store=DomainVerdictStore(path),
+        classifier=CountingClassifier(decisions),
+        flush_every=3,
+    )
+
+    # After the 3rd and 6th classification the cache on disk should be non-empty
+    # (flushed at 3 and 6), proving progress survives a mid-run interruption.
+    assert max(flushes) >= 3
+    assert len(DomainVerdictStore(path).load()) == 7
+
+
 def test_classify_pool_domains_limit(tmp_path: Path) -> None:
     """The limit caps how many new domains are classified per run."""
     store = DomainVerdictStore(tmp_path / "v.jsonl")


### PR DESCRIPTION
`classify_pool_domains` persisted the cache only at the end, so a long run killed mid-way lost everything. Now flushes every N (default 10) classifications and once at the end; re-running resumes from the cache. Same checkpoint principle as the per-query engine cache. New test asserts mid-run persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)