### PR TITLE
feat(discovery): drop redundant source-targeted search + per-run query budget cap

### DIFF
--- a/docs/batch_scraping_protocol.md
+++ b/docs/batch_scraping_protocol.md
@@ -145,6 +145,25 @@ This is the scalable successor to manual Stage B2 blocklist rounds: instead of a
 human enumerating bad domains forever, the model judges each domain once and the
 decision compounds. Implementation: `src/denbust/discovery/domain_verdicts.py`.
 
+## Search-budget discipline (Brave / Exa)
+
+Brave and Exa each give ~1,000 free queries/month; a naive run issued 435
+queries/engine, exhausting the budget in ~2–3 runs. Two levers cut this:
+
+1. **Drop source-targeted search for natively-crawled sources** (default). The
+   source-native adapters already fetch ynet/mako/maariv/haaretz/walla/ice, so
+   paying search budget to re-find their articles is redundant. Source-targeted
+   queries now cover only non-native, non-blocklisted domains — in practice this
+   takes a run from **435 → 67 queries/engine** (broad + taxonomy + social only,
+   the open-web queries that find off-list outlets like newsru/mignews). Set
+   `discovery.search_native_source_domains: true` to restore the old behaviour.
+2. **Per-run query budget cap** — `discovery.max_queries_per_run` or
+   `denbust run --job discover --query-budget N` keeps the highest-priority kinds
+   (open-web broad/taxonomy first) up to N queries and drops the rest.
+
+Implementation: `build_discovery_queries` + `source_targeted_search_domains` in
+`src/denbust/discovery/queries.py`.
+
 ## Outputs of each batch
 
 Every batch run should report:

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -98,6 +98,14 @@ def run(
             " Populate the cache first with `denbust classify-domains`. Balanced-batch mode only.",
         ),
     ] = False,
+    query_budget: Annotated[
+        int | None,
+        typer.Option(
+            "--query-budget",
+            help="Cap discovery to this many queries per engine per run (highest-priority"
+            " open-web kinds kept first). Saves Brave/Exa search budget. Discover job only.",
+        ),
+    ] = None,
 ) -> None:
     """Run a dataset/job pair through the registry."""
     from denbust.pipeline import run_job
@@ -112,6 +120,7 @@ def run(
         scrape_balanced_batch_size=balanced_batch,
         scrape_min_domain_frequency=min_domain_frequency,
         scrape_use_domain_verdicts=use_domain_verdicts,
+        query_budget=query_budget,
     )
 
 

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -337,6 +337,15 @@ class DiscoveryConfig(BaseModel):
             DiscoveryQueryKind.SOCIAL_TARGETED,
         ]
     )
+    # Source-targeted search on natively-crawled sources (ynet/mako/maariv/…)
+    # is redundant with the source-native adapters that already fetch them, so
+    # by default those domains are dropped from source-targeted search queries
+    # to save search-engine budget. Set True to restore the old behaviour.
+    search_native_source_domains: bool = False
+    # Optional hard cap on the number of queries issued per engine per run.
+    # When set, the highest-priority query kinds (broad/taxonomy open-web first)
+    # are kept up to this many queries; the rest are dropped.
+    max_queries_per_run: int | None = Field(default=None, ge=1)
 
 
 class SourceDiscoveryProducerConfig(BaseModel):

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
 from denbust.config import Config, SourceConfig, SourceType
-from denbust.discovery.candidate_filters import globally_excluded_search_domains
+from denbust.discovery.candidate_filters import (
+    globally_excluded_search_domains,
+    match_domain,
+    normalize_domain,
+)
 from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
 from denbust.discovery.source_families import generic_fetch_source_domains
 from denbust.taxonomy import default_taxonomy
@@ -69,6 +73,57 @@ def enabled_discovery_domains(config: Config) -> list[tuple[str, str]]:
     return source_domains
 
 
