### PR TITLE
feat(discovery): cross-run query rotation (#4)

### DIFF
--- a/docs/batch_scraping_protocol.md
+++ b/docs/batch_scraping_protocol.md
@@ -180,6 +180,16 @@ denbust search-budget --config <cfg>          # month-to-date queries + $ per en
 
 Implementation: `src/denbust/discovery/search_budget.py`.
 
+### Query rotation across runs
+
+When a budget cap truncates a run, the kept queries are ordered
+**least-recently-run first** (never-run queries, then oldest) within each
+priority tier. The per-query checkpoint file's mtime is the last-run timestamp,
+so successive capped runs spend their budget refreshing *different* slices of
+the query pool instead of re-issuing the same head every run — maximising fresh
+coverage per dollar. Implementation: `select_run_queries` (queries.py) +
+`query_last_run_at` (engine_checkpoint.py).
+
 ## Outputs of each batch
 
 Every batch run should report:

--- a/src/denbust/discovery/engine_checkpoint.py
+++ b/src/denbust/discovery/engine_checkpoint.py
@@ -57,6 +57,18 @@ def cache_path(cache_dir: Path, engine: str, query: DiscoveryQuery) -> Path:
     return cache_dir / engine / f"{_query_cache_key(engine, query)}.jsonl"
 
 
+def query_last_run_at(cache_dir: Path, engine: str, query: DiscoveryQuery) -> datetime | None:
+    """Return when *query* was last issued live on *engine*, or None if never.
+
+    The checkpoint file's mtime is written each time the query hits the API, so
+    it doubles as a per-query last-run timestamp for cross-run rotation.
+    """
+    path = cache_path(cache_dir, engine, query)
+    if not path.exists():
+        return None
+    return datetime.fromtimestamp(path.stat().st_mtime, UTC)
+
+
 def load_cached_candidates(
     path: Path,
     *,

--- a/src/denbust/discovery/queries.py
+++ b/src/denbust/discovery/queries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
@@ -111,17 +111,40 @@ _QUERY_KIND_PRIORITY: dict[DiscoveryQueryKind, int] = {
 }
 
 
+def select_run_queries(
+    queries: list[DiscoveryQuery],
+    max_queries: int | None,
+    *,
+    last_run_at: Callable[[DiscoveryQuery], datetime | None] | None = None,
+) -> list[DiscoveryQuery]:
+    """Cap *queries* to *max_queries*, highest-priority kinds first.
+
+    When *last_run_at* is supplied, ties within a priority tier are broken by
+    **least-recently-run first** (never-run queries first, then oldest), so a
+    budget-capped run refreshes a different slice of the pool each time
+    (cross-run rotation) instead of re-issuing the same head every run.
+    """
+    if max_queries is None or len(queries) <= max_queries:
+        return queries
+
+    def sort_key(pair: tuple[int, DiscoveryQuery]) -> tuple[object, ...]:
+        index, query = pair
+        priority = _QUERY_KIND_PRIORITY.get(query.query_kind, 99)
+        if last_run_at is None:
+            return (priority, index)
+        ran_at = last_run_at(query)
+        recency = (0, 0.0) if ran_at is None else (1, ran_at.timestamp())
+        return (priority, recency, index)
+
+    ordered = sorted(enumerate(queries), key=sort_key)
+    return [query for _, query in ordered[:max_queries]]
+
+
 def apply_query_budget(
     queries: list[DiscoveryQuery], max_queries: int | None
 ) -> list[DiscoveryQuery]:
-    """Cap *queries* to *max_queries*, keeping the highest-priority kinds first."""
-    if max_queries is None or len(queries) <= max_queries:
-        return queries
-    ordered = sorted(
-        enumerate(queries),
-        key=lambda pair: (_QUERY_KIND_PRIORITY.get(pair[1].query_kind, 99), pair[0]),
-    )
-    return [query for _, query in ordered[:max_queries]]
+    """Priority-only cap (no rotation). Thin wrapper over ``select_run_queries``."""
+    return select_run_queries(queries, max_queries)
 
 
 def _taxonomy_query_specs() -> list[tuple[str, list[str]]]:
@@ -141,13 +164,15 @@ def build_discovery_queries(
     days: int,
     now: datetime | None = None,
     max_queries: int | None = None,
+    last_run_at: Callable[[DiscoveryQuery], datetime | None] | None = None,
 ) -> list[DiscoveryQuery]:
     """Build normalized discovery queries for enabled discovery engines.
 
     Source-targeted queries cover only ``source_targeted_search_domains`` —
     natively-crawled and blocklisted domains are dropped to save search budget.
     When *max_queries* (or ``config.discovery.max_queries_per_run``) is set, the
-    result is capped to that many queries, keeping the highest-priority kinds.
+    result is capped to that many queries, keeping the highest-priority kinds;
+    *last_run_at* additionally rotates within a tier (least-recently-run first).
     """
     keywords = _normalize_keywords(config.keywords)
     taxonomy_enabled = DiscoveryQueryKind.TAXONOMY_TARGETED in config.discovery.default_query_kinds
@@ -260,4 +285,4 @@ def build_discovery_queries(
                     seen_keys.add(taxonomy_source_key)
 
     budget = max_queries if max_queries is not None else config.discovery.max_queries_per_run
-    return apply_query_budget(queries, budget)
+    return select_run_queries(queries, budget, last_run_at=last_run_at)

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -55,6 +55,7 @@ from denbust.discovery.engine_checkpoint import (
 )
 from denbust.discovery.engine_checkpoint import (
     load_cached_candidates,
+    query_last_run_at,
     save_cached_candidates,
 )
 from denbust.discovery.engines.brave import BraveSearchEngine
@@ -70,7 +71,7 @@ from denbust.discovery.models import (
     ExecutedBackfillQuery,
     PersistentCandidate,
 )
-from denbust.discovery.queries import apply_query_budget, build_discovery_queries
+from denbust.discovery.queries import build_discovery_queries, select_run_queries
 from denbust.discovery.scrape_queue import (
     SCRAPEABLE_CANDIDATE_STATUSES,
     CandidateScrapeBatch,
@@ -972,12 +973,14 @@ _DISCOVERY_PERSIST_BATCH: int = 50
 
 
 def _guard_search_budget(
-    config: Config, *, engine: str, queries: list[DiscoveryQuery]
+    config: Config, *, engine: str, queries: list[DiscoveryQuery], cache_dir: Path
 ) -> list[DiscoveryQuery]:
     """Cap *queries* to what the engine's remaining monthly budget can afford.
 
     No-op when the engine has no ``monthly_budget_usd``. When the budget is
-    partly spent, keeps the highest-priority queries that fit (avoids the 402).
+    partly spent, keeps the highest-priority queries that fit (avoids the 402),
+    rotating within a tier by least-recently-run so successive capped runs
+    refresh different slices of the pool.
     """
     engine_cfg = getattr(config.discovery.engines, engine, None)
     budget = getattr(engine_cfg, "monthly_budget_usd", None)
@@ -1001,7 +1004,11 @@ def _guard_search_budget(
             spent,
             budget,
         )
-        queries = apply_query_budget(queries, affordable)
+        queries = select_run_queries(
+            queries,
+            affordable,
+            last_run_at=lambda query: query_last_run_at(cache_dir, engine, query),
+        )
     return queries
 
 
@@ -1021,8 +1028,14 @@ async def _run_brave_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Brave-powered discovery with per-query checkpointing and incremental persist."""
+    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     queries = _guard_search_budget(
-        config, engine="brave", queries=build_discovery_queries(config, days=days)
+        config,
+        engine="brave",
+        queries=build_discovery_queries(
+            config, days=days, last_run_at=lambda q: query_last_run_at(cache_dir, "brave", q)
+        ),
+        cache_dir=cache_dir,
     )
     discovery_run = DiscoveryRun(
         run_id=run_id,
@@ -1063,7 +1076,6 @@ async def _run_brave_discovery(
         max_results_per_query=config.discovery.engines.brave.max_results_per_query,
         metadata={"days": days, "engine": "brave"},
     )
-    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []
@@ -1109,8 +1121,14 @@ async def _run_exa_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Exa-powered discovery with per-query checkpointing and incremental persist."""
+    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     queries = _guard_search_budget(
-        config, engine="exa", queries=build_discovery_queries(config, days=days)
+        config,
+        engine="exa",
+        queries=build_discovery_queries(
+            config, days=days, last_run_at=lambda q: query_last_run_at(cache_dir, "exa", q)
+        ),
+        cache_dir=cache_dir,
     )
     discovery_run = DiscoveryRun(
         run_id=run_id,
@@ -1155,7 +1173,6 @@ async def _run_exa_discovery(
             "allow_find_similar": config.discovery.engines.exa.allow_find_similar,
         },
     )
-    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []
@@ -1201,8 +1218,14 @@ async def _run_google_cse_discovery(
     days: int,
 ) -> PersistedSourceDiscovery:
     """Run Google CSE-powered discovery with per-query checkpointing and incremental persist."""
+    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     queries = _guard_search_budget(
-        config, engine="google_cse", queries=build_discovery_queries(config, days=days)
+        config,
+        engine="google_cse",
+        queries=build_discovery_queries(
+            config, days=days, last_run_at=lambda q: query_last_run_at(cache_dir, "google_cse", q)
+        ),
+        cache_dir=cache_dir,
     )
     discovery_run = DiscoveryRun(
         run_id=run_id,
@@ -1255,7 +1278,6 @@ async def _run_google_cse_discovery(
         max_results_per_query=config.discovery.engines.google_cse.max_results_per_query,
         metadata={"days": days, "engine": "google_cse"},
     )
-    cache_dir = config.discovery_state_paths.engine_query_cache_dir
     live_queries = 0
     try:
         batch: list[DiscoveredCandidate] = []

--- a/tests/unit/test_discovery_queries.py
+++ b/tests/unit/test_discovery_queries.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from denbust.config import Config, SourceConfig, SourceType
-from denbust.discovery.models import DiscoveryQueryKind
+from denbust.discovery.models import DiscoveryQuery, DiscoveryQueryKind
 from denbust.discovery.queries import (
     build_discovery_queries,
     enabled_discovery_domains,
@@ -365,6 +365,42 @@ def test_build_discovery_queries_query_budget_keeps_highest_priority_kinds() -> 
     assert len(capped) == 3
     # The 3 broad (open-web) queries outrank source-targeted and social.
     assert all(q.query_kind is DiscoveryQueryKind.BROAD for q in capped)
+
+
+def test_select_run_queries_rotates_by_least_recently_run() -> None:
+    """With a recency map, a capped run keeps least-recently-run queries first."""
+    from denbust.discovery.queries import select_run_queries
+
+    config = Config(
+        keywords=["זנות", "בית בושת", "סרסור"],
+        sources=[],
+        discovery={"default_query_kinds": ["broad"]},
+    )
+    queries = build_discovery_queries(config, days=3)
+    assert len(queries) == 3
+    texts = [q.query_text for q in queries]
+
+    # Pretend the first two were run recently; the third never ran.
+    recent = {
+        texts[0]: datetime(2026, 6, 11, tzinfo=UTC),
+        texts[1]: datetime(2026, 6, 10, tzinfo=UTC),
+    }
+
+    def last_run_at(q: DiscoveryQuery) -> datetime | None:
+        return recent.get(q.query_text)
+
+    capped = select_run_queries(queries, 1, last_run_at=last_run_at)
+    # Never-run query (texts[2]) wins the single slot over the recently-run ones.
+    assert [q.query_text for q in capped] == [texts[2]]
+
+    # Next, with all run but texts[1] oldest:
+    recent2 = {
+        texts[0]: datetime(2026, 6, 11, tzinfo=UTC),
+        texts[1]: datetime(2026, 6, 1, tzinfo=UTC),
+        texts[2]: datetime(2026, 6, 9, tzinfo=UTC),
+    }
+    capped2 = select_run_queries(queries, 1, last_run_at=lambda q: recent2[q.query_text])
+    assert [q.query_text for q in capped2] == [texts[1]]  # oldest first
 
 
 def test_build_discovery_queries_query_budget_from_config() -> None:


### PR DESCRIPTION
## Summary

**PR 2 of 3.** Builds on PR 1's checkpoint log. When a budget cap truncates a run, the kept queries are ordered **least-recently-run first** (never-run, then oldest) within each priority tier — so successive capped runs refresh *different* slices of the query pool instead of re-issuing the same head every run.

The per-query checkpoint file's mtime (written each time the query hits the API) is the last-live-run timestamp, so rotation needs no new state.

- `engine_checkpoint.query_last_run_at(cache_dir, engine, query)` → checkpoint mtime or `None`.
- `queries.select_run_queries(queries, max_queries, last_run_at=...)` — priority cap with optional recency tiebreak; `apply_query_budget` is now a priority-only wrapper.
- `build_discovery_queries(..., last_run_at=...)` — threaded only by the live engine runs (backfill/tests pass `None` → unchanged).
- The `$`-budget guard and each engine fn pass a recency callback bound to that engine's checkpoint dir.

**Why it spends budget on stale queries:** a cached (fresh) query returns the same results for free, so the value is in refreshing *stale* queries — rotation directs the limited budget exactly there.

## Test plan
- [x] New test: capped selection picks never-run, then oldest, first
- [x] 1359 unit tests pass; ruff + mypy clean

Next: PR 3 (#3 yield-weighted priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)