### PR TITLE
feat(discovery): free-tier-aware budget guard + recommended Brave/Exa config

### DIFF
--- a/agents/news/local_search_brave_exa.yaml
+++ b/agents/news/local_search_brave_exa.yaml
@@ -73,16 +73,30 @@ dedup:
 discovery:
   enabled: true
   persist_candidates: true
+  # Search-budget plan (daily discovery, mostly free):
+  # - Source-targeted search on native sources is dropped by default, so a run
+  #   issues only ~67 open-web queries/engine (broad + taxonomy + social).
+  # - max_queries_per_run caps each run to the 35 highest-yield/priority queries;
+  #   rotation refreshes the rest of the ~67 pool across subsequent runs.
+  # - Daily cadence ≈ 35 x 30 = 1,050 queries/engine/month.
+  # - Each engine's first 1,000/month are free; monthly_budget_usd is REAL money
+  #   beyond that. At ~1,050/mo the paid overage is ~50 queries:
+  #   Brave ~$0.25, Exa ~$0.35 — well under the caps below.
+  max_queries_per_run: 35
   engines:
     brave:
       enabled: true
       api_key_env: DENBUST_BRAVE_SEARCH_API_KEY
       max_results_per_query: 20
+      monthly_free_queries: 1000     # Brave Search free tier ($5 credit / $5 per 1k)
+      monthly_budget_usd: 1.00       # allow up to ~200 paid queries of overage
     exa:
       enabled: true
       api_key_env: DENBUST_EXA_API_KEY
       max_results_per_query: 20
       allow_find_similar: true
+      monthly_free_queries: 1000     # Exa free tier (1,000 requests/month)
+      monthly_budget_usd: 5.00       # the $5 Exa plan: ~714 paid queries of headroom
     google_cse:
       enabled: false
       api_key_env: DENBUST_GOOGLE_CSE_API_KEY