+def source_targeted_search_domains(config: Config) -> list[tuple[str, str]]:
+    """Return the domains worth issuing source-targeted *search* queries for.
+
+    Natively-crawled sources (ynet/mako/maariv/haaretz/walla/ice) are excluded
+    by default — the source-native adapters already fetch them, so paying search
+    budget to re-find their articles is redundant. Blocklisted domains are also
+    excluded (search would only surface candidates we immediately suppress).
+    Set ``discovery.search_native_source_domains`` to re-include native sources.
+    """
+    excluded = globally_excluded_search_domains()
+    candidates: list[tuple[str, str]] = []
+    if config.discovery.search_native_source_domains:
+        candidates.extend(enabled_source_domains(config))
+    candidates.extend(generic_fetch_source_domains())
+    result: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for source_name, domain in candidates:
+        key = (source_name, domain)
+        if key in seen:
+            continue
+        seen.add(key)
+        if match_domain(normalize_domain(domain), excluded) is not None:
+            continue
+        result.append(key)
+    return result
+
+
+# Query kinds in descending budget priority: open-web broad/taxonomy first
+# (they find off-list outlets that the source-native crawl cannot), then
+# source-targeted, then social. Used when ``max_queries_per_run`` caps a run.
+_QUERY_KIND_PRIORITY: dict[DiscoveryQueryKind, int] = {
+    DiscoveryQueryKind.BROAD: 0,
+    DiscoveryQueryKind.TAXONOMY_TARGETED: 1,
+    DiscoveryQueryKind.SOURCE_TARGETED: 2,
+    DiscoveryQueryKind.SOCIAL_TARGETED: 3,
+}
+
+
+def _apply_query_budget(
+    queries: list[DiscoveryQuery], max_queries: int | None
+) -> list[DiscoveryQuery]:
+    """Cap *queries* to *max_queries*, keeping the highest-priority kinds first."""
+    if max_queries is None or len(queries) <= max_queries:
+        return queries
+    ordered = sorted(
+        enumerate(queries),
+        key=lambda pair: (_QUERY_KIND_PRIORITY.get(pair[1].query_kind, 99), pair[0]),
+    )
+    return [query for _, query in ordered[:max_queries]]
+
+
 def _taxonomy_query_specs() -> list[tuple[str, list[str]]]:
     specs_by_term: dict[str, set[str]] = {}
     for category_id, subcategory_id, term in default_taxonomy().discovery_terms():
@@ -85,8 +140,15 @@ def build_discovery_queries(
     *,
     days: int,
     now: datetime | None = None,
+    max_queries: int | None = None,
 ) -> list[DiscoveryQuery]:
-    """Build normalized discovery queries for enabled discovery engines."""
+    """Build normalized discovery queries for enabled discovery engines.
+
+    Source-targeted queries cover only ``source_targeted_search_domains`` —
+    natively-crawled and blocklisted domains are dropped to save search budget.
+    When *max_queries* (or ``config.discovery.max_queries_per_run``) is set, the
+    result is capped to that many queries, keeping the highest-priority kinds.
+    """
     keywords = _normalize_keywords(config.keywords)
     taxonomy_enabled = DiscoveryQueryKind.TAXONOMY_TARGETED in config.discovery.default_query_kinds
     if not keywords and not taxonomy_enabled:
