### PR TITLE
docs(plan): bound state repo via wrapper+squash, drop gzip idea

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -17,9 +17,11 @@
   daily-review workflow needs none. The 2026 backfill helper script and the operational/discovery
   docs point at the base config. This removes config drift between the two surfaces without an
   unscoped env-var footgun, and is the first step of the local↔CI unification track.
-- Next planned PR: `UNIFY-PR-02` — gzip the big rewrite-per-run state files to `.jsonl.gz`
-  (with a legacy uncompressed read fallback) so the git state repo stays bounded once it becomes
-  the single source of truth for both local and CI runs.
+- Next planned PR: `UNIFY-PR-02` — a shared `state-run` wrapper (shallow/treeless clone, run,
+  commit only when state changed, push `--force-with-lease`, single-writer lock) plus periodic
+  orphan-squash, to bound the git state repo before it becomes the single source of truth. State
+  files stay plain JSONL (git already delta+zlib-compresses them; pre-compressing was measured to
+  bloat history ~15x — see the state-layout note in `docs/operational_reference.md`).
 - Current blockers on main: Google CSE returns `403 PERMISSION_DENIED` locally; the canonical
   `agents/news/local_search_brave_exa.yaml` already disables Google CSE so Brave + Exa carry
   open-web discovery. Exa returns `402 Payment Required` once its prepaid balance is exhausted —
@@ -288,10 +290,14 @@
   env; the read-only daily-review workflow needs no overlay. `test_config.py` covers the merged
   CI delta, nested-key merge semantics, and missing-overlay errors. Removes config drift without an
   unscoped env-var footgun.
-- [next] `UNIFY-PR-02`: gzip the big rewrite-per-run state files (`latest_candidates.jsonl`,
-  discovery queues, provenance, scrape-attempt logs) to `.jsonl.gz` via `state_paths.py` +
-  `storage.py`, with a legacy uncompressed-`.jsonl` read fallback, so the git state repo stays
-  bounded (~8x smaller per-run blobs) when it becomes the single source of truth.
+- [next] `UNIFY-PR-02`: shared `state-run` wrapper used by both local and CI — shallow/treeless
+  clone (`--depth=1 --filter=blob:none`), run, commit only when state actually changed, push
+  `--force-with-lease` under a single-writer lock — plus a periodic orphan-squash maintenance job.
+  This is what bounds the git state repo. State files stay plain JSONL: git already delta+zlib
+  -compresses them, so gzipping-before-commit is redundant on a snapshot (~1.01x) and defeats
+  git's cross-run delta compression (measured ~15x larger history on the candidate store), besides
+  breaking unchanged-run detection because `gzip` embeds a wall-clock mtime. The earlier gzip
+  proposal (PR #208) was measured and rejected for this reason.
 - [later] `LPF-PR-10`: calibration tooling + golden-set regression CI — frozen
   `tests/golden/prefilter/golden_eval.parquet`, `denbust prefilter calibrate` and
   `denbust prefilter evaluate --golden ...`, and a `.github/workflows/ci-test.yml`

--- a/docs/operational_reference.md
+++ b/docs/operational_reference.md
@@ -308,6 +308,15 @@ tfht_enforce_idx_state/
             └── source_suggestions_latest.json
 ```
 
+State files are kept as **plain JSONL** on purpose — do not pre-compress them (e.g. to
+`*.jsonl.gz`) for storage in the state repo. Git already delta+zlib-compresses blobs, so
+gzipping first is redundant on any single snapshot (~1.01x vs git's own packing) and actively
+harmful across runs: pre-compressed blobs cannot be delta-compressed against the previous
+revision, which was measured to grow the candidate store's history roughly **15x**. Gzip also
+embeds a wall-clock mtime, so byte-identical state produces a different blob every run, breaking
+"skip the commit when nothing changed". The repo is bounded instead by the `state-run` wrapper
+(shallow/treeless clone + commit-only-on-change) and a periodic orphan-squash.
+
 Bootstrap notes:
 
 - `seen.json` may be absent initially; it is created once a run marks at least one URL as seen


### PR DESCRIPTION
Docs-only correction to the unification plan.

The previously-planned `UNIFY-PR-02` (gzip the rewrite-per-run state files to `.jsonl.gz`) was prototyped in #208, then **measured and rejected** — it's counterproductive for its own goal of bounding the git state repo:

- **git already compresses**: the 4.6 MB `latest_candidates.jsonl` packs to 495 KB in git, vs 489 KB standalone gzip — gzip-before-commit saves ~1% on a snapshot.
- **gzip defeats delta compression**: a 24-run simulation on the real candidate store grew history ~15× (773 KB plain → 11.8 MB gzip), because pre-compressed blobs can't be delta'd across revisions.
- **gzip is non-deterministic**: `gzip.open` embeds a wall-clock mtime + the source filename, so byte-identical state produces a new blob every run, breaking "skip the commit when nothing changed".

`UNIFY-PR-02` is now redefined as the shared `state-run` wrapper (shallow/treeless clone, commit-only-on-change, push `--force-with-lease` under a single-writer lock) plus a periodic orphan-squash — the levers that actually bound the repo. State files stay plain JSONL.

Updates `.agent-plan.md` (Mainline Status + the single `[next]` item) and adds a state-layout note in `docs/operational_reference.md` recording the rationale so the gzip idea isn't re-proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)