### PR TITLE
perf(state): gzip the big rewrite-per-run discovery state files

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,20 +6,17 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `UNIFY-PR-01` — local and GitHub Actions share a single base news
-  config, `agents/news/local_search_brave_exa.yaml`. The CI-only `agents/news/github.yaml` is
-  removed; CI runs the same base file with a small deployment overlay deep-merged on top via
-  `denbust run --overlay agents/news/ci.overlay.yaml`. `load_config` gained an `overlay_path`
-  parameter (recursive deep-merge); the overlay is the single auditable place where CI differs
-  (Supabase store, emailed report, and a pinned leaner cost surface — `max_articles` and
-  source-targeted-only backfill), inheriting all shared keys unchanged. The six operational
-  `denbust run` workflows reference the overlay via a `JOB_CONFIG_OVERLAY` env; the read-only
-  daily-review workflow needs none. The 2026 backfill helper script and the operational/discovery
-  docs point at the base config. This removes config drift between the two surfaces without an
-  unscoped env-var footgun, and is the first step of the local↔CI unification track.
-- Next planned PR: `UNIFY-PR-02` — gzip the big rewrite-per-run state files to `.jsonl.gz`
-  (with a legacy uncompressed read fallback) so the git state repo stays bounded once it becomes
-  the single source of truth for both local and CI runs.
+- Last merged PR on main: `UNIFY-PR-02` — the big rewrite-per-run and append-only discovery state
+  files are stored gzip-compressed (`*.jsonl.gz`) via a new suffix-driven
+  `denbust.discovery.jsonl_io` module: gz writes, append-as-gzip-member, and reads that fall back
+  to a legacy uncompressed `.jsonl` sibling so pre-existing state needs no migration.
+  `DiscoveryStatePaths` resolves the seven targets to `.jsonl.gz`; the small audit ledgers
+  (`domain_verdicts`, `search_budget`) stay uncompressed. Bounds the git state repo (~8x smaller
+  per-run blobs). Built on `UNIFY-PR-01`, which collapsed local and CI onto one base config plus a
+  `--overlay` (no `github.yaml`).
+- Next planned PR: `UNIFY-PR-03` — a shared `state-run` wrapper (pull/run/commit/push
+  --force-with-lease with a single-writer lock) for both local and CI, plus a weekly orphan-squash
+  job, to bound state-repo *history* alongside the gzipped blobs.
 - Current blockers on main: Google CSE returns `403 PERMISSION_DENIED` locally; the canonical
   `agents/news/local_search_brave_exa.yaml` already disables Google CSE so Brave + Exa carry
   open-web discovery. Exa returns `402 Payment Required` once its prepaid balance is exhausted —
@@ -288,10 +285,20 @@
   env; the read-only daily-review workflow needs no overlay. `test_config.py` covers the merged
   CI delta, nested-key merge semantics, and missing-overlay errors. Removes config drift without an
   unscoped env-var footgun.
-- [next] `UNIFY-PR-02`: gzip the big rewrite-per-run state files (`latest_candidates.jsonl`,
-  discovery queues, provenance, scrape-attempt logs) to `.jsonl.gz` via `state_paths.py` +
-  `storage.py`, with a legacy uncompressed-`.jsonl` read fallback, so the git state repo stays
-  bounded (~8x smaller per-run blobs) when it becomes the single source of truth.
+- [done] `UNIFY-PR-02`: gzip the big rewrite-per-run and append-only discovery state files
+  (`latest_candidates`, retry/backfill queues, `candidate_provenance`, `scrape_attempts`,
+  `latest_backfill_batches`, `executed_queries`) to `.jsonl.gz`. A new suffix-driven
+  `denbust.discovery.jsonl_io` module centralizes gz-aware read/write/append: writes gzip when the
+  path ends in `.gz`, reads transparently fall back to a legacy uncompressed `.jsonl` sibling, and
+  the first append folds any legacy file into the gz so data is never split. `DiscoveryStatePaths`
+  now resolves these seven files to `.jsonl.gz`; the duplicated `_read_jsonl`/`_append_jsonl` in
+  `storage.py` and `diagnostics/discovery.py`, the `write_*_jsonl` helpers, the prefilter label
+  loader, and the pipeline existence checks all route through `jsonl_io`. The small append-only
+  audit ledgers (`domain_verdicts.jsonl`, `search_budget.jsonl`) stay uncompressed. Bounds the git
+  state repo (~8x smaller per-run blobs) ahead of it becoming the single source of truth.
+- [next] `UNIFY-PR-03`: shared `state-run` wrapper (pull -> run -> commit -> push --force-with-lease,
+  single-writer lock) used by both local and CI, plus the weekly orphan-squash maintenance job and
+  DRYing the workflows' inline checkout/commit. Bounds state-repo history alongside the gzip blobs.
 - [later] `LPF-PR-10`: calibration tooling + golden-set regression CI — frozen
   `tests/golden/prefilter/golden_eval.parquet`, `denbust prefilter calibrate` and
   `denbust prefilter evaluate --golden ...`, and a `.github/workflows/ci-test.yml`