@@ -97,7 +159,7 @@ def build_discovery_queries(
     date_to = current_time
     queries: list[DiscoveryQuery] = []
     seen_keys: set[tuple[object, ...]] = set()
-    source_domains = enabled_discovery_domains(config)
+    source_domains = source_targeted_search_domains(config)
     # Domains that are structurally off-topic — excluded from every broad and
     # taxonomy query to avoid wasting search-engine quota and classifier credits.
     # Source-targeted queries are already scoped to a single preferred domain, so
@@ -197,4 +259,5 @@ def build_discovery_queries(
                     )
                     seen_keys.add(taxonomy_source_key)
 
-    return queries
+    budget = max_queries if max_queries is not None else config.discovery.max_queries_per_run
+    return _apply_query_budget(queries, budget)

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -3367,6 +3367,7 @@ def _run_job_from_config(
     scrape_balanced_batch_size: int | None = None,
     scrape_min_domain_frequency: int | None = None,
     scrape_use_domain_verdicts: bool = False,
+    query_budget: int | None = None,
 ) -> RunSnapshot:
     """Shared sync wrapper for CLI-triggered job runs."""
     setup_logging()
@@ -3377,6 +3378,13 @@ def _run_job_from_config(
         update["dataset_name"] = DatasetName(dataset_name)
     if job_name is not None:
         update["job_name"] = JobName(job_name)
+    if query_budget is not None:
+        if query_budget < 1:
+            print("Error: --query-budget must be a positive integer")
+            sys.exit(1)
+        update["discovery"] = config.discovery.model_copy(
+            update={"max_queries_per_run": query_budget}
+        )
     if scrape_pub_date_from is not None:
         try:
             update["scrape_pub_date_from"] = datetime.fromisoformat(scrape_pub_date_from).replace(
@@ -3476,6 +3484,7 @@ def run_job(
     scrape_balanced_batch_size: int | None = None,
     scrape_min_domain_frequency: int | None = None,
     scrape_use_domain_verdicts: bool = False,
+    query_budget: int | None = None,
 ) -> None:
     """Run a dataset/job pair through the generic registry."""
     _run_job_from_config(
@@ -3488,6 +3497,7 @@ def run_job(
         scrape_balanced_batch_size=scrape_balanced_batch_size,
         scrape_min_domain_frequency=scrape_min_domain_frequency,
         scrape_use_domain_verdicts=scrape_use_domain_verdicts,
+        query_budget=query_budget,
     )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -74,6 +74,7 @@ class TestCli:
             scrape_balanced_batch_size: int | None = None,  # noqa: ARG001
             scrape_min_domain_frequency: int | None = None,  # noqa: ARG001
             scrape_use_domain_verdicts: bool = False,  # noqa: ARG001
+            query_budget: int | None = None,  # noqa: ARG001
         ) -> None:
             captured["config_path"] = config_path
             captured["dataset_name"] = dataset_name

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -16,6 +16,9 @@ from denbust.taxonomy import default_taxonomy
 
 def test_build_discovery_queries_creates_all_default_query_types() -> None:
     """Query construction should include broad, source-targeted, taxonomy-targeted, and social-targeted variants."""
+    # search_native_source_domains=True restores native sources in source-targeted
+    # (default drops them as redundant with the source-native crawl). globes/themarker
+    # stay dropped because they are blocklisted.
     config = Config(
         keywords=["בית בושת", "זנות"],
         sources=[
@@ -26,7 +29,7 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
             ),
             SourceConfig(name="mako", type=SourceType.SCRAPER),
         ],
-        discovery={"enabled": True},
+        discovery={"enabled": True, "search_native_source_domains": True},
     )
 
     queries = build_discovery_queries(
@@ -51,8 +54,9 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     taxonomy_targeted_source_queries = [
         query for query in targeted_queries if "taxonomy" in query.tags
     ]
-    assert len(keyword_targeted_queries) == 8
-    assert len(taxonomy_targeted_source_queries) == len(taxonomy_queries) * 4
+    # 2 keywords x 2 native sources (globes/themarker dropped as blocklisted).
+    assert len(keyword_targeted_queries) == 4
+    assert len(taxonomy_targeted_source_queries) == len(taxonomy_queries) * 2
     assert len(taxonomy_queries) == len(
         {term for _, _, term in default_taxonomy().discovery_terms()}
     )
@@ -63,8 +67,6 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     } == {
         ("ynet", ("www.ynet.co.il",)),
         ("mako", ("www.mako.co.il",)),
-        ("globes", ("www.globes.co.il",)),
-        ("themarker", ("www.themarker.com",)),
     }
     assert all(not query.preferred_domains for query in taxonomy_queries)
     assert {
@@ -73,8 +75,6 @@ def test_build_discovery_queries_creates_all_default_query_types() -> None:
     } == {
         ("ynet", ("www.ynet.co.il",)),
         ("mako", ("www.mako.co.il",)),
-        ("globes", ("www.globes.co.il",)),
-        ("themarker", ("www.themarker.com",)),
     }
     assert any(
         query.query_text == "נישואין בכפייה"
@@ -103,13 +103,15 @@ def test_build_discovery_queries_respects_enabled_query_kinds() -> None:
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
         discovery={
             "enabled": True,
+            "search_native_source_domains": True,
             "default_query_kinds": [DiscoveryQueryKind.SOURCE_TARGETED],
         },
     )
 
     queries = build_discovery_queries(config, days=3)
 
-    assert [query.source_hint for query in queries] == ["mako", "globes", "themarker"]
+    # Native mako kept (flag on); globes/themarker dropped as blocklisted.
+    assert [query.source_hint for query in queries] == ["mako"]
     assert all(query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED for query in queries)
 
 
@@ -138,7 +140,10 @@ def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
     config = Config(
         keywords=["זנות"],
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
-        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+        discovery={
+            "search_native_source_domains": True,
+            "default_query_kinds": ["source_targeted", "taxonomy_targeted"],
+        },
     )
 
     queries = build_discovery_queries(
@@ -157,8 +162,6 @@ def test_build_discovery_queries_emits_source_targeted_taxonomy_terms(
         (query.source_hint, tuple(query.preferred_domains)) for query in taxonomy_source_queries
     } == {
         ("mako", ("www.mako.co.il",)),
-        ("globes", ("www.globes.co.il",)),
-        ("themarker", ("www.themarker.com",)),
     }
     assert all(
         query.date_from == datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
@@ -182,7 +185,10 @@ def test_build_discovery_queries_keeps_taxonomy_source_provenance_for_keyword_ov
     config = Config(
         keywords=["זנות"],
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
-        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+        discovery={
+            "search_native_source_domains": True,
+            "default_query_kinds": ["source_targeted", "taxonomy_targeted"],
+        },
     )
 
     queries = build_discovery_queries(config, days=3)
@@ -192,15 +198,9 @@ def test_build_discovery_queries_keeps_taxonomy_source_provenance_for_keyword_ov
         for query in queries
         if query.query_kind is DiscoveryQueryKind.SOURCE_TARGETED and query.query_text == "זנות"
     ]
-    assert len(source_queries) == 6
-    assert sorted("taxonomy" in query.tags for query in source_queries) == [
-        False,
-        False,
-        False,
-        True,
-        True,
-        True,
-    ]
+    # Only native mako (globes/themarker blocklisted): one keyword + one taxonomy query.
+    assert len(source_queries) == 2
+    assert sorted("taxonomy" in query.tags for query in source_queries) == [False, True]
 
 
 def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() -> None:
@@ -213,7 +213,7 @@ def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() 
             SourceConfig(name="rss-no-url", type=SourceType.RSS),
             SourceConfig(name="mako", type=SourceType.SCRAPER),
         ],
-        discovery={"enabled": True},
+        discovery={"enabled": True, "search_native_source_domains": True},
     )
 
     queries = build_discovery_queries(config, days=3)
@@ -225,13 +225,10 @@ def test_build_discovery_queries_filters_blank_duplicate_and_unusable_sources() 
     keyword_targeted_queries = [query for query in targeted_queries if "taxonomy" not in query.tags]
 
     assert len(broad_queries) == 1
-    assert len(keyword_targeted_queries) == 3
+    # Only native mako survives (unknown source has no domain; globes/themarker blocklisted).
+    assert len(keyword_targeted_queries) == 1
     assert broad_queries[0].query_text == "זנות"
-    assert {query.source_hint for query in keyword_targeted_queries} == {
-        "mako",
-        "globes",
-        "themarker",
-    }
+    assert {query.source_hint for query in keyword_targeted_queries} == {"mako"}
 
 
 def test_build_discovery_queries_returns_taxonomy_queries_for_empty_keyword_set() -> None:
@@ -239,7 +236,7 @@ def test_build_discovery_queries_returns_taxonomy_queries_for_empty_keyword_set(
     config = Config(
         keywords=["", "   "],
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
-        discovery={"enabled": True},
+        discovery={"enabled": True, "search_native_source_domains": True},
     )
 
     queries = build_discovery_queries(config, days=3)
@@ -264,7 +261,7 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
                 url="https://www.ynet.co.il/another-feed.xml",
             ),
         ],
