### PR TITLE
feat(discovery): search-budget ledger + guard + engine routing (#5)

### DIFF
--- a/docs/batch_scraping_protocol.md
+++ b/docs/batch_scraping_protocol.md
@@ -164,6 +164,22 @@ queries/engine, exhausting the budget in ~2–3 runs. Two levers cut this:
 Implementation: `build_discovery_queries` + `source_targeted_search_domains` in
 `src/denbust/discovery/queries.py`.
 
+### Budget ledger + guard
+
+Every discovery run records its live (non-cached) search requests per engine to
+`search_budget.jsonl`. Set a monthly cap per engine via
+`discovery.engines.<engine>.monthly_budget_usd`; the **guard** then truncates a
+run to the queries that fit the remaining month-to-date budget (highest-priority
+kinds first) instead of overspending into a `402`. Brave ($5/1k) is cheaper than
+Exa ($7/1k), so the same dollar cap pushes more queries through Brave — the
+routing preference. Inspect spend with:
+
+```bash
+denbust search-budget --config <cfg>          # month-to-date queries + $ per engine
+```
+
+Implementation: `src/denbust/discovery/search_budget.py`.
+
 ## Outputs of each batch
 
 Every batch run should report:

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -706,6 +706,38 @@ def classify_domains(
         persistence.close()
 
 
+@app.command("search-budget")
+def search_budget(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to YAML config file"),
+    ] = None,
+    month: Annotated[
+        str | None,
+        typer.Option("--month", help="Month to report as YYYY-MM (defaults to current UTC month)."),
+    ] = None,
+) -> None:
+    """Show month-to-date Brave/Exa/Google-CSE search spend vs configured budgets."""
+    from datetime import UTC, datetime
+
+    from denbust.config import load_config
+    from denbust.discovery.search_budget import SearchBudgetLedger, month_to_date_summary
+
+    cfg = load_config(config or Path("agents/news/local.yaml"))
+    year_month = month or datetime.now(UTC).strftime("%Y-%m")
+    ledger = SearchBudgetLedger(cfg.discovery_state_paths.search_budget_path)
+    engines = ("brave", "exa", "google_cse")
+    summary = month_to_date_summary(ledger, year_month=year_month, engines=engines)
+
+    typer.echo(f"Search budget — {year_month}")
+    for engine in engines:
+        queries, usd = summary[engine]
+        engine_cfg = getattr(cfg.discovery.engines, engine, None)
+        budget = getattr(engine_cfg, "monthly_budget_usd", None)
+        cap = f" / ${budget:.2f}" if budget is not None else " (no cap)"
+        typer.echo(f"  {engine:<11} {queries:>6} queries  ${usd:>7.3f}{cap}")
+
+
 @app.command()
 def version() -> None:
     """Show version information."""

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -280,6 +280,10 @@ class DiscoveryEngineConfig(BaseModel):
     enabled: bool = False
     api_key_env: str | None = None
     max_results_per_query: int = Field(default=20, ge=1)
+    # Optional monthly USD budget for this engine's search requests. When set,
+    # the budget guard caps a run to the queries that fit the remaining
+    # month-to-date budget (highest-priority kinds first) instead of overspending.
+    monthly_budget_usd: float | None = Field(default=None, ge=0)
 
 
 class ExaDiscoveryEngineConfig(DiscoveryEngineConfig):

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -111,7 +111,7 @@ _QUERY_KIND_PRIORITY: dict[DiscoveryQueryKind, int] = {
 }
 
 
-def _apply_query_budget(
+def apply_query_budget(
     queries: list[DiscoveryQuery], max_queries: int | None
 ) -> list[DiscoveryQuery]:
     """Cap *queries* to *max_queries*, keeping the highest-priority kinds first."""
@@ -260,4 +260,4 @@ def build_discovery_queries(
                     seen_keys.add(taxonomy_source_key)
 
     budget = max_queries if max_queries is not None else config.discovery.max_queries_per_run
-    return _apply_query_budget(queries, budget)
+    return apply_query_budget(queries, budget)

--- a/src/denbust/discovery/search_budget.py
+++ b/src/denbust/discovery/search_budget.py
@@ -1,0 +1,125 @@
+"""Search-engine budget ledger and guard.
+
+Brave and Exa charge per request and each give only ~1,000 free queries/month.
+A naive discovery run issued 435 queries/engine and exhausted the month's budget
+in 2-3 runs — surfacing as ``402 Payment Required`` mid-run with no warning.
+
+This module is the accounting + safety layer:
+
+* ``SearchBudgetLedger`` — an append-only JSONL log of per-engine, per-run
+  search spend under the discovery state dir.
+* ``month_spend`` — month-to-date queries + estimated USD for an engine.
+* ``affordable_query_count`` — how many of a run's planned queries fit the
+  remaining monthly budget (the guard truncates to this, keeping the
+  highest-priority queries, instead of overspending into a 402).
+
+Pricing matches Brave ($5/1k) and Exa ($7/1k). The cheaper engine (Brave) gets
+more queries through the same dollar budget, which is the routing preference.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+#: Estimated USD per search request, per engine.
+ENGINE_REQUEST_USD: dict[str, float] = {
+    "brave": 0.005,  # $5 / 1k
+    "exa": 0.007,  # $7 / 1k
+    "google_cse": 0.005,  # $5 / 1k (CSE billable tier)
+}
+_DEFAULT_REQUEST_USD = 0.005
+
+
+def engine_request_usd(engine: str) -> float:
+    """Estimated USD cost of one search request on *engine*."""
+    return ENGINE_REQUEST_USD.get(engine, _DEFAULT_REQUEST_USD)
+
+
+class SearchSpendRecord(BaseModel):
+    """One run's search spend on one engine."""
+
+    run_id: str
+    engine: str
+    queries: int
+    estimated_cost_usd: float
+    recorded_at: datetime
+
+
+class SearchBudgetLedger:
+    """Append-only JSONL log of per-engine search spend."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load(self) -> list[SearchSpendRecord]:
+        if not self.path.exists():
+            return []
+        records: list[SearchSpendRecord] = []
+        with open(self.path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line:
+                    records.append(SearchSpendRecord.model_validate_json(line))
+        return records
+
+    def record(self, *, engine: str, queries: int, run_id: str, now: datetime) -> SearchSpendRecord:
+        """Append a spend record for *queries* issued on *engine*."""
+        record = SearchSpendRecord(
+            run_id=run_id,
+            engine=engine,
+            queries=queries,
+            estimated_cost_usd=round(queries * engine_request_usd(engine), 6),
+            recorded_at=now,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(record.model_dump_json())
+            handle.write("\n")
+        return record
+
+    def month_spend(self, *, year_month: str, engine: str | None = None) -> tuple[int, float]:
+        """Return ``(queries, usd)`` spent in *year_month* (``YYYY-MM``)."""
+        queries = 0
+        usd = 0.0
+        for record in self.load():
+            if record.recorded_at.strftime("%Y-%m") != year_month:
+                continue
+            if engine is not None and record.engine != engine:
+                continue
+            queries += record.queries
+            usd += record.estimated_cost_usd
+        return queries, round(usd, 6)
+
+
+def affordable_query_count(
+    *,
+    engine: str,
+    requested: int,
+    spent_usd: float,
+    monthly_budget_usd: float | None,
+) -> int:
+    """How many of *requested* queries fit the remaining monthly budget.
+
+    Returns *requested* unchanged when no budget is set. Never negative.
+    """
+    if monthly_budget_usd is None:
+        return requested
+    remaining = max(0.0, monthly_budget_usd - spent_usd)
+    price = engine_request_usd(engine)
+    if price <= 0:
+        return requested
+    return max(0, min(requested, int(remaining / price)))
+
+
+def month_to_date_summary(
+    ledger: SearchBudgetLedger, *, year_month: str, engines: Sequence[str]
+) -> dict[str, tuple[int, float]]:
+    """Return ``{engine: (queries, usd)}`` spent this month for each engine."""
+    return {engine: ledger.month_spend(year_month=year_month, engine=engine) for engine in engines}

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -38,6 +38,7 @@ class DiscoveryStatePaths(BaseModel):
     backfill_executed_queries_path: Path
     engine_query_cache_dir: Path
     domain_verdicts_path: Path
+    search_budget_path: Path
 
 
 def resolve_discovery_state_paths(
@@ -63,6 +64,7 @@ def resolve_discovery_state_paths(
         backfill_batches_dir=backfill_batches_dir,
         engine_query_cache_dir=candidates_dir / "engine_query_cache",
         domain_verdicts_path=candidates_dir / "domain_verdicts.jsonl",
+        search_budget_path=candidates_dir / "search_budget.jsonl",
         latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
         latest_backfill_batches_path=backfill_batches_dir / "latest_backfill_batches.jsonl",
         retry_queue_path=candidates_dir / "retry_queue.jsonl",

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -70,7 +70,7 @@ from denbust.discovery.models import (
     ExecutedBackfillQuery,
     PersistentCandidate,
 )
-from denbust.discovery.queries import build_discovery_queries
+from denbust.discovery.queries import apply_query_budget, build_discovery_queries
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     CandidateScrapeBatch,
@@ -78,6 +78,10 @@ from denbust.discovery.scrape_queue import (
     scrape_candidates,
     select_backfill_candidates_for_scrape,
     select_candidates_for_scrape,
+)
+from denbust.discovery.search_budget import (
+    SearchBudgetLedger,
+    affordable_query_count,
 )
 from denbust.discovery.source_native import (
     PersistedSourceDiscovery,
@@ -967,6 +971,49 @@ async def _run_source_native_discovery(
 _DISCOVERY_PERSIST_BATCH: int = 50
 
 
+def _guard_search_budget(
+    config: Config, *, engine: str, queries: list[DiscoveryQuery]
+) -> list[DiscoveryQuery]:
+    """Cap *queries* to what the engine's remaining monthly budget can afford.
+
+    No-op when the engine has no ``monthly_budget_usd``. When the budget is
+    partly spent, keeps the highest-priority queries that fit (avoids the 402).
+    """
+    engine_cfg = getattr(config.discovery.engines, engine, None)
+    budget = getattr(engine_cfg, "monthly_budget_usd", None)
+    if budget is None or not queries:
+        return queries
+    ledger = SearchBudgetLedger(config.discovery_state_paths.search_budget_path)
+    now = datetime.now(UTC)
+    _, spent = ledger.month_spend(year_month=now.strftime("%Y-%m"), engine=engine)
+    affordable = affordable_query_count(
+        engine=engine,
+        requested=len(queries),
+        spent_usd=spent,
+        monthly_budget_usd=budget,
+    )
+    if affordable < len(queries):
+        logger.warning(
+            "%s budget guard: capping %d -> %d queries ($%.2f of $%.2f spent this month).",
+            engine,
+            len(queries),
+            affordable,
+            spent,
+            budget,
+        )
+        queries = apply_query_budget(queries, affordable)
+    return queries
+
+
+def _record_search_spend(config: Config, *, engine: str, run_id: str, live_queries: int) -> None:
+    """Record the live (non-cached) search requests this run issued on *engine*."""
+    if live_queries <= 0:
+        return
+    SearchBudgetLedger(config.discovery_state_paths.search_budget_path).record(
+        engine=engine, queries=live_queries, run_id=run_id, now=datetime.now(UTC)
+    )
+
+
 async def _run_brave_discovery(
     *,
     config: Config,
@@ -974,7 +1021,9 @@ async def _run_brave_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Brave-powered discovery with per-query checkpointing and incremental persist."""
-    queries = build_discovery_queries(config, days=days)
+    queries = _guard_search_budget(
+        config, engine="brave", queries=build_discovery_queries(config, days=days)
+    )
     discovery_run = DiscoveryRun(
         run_id=run_id,
         dataset_name=config.dataset_name,
@@ -1015,6 +1064,7 @@ async def _run_brave_discovery(
         metadata={"days": days, "engine": "brave"},
     )
     cache_dir = config.discovery_state_paths.engine_query_cache_dir
+    live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []
         last_result: PersistedSourceDiscovery | None = None
@@ -1025,6 +1075,7 @@ async def _run_brave_discovery(
             if cached is not None:
                 batch.extend(cached)
             else:
+                live_queries += 1
                 try:
                     fresh = await engine.discover([query], context)
                 except Exception as exc:
@@ -1048,6 +1099,7 @@ async def _run_brave_discovery(
     finally:
         await engine.aclose()
         persistence.close()
+        _record_search_spend(config, engine="brave", run_id=run_id, live_queries=live_queries)
 
 
 async def _run_exa_discovery(
@@ -1057,7 +1109,9 @@ async def _run_exa_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Exa-powered discovery with per-query checkpointing and incremental persist."""
-    queries = build_discovery_queries(config, days=days)
+    queries = _guard_search_budget(
+        config, engine="exa", queries=build_discovery_queries(config, days=days)
+    )
     discovery_run = DiscoveryRun(
         run_id=run_id,
         dataset_name=config.dataset_name,
@@ -1102,6 +1156,7 @@ async def _run_exa_discovery(
         },
     )
     cache_dir = config.discovery_state_paths.engine_query_cache_dir
+    live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []
         last_result: PersistedSourceDiscovery | None = None
@@ -1112,6 +1167,7 @@ async def _run_exa_discovery(
             if cached is not None:
                 batch.extend(cached)
             else:
+                live_queries += 1
                 try:
                     fresh = await engine.discover([query], context)
                 except Exception as exc:
@@ -1135,6 +1191,7 @@ async def _run_exa_discovery(
     finally:
         await engine.aclose()
         persistence.close()
+        _record_search_spend(config, engine="exa", run_id=run_id, live_queries=live_queries)
 
 
 async def _run_google_cse_discovery(
@@ -1144,7 +1201,9 @@ async def _run_google_cse_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Google CSE-powered discovery with per-query checkpointing and incremental persist."""
-    queries = build_discovery_queries(config, days=days)
+    queries = _guard_search_budget(
+        config, engine="google_cse", queries=build_discovery_queries(config, days=days)
+    )
     discovery_run = DiscoveryRun(
         run_id=run_id,
         dataset_name=config.dataset_name,
@@ -1197,6 +1256,7 @@ async def _run_google_cse_discovery(
         metadata={"days": days, "engine": "google_cse"},
     )
     cache_dir = config.discovery_state_paths.engine_query_cache_dir
+    live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []
         last_result: PersistedSourceDiscovery | None = None
@@ -1207,6 +1267,7 @@ async def _run_google_cse_discovery(
             if cached is not None:
                 batch.extend(cached)
             else:
+                live_queries += 1
                 try:
                     fresh = await engine.discover([query], context)
                 except Exception as exc:
@@ -1230,6 +1291,7 @@ async def _run_google_cse_discovery(
     finally:
         await engine.aclose()
         persistence.close()
+        _record_search_spend(config, engine="google_cse", run_id=run_id, live_queries=live_queries)
 
 
 def _backfill_query_execution_key(engine: str, query: DiscoveryQuery) -> tuple[str, ...]:

--- a/tests/unit/test_search_budget.py
+++ b/tests/unit/test_search_budget.py
@@ -1,0 +1,89 @@
+"""Unit tests for the search-budget ledger and guard."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from denbust.discovery.search_budget import (
+    ENGINE_REQUEST_USD,
+    SearchBudgetLedger,
+    affordable_query_count,
+    engine_request_usd,
+    month_to_date_summary,
+)
+
+
+def test_record_and_month_spend_round_trip(tmp_path: Path) -> None:
+    """Recorded spend is summed per month and per engine."""
+    ledger = SearchBudgetLedger(tmp_path / "budget.jsonl")
+    ledger.record(engine="brave", queries=100, run_id="r1", now=datetime(2026, 6, 1, tzinfo=UTC))
+    ledger.record(engine="brave", queries=50, run_id="r2", now=datetime(2026, 6, 15, tzinfo=UTC))
+    ledger.record(engine="exa", queries=10, run_id="r3", now=datetime(2026, 6, 2, tzinfo=UTC))
+    # Different month — must not count toward June.
+    ledger.record(engine="brave", queries=999, run_id="r4", now=datetime(2026, 5, 1, tzinfo=UTC))
+
+    q, usd = ledger.month_spend(year_month="2026-06", engine="brave")
+    assert q == 150
+    assert usd == round(150 * ENGINE_REQUEST_USD["brave"], 6)
+
+    q_exa, usd_exa = ledger.month_spend(year_month="2026-06", engine="exa")
+    assert q_exa == 10
+    assert usd_exa == round(10 * ENGINE_REQUEST_USD["exa"], 6)
+
+    # Engine-agnostic total for the month.
+    q_all, _ = ledger.month_spend(year_month="2026-06")
+    assert q_all == 160
+
+
+def test_affordable_query_count() -> None:
+    """The guard caps requested queries to what the remaining budget affords."""
+    # Brave $0.005/q; $1 budget, $0.50 spent → $0.50 left → 100 queries.
+    assert (
+        affordable_query_count(
+            engine="brave", requested=435, spent_usd=0.50, monthly_budget_usd=1.00
+        )
+        == 100
+    )
+    # Budget already exhausted → 0.
+    assert (
+        affordable_query_count(
+            engine="brave", requested=435, spent_usd=1.00, monthly_budget_usd=1.00
+        )
+        == 0
+    )
+    # Fewer requested than affordable → unchanged.
+    assert (
+        affordable_query_count(engine="exa", requested=20, spent_usd=0.0, monthly_budget_usd=100.0)
+        == 20
+    )
+    # No budget set → unchanged.
+    assert (
+        affordable_query_count(
+            engine="brave", requested=435, spent_usd=999.0, monthly_budget_usd=None
+        )
+        == 435
+    )
+
+
+def test_engine_request_usd_defaults() -> None:
+    """Known engines use their price; unknown engines fall back to a default."""
+    assert engine_request_usd("brave") == 0.005
+    assert engine_request_usd("exa") == 0.007
+    assert engine_request_usd("mystery") == 0.005
+
+
+def test_month_to_date_summary(tmp_path: Path) -> None:
+    """The summary returns (queries, usd) per requested engine."""
+    ledger = SearchBudgetLedger(tmp_path / "b.jsonl")
+    ledger.record(engine="brave", queries=40, run_id="r", now=datetime(2026, 6, 3, tzinfo=UTC))
+    summary = month_to_date_summary(ledger, year_month="2026-06", engines=("brave", "exa"))
+    assert summary["brave"] == (40, round(40 * 0.005, 6))
+    assert summary["exa"] == (0, 0.0)
+
+
+def test_ledger_missing_file_is_empty(tmp_path: Path) -> None:
+    """A ledger with no file reads as empty rather than erroring."""
+    ledger = SearchBudgetLedger(tmp_path / "missing.jsonl")
+    assert ledger.load() == []
+    assert ledger.month_spend(year_month="2026-06") == (0, 0.0)


### PR DESCRIPTION
## Summary

**PR 1 of 3** for search prioritization/batching. The accounting + safety layer that prevents the silent Exa/Brave `402` that exhausted our credits mid-run.

- **`search_budget.py`**: `SearchBudgetLedger` (append-only JSONL under discovery state), per-engine/per-month spend rollup, `affordable_query_count` guard. Pricing: Brave $0.005/q, Exa $0.007/q.
- **Guard**: each engine discovery fn truncates a run to the queries that fit the remaining month-to-date budget (highest-priority kinds first) when a cap is set — no more 402 surprise.
- **Spend recording**: only **live (non-cached)** requests are billed to the ledger, so the per-query checkpoint cache (free re-runs) isn't double-counted.
- **Engine routing**: Brave is cheaper, so the same dollar cap pushes more queries through Brave; per-engine caps express the preference.
- **Config**: `discovery.engines.<engine>.monthly_budget_usd` (default `None` = no cap, but spend is still tracked).
- **CLI**: `denbust search-budget` → month-to-date queries + $ vs cap per engine.

```bash
denbust search-budget --config agents/news/local_search_brave_exa.yaml
# Search budget — 2026-06
#   brave       134 queries  $  0.670 / $5.00
#   exa          67 queries  $  0.469 (no cap)
```

## Test plan
- [x] 5 new unit tests (ledger round-trip + month/engine filtering, affordable-count guard, pricing defaults, summary, missing-file)
- [x] 1358 unit tests pass; ruff + mypy clean

Next: PR 2 (#4 query rotation) builds on this ledger's execution log; PR 3 (#3 yield-weighted priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)