### PR TITLE
feat(discovery): GitHub search backstop (only search if local was idle)

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,23 +6,20 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `UNIFY-PR-04` — the GH-never-scrapes guardrail (first half of the
-  GH/local partition). A top-level `Config.scraping_enabled` master switch (default `True`) gates
-  all source-site / article-body fetching; `agents/news/ci.overlay.yaml` sets it `false` so GitHub
-  Actions never scrapes (its datacenter IPs are bot-blocked by Israeli news sites). Every
-  source-site fetch path respects it: `scrape_candidates()` no-ops (candidates left for a local
-  run), the ingest `fetch_all_sources` call is skipped, and source-native discovery in the
-  `discover`/`backfill_discover` jobs (`_run_source_native_discovery`,
-  `_run_source_native_backfill_discovery`) is skipped while the Brave/Exa search engines still run.
-  (`daily-review` already runs `diagnose-sources --artifacts-only`, so it does no live fetch on GH.)
-  GH still searches, classifies, and runs the deterministic phases. Inert until the operational
-  workflows are enabled. Covered by config, scrape-queue, discover, and ingest-pipeline tests.
-- Next planned PR: `UNIFY-PR-05` — the search-backstop half: on GitHub, run Brave/Exa search only
-  when a local run did not already search that calendar day (gated on the search-budget ledger's
-  `recorded_at` timestamps). Then the operational step: seed the state repo and re-enable only the
-  search-backstop / release / report / backup / squash workflows. State files stay plain JSONL
-  (git already delta+zlib-compresses them; pre-compressing was measured to bloat history ~15x —
-  see the state-layout note in `docs/operational_reference.md`).
+- Last merged PR on main: `UNIFY-PR-05` — the search-backstop half of the GH/local partition.
+  `SearchBudgetLedger.searched_on(day=...)` reports whether any run (local or CI) recorded a
+  search on a UTC calendar day; `DiscoveryConfig.search_backstop_only` (set `true` in
+  `ci.overlay.yaml`) makes the `discover` job issue Brave/Exa queries only when no search was
+  recorded that day, so the day's paid search budget is spent at most once and local takes
+  priority. When the backstop skips, the job completes non-fatal with `search_backstop_skipped=true`
+  (a fix to the `failed_runs == len(persisted_runs)` check so a zero-run day is not treated as
+  all-failed). This completes the code side of the GH/local partition (`UNIFY-PR-04` was the
+  no-scrape guardrail). Covered by ledger + config + discover-job tests.
+- Next planned PR: `UNIFY-PR-06` (operational) — seed the state repo from the current local state
+  and re-enable only the search-backstop / release / report / backup / squash workflows (GitHub
+  never scrapes, so the scraping ingest/backfill-scrape jobs stay local). First confirm the
+  `STATE_REPO_PAT` has push (and force-push, for the squash) rights to the state repo's `main`.
+  The parked scrape→classify decouple is tracked separately as GitHub issue #213.
 - Current blockers on main: Google CSE returns `403 PERMISSION_DENIED` locally; the canonical
   `agents/news/local_search_brave_exa.yaml` already disables Google CSE so Brave + Exa carry
   open-web discovery. Exa returns `402 Payment Required` once its prepaid balance is exhausted —
@@ -319,10 +316,16 @@
   jobs is skipped — so GitHub never fetches from source sites (bot-blocked datacenter IPs) while still
   searching, classifying, and running the deterministic phases. Covered by config + scrape-queue +
   discover + ingest-pipeline tests.