-        discovery={"enabled": True},
+        discovery={"enabled": True, "search_native_source_domains": True},
     )
 
     queries = build_discovery_queries(config, days=3)
@@ -277,8 +274,6 @@ def test_build_discovery_queries_avoids_duplicate_source_targeted_entries() -> N
         (query.source_hint, tuple(query.preferred_domains)) for query in keyword_targeted_queries
     } == {
         ("ynet", ("www.ynet.co.il",)),
-        ("globes", ("www.globes.co.il",)),
-        ("themarker", ("www.themarker.com",)),
     }
 
 
@@ -321,7 +316,10 @@ def test_build_discovery_queries_source_targeted_queries_have_no_excluded_domain
     config = Config(
         keywords=["בית בושת"],
         sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
-        discovery={"default_query_kinds": ["source_targeted"]},
+        discovery={
+            "search_native_source_domains": True,
+            "default_query_kinds": ["source_targeted"],
+        },
     )
 
     queries = build_discovery_queries(config, days=3)
@@ -332,6 +330,51 @@ def test_build_discovery_queries_source_targeted_queries_have_no_excluded_domain
     assert source_queries
     for query in source_queries:
         assert not query.excluded_domains
+
+
+def test_build_discovery_queries_drops_native_source_targeted_by_default() -> None:
+    """By default, natively-crawled sources get no source-targeted search queries."""
+    config = Config(
+        keywords=["זנות"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["broad", "source_targeted"]},
+    )
+
+    queries = build_discovery_queries(config, days=3)
+
+    # mako is native (dropped); globes/themarker are blocklisted (dropped) → none left.
+    assert [q for q in queries if q.query_kind is DiscoveryQueryKind.SOURCE_TARGETED] == []
+    assert [q.query_kind for q in queries] == [DiscoveryQueryKind.BROAD]
+
+
+def test_build_discovery_queries_query_budget_keeps_highest_priority_kinds() -> None:
+    """A query budget keeps open-web (broad/taxonomy) kinds first, dropping the rest."""
+    config = Config(
+        keywords=["זנות", "בית בושת", "סרסור"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={
+            "search_native_source_domains": True,
+            "default_query_kinds": ["broad", "source_targeted", "social_targeted"],
+        },
+    )
+
+    full = build_discovery_queries(config, days=3)
+    assert len(full) > 3  # broad + source-targeted + social present
+
+    capped = build_discovery_queries(config, days=3, max_queries=3)
+    assert len(capped) == 3
+    # The 3 broad (open-web) queries outrank source-targeted and social.
+    assert all(q.query_kind is DiscoveryQueryKind.BROAD for q in capped)
+
+
+def test_build_discovery_queries_query_budget_from_config() -> None:
+    """The cap can come from config.discovery.max_queries_per_run."""
+    config = Config(
+        keywords=["זנות", "בית בושת"],
+        sources=[SourceConfig(name="mako", type=SourceType.SCRAPER)],
+        discovery={"default_query_kinds": ["broad"], "max_queries_per_run": 1},
+    )
+    assert len(build_discovery_queries(config, days=3)) == 1
 
 
 def test_build_discovery_queries_can_disable_social_targeted_generation() -> None:

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -4065,6 +4065,7 @@ class TestRunPipeline:
             "scrape_balanced_batch_size": None,
             "scrape_min_domain_frequency": None,
             "scrape_use_domain_verdicts": False,
+            "query_budget": None,
         }
 
     def test_run_job_from_config_passes_operational_store_to_async_runner(

--- a/tests/unit/test_ynet_search_recall_fixture.py
+++ b/tests/unit/test_ynet_search_recall_fixture.py
@@ -104,7 +104,10 @@ async def test_ynet_source_targeted_taxonomy_search_result_fallback_reaches_clas
                 url="https://www.ynet.co.il/Integration/StoryRss2.xml",
             )
         ],