--- a/docs/operational_reference.md
+++ b/docs/operational_reference.md
@@ -295,18 +295,28 @@ tfht_enforce_idx_state/
     └── discover/
         ├── runs/
         ├── candidates/
-        │   ├── backfill_queue.jsonl
-        │   ├── latest_candidates.jsonl
-        │   ├── retry_queue.jsonl
-        │   └── scrape_attempts.jsonl
+        │   ├── backfill_queue.jsonl.gz
+        │   ├── latest_candidates.jsonl.gz
+        │   ├── retry_queue.jsonl.gz
+        │   ├── scrape_attempts.jsonl.gz
+        │   ├── candidate_provenance.jsonl.gz
+        │   ├── domain_verdicts.jsonl
+        │   └── search_budget.jsonl
         ├── backfill_batches/
-        │   ├── latest_backfill_batches.jsonl
+        │   ├── latest_backfill_batches.jsonl.gz
+        │   ├── executed_queries.jsonl.gz
         │   └── <batch-id>.json
         └── metrics/
             ├── engine_overlap_latest.json
             ├── discovery_diagnostics_latest.json
             └── source_suggestions_latest.json
 ```
+
+The big rewrite-per-run and append-only discovery files are stored gzip-compressed
+(`*.jsonl.gz`) to keep the git state repo bounded; readers transparently fall back to
+a legacy uncompressed `*.jsonl` sibling, so pre-existing state needs no migration.
+The small append-only audit ledgers (`domain_verdicts.jsonl`, `search_budget.jsonl`)
+stay uncompressed.
 
 Bootstrap notes:
 

--- a/src/denbust/diagnostics/discovery.py
+++ b/src/denbust/diagnostics/discovery.py
@@ -11,6 +11,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from denbust.config import Config, OperationalProvider, load_config
+from denbust.discovery import jsonl_io
 from denbust.discovery.models import (
     CandidateProvenance,
     CandidateStatus,
@@ -737,16 +738,9 @@ def _read_jsonl(
     path: Path,
     model: type[PersistentCandidate] | type[ScrapeAttempt] | type[CandidateProvenance],
 ) -> list[Any]:
-    if not path.exists():
-        return []
-    rows: list[Any] = []
-    with open(path, encoding="utf-8") as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
-            rows.append(model.model_validate_json(line))
-    return rows
+    # Gzip-aware with a legacy uncompressed read fallback; see
+    # ``denbust.discovery.jsonl_io``.
+    return jsonl_io.read_models(path, model)
 
 
 def _is_search_engine_candidate(candidate: PersistentCandidate) -> bool:

--- a/src/denbust/discovery/jsonl_io.py
+++ b/src/denbust/discovery/jsonl_io.py
@@ -1,0 +1,141 @@
+"""Gzip-aware JSONL I/O for the durable discovery state files.
+
+The big rewrite-per-run and append-only discovery state files (the candidate
+store, retry/backfill queues, provenance and scrape-attempt logs, backfill
+batches and executed-query logs) are stored gzip-compressed (``*.jsonl.gz``) to
+keep the git state repo bounded: each is rewritten or extended on every run, and
+gzip shrinks each blob roughly 8x.
+
+All I/O here is *suffix-driven* — a path ending in ``.gz`` is read/written as
+gzip, any other path as plain text — so the storage format is chosen entirely by
+the resolved state path. Reads transparently fall back to a legacy uncompressed
+sibling (``foo.jsonl`` for ``foo.jsonl.gz``) so pre-existing state keeps working
+without a separate migration step; writing a ``.gz`` file removes that legacy
+sibling, and the first append folds any legacy content into the gz file so data
+is never split across the two.
+"""
+
+from __future__ import annotations
+
+import gzip
+from collections.abc import Iterable, Iterator, Sequence
+from pathlib import Path
+from typing import IO, Any, cast
+
+from pydantic import BaseModel
+
+_GZ_SUFFIX = ".gz"
+
+
+def legacy_sibling(path: Path) -> Path | None:
+    """Return the uncompressed sibling of a ``*.gz`` path, or ``None`` otherwise."""
+    if path.suffix == _GZ_SUFFIX:
+        return path.with_suffix("")
+    return None
+
+
+def resolve_read_path(path: Path) -> Path | None:
+    """Return the physical file to read for *path*.
+
+    Prefers *path* as given; for a ``.gz`` path that does not exist yet, falls
+    back to a legacy uncompressed sibling. Returns ``None`` when neither exists.
+    """
+    if path.exists():
+        return path
+    legacy = legacy_sibling(path)
+    if legacy is not None and legacy.exists():
+        return legacy
+    return None
+
+
+def state_file_exists(path: Path) -> bool:
+    """True if *path* or its legacy uncompressed sibling exists."""
+    return resolve_read_path(path) is not None
+
+
+def iter_jsonl_lines(path: Path) -> Iterator[str]:
+    """Yield non-blank, stripped lines from *path* (gz or legacy, transparently)."""
+    physical = resolve_read_path(path)
+    if physical is None:
+        return
+    with _open_text(physical, append=False, read=True) as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                yield stripped
+
+
+def read_models(path: Path, model: type[BaseModel]) -> list[Any]:
+    """Read and validate every JSONL row in *path* into *model* instances."""
+    return [model.model_validate_json(line) for line in iter_jsonl_lines(path)]
+
+
+def write_jsonl(path: Path, lines: Iterable[str]) -> Path:
+    """Rewrite *path* with *lines* (gzip when ``.gz``); drop any legacy sibling."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _open_text(path, append=False, read=False) as handle:
+        for line in lines:
+            handle.write(line)
+            handle.write("\n")
+    _drop_legacy_sibling(path)
+    return path
+
+
+def write_models(path: Path, rows: Iterable[BaseModel]) -> Path:
+    """Rewrite *path* with the JSON serialization of *rows*."""
+    return write_jsonl(path, (row.model_dump_json() for row in rows))
+
+
+def append_jsonl(path: Path, lines: Sequence[str]) -> Path:
+    """Append *lines* to *path*.
+
+    For a ``.gz`` path this writes a new gzip member (gzip transparently reads
+    concatenated members on the way back). If only a legacy uncompressed sibling
+    exists, its contents are folded into a fresh gz file first so data is never
+    split across the two files.
+    """
+    if not lines:
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _migrate_legacy_into_gz(path)
+    with _open_text(path, append=True, read=False) as handle:
+        for line in lines:
+            handle.write(line)
+            handle.write("\n")
+    return path
+
+
+def append_models(path: Path, rows: Sequence[BaseModel]) -> Path:
+    """Append the JSON serialization of *rows* to *path*."""
+    return append_jsonl(path, [row.model_dump_json() for row in rows])
+
+
+def _open_text(path: Path, *, append: bool, read: bool) -> IO[str]:
+    """Open *path* as a UTF-8 text stream, gzip-aware by suffix."""
+    mode = "rt" if read else "at" if append else "wt"
+    if path.suffix == _GZ_SUFFIX:
+        # gzip.open's return type is a union for a non-literal mode; in text mode
+        # ("rt"/"wt"/"at") it is always a text stream.
+        return cast("IO[str]", gzip.open(path, mode, encoding="utf-8"))
+    return path.open(mode[0], encoding="utf-8")
+
+
+def _drop_legacy_sibling(path: Path) -> None:
+    """Remove the legacy uncompressed sibling once a ``.gz`` file is authoritative."""
+    legacy = legacy_sibling(path)
+    if legacy is not None and legacy != path and legacy.exists():
+        legacy.unlink()
+
+
+def _migrate_legacy_into_gz(path: Path) -> None:
+    """Fold a legacy uncompressed sibling into a fresh gz file before appending.
+
+    No-op unless *path* is a ``.gz`` file that does not exist yet while its legacy
+    sibling does — that is exactly the first append after the format switch.
+    """
+    if path.suffix != _GZ_SUFFIX or path.exists():
+        return
+    legacy = legacy_sibling(path)
+    if legacy is None or not legacy.exists():
+        return
+    write_jsonl(path, list(iter_jsonl_lines(legacy)))

--- a/src/denbust/discovery/state_paths.py
+++ b/src/denbust/discovery/state_paths.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from denbust.discovery.jsonl_io import write_models
 from denbust.discovery.models import PersistentCandidate
 from denbust.models.common import DatasetName, JobName
 from denbust.store.run_snapshots import snapshot_filename
@@ -67,16 +68,20 @@ def resolve_discovery_state_paths(
         domain_verdicts_path=candidates_dir / "domain_verdicts.jsonl",
         search_budget_path=candidates_dir / "search_budget.jsonl",
         query_yield_path=candidates_dir / "query_yield.json",
-        latest_candidates_path=candidates_dir / "latest_candidates.jsonl",
-        latest_backfill_batches_path=backfill_batches_dir / "latest_backfill_batches.jsonl",
-        retry_queue_path=candidates_dir / "retry_queue.jsonl",
-        backfill_queue_path=candidates_dir / "backfill_queue.jsonl",
-        candidate_provenance_path=candidates_dir / "candidate_provenance.jsonl",
-        scrape_attempts_path=candidates_dir / "scrape_attempts.jsonl",
+        # Big rewrite-per-run / append-only state files are gzip-compressed
+        # (``*.jsonl.gz``) to keep the git state repo bounded; see
+        # ``denbust.discovery.jsonl_io``. Reads fall back to a legacy ``*.jsonl``
+        # sibling, so pre-existing uncompressed state keeps working.
+        latest_candidates_path=candidates_dir / "latest_candidates.jsonl.gz",
+        latest_backfill_batches_path=backfill_batches_dir / "latest_backfill_batches.jsonl.gz",
+        retry_queue_path=candidates_dir / "retry_queue.jsonl.gz",
+        backfill_queue_path=candidates_dir / "backfill_queue.jsonl.gz",
+        candidate_provenance_path=candidates_dir / "candidate_provenance.jsonl.gz",
+        scrape_attempts_path=candidates_dir / "scrape_attempts.jsonl.gz",
         engine_overlap_latest_path=metrics_dir / "engine_overlap_latest.json",
         discovery_diagnostics_latest_path=metrics_dir / "discovery_diagnostics_latest.json",
         source_suggestions_latest_path=metrics_dir / "source_suggestions_latest.json",
-        backfill_executed_queries_path=backfill_batches_dir / "executed_queries.jsonl",
+        backfill_executed_queries_path=backfill_batches_dir / "executed_queries.jsonl.gz",
     )
 
 
@@ -98,23 +103,13 @@ def write_discovery_run_snapshot(
 
 
 def write_candidate_jsonl(path: Path, candidates: list[PersistentCandidate]) -> Path:
-    """Write candidate rows to a JSONL file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        for candidate in candidates:
-            handle.write(candidate.model_dump_json())
-            handle.write("\n")
-    return path
+    """Rewrite candidate rows to a JSONL file (gzip-aware by path suffix)."""
+    return write_models(path, candidates)
 
 
 def write_model_jsonl(path: Path, rows: Sequence[BaseModel]) -> Path:
-    """Write generic Pydantic rows to a JSONL file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(row.model_dump_json())
-            handle.write("\n")
-    return path
+    """Rewrite generic Pydantic rows to a JSONL file (gzip-aware by path suffix)."""
+    return write_models(path, rows)
 
 
 def write_json_snapshot(path: Path, payload: dict[str, Any]) -> Path:

--- a/src/denbust/discovery/storage.py
+++ b/src/denbust/discovery/storage.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 
 from denbust.config import Config, OperationalProvider
+from denbust.discovery import jsonl_io
 from denbust.discovery.models import (
     BackfillBatch,
     BackfillBatchStatus,
@@ -426,25 +427,10 @@ class StateRepoDiscoveryPersistence(DiscoveryPersistence):
         return None
 
     def _append_jsonl(self, path: Path, rows: Sequence[Any]) -> None:
-        if not rows:
-            return
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "a", encoding="utf-8") as handle:
-            for row in rows:
-                handle.write(row.model_dump_json())
-                handle.write("\n")
+        jsonl_io.append_models(path, rows)
 
     def _read_jsonl(self, path: Path, model: type[Any]) -> list[Any]:
-        if not path.exists():
-            return []
-        rows: list[Any] = []
-        with open(path, encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                rows.append(model.model_validate_json(line))
-        return rows
+        return jsonl_io.read_models(path, model)
 
 
 class SupabaseDiscoveryPersistence(DiscoveryPersistence):

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -32,6 +32,7 @@ from denbust.diagnostics.discovery import (
     build_discovery_diagnostic_report,
     persist_discovery_diagnostic_artifacts,
 )
+from denbust.discovery import jsonl_io
 from denbust.discovery.backfill import (
     BACKFILL_BATCH_ID_ENV,
     BACKFILL_DATE_FROM_ENV,
@@ -728,8 +729,12 @@ def _write_discovery_diagnostic_artifacts(
     overlap_candidates: list[PersistentCandidate],
 ) -> None:
     """Persist the latest discovery diagnostics and overlap artifacts."""
-    persisted_candidates_available = config.discovery_state_paths.latest_candidates_path.exists()
-    persisted_attempts_available = config.discovery_state_paths.scrape_attempts_path.exists()
+    persisted_candidates_available = jsonl_io.state_file_exists(
+        config.discovery_state_paths.latest_candidates_path
+    )
+    persisted_attempts_available = jsonl_io.state_file_exists(
+        config.discovery_state_paths.scrape_attempts_path
+    )
     if persisted_candidates_available or persisted_attempts_available:
         report = build_discovery_diagnostic_report(
             config=config,

--- a/src/denbust/prefilter/labels.py
+++ b/src/denbust/prefilter/labels.py
@@ -25,6 +25,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from denbust.discovery import jsonl_io
 from denbust.discovery.state_paths import DiscoveryStatePaths
 
 if TYPE_CHECKING:
@@ -246,22 +247,16 @@ def _triage_label(
 
 
 def _load_candidates(candidates_path: Path) -> dict[str, dict[str, object]]:
-    """Return ``{candidate_id: record}`` from a ``latest_candidates.jsonl`` file."""
+    """Return ``{candidate_id: record}`` from a ``latest_candidates.jsonl(.gz)`` file."""
     candidates: dict[str, dict[str, object]] = {}
-    if not candidates_path.exists():
-        return candidates
-    with candidates_path.open(encoding="utf-8") as fh:
-        for line in fh:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row: dict[str, object] = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            cid = row.get("candidate_id")
-            if cid:
-                candidates[str(cid)] = row
+    for line in jsonl_io.iter_jsonl_lines(candidates_path):
+        try:
+            row: dict[str, object] = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        cid = row.get("candidate_id")
+        if cid:
+            candidates[str(cid)] = row
     return candidates
 
 

--- a/tests/unit/test_backfill_query_tracking.py
+++ b/tests/unit/test_backfill_query_tracking.py
@@ -149,5 +149,5 @@ class TestStateRepoExecutedQueryPersistence:
             state_root=tmp_path, dataset_name=DatasetName.NEWS_ITEMS
         )
         assert paths.backfill_executed_queries_path == (
-            tmp_path / "news_items" / "discover" / "backfill_batches" / "executed_queries.jsonl"
+            tmp_path / "news_items" / "discover" / "backfill_batches" / "executed_queries.jsonl.gz"
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -65,7 +65,7 @@ class TestConfig:
         assert config.state_paths.publication_dir == Path("data/news_items/ingest/publication")
         assert config.discovery_state_paths.namespace_dir == Path("data/news_items/discover")
         assert config.discovery_state_paths.latest_candidates_path == Path(
-            "data/news_items/discover/candidates/latest_candidates.jsonl"
+            "data/news_items/discover/candidates/latest_candidates.jsonl.gz"
         )
 
     def test_custom_days(self) -> None:

--- a/tests/unit/test_discovery_state_paths.py
+++ b/tests/unit/test_discovery_state_paths.py
@@ -1,9 +1,11 @@
 """Unit tests for discovery-layer state path helpers."""
 
+import gzip
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+from denbust.discovery.jsonl_io import iter_jsonl_lines
 from denbust.discovery.models import BackfillBatch, PersistentCandidate
 from denbust.discovery.state_paths import (
     discovery_snapshot_filename,
@@ -27,13 +29,13 @@ def test_resolve_discovery_state_paths_uses_discover_namespace() -> None:
     assert paths.namespace_dir == Path("state_repo/news_items/discover")
     assert paths.runs_dir == Path("state_repo/news_items/discover/runs")
     assert paths.latest_candidates_path == Path(
-        "state_repo/news_items/discover/candidates/latest_candidates.jsonl"
+        "state_repo/news_items/discover/candidates/latest_candidates.jsonl.gz"
     )
     assert paths.latest_backfill_batches_path == Path(
-        "state_repo/news_items/discover/backfill_batches/latest_backfill_batches.jsonl"
+        "state_repo/news_items/discover/backfill_batches/latest_backfill_batches.jsonl.gz"
     )
     assert paths.scrape_attempts_path == Path(
-        "state_repo/news_items/discover/candidates/scrape_attempts.jsonl"
+        "state_repo/news_items/discover/candidates/scrape_attempts.jsonl.gz"
     )
     assert paths.engine_overlap_latest_path == Path(
         "state_repo/news_items/discover/metrics/engine_overlap_latest.json"
@@ -90,7 +92,12 @@ def test_write_discovery_layer_artifacts(tmp_path: Path) -> None:
     assert metrics_path.exists()
     assert snapshot_path.exists()
     assert json.loads(metrics_path.read_text(encoding="utf-8")) == {"brave": 3}
-    candidate_lines = candidates_path.read_text(encoding="utf-8").splitlines()
+    # The candidate store is gzip-compressed; read it back through the gz-aware reader.
+    candidate_lines = list(iter_jsonl_lines(candidates_path))
     assert len(candidate_lines) == 1
     candidate_record = json.loads(candidate_lines[0])
     assert candidate_record["current_url"] == "https://www.ynet.co.il/item"
+    # The physical file really is gzip, not plain text.
+    assert candidates_path.suffix == ".gz"
+    with gzip.open(candidates_path, "rt", encoding="utf-8") as handle:
+        assert handle.read().strip() != ""

--- a/tests/unit/test_discovery_storage.py
+++ b/tests/unit/test_discovery_storage.py
@@ -441,8 +441,8 @@ def test_state_repo_discovery_persistence_round_trips(tmp_path: Path) -> None:
     store.append_provenance([build_provenance("queued"), build_provenance("backfill")])
     store.append_attempts([build_attempt("queued"), build_attempt("backfill")])
 
-    assert store.provenance_path == paths.candidates_dir / "candidate_provenance.jsonl"
-    assert store.attempts_path == paths.candidates_dir / "scrape_attempts.jsonl"
+    assert store.provenance_path == paths.candidates_dir / "candidate_provenance.jsonl.gz"
+    assert store.attempts_path == paths.candidates_dir / "scrape_attempts.jsonl.gz"
     assert store.get_candidate("queued") is not None
     assert store.get_candidate("missing") is None
     assert len(store.list_candidates()) == 2
@@ -496,11 +496,13 @@ def test_state_repo_discovery_persistence_handles_missing_and_blank_jsonl(tmp_pa
 
     assert store.list_candidates() == []
 
+    # Blank lines are written to the legacy uncompressed *.jsonl siblings, which
+    # also exercises the gz reader's fallback to pre-existing uncompressed state.
     paths.latest_candidates_path.parent.mkdir(parents=True, exist_ok=True)
     paths.latest_backfill_batches_path.parent.mkdir(parents=True, exist_ok=True)
-    paths.latest_candidates_path.write_text("\n\n", encoding="utf-8")
-    paths.backfill_queue_path.write_text("\n\n", encoding="utf-8")
-    paths.latest_backfill_batches_path.write_text("\n\n", encoding="utf-8")
+    paths.latest_candidates_path.with_suffix("").write_text("\n\n", encoding="utf-8")
+    paths.backfill_queue_path.with_suffix("").write_text("\n\n", encoding="utf-8")
+    paths.latest_backfill_batches_path.with_suffix("").write_text("\n\n", encoding="utf-8")
     store.append_provenance([])
     store.append_attempts([])
     store.upsert_candidates([])

--- a/tests/unit/test_jsonl_io.py
+++ b/tests/unit/test_jsonl_io.py
@@ -1,0 +1,106 @@
+"""Unit tests for the gzip-aware JSONL state I/O helpers."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from denbust.discovery import jsonl_io
+
+
+class _Row(BaseModel):
+    id: str
+    n: int
+
+
+def test_write_jsonl_gz_roundtrips_and_compresses(tmp_path: Path) -> None:
+    """A .gz path is written as real gzip and reads back identically."""
+    path = tmp_path / "rows.jsonl.gz"
+    jsonl_io.write_jsonl(path, ["a", "b", "c"])
+
+    # The physical file is gzip, not plain text.
+    with path.open("rb") as raw:
+        assert raw.read(2) == b"\x1f\x8b"  # gzip magic
+    assert list(jsonl_io.iter_jsonl_lines(path)) == ["a", "b", "c"]
+
+
+def test_plain_jsonl_path_stays_uncompressed(tmp_path: Path) -> None:
+    """A non-.gz path is written as plain text (suffix-driven)."""
+    path = tmp_path / "rows.jsonl"
+    jsonl_io.write_jsonl(path, ["x", "y"])
+
+    assert path.read_text(encoding="utf-8") == "x\ny\n"
+    assert list(jsonl_io.iter_jsonl_lines(path)) == ["x", "y"]
+
+
+def test_read_falls_back_to_legacy_uncompressed_sibling(tmp_path: Path) -> None:
+    """Reading a .gz path finds a pre-existing uncompressed .jsonl sibling."""
+    gz_path = tmp_path / "rows.jsonl.gz"
+    legacy = tmp_path / "rows.jsonl"
+    legacy.write_text("old1\n\nold2\n", encoding="utf-8")  # includes a blank line
+
+    assert jsonl_io.state_file_exists(gz_path) is True
+    assert list(jsonl_io.iter_jsonl_lines(gz_path)) == ["old1", "old2"]
+
+
+def test_write_gz_drops_stale_legacy_sibling(tmp_path: Path) -> None:
+    """Once the .gz file is authoritative the legacy sibling is removed."""
+    gz_path = tmp_path / "rows.jsonl.gz"
+    legacy = tmp_path / "rows.jsonl"
+    legacy.write_text("stale\n", encoding="utf-8")
+
+    jsonl_io.write_jsonl(gz_path, ["fresh"])
+
+    assert not legacy.exists()
+    assert list(jsonl_io.iter_jsonl_lines(gz_path)) == ["fresh"]
+
+
+def test_append_concatenates_gzip_members(tmp_path: Path) -> None:
+    """Appending to a .gz file writes additional members that read back in order."""
+    path = tmp_path / "log.jsonl.gz"
+    jsonl_io.append_jsonl(path, ["one"])
+    jsonl_io.append_jsonl(path, ["two", "three"])
+
+    # Reads transparently across the concatenated gzip members.
+    assert list(jsonl_io.iter_jsonl_lines(path)) == ["one", "two", "three"]
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        assert handle.read() == "one\ntwo\nthree\n"
+
+
+def test_append_migrates_legacy_then_extends_single_gz(tmp_path: Path) -> None:
+    """First append folds a legacy .jsonl into the gz file; data is not split."""
+    gz_path = tmp_path / "log.jsonl.gz"
+    legacy = tmp_path / "log.jsonl"
+    legacy.write_text("legacy1\nlegacy2\n", encoding="utf-8")
+
+    jsonl_io.append_jsonl(gz_path, ["new1"])
+
+    assert not legacy.exists()  # migrated, not left behind
+    assert list(jsonl_io.iter_jsonl_lines(gz_path)) == ["legacy1", "legacy2", "new1"]
+
+
+def test_models_roundtrip(tmp_path: Path) -> None:
+    """write_models / append_models / read_models round-trip pydantic rows."""
+    path = tmp_path / "models.jsonl.gz"
+    jsonl_io.write_models(path, [_Row(id="a", n=1)])
+    jsonl_io.append_models(path, [_Row(id="b", n=2)])
+
+    rows = jsonl_io.read_models(path, _Row)
+    assert [(r.id, r.n) for r in rows] == [("a", 1), ("b", 2)]
+
+
+def test_missing_file_reads_empty(tmp_path: Path) -> None:
+    """A missing path (and missing legacy sibling) reads as empty, not an error."""
+    path = tmp_path / "absent.jsonl.gz"
+    assert jsonl_io.state_file_exists(path) is False
+    assert list(jsonl_io.iter_jsonl_lines(path)) == []
+    assert jsonl_io.read_models(path, _Row) == []
+
+
+def test_append_empty_is_noop(tmp_path: Path) -> None:
+    """Appending nothing does not create a file."""
+    path = tmp_path / "log.jsonl.gz"
+    jsonl_io.append_jsonl(path, [])
+    assert not path.exists()

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -24,6 +24,7 @@ from denbust.data_models import (
     SubCategory,
     UnifiedItem,
 )
+from denbust.discovery import jsonl_io
 from denbust.discovery.models import (
     CandidateStatus,
     ContentBasis,
@@ -3871,10 +3872,9 @@ class TestRunPipeline:
         assert result.raw_article_count == 1
         assert result.unified_item_count == 1
         assert result.fatal is False
-        candidate_lines = (
-            config.discovery_state_paths.latest_candidates_path.read_text(encoding="utf-8")
-            .strip()
-            .splitlines()
+        # The candidate store is gzip-compressed; read it via the gz-aware reader.
+        candidate_lines = list(
+            jsonl_io.iter_jsonl_lines(config.discovery_state_paths.latest_candidates_path)
         )
         assert len(candidate_lines) == 1
 


### PR DESCRIPTION
## Summary

The discovery state files that are **rewritten or extended on every run** — the candidate store, retry/backfill queues, provenance and scrape-attempt logs, backfill batches, and the executed-query log — are stored uncompressed today. As the git state repo becomes the single source of truth for both local and CI runs (the local↔CI unification track), those per-run blobs bloat history. This PR stores them **gzip-compressed (`*.jsonl.gz`)**, ~8× smaller per blob, with a transparent legacy read fallback so there is no migration step.

This is **UNIFY-PR-02**, building on [#207](https://github.com/DataHackIL/tfht_enforce_idx/pull/207) (one base config + `--overlay`).

## Design — one suffix-driven I/O module

New `src/denbust/discovery/jsonl_io.py` centralizes all gzip-aware JSONL I/O. The format is chosen **entirely by the path suffix**, so flipping the state paths to `.jsonl.gz` is what switches the format:

- **write** → gzip when the path ends in `.gz`, plain text otherwise;
- **append** → writes an additional gzip *member* (gzip reads concatenated members back transparently), so the append-only logs keep their append semantics without rewriting the whole file;
- **read** → falls back to a legacy uncompressed `.jsonl` sibling when the `.gz` doesn't exist, so **pre-existing state keeps working with no migration**. The first write/append of a `.gz` file folds in and removes that legacy sibling, so data is never split across the two.

## What routes through it

`DiscoveryStatePaths` now resolves these **seven** files to `.jsonl.gz`: `latest_candidates`, `retry_queue`, `backfill_queue`, `candidate_provenance`, `scrape_attempts`, `latest_backfill_batches`, `executed_queries`.

All readers/writers now go through the module — and in doing so, the **two duplicated `_read_jsonl` implementations** (in `storage.py` and `diagnostics/discovery.py`) are collapsed onto one helper:

- `storage.py`: `_read_jsonl` / `_append_jsonl` → `jsonl_io.read_models` / `append_models`
- `diagnostics/discovery.py`: `_read_jsonl` → `jsonl_io.read_models`
- `state_paths.py`: `write_candidate_jsonl` / `write_model_jsonl` → `jsonl_io.write_models`
- `prefilter/labels.py`: candidate loader → `jsonl_io.iter_jsonl_lines`
- `pipeline.py`: diagnostic `.exists()` guards → `jsonl_io.state_file_exists` (so a legacy `.jsonl`-only state still satisfies the guard)

**Deliberately left uncompressed:** the small append-only audit ledgers `domain_verdicts.jsonl` and `search_budget.jsonl` (their own I/O in `domain_verdicts.py` / `search_budget.py`, untouched).

## Tests

- New `tests/unit/test_jsonl_io.py`: gz round-trip + real gzip-magic check, plain-text passthrough, **legacy read fallback**, stale-sibling cleanup, **append member concatenation**, **legacy→gz migration on first append**, models round-trip, empty/missing handling.
- Updated storage / state-path / pipeline / config / backfill-tracking tests to the gz format. The blank-line tolerance test now writes to the legacy `.jsonl` sibling, so it doubles as a fallback test.

## Validation

- `ruff format .` / `ruff check .` — clean
- `mypy src/` — clean (105 files)
- `pytest -q tests/unit` — **1378 passed, 2 skipped**
- `pytest -q tests/integration` — **168 passed**

## Notes

- **No migration needed**: existing uncompressed state is read via the fallback and transparently re-written as `.jsonl.gz` on the next run.
- Gzip bounds per-blob *size*; bounding state-repo *history* (gzip blobs don't git-delta) is the next PR — **UNIFY-PR-03** adds the shared `state-run` wrapper + weekly orphan-squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)