-- [next] `UNIFY-PR-05`: search-backstop half — on GitHub, run Brave/Exa search only when a local
-  run did not already search that calendar day (gated on the search-budget ledger's `recorded_at`
-  timestamps). Then seed the state repo and re-enable only the search-backstop / release / report /
-  backup / squash workflows.
+- [done] `UNIFY-PR-05`: search-backstop half. `SearchBudgetLedger.searched_on(day=...)` plus
+  `DiscoveryConfig.search_backstop_only` (set `true` in `ci.overlay.yaml`) make the `discover` job
+  issue Brave/Exa queries only when no run already searched that UTC day, so the day's paid search
+  budget is spent at most once and local takes priority. A zero-run day now finishes non-fatal.
+  Covered by ledger + config + discover-job tests.
+- [next] `UNIFY-PR-06` (operational): seed the state repo from current local state and re-enable
+  only the search-backstop / release / report / backup / squash workflows — GitHub never scrapes,
+  so the scraping ingest / backfill-scrape jobs stay local. Confirm the `STATE_REPO_PAT` can push
+  (and force-push, for the squash) to the state repo's `main` first. (Parked scrape→classify
+  decouple: GitHub issue #213.)
 - [later] `LPF-PR-10`: calibration tooling + golden-set regression CI — frozen
   `tests/golden/prefilter/golden_eval.parquet`, `denbust prefilter calibrate` and
   `denbust prefilter evaluate --golden ...`, and a `.github/workflows/ci-test.yml`

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -7,14 +7,16 @@
 ## Mainline Status
 
 - Last merged PR on main: `UNIFY-PR-05` — the search-backstop half of the GH/local partition.
-  `SearchBudgetLedger.searched_on(day=...)` reports whether any run (local or CI) recorded a
-  search on a UTC calendar day; `DiscoveryConfig.search_backstop_only` (set `true` in
-  `ci.overlay.yaml`) makes the `discover` job issue Brave/Exa queries only when no search was
-  recorded that day, so the day's paid search budget is spent at most once and local takes
-  priority. When the backstop skips, the job completes non-fatal with `search_backstop_skipped=true`
+  `SearchBudgetLedger.searched_since(since=...)` reports whether any run (local or CI) recorded a
+  search at or after a cutoff; `DiscoveryConfig.search_backstop_only` (set `true` in
+  `ci.overlay.yaml`) makes the `discover` job issue Brave/Exa queries only when no run searched in
+  the prior 24h. A rolling window (not a calendar day) means GH defers to a recent local search
+  regardless of clock ordering — as long as local runs at least daily, GH always skips and only
+  searches once local has been idle longer than a day, so the paid search budget is spent at most
+  once. When the backstop skips, the job completes non-fatal with `search_backstop_skipped=true`
   (a fix to the `failed_runs == len(persisted_runs)` check so a zero-run day is not treated as
   all-failed). This completes the code side of the GH/local partition (`UNIFY-PR-04` was the
-  no-scrape guardrail). Covered by ledger + config + discover-job tests.
+  no-scrape guardrail). Covered by ledger + config + discover-job tests (incl. the real CI triple).
 - Next planned PR: `UNIFY-PR-06` (operational) — seed the state repo from the current local state
   and re-enable only the search-backstop / release / report / backup / squash workflows (GitHub
   never scrapes, so the scraping ingest/backfill-scrape jobs stay local). First confirm the
@@ -316,10 +318,11 @@
   jobs is skipped — so GitHub never fetches from source sites (bot-blocked datacenter IPs) while still
   searching, classifying, and running the deterministic phases. Covered by config + scrape-queue +
   discover + ingest-pipeline tests.
-- [done] `UNIFY-PR-05`: search-backstop half. `SearchBudgetLedger.searched_on(day=...)` plus
+- [done] `UNIFY-PR-05`: search-backstop half. `SearchBudgetLedger.searched_since(since=...)` plus
   `DiscoveryConfig.search_backstop_only` (set `true` in `ci.overlay.yaml`) make the `discover` job
-  issue Brave/Exa queries only when no run already searched that UTC day, so the day's paid search
-  budget is spent at most once and local takes priority. A zero-run day now finishes non-fatal.
+  issue Brave/Exa queries only when no run searched in the prior 24h (a rolling window, so GH
+  defers to a recent local search regardless of clock ordering). A zero-run day now finishes
+  non-fatal.
   Covered by ledger + config + discover-job tests.
 - [next] `UNIFY-PR-06` (operational): seed the state repo from current local state and re-enable
   only the search-backstop / release / report / backup / squash workflows — GitHub never scrapes,

--- a/agents/news/ci.overlay.yaml
+++ b/agents/news/ci.overlay.yaml
@@ -14,6 +14,12 @@
 # locally). GH still searches, classifies, and runs the deterministic phases.
 scraping_enabled: false
 