-        discovery={"default_query_kinds": ["source_targeted", "taxonomy_targeted"]},
+        discovery={
+            "search_native_source_domains": True,
+            "default_query_kinds": ["source_targeted", "taxonomy_targeted"],
+        },
         store={"state_root": tmp_path},
     )
 


### PR DESCRIPTION
## Summary

Applies the budget-first discipline to **search** (Brave/Exa), where credits were our biggest blocker. Each engine gives ~1,000 free queries/month, but a run issued **435 queries/engine** — exhausting the budget in ~2-3 runs (the Exa `402`s). Two levers:

### 1. Drop source-targeted search for natively-crawled sources (default)
We already fetch ynet/mako/maariv/haaretz/walla/ice via the source-native adapters, so `site:`-search on them just re-finds articles we have for free. `source_targeted_search_domains()` now returns only non-native, non-blocklisted domains. Since the only two source-targeted families (globes/themarker) are blocklisted, source-targeted effectively drops to zero.

**Net: 435 → 67 queries/engine/run** (broad 21 + taxonomy 25 + social 21) — the open-web queries that find the off-list outlets (newsru, mignews, israelan) which produced **most of our verified records**. That's an **85% cut** with near-zero recall loss.

`discovery.search_native_source_domains: true` restores the old behaviour.

### 2. Per-run query budget cap
`discovery.max_queries_per_run` or `denbust run --job discover --query-budget N` keeps the highest-priority kinds (open-web broad/taxonomy first) up to N and drops the rest.

## Budget impact
- Before: 435/engine → ~2.3 free runs/month
- After: 67/engine → **daily** discovery (30 × 67 ≈ 2,010/month) fits ~$5–10, and still concentrates spend on the high-yield open-web queries.

## Test plan
- [x] Existing query tests updated to the new contract (native + blocklisted dropped from source-targeted)
- [x] New tests: native-drop default, budget priority ordering, config-sourced cap
- [x] 1353 unit tests pass; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)