--- a/src/denbust/cli.py
+++ b/src/denbust/cli.py
@@ -721,7 +721,11 @@ def search_budget(
     from datetime import UTC, datetime
 
     from denbust.config import load_config
-    from denbust.discovery.search_budget import SearchBudgetLedger, month_to_date_summary
+    from denbust.discovery.search_budget import (
+        SearchBudgetLedger,
+        billed_cost_usd,
+        month_to_date_summary,
+    )
 
     cfg = load_config(config or Path("agents/news/local.yaml"))
     year_month = month or datetime.now(UTC).strftime("%Y-%m")
@@ -729,13 +733,15 @@ def search_budget(
     engines = ("brave", "exa", "google_cse")
     summary = month_to_date_summary(ledger, year_month=year_month, engines=engines)
 
-    typer.echo(f"Search budget — {year_month}")
+    typer.echo(f"Search budget — {year_month}  (queries used / free | real $ spent / budget)")
     for engine in engines:
-        queries, usd = summary[engine]
+        queries, _ = summary[engine]
         engine_cfg = getattr(cfg.discovery.engines, engine, None)
         budget = getattr(engine_cfg, "monthly_budget_usd", None)
-        cap = f" / ${budget:.2f}" if budget is not None else " (no cap)"
-        typer.echo(f"  {engine:<11} {queries:>6} queries  ${usd:>7.3f}{cap}")
+        free = getattr(engine_cfg, "monthly_free_queries", 0)
+        spent = billed_cost_usd(engine, queries=queries, monthly_free_queries=free)
+        budget_str = f"${budget:.2f}" if budget is not None else "—"
+        typer.echo(f"  {engine:<11} {queries:>5}/{free:<5} queries   ${spent:>6.3f} / {budget_str}")
 
 
 @app.command("query-yield")

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -280,9 +280,13 @@ class DiscoveryEngineConfig(BaseModel):
     enabled: bool = False
     api_key_env: str | None = None
     max_results_per_query: int = Field(default=20, ge=1)
-    # Optional monthly USD budget for this engine's search requests. When set,
-    # the budget guard caps a run to the queries that fit the remaining
-    # month-to-date budget (highest-priority kinds first) instead of overspending.
+    # Free search requests included per month (Brave/Exa each give ~1,000). The
+    # budget guard spends these before billing anything, so monthly_budget_usd
+    # is real money beyond the free tier — not a list-price ceiling.
+    monthly_free_queries: int = Field(default=0, ge=0)
+    # Optional monthly USD budget for PAID requests (beyond monthly_free_queries).
+    # The guard caps a run to free-remaining + what this budget can still buy
+    # (highest-yield/priority queries first) instead of overspending into a 402.
     monthly_budget_usd: float | None = Field(default=None, ge=0)
 
 

--- a/src/denbust/discovery/search_budget.py
+++ b/src/denbust/discovery/search_budget.py
@@ -98,24 +98,38 @@ class SearchBudgetLedger:
         return queries, round(usd, 6)
 
 
+def billed_cost_usd(engine: str, *, queries: int, monthly_free_queries: int = 0) -> float:
+    """Real USD for *queries* this month after the free allowance is consumed."""
+    paid = max(0, queries - monthly_free_queries)
+    return round(paid * engine_request_usd(engine), 6)
+
+
 def affordable_query_count(
     *,
     engine: str,
     requested: int,
-    spent_usd: float,
+    queries_spent: int,
     monthly_budget_usd: float | None,
+    monthly_free_queries: int = 0,
 ) -> int:
-    """How many of *requested* queries fit the remaining monthly budget.
+    """How many of *requested* queries fit the remaining monthly allowance.
 
-    Returns *requested* unchanged when no budget is set. Never negative.
+    Spends the free monthly allowance first, then the paid *monthly_budget_usd*.
+    Returns *requested* unchanged when neither a free allowance nor a budget is
+    set. Never negative.
     """
+    free_remaining = max(0, monthly_free_queries - queries_spent)
     if monthly_budget_usd is None:
-        return requested
-    remaining = max(0.0, monthly_budget_usd - spent_usd)
+        if monthly_free_queries <= 0:
+            return requested
+        return min(requested, free_remaining)
     price = engine_request_usd(engine)
     if price <= 0:
         return requested
-    return max(0, min(requested, int(remaining / price)))
+    paid_spent = max(0, queries_spent - monthly_free_queries)
+    paid_budget_remaining = max(0.0, monthly_budget_usd - paid_spent * price)
+    paid_affordable = int(paid_budget_remaining / price)
+    return max(0, min(requested, free_remaining + paid_affordable))
 
 
 def month_to_date_summary(

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -991,32 +991,35 @@ def _guard_search_budget(
 ) -> list[DiscoveryQuery]:
     """Cap *queries* to what the engine's remaining monthly budget can afford.
 
-    No-op when the engine has no ``monthly_budget_usd``. When the budget is
-    partly spent, keeps the best queries that fit (highest yield, then kind
-    priority, then least-recently-run rotation) so the spend goes to the most
-    productive queries and successive runs refresh different slices.
+    No-op when the engine has no free allowance and no budget. Otherwise spends
+    the free monthly allowance first, then the paid budget, keeping the best
+    queries that fit (highest yield, then kind priority, then least-recently-run
+    rotation) so the spend goes to the most productive queries.
     """
     engine_cfg = getattr(config.discovery.engines, engine, None)
     budget = getattr(engine_cfg, "monthly_budget_usd", None)
-    if budget is None or not queries:
+    free = getattr(engine_cfg, "monthly_free_queries", 0)
+    if (budget is None and free <= 0) or not queries:
         return queries
     ledger = SearchBudgetLedger(config.discovery_state_paths.search_budget_path)
     now = datetime.now(UTC)
-    _, spent = ledger.month_spend(year_month=now.strftime("%Y-%m"), engine=engine)
+    spent_queries, _ = ledger.month_spend(year_month=now.strftime("%Y-%m"), engine=engine)
     affordable = affordable_query_count(
         engine=engine,
         requested=len(queries),
-        spent_usd=spent,
+        queries_spent=spent_queries,
         monthly_budget_usd=budget,
+        monthly_free_queries=free,
     )
     if affordable < len(queries):
         logger.warning(
-            "%s budget guard: capping %d -> %d queries ($%.2f of $%.2f spent this month).",
+            "%s budget guard: capping %d -> %d queries (%d used this month; free=%d, budget=%s).",
             engine,
             len(queries),
             affordable,
-            spent,
-            budget,
+            spent_queries,
+            free,
+            f"${budget:.2f}" if budget is not None else "none",
         )
         queries = select_run_queries(
             queries,

--- a/tests/unit/test_search_budget.py
+++ b/tests/unit/test_search_budget.py
@@ -9,9 +9,19 @@ from denbust.discovery.search_budget import (
     ENGINE_REQUEST_USD,
     SearchBudgetLedger,
     affordable_query_count,
+    billed_cost_usd,
     engine_request_usd,
     month_to_date_summary,
 )
+
+
+def test_billed_cost_usd_after_free_allowance() -> None:
+    """Real cost bills only queries beyond the free allowance."""
+    assert billed_cost_usd("brave", queries=900, monthly_free_queries=1000) == 0.0
+    assert billed_cost_usd("brave", queries=1200, monthly_free_queries=1000) == round(
+        200 * 0.005, 6
+    )
+    assert billed_cost_usd("exa", queries=1100, monthly_free_queries=1000) == round(100 * 0.007, 6)
 
 
 def test_record_and_month_spend_round_trip(tmp_path: Path) -> None:
@@ -37,32 +47,75 @@ def test_record_and_month_spend_round_trip(tmp_path: Path) -> None:
 
 
 def test_affordable_query_count() -> None:
-    """The guard caps requested queries to what the remaining budget affords."""
-    # Brave $0.005/q; $1 budget, $0.50 spent → $0.50 left → 100 queries.
+    """The guard spends the free allowance first, then the paid budget."""
+    # No free, brave $0.005/q; $1 budget, 100 spent ($0.50) → $0.50 left → 100 more.
     assert (
         affordable_query_count(
-            engine="brave", requested=435, spent_usd=0.50, monthly_budget_usd=1.00
+            engine="brave", requested=435, queries_spent=100, monthly_budget_usd=1.00
         )
         == 100
     )
-    # Budget already exhausted → 0.
+    # Budget exhausted (200 spent = $1.00 of $1.00) → 0.
     assert (
         affordable_query_count(
-            engine="brave", requested=435, spent_usd=1.00, monthly_budget_usd=1.00
+            engine="brave", requested=435, queries_spent=200, monthly_budget_usd=1.00
         )
         == 0
     )
-    # Fewer requested than affordable → unchanged.
-    assert (
-        affordable_query_count(engine="exa", requested=20, spent_usd=0.0, monthly_budget_usd=100.0)
-        == 20
-    )
-    # No budget set → unchanged.
+    # Neither free nor budget → unchanged.
     assert (
         affordable_query_count(
-            engine="brave", requested=435, spent_usd=999.0, monthly_budget_usd=None
+            engine="brave", requested=435, queries_spent=999, monthly_budget_usd=None
         )
         == 435
+    )
+
+
+def test_affordable_query_count_free_allowance() -> None:
+    """The free monthly allowance is spent before any paid budget."""
+    # 1,000 free, no paid budget: 600 used → 400 free left.
+    assert (
+        affordable_query_count(
+            engine="brave",
+            requested=435,
+            queries_spent=600,
+            monthly_budget_usd=None,
+            monthly_free_queries=1000,
+        )
+        == 400
+    )
+    # Free exhausted, no paid budget → 0.
+    assert (
+        affordable_query_count(
+            engine="exa",
+            requested=67,
+            queries_spent=1000,
+            monthly_budget_usd=None,
+            monthly_free_queries=1000,
+        )
+        == 0
+    )
+    # 1,000 free + $5 budget on exa ($0.007/q → 714 paid): 1,000 used → 0 free + 714 paid.
+    assert (
+        affordable_query_count(
+            engine="exa",
+            requested=999,
+            queries_spent=1000,
+            monthly_budget_usd=5.00,
+            monthly_free_queries=1000,
+        )
+        == 714
+    )
+    # Well within free → full request.
+    assert (
+        affordable_query_count(
+            engine="brave",
+            requested=35,
+            queries_spent=100,
+            monthly_budget_usd=1.00,
+            monthly_free_queries=1000,
+        )
+        == 35
     )
 
 


### PR DESCRIPTION
## Summary

Wires a recommended search-budget config for daily, mostly-free discovery — and first makes the budget guard **free-tier-aware** so the `$` numbers are real money, not list-price.

### Free-allowance model
Brave and Exa each include ~1,000 free queries/month. The guard now:
- spends `monthly_free_queries` **first**, then the paid `monthly_budget_usd`;
- `affordable_query_count(queries_spent, monthly_free_queries, monthly_budget_usd)` returns free-remaining + paid-affordable;
- `billed_cost_usd` reports real cost (queries beyond free × price);
- `denbust search-budget` shows `queries used/free | real $ spent/budget`.

### Recommended config (`local_search_brave_exa.yaml`)
```yaml
discovery:
  max_queries_per_run: 35          # top 35 of ~67 open-web queries; rotation covers the rest
  engines:
    brave: { monthly_free_queries: 1000, monthly_budget_usd: 1.00 }
    exa:   { monthly_free_queries: 1000, monthly_budget_usd: 5.00 }  # the $5 plan
```
At **daily** cadence ≈ 1,050 queries/engine/month → ~50 paid over the free 1,000 → **Brave ~$0.25, Exa ~$0.35/month**. The guard hard-stops before the 402.

## Test plan
- [x] Updated + new budget tests (free-allowance spend order, billed cost, free-then-paid)
- [x] Config loads with the new fields; `search-budget` CLI renders the free-aware view
- [x] 1366 unit tests pass; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)