+discovery:
+  # Search backstop: GH issues Brave/Exa queries only when no run already searched
+  # that UTC day (per the search-budget ledger). Local runs search on their own
+  # cadence and take priority; GH covers only the days local was idle.
+  search_backstop_only: true
+
 operational:
   # Local runs persist to the git state repo as local JSON; CI additionally mirrors
   # operational records into Supabase. (Deployment identity, not a tuning knob.)

--- a/agents/news/ci.overlay.yaml
+++ b/agents/news/ci.overlay.yaml
@@ -15,9 +15,11 @@
 scraping_enabled: false
 
 discovery:
-  # Search backstop: GH issues Brave/Exa queries only when no run already searched
-  # that UTC day (per the search-budget ledger). Local runs search on their own
-  # cadence and take priority; GH covers only the days local was idle.
+  # Search backstop: GH issues Brave/Exa queries only when no run (local or CI)
+  # searched in the prior 24h, per the search-budget ledger. The rolling window
+  # means GH defers to a recent local search regardless of clock ordering — so as
+  # long as local runs at least daily, GH always skips and only searches once local
+  # has been idle for more than a day. Schedule GH discover to run at least daily.
   search_backstop_only: true
 
 operational:

--- a/docs/operational_reference.md
+++ b/docs/operational_reference.md
@@ -832,13 +832,15 @@ source fetch, so it does not scrape on GH either. Because the operational workfl
 still `workflow_dispatch`-only, this is a guardrail that takes effect when they are enabled.
 
 The overlay also sets `discovery.search_backstop_only: true` — the **search backstop**.
-Brave/Exa are a paid, ~1,000-free-queries/month resource, so the day's search budget should
-be spent once. With this flag, the `discover` job issues open-web search queries only when
-the search-budget ledger shows **no search recorded that UTC calendar day** (by any run,
-local or CI). Local runs search on their own cadence and take priority; GH searches only on
-a day local was idle, then records its spend so a later GH run the same day also skips. When
-the backstop skips, the job completes normally (non-fatal) with `search_backstop_skipped=true`
-in its warnings; source-native discovery and the deterministic phases are unaffected.
+Brave/Exa are a paid, ~1,000-free-queries/month resource, so the search budget should be
+spent once. With this flag, the `discover` job issues open-web search queries only when the
+search-budget ledger shows **no search recorded in the prior 24h** (by any run, local or CI).
+A rolling 24h window (rather than a calendar day) means GH defers to a recent local search
+regardless of clock-time ordering — as long as local runs at least daily, GH always skips and
+only searches once local has been idle for more than a day. **Schedule GH discover to run at
+least daily** so the backstop is timely. When it skips, the job completes normally (non-fatal)
+with `search_backstop_skipped=true` in its warnings; source-native discovery and the
+deterministic phases are unaffected.
 
 Release and backup jobs rely on dedicated configs:
 

--- a/docs/operational_reference.md
+++ b/docs/operational_reference.md
@@ -831,6 +831,15 @@ The `daily-review` workflow runs `diagnose-sources --artifacts-only`, which does
 source fetch, so it does not scrape on GH either. Because the operational workflows are
 still `workflow_dispatch`-only, this is a guardrail that takes effect when they are enabled.
 
+The overlay also sets `discovery.search_backstop_only: true` — the **search backstop**.
+Brave/Exa are a paid, ~1,000-free-queries/month resource, so the day's search budget should
+be spent once. With this flag, the `discover` job issues open-web search queries only when
+the search-budget ledger shows **no search recorded that UTC calendar day** (by any run,
+local or CI). Local runs search on their own cadence and take priority; GH searches only on
+a day local was idle, then records its spend so a later GH run the same day also skips. When
+the backstop skips, the job completes normally (non-fatal) with `search_backstop_skipped=true`
+in its warnings; source-native discovery and the deterministic phases are unaffected.
+
 Release and backup jobs rely on dedicated configs:
 
 - `agents/release/news_items.yaml`

