### PR TITLE
ci(state): install gitleaks in setup-denbust-state-job (unblocks go-live)

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -360,6 +360,14 @@
   `supabase/migrations/20260616_discovery_runs_skipped_query_count.sql` plus a regression test and a
   guard test asserting every `DiscoveryRun` field maps to a `discovery_runs` column. Clears the
   schema break that would otherwise fail the `UNIFY-PR-06` go-live dispatch.
+- [done] `FIX-CI-GITLEAKS-STATE-JOBS`: install gitleaks in the `setup-denbust-state-job` composite
+  action so the fail-closed `scripts/state-run.sh` secret scan has its binary on the runner. After
+  `GUARD-PR-SECRET-SCAN` (#220), state-run refuses to push when gitleaks is absent; only `ci-test.yml`
+  installed it, so all eight scheduled state-writing workflows (discover, daily/weekly state-run,
+  backfill-discover/scrape, monthly-report, backup, release) would have failed at persist on their
+  first scheduled run. Pinned to v8.30.1 to match `.gitleaks.toml`. (`state-repo-squash` uses
+  `state-squash.sh`, which does not scan, so it is unaffected.) Prerequisite for the `UNIFY-PR-06`
+  go-live dispatch.
 - [next] `UNIFY-PR-06` (operational, go-live): the state repo is **seeded** (key-scrubbed after the
   incident below) with the recovered core state from local `data/news_items` (27,568 candidates +
   queues/attempts/verdicts/budget/yield + backfill_batches/runs/metrics; excluded: prefilter models

--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -6,11 +6,14 @@
 
 ## Mainline Status
 
-- Last merged PR on main: `#223` (`FIX-DISCOVERY-RUNS-SCHEMA`; refs #150/#152/#156/#184/#186, closed on deploy) —
-  add the missing `discovery_runs.skipped_query_count` column whose absence was failing every
-  Supabase run-metadata write and blocking candidate persistence on daily-review runs; a guard test
-  now asserts every `DiscoveryRun` field maps to a column. Clears the schema break on the
-  `UNIFY-PR-06` go-live path. Prior: `#220` (`GUARD-PR-SECRET-SCAN`, closes #218) — the three-layer
+- Last merged PR on main: `#224` (`FIX-CI-GITLEAKS-STATE-JOBS`) — install gitleaks in the
+  `setup-denbust-state-job` composite action so the fail-closed `scripts/state-run.sh` secret scan
+  has its binary on the runner; without it every scheduled state-writing workflow would have failed
+  at persist on its first scheduled run. The last `UNIFY-PR-06` prerequisite. Prior: `#223`
+  (`FIX-DISCOVERY-RUNS-SCHEMA`; refs #150/#152/#156/#184/#186, closed on deploy) — add the missing
+  `discovery_runs.skipped_query_count` column whose absence was failing every Supabase run-metadata
+  write and blocking candidate persistence on daily-review runs; a guard test now asserts every
+  `DiscoveryRun` field maps to a column. Earlier: `#220` (`GUARD-PR-SECRET-SCAN`, closes #218) — the three-layer
   [gitleaks](https://github.com/gitleaks/gitleaks) secret-scan guard (the outer defense following
   the seed-time leak incident below): a shared `.gitleaks.toml`, a `pre-commit` pre-push hook, a
   fail-closed `scripts/state-run.sh` scan before each state push, and a Claude Code
@@ -360,7 +363,7 @@
   `supabase/migrations/20260616_discovery_runs_skipped_query_count.sql` plus a regression test and a
   guard test asserting every `DiscoveryRun` field maps to a `discovery_runs` column. Clears the
   schema break that would otherwise fail the `UNIFY-PR-06` go-live dispatch.
-- [done] `FIX-CI-GITLEAKS-STATE-JOBS`: install gitleaks in the `setup-denbust-state-job` composite
+- [done] `FIX-CI-GITLEAKS-STATE-JOBS` (#224): install gitleaks in the `setup-denbust-state-job` composite
   action so the fail-closed `scripts/state-run.sh` secret scan has its binary on the runner. After
   `GUARD-PR-SECRET-SCAN` (#220), state-run refuses to push when gitleaks is absent; only `ci-test.yml`
   installed it, so all eight scheduled state-writing workflows (discover, daily/weekly state-run,

--- a/.github/actions/setup-denbust-state-job/action.yml
+++ b/.github/actions/setup-denbust-state-job/action.yml
@@ -28,6 +28,17 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
 
+    # Required by scripts/state-run.sh, which fails closed (refuses to push) if
+    # gitleaks is missing. Every state-writing job runs through state-run, so the
+    # binary must be present on the runner. Pinned to match .gitleaks.toml's rev.
+    - name: Install gitleaks
+      shell: bash
+      run: |
+        VERSION=8.30.1
+        curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+          | sudo tar -xz -C /usr/local/bin gitleaks
+        gitleaks version
+
     - name: Install Playwright Chromium
       if: ${{ inputs.install-playwright == 'true' }}
       shell: bash


### PR DESCRIPTION
## Why

A latent go-live blocker introduced by #220. `scripts/state-run.sh` now **fails closed** — `scan_state_for_secrets()` refuses to commit/push when gitleaks isn't on the runner. But gitleaks was installed only in `ci-test.yml`; the `setup-denbust-state-job` composite action — used by **every** state-writing workflow — never installed it.

Because all eight scheduled state jobs are currently `workflow_dispatch`-only (pre-go-live), this has been dormant. The moment `UNIFY-PR-06` flips the schedules on, each of these would run the job and then **fail at the persist step** with `gitleaks not installed — refusing to push state unscanned`:

`news-items-discover`, `daily-state-run`, `weekly-state-run`, `news-items-backfill-discover`, `news-items-backfill-scrape`, `news-items-monthly-report`, `news-items-backup`, `news-items-release`.

## What

Add a pinned `gitleaks` install (v8.30.1, matching `.gitleaks.toml`) to the shared `setup-denbust-state-job` composite action — one place covers all eight consumers. The read-only `news-items-daily-review` also uses the action and gets gitleaks harmlessly (a ~2s download it doesn't use). `state-repo-squash` uses `state-squash.sh` (which does not scan) and is correctly unaffected.

## Verification

- Confirmed all 8 workflows that invoke `state-run.sh` use this composite action → all now have gitleaks.
- `action.yml` parses as valid YAML; install step mirrors the proven `ci-test.yml` step.

## Why now

This is the **prerequisite for the `UNIFY-PR-06` go-live dispatch** — surfaced while scoping that verification run. Until it lands, a scheduled `news-items-discover` would run, search/classify, then refuse to persist. With it, the fail-closed guard has its binary and the dispatch can actually exercise the seeded-state → guarded-state-run → Supabase-persist path.