### PR TITLE
docs(plan): record state-repo seed; go-live is the remaining step

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -17,11 +17,17 @@
   (a fix to the `failed_runs == len(persisted_runs)` check so a zero-run day is not treated as
   all-failed). This completes the code side of the GH/local partition (`UNIFY-PR-04` was the
   no-scrape guardrail). Covered by ledger + config + discover-job tests (incl. the real CI triple).
-- Next planned PR: `UNIFY-PR-06` (operational) — seed the state repo from the current local state
-  and re-enable only the search-backstop / release / report / backup / squash workflows (GitHub
-  never scrapes, so the scraping ingest/backfill-scrape jobs stay local). First confirm the
-  `STATE_REPO_PAT` has push (and force-push, for the squash) rights to the state repo's `main`.
-  The parked scrape→classify decouple is tracked separately as GitHub issue #213.
+- Next planned PR: `UNIFY-PR-06` (operational, go-live) — re-enable only the non-scraping
+  workflows on schedules (discover ≥daily for the backstop, daily-review, monthly-report, release,
+  backup, squash); the scraping ingest / backfill-scrape jobs stay local since GitHub never
+  scrapes. Deferred by operator choice until a manual dispatch verifies the seeded state end to end.
+  Done so far: the state repo `DataHackIL/tfht_enforce_idx_state` has been **seeded** from local
+  `data/news_items` — the rich candidate state (27,568 candidates + queues + attempts + verdicts +
+  budget + yield + backfill_batches + runs + metrics) recovered from orphaned `.jsonl.gz` back to
+  plain JSONL. Excluded from the seed: the prefilter ML models + decision-log telemetry, the
+  regenerable engine_query_cache, and `candidate_provenance.jsonl` (119 MB — over GitHub's 100 MB
+  per-file limit; rebuilds going forward). `latest_candidates.jsonl` (62 MB) and `backfill_queue.jsonl`
+  (52 MB) are over GitHub's 50 MB soft-warning size. Parked scrape→classify decouple: GitHub issue #213.
 - Current blockers on main: Google CSE returns `403 PERMISSION_DENIED` locally; the canonical
   `agents/news/local_search_brave_exa.yaml` already disables Google CSE so Brave + Exa carry
   open-web discovery. Exa returns `402 Payment Required` once its prepaid balance is exhausted —
@@ -324,11 +330,13 @@
   defers to a recent local search regardless of clock ordering). A zero-run day now finishes
   non-fatal.
   Covered by ledger + config + discover-job tests.
-- [next] `UNIFY-PR-06` (operational): seed the state repo from current local state and re-enable
-  only the search-backstop / release / report / backup / squash workflows — GitHub never scrapes,
-  so the scraping ingest / backfill-scrape jobs stay local. Confirm the `STATE_REPO_PAT` can push
-  (and force-push, for the squash) to the state repo's `main` first. (Parked scrape→classify
-  decouple: GitHub issue #213.)
+- [next] `UNIFY-PR-06` (operational, go-live): the state repo is now **seeded** with the recovered
+  core state from local `data/news_items` (27,568 candidates + queues/attempts/verdicts/budget/yield
+  + backfill_batches/runs/metrics; excluded: prefilter models + decision logs, engine_query_cache,
+  and the 119 MB candidate_provenance which exceeds GitHub's 100 MB file limit). Remaining: re-enable
+  only the non-scraping workflows on schedules (discover ≥daily, daily-review, monthly-report,
+  release, backup, squash) — deferred until a manual dispatch verifies the seeded state end to end.
+  Scraping ingest / backfill-scrape stay local. (Parked scrape→classify decouple: GitHub issue #213.)
 - [later] `LPF-PR-10`: calibration tooling + golden-set regression CI — frozen
   `tests/golden/prefilter/golden_eval.parquet`, `denbust prefilter calibrate` and
   `denbust prefilter evaluate --golden ...`, and a `.github/workflows/ci-test.yml`


### PR DESCRIPTION
Docs-only `.agent-plan.md` update to mainline truth.

The state repo `DataHackIL/tfht_enforce_idx_state` has been **seeded** from local `data/news_items` as the discovery/ingest source of truth:

- Recovered the rich candidate state from orphaned `.jsonl.gz` (left by the reverted gzip experiment #208) back to plain JSONL: **27,568 candidates** + retry/backfill queues + scrape attempts + domain verdicts + search budget + query yield + backfill_batches + runs + metrics.
- **Excluded** (not state SoT): prefilter ML models + decision-log telemetry (~183 MB), the regenerable `engine_query_cache`, and `candidate_provenance.jsonl` (119 MB — over GitHub's 100 MB per-file limit; rebuilds going forward).
- Packed ~30 MB; `latest_candidates.jsonl` (62 MB) and `backfill_queue.jsonl` (52 MB) are over GitHub's 50 MB soft-warning size.

**Go-live (re-enabling scheduled workflows) is deferred** by operator choice until a manual dispatch verifies the seeded state end to end. The parked scrape→classify decouple stays tracked as [#213](https://github.com/DataHackIL/tfht_enforce_idx/issues/213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)