--- a/src/denbust/config.py
+++ b/src/denbust/config.py
@@ -354,6 +354,11 @@ class DiscoveryConfig(BaseModel):
     # When set, the highest-priority query kinds (broad/taxonomy open-web first)
     # are kept up to this many queries; the rest are dropped.
     max_queries_per_run: int | None = Field(default=None, ge=1)
+    # Backstop mode (set True on GitHub Actions): issue open-web search-engine
+    # queries only when no run already searched that UTC calendar day, per the
+    # search-budget ledger. Local runs search on their own cadence and take
+    # priority; GH only searches on a day local was idle. See ci.overlay.yaml.
+    search_backstop_only: bool = False
 
 
 class SourceDiscoveryProducerConfig(BaseModel):

--- a/src/denbust/discovery/search_budget.py
+++ b/src/denbust/discovery/search_budget.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -84,19 +84,26 @@ class SearchBudgetLedger:
             handle.write("\n")
         return record
 
-    def searched_on(self, *, day: date, engine: str | None = None) -> bool:
-        """True if a search (queries > 0) was recorded on the UTC calendar day *day*.
+    def searched_since(self, *, since: datetime, engine: str | None = None) -> bool:
+        """True if a search (queries > 0) was recorded at or after *since*.
 
-        Used by the GitHub search backstop: GH issues open-web queries only when no
-        run — local or CI — already searched that day, so the day's search budget is
-        spent at most once and local takes priority on its own cadence.
+        Backs the GitHub search backstop: GH issues open-web queries only when no
+        run — local or CI — searched within the trailing window (the discover job
+        uses the last 24h). A rolling window (rather than a calendar day) means GH
+        defers to a recent local search regardless of clock-time ordering: as long
+        as local runs at least daily, GH always skips and only searches once local
+        has been idle for longer than the window. ``since`` is compared in an aware
+        fashion; a tz-naive ``recorded_at`` is treated as UTC.
         """
         for record in self.load():
             if record.queries <= 0:
                 continue
             if engine is not None and record.engine != engine:
                 continue
-            if record.recorded_at.astimezone(UTC).date() == day:
+            recorded_at = record.recorded_at
+            if recorded_at.tzinfo is None:
+                recorded_at = recorded_at.replace(tzinfo=UTC)
+            if recorded_at >= since:
                 return True
         return False
 

--- a/src/denbust/discovery/search_budget.py
+++ b/src/denbust/discovery/search_budget.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -83,6 +83,22 @@ class SearchBudgetLedger:
             handle.write(record.model_dump_json())
             handle.write("\n")
         return record
+
+    def searched_on(self, *, day: date, engine: str | None = None) -> bool:
+        """True if a search (queries > 0) was recorded on the UTC calendar day *day*.
+
+        Used by the GitHub search backstop: GH issues open-web queries only when no
+        run — local or CI — already searched that day, so the day's search budget is
+        spent at most once and local takes priority on its own cadence.
+        """
+        for record in self.load():
+            if record.queries <= 0:
+                continue
+            if engine is not None and record.engine != engine:
+                continue
+            if record.recorded_at.astimezone(UTC).date() == day:
+                return True
+        return False
 
     def month_spend(self, *, year_month: str, engine: str | None = None) -> tuple[int, float]:
         """Return ``(queries, usd)`` spent in *year_month* (``YYYY-MM``)."""

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -9,7 +9,7 @@ import os
 import sys
 from collections import defaultdict
 from collections.abc import Callable, Mapping
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
 from uuid import uuid4
@@ -2536,18 +2536,19 @@ async def run_news_discover_job(
         return result.finish("fatal: no sources configured")
 
     # Search backstop (GitHub Actions): only issue open-web search queries when no
-    # run already searched this UTC day. Local runs search on their own cadence and
-    # take priority; GH searches only on a day local was idle, so the day's search
-    # budget is spent at most once. Source-native discovery is unaffected.
+    # run searched in the trailing 24h. A rolling window means GH defers to a recent
+    # local search regardless of clock-time ordering — as long as local runs at least
+    # daily, GH always skips and only searches once local has been idle longer than
+    # the window, so the search budget is spent at most once. Source-native discovery
+    # and the deterministic phases are unaffected.
     if config.discovery.search_backstop_only and (
         brave_can_run or exa_can_run or google_cse_can_run
     ):
-        run_day = result.run_timestamp.astimezone(UTC).date()
+        since = result.run_timestamp - timedelta(hours=24)
         ledger = SearchBudgetLedger(config.discovery_state_paths.search_budget_path)
-        if ledger.searched_on(day=run_day):
+        if ledger.searched_since(since=since):
             logger.info(
-                "Search backstop: a search was already recorded on %s; skipping engine search.",
-                run_day.isoformat(),
+                "Search backstop: a search was recorded within the last 24h; skipping engine search."
             )
             result.warnings.append("search_backstop_skipped=true")
             brave_can_run = exa_can_run = google_cse_can_run = False

--- a/src/denbust/pipeline.py
+++ b/src/denbust/pipeline.py
@@ -2535,6 +2535,23 @@ async def run_news_discover_job(
         result.errors.append("No sources configured")
         return result.finish("fatal: no sources configured")
 
+    # Search backstop (GitHub Actions): only issue open-web search queries when no
+    # run already searched this UTC day. Local runs search on their own cadence and
+    # take priority; GH searches only on a day local was idle, so the day's search
+    # budget is spent at most once. Source-native discovery is unaffected.
+    if config.discovery.search_backstop_only and (
+        brave_can_run or exa_can_run or google_cse_can_run
+    ):
+        run_day = result.run_timestamp.astimezone(UTC).date()
+        ledger = SearchBudgetLedger(config.discovery_state_paths.search_budget_path)
+        if ledger.searched_on(day=run_day):
+            logger.info(
+                "Search backstop: a search was already recorded on %s; skipping engine search.",
+                run_day.isoformat(),
+            )
+            result.warnings.append("search_backstop_skipped=true")
+            brave_can_run = exa_can_run = google_cse_can_run = False
+
     persisted_runs: list[tuple[str, PersistedSourceDiscovery]] = []
     run_base = result.run_timestamp.astimezone(UTC).isoformat()
 
@@ -2647,7 +2664,9 @@ async def run_news_discover_job(
     )
     result.unified_item_count = len(merged_candidate_ids)
 
-    if failed_runs == len(persisted_runs):
+    # Fatal only when runs were attempted and all failed — not when nothing ran
+    # (e.g. the search backstop intentionally skipped engine search for the day).
+    if persisted_runs and failed_runs == len(persisted_runs):
         result.fatal = True
 
     result.finish(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -574,6 +574,7 @@ store:
         assert local.max_articles == 100
         assert local.backfill.query_kinds is None  # falls back to the 4-kind default
         assert local.scraping_enabled is True  # local scrapes article bodies
+        assert local.discovery.search_backstop_only is False  # local always searches
 
         # CI runtime: base + overlay, merged before validation.
         ci = load_config(base_path, overlay_path=overlay_path)
@@ -582,6 +583,7 @@ store:
         assert ci.max_articles == 30
         assert ci.backfill.query_kinds == [DiscoveryQueryKind.SOURCE_TARGETED]
         assert ci.scraping_enabled is False  # GH never scrapes (bot-blocked IPs)
+        assert ci.discovery.search_backstop_only is True  # GH searches only when local was idle
 
         # Shared keys are inherited unchanged — the two runtimes cannot drift on them.
         assert ci.discovery.engines.brave.enabled is True

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2813,35 +2813,44 @@ class TestRunPipelineAsync:
         assert '"dataset_name": "news_items"' in diagnostics_payload
 
     @pytest.mark.asyncio
-    async def test_discover_search_backstop_skips_when_already_searched_today(
+    async def test_discover_search_backstop_skips_with_real_ci_config(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """With search_backstop_only, GH skips engine search if a run already searched today."""
-        from datetime import UTC, datetime
+        """The actual CI triple — source_discovery on, scraping off, backstop on — skips
+        engine search when a run searched in the last 24h and still completes non-fatal
+        (source-native runs empty but SUCCEEDED, so the zero-engine day is not all-failed)."""
+        from datetime import UTC, datetime, timedelta
 
         from denbust.discovery.search_budget import SearchBudgetLedger
 
         config = Config(
             store={"state_root": tmp_path},
-            source_discovery={"enabled": False},
+            scraping_enabled=False,
+            source_discovery={"enabled": True},
             discovery={
                 "enabled": True,
                 "engines": {"brave": {"enabled": True}},
                 "search_backstop_only": True,
             },
         )
-        # A local run already searched earlier today.
+        # A run searched ~1h ago (inside the 24h window).
         SearchBudgetLedger(config.discovery_state_paths.search_budget_path).record(
-            engine="brave", queries=20, run_id="local-run", now=datetime.now(UTC)
+            engine="brave",
+            queries=20,
+            run_id="local-run",
+            now=datetime.now(UTC) - timedelta(hours=1),
         )
+        source = MagicMock()
+        source.name = "ynet"
         brave = AsyncMock()
-        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [source])
         monkeypatch.setattr("denbust.pipeline._run_brave_discovery", brave)
 
         result = await run_news_discover_job(config)
 
-        brave.assert_not_called()
-        assert result.fatal is False
+        brave.assert_not_called()  # engine search skipped by the backstop
+        source.fetch.assert_not_called()  # source-native skipped by scraping_enabled
+        assert result.fatal is False  # zero-engine day is non-fatal
         assert "search_backstop_skipped=true" in result.warnings
 
     @pytest.mark.asyncio

--- a/tests/unit/test_pipeline_core.py
+++ b/tests/unit/test_pipeline_core.py
@@ -2813,6 +2813,72 @@ class TestRunPipelineAsync:
         assert '"dataset_name": "news_items"' in diagnostics_payload
 
     @pytest.mark.asyncio
+    async def test_discover_search_backstop_skips_when_already_searched_today(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """With search_backstop_only, GH skips engine search if a run already searched today."""
+        from datetime import UTC, datetime
+
+        from denbust.discovery.search_budget import SearchBudgetLedger
+
+        config = Config(
+            store={"state_root": tmp_path},
+            source_discovery={"enabled": False},
+            discovery={
+                "enabled": True,
+                "engines": {"brave": {"enabled": True}},
+                "search_backstop_only": True,
+            },
+        )
+        # A local run already searched earlier today.
+        SearchBudgetLedger(config.discovery_state_paths.search_budget_path).record(
+            engine="brave", queries=20, run_id="local-run", now=datetime.now(UTC)
+        )
+        brave = AsyncMock()
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr("denbust.pipeline._run_brave_discovery", brave)
+
+        result = await run_news_discover_job(config)
+
+        brave.assert_not_called()
+        assert result.fatal is False
+        assert "search_backstop_skipped=true" in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_discover_search_backstop_runs_when_no_search_today(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """With search_backstop_only, GH still searches on a day no run has searched yet."""
+        config = Config(
+            store={"state_root": tmp_path},
+            source_discovery={"enabled": False},
+            discovery={
+                "enabled": True,
+                "engines": {"brave": {"enabled": True}},
+                "search_backstop_only": True,
+            },
+        )
+        brave = AsyncMock(
+            return_value=PersistedSourceDiscovery(
+                run=DiscoveryRun(
+                    run_id="run-discover:brave",
+                    dataset_name=DatasetName.NEWS_ITEMS,
+                    job_name=JobName.DISCOVER,
+                    status=DiscoveryRunStatus.SUCCEEDED,
+                ),
+                candidates=[],
+                provenance=[],
+            )
+        )
+        monkeypatch.setattr("denbust.pipeline.create_sources", lambda _config: [])
+        monkeypatch.setattr("denbust.pipeline._run_brave_discovery", brave)
+
+        result = await run_news_discover_job(config)  # empty ledger → no search today
+
+        brave.assert_awaited_once()
+        assert "search_backstop_skipped=true" not in result.warnings
+
+    @pytest.mark.asyncio
     async def test_run_news_discover_job_supports_exa_only_and_writes_metrics(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_search_budget.py
+++ b/tests/unit/test_search_budget.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 from denbust.discovery.search_budget import (
@@ -140,3 +140,32 @@ def test_ledger_missing_file_is_empty(tmp_path: Path) -> None:
     ledger = SearchBudgetLedger(tmp_path / "missing.jsonl")
     assert ledger.load() == []
     assert ledger.month_spend(year_month="2026-06") == (0, 0.0)
+
+
+def test_searched_on_detects_a_same_day_search(tmp_path: Path) -> None:
+    """searched_on backs the GitHub search backstop: only days with a real search count."""
+    ledger = SearchBudgetLedger(tmp_path / "b.jsonl")
+    assert ledger.searched_on(day=date(2026, 6, 13)) is False  # empty ledger
+
+    ledger.record(engine="brave", queries=10, run_id="r1", now=datetime(2026, 6, 13, 9, tzinfo=UTC))
+    # A budget-skipped run that recorded 0 queries does not count as "searched".
+    ledger.record(engine="exa", queries=0, run_id="r2", now=datetime(2026, 6, 13, 10, tzinfo=UTC))
+
+    assert ledger.searched_on(day=date(2026, 6, 13)) is True
+    assert ledger.searched_on(day=date(2026, 6, 12)) is False  # a different day
+    assert ledger.searched_on(day=date(2026, 6, 13), engine="brave") is True
+    assert ledger.searched_on(day=date(2026, 6, 13), engine="exa") is False  # exa logged 0
+
+
+def test_searched_on_compares_in_utc(tmp_path: Path) -> None:
+    """A timestamp is bucketed by its UTC calendar day."""
+    ledger = SearchBudgetLedger(tmp_path / "b.jsonl")
+    # 2026-06-13T23:30-05:00 is 2026-06-14T04:30Z.
+    ledger.record(
+        engine="brave",
+        queries=5,
+        run_id="r",
+        now=datetime.fromisoformat("2026-06-13T23:30:00-05:00"),
+    )
+    assert ledger.searched_on(day=date(2026, 6, 14)) is True
+    assert ledger.searched_on(day=date(2026, 6, 13)) is False

--- a/tests/unit/test_search_budget.py
+++ b/tests/unit/test_search_budget.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from denbust.discovery.search_budget import (
@@ -142,30 +142,40 @@ def test_ledger_missing_file_is_empty(tmp_path: Path) -> None:
     assert ledger.month_spend(year_month="2026-06") == (0, 0.0)
 
 
-def test_searched_on_detects_a_same_day_search(tmp_path: Path) -> None:
-    """searched_on backs the GitHub search backstop: only days with a real search count."""
+def test_searched_since_window(tmp_path: Path) -> None:
+    """searched_since backs the GitHub backstop: only real searches in-window count."""
     ledger = SearchBudgetLedger(tmp_path / "b.jsonl")
-    assert ledger.searched_on(day=date(2026, 6, 13)) is False  # empty ledger
+    cutoff = datetime(2026, 6, 13, 0, tzinfo=UTC)
+    assert ledger.searched_since(since=cutoff) is False  # empty ledger
 
-    ledger.record(engine="brave", queries=10, run_id="r1", now=datetime(2026, 6, 13, 9, tzinfo=UTC))
-    # A budget-skipped run that recorded 0 queries does not count as "searched".
-    ledger.record(engine="exa", queries=0, run_id="r2", now=datetime(2026, 6, 13, 10, tzinfo=UTC))
+    # Before the window — does not count.
+    ledger.record(engine="brave", queries=9, run_id="old", now=datetime(2026, 6, 12, 9, tzinfo=UTC))
+    assert ledger.searched_since(since=cutoff) is False
 
-    assert ledger.searched_on(day=date(2026, 6, 13)) is True
-    assert ledger.searched_on(day=date(2026, 6, 12)) is False  # a different day
-    assert ledger.searched_on(day=date(2026, 6, 13), engine="brave") is True
-    assert ledger.searched_on(day=date(2026, 6, 13), engine="exa") is False  # exa logged 0
+    # In window, but a budget-skipped 0-query run does not count as "searched".
+    ledger.record(engine="exa", queries=0, run_id="zero", now=datetime(2026, 6, 13, 9, tzinfo=UTC))
+    assert ledger.searched_since(since=cutoff) is False
 
-
-def test_searched_on_compares_in_utc(tmp_path: Path) -> None:
-    """A timestamp is bucketed by its UTC calendar day."""
-    ledger = SearchBudgetLedger(tmp_path / "b.jsonl")
-    # 2026-06-13T23:30-05:00 is 2026-06-14T04:30Z.
+    # In window with real queries — counts.
     ledger.record(
-        engine="brave",
-        queries=5,
-        run_id="r",
-        now=datetime.fromisoformat("2026-06-13T23:30:00-05:00"),
+        engine="brave", queries=5, run_id="now", now=datetime(2026, 6, 13, 10, tzinfo=UTC)
     )
-    assert ledger.searched_on(day=date(2026, 6, 14)) is True
-    assert ledger.searched_on(day=date(2026, 6, 13)) is False
+    assert ledger.searched_since(since=cutoff) is True
+    assert ledger.searched_since(since=cutoff, engine="brave") is True
+    assert ledger.searched_since(since=cutoff, engine="exa") is False  # exa logged 0
+    # A cutoff after that search excludes it again.
+    assert ledger.searched_since(since=datetime(2026, 6, 13, 11, tzinfo=UTC)) is False
+
+
+def test_searched_since_treats_naive_timestamp_as_utc(tmp_path: Path) -> None:
+    """A tz-naive recorded_at is compared as UTC rather than mis-bucketed to local."""
+    path = tmp_path / "b.jsonl"
+    # Hand-write a record with a naive recorded_at (no offset).
+    path.write_text(
+        '{"run_id":"r","engine":"brave","queries":5,'
+        '"estimated_cost_usd":0.025,"recorded_at":"2026-06-13T12:00:00"}\n',
+        encoding="utf-8",
+    )
+    ledger = SearchBudgetLedger(path)
+    assert ledger.searched_since(since=datetime(2026, 6, 13, 11, tzinfo=UTC)) is True
+    assert ledger.searched_since(since=datetime(2026, 6, 13, 13, tzinfo=UTC)) is False


### PR DESCRIPTION
## Summary

**`UNIFY-PR-05`** — the second half of the GH/local partition, completing its code side. Brave/Exa are paid (~1,000 free queries/month each), so the day's search budget should be spent **once**. GitHub should search only as a **backstop**: when a local run did not already search that calendar day.

## Change

- **`SearchBudgetLedger.searched_on(day=..., engine=...)`** — True if a search (`queries > 0`) was recorded on the given **UTC** calendar day. A budget-skipped run that logged 0 queries doesn't count.
- **`DiscoveryConfig.search_backstop_only`** (default `False`), set **`true`** in `agents/news/ci.overlay.yaml`. When True, `run_news_discover_job` checks the ledger before issuing engine queries and **skips Brave/Exa/Google CSE for the day** if a search was already recorded (by any run, local or CI), recording a `search_backstop_skipped=true` warning. Source-native discovery and the deterministic phases are unaffected.

Local runs search on their own cadence and take priority; GH searches only on a day local was idle, then records its spend so a later GH run the same day also skips.

## A fix the backstop surfaced

The post-run check `failed_runs == len(persisted_runs)` fataled on `0 == 0` when the backstop skipped *all* engines (a zero-run day). Guarded it with `persisted_runs and …`, so "nothing ran" is non-fatal while "all attempted runs failed" still is.

## Tests

- `searched_on`: same-day detection, **zero-query exclusion**, **UTC bucketing** (a `23:30-05:00` record counts as the next UTC day).
- CI-overlay config test now asserts the flip (`local` False → `ci` True).
- Discover-job behavioral tests: **skips** search when a search is already recorded today (engine never awaited, warning set, non-fatal); **runs** search when the ledger is empty.

ruff/mypy clean; **1376 unit tests pass**.

## Scope / sequencing

- This completes the **code** side of the partition (`UNIFY-PR-04` = no-scrape guardrail; this = search-backstop).
- Re-enabling the workflows + **seeding the state repo** is the operational follow-up (`UNIFY-PR-06`); confirm `STATE_REPO_PAT` push/force-push rights first.
- The parked **scrape→classify decouple** is tracked as [#213](https://github.com/DataHackIL/tfht_enforce_idx/issues/213).
- `backfill_discover` (a manual operator recovery job) is intentionally **not** backstop-gated.
- Guardrail is inert until the workflows are enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)